### PR TITLE
DigitalOcean migration + Layer 1 finance gbrain (hosted MemoryAgent)

### DIFF
--- a/.claude/commands/gbrain.md
+++ b/.claude/commands/gbrain.md
@@ -1,0 +1,37 @@
+---
+description: Save to / search / load the finance GBrain (Neo4j memory). Usage: /gbrain <save|add|search|get|link> ...
+argument-hint: <save|add|search|get|link> ...
+allowed-tools: Read, mcp__memory__put_page, mcp__memory__get_page, mcp__memory__search, mcp__memory__create_link
+---
+
+You are operating the **finance GBrain** — a persistent knowledge base exposed by the MCP
+server registered as `memory` (tools: `put_page`, `get_page`, `search`, `create_link`).
+
+**Prerequisite:** the server must be registered once with
+`claude mcp add memory -- python FinAgents/memory/memory_server.py`.
+If the `mcp__memory__*` tools are unavailable, tell the user to run that command and stop.
+
+Parse the request from this input: **$ARGUMENTS**
+
+Choose the action from the first word:
+
+- **add `<path-to-file.md>` [--ns NS] [--kind KIND]**
+  1. `Read` the file at the given path.
+  2. Derive `title` from the first `# H1` heading, else the filename (no extension).
+  3. Choose `kind`: use `--kind` if given; otherwise infer — `strategy` if the doc reads
+     like a playbook/checklist of rules, else `knowledge`.
+  4. Call `put_page(title, body=<full file contents>, namespace=NS or "default", kind,
+     tags=<a few derived from headings>, source=<the path>)`.
+  5. Report the resulting slug + version.
+
+- **save `<text…>` [--ns NS]** — derive a concise title and call `put_page` with the text as body.
+
+- **search `<query…>` [--ns NS] [--kind KIND]** — call `search`; show results as
+  `score  slug  [kind]  title`, ranked best-first.
+
+- **get `<slug>` [--ns NS]** — call `get_page`; show the page and its links.
+
+- **link `<from-slug> <to-slug>` [--ns NS]** — call `create_link`.
+
+Default namespace is `default` unless `--ns` is given. After any write, confirm what was
+stored (namespace, slug, version). Keep responses concise.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Secrets & local config — must never enter the image (use fly secrets)
+.env
+.env.*
+
+# Build/runtime cruft & large dirs not needed by the memory service
+.venv
+venv
+.git
+.github
+data
+examples
+tests
+docs
+scripts
+*.pkl
+*.log
+**/__pycache__
+.DS_Store
+fly.toml

--- a/Architecture.md
+++ b/Architecture.md
@@ -1,0 +1,212 @@
+# Architecture — Finance GBrain (Hosted MemoryAgent), Layer 1
+
+This document describes **Layer 1**: a live, hosted, persistent knowledge base
+("finance gbrain") an LLM agent runtime can always reach. Layer 1 is the build.
+Crucially, Layer 1 also ships the **interface seams** that Layers 2 and 3 require —
+so those layers plug in later without re-migrating the store.
+
+---
+
+## 1. The three layers (scope boundary)
+
+| Layer | What it is | This effort builds… |
+|---|---|---|
+| **1. Memory / knowledge + seams** | Hosted, generalized, semantic-search store + MCP tools, **plus the seams below** | **Everything** |
+| 2. Control plane | "Claude prompts change agent behavior 24/7" | Only the **seams** (§9) — not the agent loops |
+| 3. Fleet orchestration | Multiple agents of each type running at once | Only the **seams** (§9) — not the supervisor |
+
+> Design rule: Layer 1 is a **memory + event + coordination service**. It exposes the
+> *primitives* Layers 2/3 consume (config pages, change events, compare-and-set, leases),
+> but it does **not** run agent control loops or supervise processes. Building those into
+> the memory server is a category error.
+
+---
+
+## 2. System diagram (Layer 1 + the seams)
+
+```
+   LAYER 2 (later)            LAYER 3 (later)
+   behavior control          fleet of agents (N per type)
+   ┌───────────────┐         ┌───────────────────────────┐
+   │ Claude writes │         │ momentum#1 momentum#2 ...  │
+   │ strategy page │         │ risk#1  risk#2  ...        │
+   └──────┬────────┘         └─────────────┬─────────────┘
+          │ put_page(kind=strategy)        │ subscribe / claim / CAS
+          │ (rw token)                     │ (per-agent tokens)
+          ▼                                ▼
+   ┌─────────────────────────────────────────────────────────────────────────┐
+   │  MEMORYAGENT SERVICE   (always-on container, single instance for MVP)     │
+   │  ───────────────────────────────────────────────────────────────────────│
+   │  ① Auth: read-only | read-write | per-agent identity                      │
+   │  ② FastMCP app (uvicorn ASGI, stateless_http=True)                        │
+   │  ③ Knowledge tools:  put_page · get_page · search · create_link           │
+   │  ④ SEAMS for L2/L3:                                                        │
+   │       • events:  publish-on-write  +  subscribe(namespace[,kind])         │
+   │       • concurrency:  put_page(expected_version=N)  → CAS / 409           │
+   │       • coordination:  claim(key,owner,ttl) · release(key,owner)          │
+   │       • attribution:  written_by, agent_type, agent_instance_id           │
+   │  ⑤ Indexer: text → embedding ──────────────┐                              │
+   │  ⑥ /health  /docs                          │                              │
+   └───────────────┬────────────────────────────┼──────────────────────────────┘
+                   │ Bolt+TLS                    │ HTTPS (embed)
+                   ▼                             ▼
+     ┌──────────────────────────────┐   ┌──────────────────────────────┐
+     │  Neo4j Aura (52b4f6d4)        │   │  DigitalOcean Gradient AI     │
+     │  - :Page nodes (+ :Memory)    │   │  - embeddings: bge-m3 (1024)  │
+     │  - vector index 1024/cosine   │   │  - LLM: openai-gpt-oss-120b   │
+     │  - :Event log  · :Lease nodes │   │    (optional summaries)       │
+     │  - graph links/traversal      │   └──────────────────────────────┘
+     └──────────────────────────────┘
+                   ▲ keep-alive ping (cron) — prevents Aura Free auto-pause
+```
+
+The event log and lease nodes live **in Neo4j** (durable), not in process — so the
+seams survive restarts and work once Layer 3 runs multiple agents (and, later, replicas).
+
+---
+
+## 3. Components & where they live
+
+| Component | Implementation | Hosted where |
+|---|---|---|
+| MemoryAgent (MCP server) | `FinAgents/memory/memory_server.py` — FastMCP, `app = mcp.streamable_http_app()`, stateless | Always-on container (Fly.io recommended) |
+| Graph + vector store | Neo4j Aura `52b4f6d4` (pages, vector index, event log, leases) | Neo4j Aura (managed) |
+| Embeddings | `bge-m3` (1024-dim) via OpenAI-compatible API | DigitalOcean Gradient AI |
+| LLM (optional, brain-side summaries) | `openai-gpt-oss-120b` | DigitalOcean Gradient AI |
+| MCP client | `FinAgents/memory/interface.py` (streamable-http) | Agent runtime |
+| Event bus / coordination | Neo4j-backed (durable); `realtime_stream_processor` formalized | In the service + Neo4j |
+| Keep-alive / backups | Cron (host scheduler / GitHub Action) | Free |
+
+---
+
+## 4. Provider stack (decided)
+
+- **LLM + embeddings:** DigitalOcean Gradient AI (OpenAI-compatible). Base URL
+  `https://inference.do-ai.run/v1`; OpenAI SDK auto-reads `OPENAI_API_KEY` + `OPENAI_BASE_URL`.
+  - Chat: **`openai-gpt-oss-120b`**. Embeddings: **`bge-m3`** (1024-dim, cosine).
+  - **Tier limit:** `openai-gpt-4o` / `anthropic-*` return `403` (account tier, not key).
+- **Datastore:** Neo4j (graph-native links + durable event log/leases for the seams).
+  Aura DB = `52b4f6d4`.
+
+---
+
+## 5. Data model (Layer 1, seam-ready)
+
+```
+(:Page {
+   id, slug, namespace,           # identity; unique (namespace, slug)
+   kind,                          # "knowledge" | "strategy" | "config"   ← enables L2
+   title, body, tags[],
+   version,                       # monotonic int; bumped per write       ← enables CAS (L2/L3)
+   embedding: float[1024],        # vector-indexed (bge-m3 / cosine)
+   embedding_model, embedding_dim, needs_embedding,
+   written_by, agent_type, agent_instance_id,   # provenance              ← enables L3
+   created_at, updated_at
+})
+(:Page)-[:LINKS_TO]->(:Page)      # native graph links
+
+(:Event {                          # durable change log                    ← enables L2/L3
+   namespace, slug, kind, version, op, written_by, ts
+})
+(:Lease {                          # atomic coordination primitive          ← enables L3
+   key, owner, expires_at
+})
+```
+
+Existing trading nodes (`:Memory`, `:Agent`, `:Signal`, `:Strategy`) remain; `:Page`,
+`:Event`, `:Lease` are additive.
+
+---
+
+## 6. Locked decisions (Layer 1)
+
+1. **Embedding model/dim — LOCKED:** `bge-m3`, **1024-dim, cosine**. Swap to any other
+   1024-dim model via re-embed only (no index rebuild). Never index at 384 or 768.
+2. **Retrieval unit:** page-level for MVP; chunking later (additive).
+3. **Tenancy:** mandatory `namespace` from day one.
+4. **Identity/writes:** UUID `id` + `slug` unique within namespace; `put_page` upserts via
+   `MERGE (namespace, slug)`; `version`/`updated_at` tracked.
+5. **Auth:** bearer tokens — **read-only**, **read-write**, and **per-agent identity** (for L3 attribution).
+6. **Embed-on-write resilience:** store even if embedding fails; `needs_embedding=true`; cron re-embeds.
+7. **Interface:** MCP-primary; `/health` + debug `GET /search`.
+8. **Schema as idempotent boot code:** constraints + vector index + event/lease constraints at startup.
+9. **Backups:** weekly cron dump (Aura Free has none).
+
+---
+
+## 7. Current state (implemented)
+
+- ✅ Provider migrated to DigitalOcean; LLM `openai-gpt-oss-120b`.
+- ✅ `.env`-driven `OPENAI_*` + `NEO4J_*`; Aura `52b4f6d4` wired & verified.
+- ✅ Embeddings default = DO `bge-m3` (1024) with local fallbacks.
+- ✅ Vector index `memory_embedding_index` (1024/cosine) ensured at startup.
+
+## 8. Known gaps
+
+- ✅ Containerized + deployed to Fly (HTTP); **stdio transport works locally against Aura** (default).
+- ✅ Per-session lifespan teardown crash fixed; **stdout kept clean** for stdio MCP.
+- ⛔ Embeddings not yet persisted to Neo4j (still in `memory_index.pkl`).
+- ⛔ `semantic_search_memories` uses in-process cosine, not `db.index.vector.queryNodes`.
+- ⛔ No `:Page` generalization / neutral tools yet.
+- ⛔ No auth on the HTTP MCP path (stdio is local-only → lower risk).
+- ⛔ HTTP mode still re-inits resources per request (fleet path); **stdio (default) does not**.
+- ⛔ Seams (§9) not yet built.
+
+---
+
+## 9. Layer 1 ↔ Layer 2/3 interface seams (the point of this revision)
+
+These are **built in Layer 1** so the later layers attach cleanly. For each: what Layer 1
+provides vs. what the consumer (built later) does.
+
+| Seam | Layer 1 provides (now) | Consumer does (L2/L3, later) | Enables |
+|---|---|---|---|
+| **Config-as-pages** | Store/serve `kind=strategy|config` pages by stable `(namespace, slug)` | Agents `get_page` their behavior on each loop | L2 |
+| **Change events** | `publish-on-write` to a durable `:Event` log + `subscribe(namespace[,kind])` stream | Agents subscribe and **hot-reload** behavior on change | L2, L3 |
+| **Compare-and-set** | `put_page(expected_version=N)` → 409 on mismatch; `version` per page | Atomic strategy swap + rollback; safe multi-writer updates | L2, L3 |
+| **Claim / lease** | Atomic `claim(key, owner, ttl)` / `release` backed by `:Lease` (single-tx MERGE) | Instances coordinate so only one handles a unit of work | L3 |
+| **Identity / attribution** | `written_by`, `agent_type`, `agent_instance_id` on writes + events; per-agent tokens | Trace which instance did what; partition shared vs private memory | L3 |
+
+**Critical forward-compat rule:** the event bus and leases are **Neo4j-backed (durable)**,
+never in-process-only. The memory server is `stateless_http=True`, but its stream-processor
+state is in-memory today → **run a single instance for the MVP**. Externalizing
+coordination to Neo4j (done via these seams) is what later permits multiple agents and,
+eventually, multiple server replicas without changing the tool contract.
+
+**What is explicitly NOT in Layer 1:** the agent control loops, the behavior-reload logic,
+process spawning/supervision, and work-partitioning policy. Layer 1 hands those layers the
+primitives; it does not implement their behavior.
+
+---
+
+## 10. Transport & provider model (gbrain-aligned)
+
+**Transport: stdio-first.** gbrain runs `gbrain serve` as a *local stdio* MCP server over a
+remote Postgres — it centralizes the **database**, not the server. We adopt the same shape:
+the MemoryAgent **defaults to stdio MCP** — one long-lived process per client, all sharing the
+always-on Neo4j Aura brain. In stdio mode the lifespan runs once per process, so init is
+effectively a startup singleton (no per-request re-init). HTTP (`MCP_TRANSPORT=http`) is
+reserved for the hosted, headless Layer 3 fleet.
+
+- **Default (dev / Claude Code / single agent):** `claude mcp add memory -- python memory_server.py`.
+- **Fleet (Layer 3, 24/7 headless):** the containerized HTTP server on a host.
+- **"Always reachable" is guaranteed by Aura's uptime, not a hosted container** — removing the
+  always-on-container / billing / public-auth burden for the common case. (This is the lesson
+  from the Fly deploy: hosting a public MCP server was self-imposed cost; Aura already is the
+  always-on shared layer.)
+
+**Provider / dependency reductions (lean-binary ethos):**
+- The events seam is **poll-based** over the durable `:Event` log (`get_events(since=cursor)`),
+  not WebSocket push → **`websockets` dropped**.
+- Once search runs through Neo4j's vector index + DO `bge-m3`, the in-process `scikit-learn`
+  cosine and `memory_index.pkl` are dead weight → **`scikit-learn` / `scipy` dropped**.
+- Net: the three deps that broke the first Fly build all disappear.
+
+**Trust boundary on ingested content.** Web/Exa-sourced pages carry `source` + `trust`
+(`trusted`|`untrusted`); untrusted content is envelope-wrapped before being surfaced to an LLM
+— a lightweight take on gstack's layered prompt-injection defense, relevant because Layers 2/3
+will store web research in the brain.
+
+**What does NOT transfer from gstack:** "no MCP" (that's gstack's *browser* tool; gbrain itself
+uses MCP, so we keep it) and "no multi-user" (we deliberately want multi-agent → scoped tokens,
+modeled on gbrain's per-repo trust triad).

--- a/Deploy.md
+++ b/Deploy.md
@@ -1,0 +1,164 @@
+# Deploy — Finance GBrain Layer 1
+
+How to take the MemoryAgent from local to a **live, always-reachable hosted instance**,
+what **you (the human) must set up ahead of time**, and the deployment constraints that
+keep the **Layer 2/3 seams** (events, leases, per-agent identity) working as the system grows.
+
+---
+
+## 0. Prerequisites you must provide (READ FIRST)
+
+Only **you** can do these (accounts, billing, secrets, decisions). Blocking = ⛔.
+
+### Accounts & credentials
+- [x] **DigitalOcean Gradient key** — in `.env` (`doo_v1_…`, gitignored). Tier 403s `gpt-4o`/Anthropic.
+- [x] **Neo4j Aura instance** `52b4f6d4` — creds in `.env`.
+- [ ] **(Optional — fleet only) Hosting account** for the HTTP container — e.g. **Fly.io**.
+  **Not required for the Layer 1 demo** (stdio + always-on Aura). Needed only for the Layer 3
+  headless fleet. Note: Fly **trial machines stop after 5 min without a credit card** — add
+  billing for an always-on HTTP instance. (flyctl is installed; `agentictrading` app exists.)
+- [x] **Generate API tokens** — `MEMORY_API_TOKEN_RW` + `MEMORY_API_TOKEN_RO` generated and in `.env`.
+  - 🔌 **Per-agent tokens (for L3 later):** plan to mint one token per agent identity so writes
+    can be attributed (`written_by`). For the Layer 1 demo, the two scope tokens suffice.
+
+### Decisions
+- [x] **Neo4j always-on strategy: CHOSEN → A (Aura Free + keep-alive ping).** Free; node caps;
+  no backups → weekly export cron is required (see §6). Upgrade to Aura Professional later if needed.
+- [ ] **Backup destination** (Aura Free has none): private git repo or object-storage bucket.
+
+### Local tooling
+- [x] Python virtualenv (`.venv`) with `requirements.txt`.
+- [ ] **Docker Desktop** locally — optional (Fly can build remotely).
+- [ ] **Git remote** for this repo if using git-push deploys.
+
+> **Blocking minimum (revised — gbrain stdio model):** **none for the Layer 1 demo.** Default
+> transport is stdio against the always-on Aura brain, so **Fly is now optional (fleet-only)**.
+> Tokens ✅ and Neo4j strategy ✅ are done. Fly billing/auth matters *only* for the hosted HTTP
+> fleet (Layer 3) — the 5-minute trial-stop we hit is irrelevant to the stdio demo.
+
+---
+
+## 1. Environment variables
+
+`.env` locally (gitignored); **host secrets** in prod (never in the image).
+
+| Variable | Purpose | Source |
+|---|---|---|
+| `OPENAI_API_KEY` | DigitalOcean model access key | `.env` ✅ |
+| `OPENAI_BASE_URL` | `https://inference.do-ai.run/v1` | `.env` ✅ |
+| `NEO4J_URI` | `neo4j+s://52b4f6d4.databases.neo4j.io` | `.env` ✅ |
+| `NEO4J_USERNAME` / `NEO4J_PASSWORD` / `NEO4J_DATABASE` | Aura creds (`52b4f6d4`) | `.env` ✅ |
+| `MEMORY_API_TOKEN_RW` / `MEMORY_API_TOKEN_RO` | bearer tokens | **you generate** |
+| `MEMORY_AGENT_TOKENS` (later) | 🔌 per-agent identity→token map (L3 attribution) | **you generate, later** |
+
+---
+
+## 2. Run locally
+
+**Default — stdio MCP (gbrain model):** one local process sharing the always-on Aura brain.
+
+```bash
+# register with Claude Code (or any stdio MCP client)
+claude mcp add memory -- python FinAgents/memory/memory_server.py
+# or run directly (MCP_TRANSPORT defaults to stdio; reads .env)
+python FinAgents/memory/memory_server.py
+```
+
+In stdio mode the lifespan runs **once per process** (init is a startup singleton) and all
+diagnostics go to **stderr** — stdout is the JSON-RPC channel.
+
+**HTTP mode (hosted fleet only):**
+
+```bash
+cd FinAgents/memory
+MCP_TRANSPORT=http uvicorn memory_server:app --host 0.0.0.0 --port 8000
+curl localhost:8000/health
+```
+
+HTTP `/mcp` is streamable-HTTP/stateless. Change events (once built) are **poll-based**
+(`get_events(namespace, since_cursor)`), not a streaming subscribe.
+
+---
+
+## 3. Containerize (Phase 5)
+
+`Dockerfile` (repo root):
+
+```dockerfile
+FROM python:3.13-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY FinAgents/ ./FinAgents/
+WORKDIR /app/FinAgents/memory
+EXPOSE 8000
+CMD ["uvicorn", "memory_server:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+Embeddings use the DO API (no local model) → light image; no `torch`/`sentence-transformers` in prod.
+
+---
+
+## 4. Deploy to Fly.io
+
+```bash
+fly auth login
+fly launch --no-deploy                 # set internal_port = 8000 in fly.toml
+fly secrets set \
+  OPENAI_API_KEY=... OPENAI_BASE_URL=https://inference.do-ai.run/v1 \
+  NEO4J_URI=neo4j+s://52b4f6d4.databases.neo4j.io NEO4J_USERNAME=52b4f6d4 \
+  NEO4J_PASSWORD=... NEO4J_DATABASE=52b4f6d4 \
+  MEMORY_API_TOKEN_RW=... MEMORY_API_TOKEN_RO=...
+fly deploy
+curl https://<app>.fly.dev/health
+```
+
+Health check → `/health`. Client: `MCP_SERVER_URL=https://<app>.fly.dev/mcp` + header
+`Authorization: Bearer <MEMORY_API_TOKEN_RW>`.
+
+### ⚠️ Scaling constraint that protects the L2/L3 seams
+**Run a single instance for the MVP.** The change-event/lease seams are designed to be
+**Neo4j-backed (durable)** precisely so multiple *agents* (Layer 3) can use them — but the
+in-process stream-processor state in the server is **not** shared across **server replicas**.
+Do not scale the MemoryAgent past one container until that state is fully externalized to
+Neo4j/Redis. Many agents against **one** server instance is fine and is the L3 MVP target.
+
+---
+
+## 5. Keep-alive (Aura Free anti-pause) — Phase 6
+
+Cron every few hours curling `/health` (GitHub Action, Fly scheduled machine, or uptime pinger)
+keeps the app and Aura Free awake — important once Layer 2 agents poll/subscribe 24/7.
+
+---
+
+## 6. Backups — Phase 6
+
+Aura Free has no backups. Weekly cron exports the graph (APOC `apoc.export.cypher` or Cypher
+dump) — **including `:Page`, `:Event`, `:Lease`** — to your private git repo / bucket.
+
+---
+
+## 7. Security checklist (before public exposure)
+
+- [ ] Bearer-token middleware live; unauth → 401.
+- [ ] Write/prune require **read-write**; search/get accept **read-only**.
+- [ ] 🔌 Per-agent tokens stamp `written_by` (L3 attribution).
+- [ ] Secrets only as host secrets / `.env` — never committed, never in argv.
+- [ ] **Single server instance** (in-memory stream state not yet replica-safe).
+- [ ] `/health` the only unauthenticated route.
+
+---
+
+## 8. Quick reference — live resources
+
+| Resource | Value |
+|---|---|
+| DigitalOcean inference | `https://inference.do-ai.run/v1` |
+| Chat model | `openai-gpt-oss-120b` |
+| Embedding model | `bge-m3` (1024-dim, cosine) |
+| Neo4j Aura URI | `neo4j+s://52b4f6d4.databases.neo4j.io` |
+| Neo4j database | `52b4f6d4` |
+| MCP endpoint (prod) | `https://<host>/mcp` |
+| Health endpoint | `https://<host>/health` |
+| Seam tools (Layer 1) | `put_page` · `get_page` · `search` · `create_link` · `subscribe` · `claim`/`release` · CAS via `expected_version` |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Finance GBrain — Layer 1 MemoryAgent (FastMCP streamable-HTTP server)
+# Embeddings use the DigitalOcean API (no torch/sentence-transformers), so the image stays light.
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Install deps first for layer caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Only the self-contained memory service is needed
+COPY FinAgents/memory/ ./FinAgents/memory/
+
+WORKDIR /app/FinAgents/memory
+
+EXPOSE 8000
+
+# Stateless streamable-HTTP MCP app (config comes from env / fly secrets, not .env)
+CMD ["uvicorn", "memory_server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/FinAgents/agent_pools/alpha_agent_demo/alpha_signal_agent.py
+++ b/FinAgents/agent_pools/alpha_agent_demo/alpha_signal_agent.py
@@ -422,7 +422,7 @@ class AlphaSignalAgent:
     def __init__(
         self,
         name: str = "AlphaSignalAgent",
-        model: str = "gpt-4o",
+        model: str = "openai-gpt-oss-120b",
         qlib_config: Optional[QlibConfig] = None
     ):
         self.name = name

--- a/FinAgents/agent_pools/alpha_agent_pool/agents.py
+++ b/FinAgents/agent_pools/alpha_agent_pool/agents.py
@@ -31,7 +31,7 @@ class Agent:
     General-purpose agent class supporting OpenAI Function Calling with automatic tool execution.
     """
 
-    def __init__(self, name="Agent", instructions="", model="gpt-4o-mini", tools=None):
+    def __init__(self, name="Agent", instructions="", model="openai-gpt-oss-120b", tools=None):
         self.name = name
         self.instructions = instructions
         self.model = model

--- a/FinAgents/agent_pools/alpha_agent_pool/agents/theory_driven/mean_reversion_agent.py
+++ b/FinAgents/agent_pools/alpha_agent_pool/agents/theory_driven/mean_reversion_agent.py
@@ -685,7 +685,7 @@ Always prioritize statistical rigor, research transparency, and practical applic
 
 mean_reversion_agent = Agent(
     name="mean-reversion-alpha-agent",
-    model="gpt-4",  # Can be changed to "claude-sonnet-4.5" or other supported models
+    model="openai-gpt-oss-120b",  # Can be changed to "claude-sonnet-4.5" or other supported models
     instructions=AGENT_INSTRUCTIONS,
     tools=[
         fetch_data,

--- a/FinAgents/agent_pools/alpha_agent_pool/agents/theory_driven/momentum_agent.py
+++ b/FinAgents/agent_pools/alpha_agent_pool/agents/theory_driven/momentum_agent.py
@@ -817,7 +817,7 @@ Focus on intelligent adaptation and RL-style learning. Use the multi-timeframe a
         
         try:
             response = await self.llm_client.chat.completions.create(
-                model="o4-mini",
+                model="openai-gpt-oss-120b",
                 messages=[
                     {"role": "system", "content": "You are an expert quantitative analyst specializing in multi-timeframe momentum analysis. Make intelligent, adaptive trading decisions."},
                     {"role": "user", "content": prompt}
@@ -1339,7 +1339,7 @@ Focus on intelligent adaptation and RL-style learning. Use the multi-timeframe a
             """
             
             response = await self.llm_client.chat.completions.create(
-                model="gpt-4o-mini",
+                model="openai-gpt-oss-120b",
                 messages=[{"role": "user", "content": context}],
                 temperature=0.1,
                 max_tokens=500

--- a/FinAgents/agent_pools/alpha_agent_pool/alpha_research_agent.py
+++ b/FinAgents/agent_pools/alpha_agent_pool/alpha_research_agent.py
@@ -258,7 +258,7 @@ class AlphaResearchAgent:
         self.context = AlphaResearchContext()
         self.agent = Agent(
             name="AlphaResearchAgent",
-            model="gpt-4o-mini",
+            model="openai-gpt-oss-120b",
             instructions="""
 You are a professional quantitative research assistant. You can call the following tools:
 - load_and_analyze_data
@@ -317,7 +317,7 @@ Please provide:
 
         try:
             response = self.agent.client.chat.completions.create(
-                model="gpt-4o-mini",
+                model="openai-gpt-oss-120b",
                 messages=[
                     {"role": "system", "content": "You are a professional quantitative analyst specializing in alpha factor research."},
                     {"role": "user", "content": text_prompt},

--- a/FinAgents/agent_pools/alpha_agent_pool/alphaquant.py
+++ b/FinAgents/agent_pools/alpha_agent_pool/alphaquant.py
@@ -176,7 +176,7 @@ feats_global = []
 for rnd in range(1, ROUNDS + 1):
     print(f"\n===== Round {rnd} =====")
     feats, names, errors, code_str = llm_generate_features(
-        client, "gpt-4o-mini", log_returns, top_examples, eliminated, prev_errors, feedback, NUM_FEATURES)
+        client, "openai-gpt-oss-120b", log_returns, top_examples, eliminated, prev_errors, feedback, NUM_FEATURES)
 
     if not feats:
         print("No valid features generated.")

--- a/FinAgents/agent_pools/backtest_agent/backtest_agent.py
+++ b/FinAgents/agent_pools/backtest_agent/backtest_agent.py
@@ -79,7 +79,7 @@ class BacktestAgent(Agent):
         self.name = "BacktestAgent"
         self.description = "An agent that performs backtesting of trading strategies using historical market data and Qlib framework."
         self.model = ModelSettings(
-            model_name="gpt-4-turbo",
+            model_name="openai-gpt-oss-120b",
             temperature=0.3,
             max_tokens=2000,
             top_p=1.0,

--- a/FinAgents/agent_pools/backtest_agent/local_agents.py
+++ b/FinAgents/agent_pools/backtest_agent/local_agents.py
@@ -4,7 +4,7 @@ Simple Agent framework for trading agents
 
 class ModelSettings:
     """Model settings for AI agents"""
-    def __init__(self, model_name="gpt-4", temperature=0.3, max_tokens=2000, 
+    def __init__(self, model_name="openai-gpt-oss-120b", temperature=0.3, max_tokens=2000, 
                  top_p=1.0, frequency_penalty=0.0, presence_penalty=0.0):
         self.model_name = model_name
         self.temperature = temperature

--- a/FinAgents/agent_pools/data_agent_pool/agents/equity/polygon_agent.py
+++ b/FinAgents/agent_pools/data_agent_pool/agents/equity/polygon_agent.py
@@ -69,7 +69,7 @@ class PolygonAgent(BaseAgent):
         - Context management
         """
         self.llm = ChatOpenAI(
-            model_name="o4-mini",
+            model_name="openai-gpt-oss-120b",
             temperature=1 
         )
         # Enhanced system prompt for robust multi-step, multi-symbol, multi-type planning

--- a/FinAgents/agent_pools/data_agent_pool/agents/equity/use_yfinance_mcp.py
+++ b/FinAgents/agent_pools/data_agent_pool/agents/equity/use_yfinance_mcp.py
@@ -140,7 +140,7 @@ async def run_agent_with_yfinance_server(args: argparse.Namespace) -> None:
                 "before answering. Respond with JSON only."
             ),
             mcp_servers=[server],
-            model_settings=ModelSettings(model="gpt-4.1-mini", tool_choice="required"),
+            model_settings=ModelSettings(model="openai-gpt-oss-120b", tool_choice="required"),
         )
 
         result = await Runner.run(agent, prompt)

--- a/FinAgents/agent_pools/data_agent_pool/agents/news/alphavantage_agent.py
+++ b/FinAgents/agent_pools/data_agent_pool/agents/news/alphavantage_agent.py
@@ -63,7 +63,7 @@ class AlphaVantageNewsAgent(BaseAgent):
     def _init_llm_interface(self):
         """Configure LLM interface for news and sentiment analysis."""
         self.llm = ChatOpenAI(
-            model_name="gpt-4o-mini",
+            model_name="openai-gpt-oss-120b",
             temperature=0.1 
         )
         

--- a/FinAgents/agent_pools/data_agent_pool/agents/news/newsapi_agent.py
+++ b/FinAgents/agent_pools/data_agent_pool/agents/news/newsapi_agent.py
@@ -58,7 +58,7 @@ class NewsAPIAgent(BaseAgent):
     def _init_llm_interface(self):
         """Configure LLM interface for news analysis."""
         self.llm = ChatOpenAI(
-            model_name="gpt-4o-mini",
+            model_name="openai-gpt-oss-120b",
             temperature=0.1 
         )
         

--- a/FinAgents/agent_pools/portfolio_agent_demo/portfolio_agent.py
+++ b/FinAgents/agent_pools/portfolio_agent_demo/portfolio_agent.py
@@ -156,7 +156,7 @@ class PortfolioAgent:
     def __init__(
         self,
         name: str = "PortfolioAgent",
-        model: str = "gpt-4o",
+        model: str = "openai-gpt-oss-120b",
         mode: str = "backtest"
     ):
         self.name = name

--- a/FinAgents/agent_pools/portfolio_construction_agent_pool/core.py
+++ b/FinAgents/agent_pools/portfolio_construction_agent_pool/core.py
@@ -649,7 +649,7 @@ class PortfolioConstructionAgentPool:
             user_prompt = f"Portfolio construction request: {user_input}"
             
             response = await self.openai_client.chat.completions.create(
-                model="gpt-4",
+                model="openai-gpt-oss-120b",
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt}
@@ -1491,7 +1491,7 @@ class PortfolioConstructionAgent:
         # Initialize LLM if OpenAI is available
         if agent_pool.openai_client:
             self.llm = ChatOpenAI(
-                model="gpt-4",
+                model="openai-gpt-oss-120b",
                 temperature=0.1,
                 api_key=agent_pool.openai_api_key
             )

--- a/FinAgents/agent_pools/risk_agent_demo/risk_signal_agent.py
+++ b/FinAgents/agent_pools/risk_agent_demo/risk_signal_agent.py
@@ -196,7 +196,7 @@ class RiskSignalAgent:
     def __init__(
         self,
         name: str = "RiskSignalAgent",
-        model: str = "gpt-4o",
+        model: str = "openai-gpt-oss-120b",
         qlib_config: Optional[QlibConfig] = None
     ):
         self.name = name

--- a/FinAgents/agent_pools/risk_agent_demo/test_with_real_data.py
+++ b/FinAgents/agent_pools/risk_agent_demo/test_with_real_data.py
@@ -278,7 +278,7 @@ def main():
     
     # Initialize agent
     print(f"\n2. Initializing Risk Signal Agent...")
-    agent = RiskSignalAgent(name="RealDataRiskAgent", model="gpt-5")
+    agent = RiskSignalAgent(name="RealDataRiskAgent", model="openai-gpt-oss-120b")
     
     # Prepare data summary for agent context
     data_summary = {

--- a/FinAgents/agent_pools/risk_agent_pool/core.py
+++ b/FinAgents/agent_pools/risk_agent_pool/core.py
@@ -108,7 +108,7 @@ class ContextDecompressor:
             """
             
             response = await self.openai_client.chat.completions.create(
-                model="gpt-4o-mini",
+                model="openai-gpt-oss-120b",
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": f"Parse this risk analysis request: {context}"}

--- a/FinAgents/memory/gbrain_cli.py
+++ b/FinAgents/memory/gbrain_cli.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+gbrain CLI — basic commands to test the Finance GBrain MemoryAgent (Layer 1).
+
+A thin terminal wrapper over the same UnifiedDatabaseManager methods the MCP tools
+use (put_page / get_page / search_pages / link_pages), so you can poke at the brain
+without an MCP client.
+
+Usage:
+  python gbrain_cli.py put "<title>" "<body>" [--ns NS] [--kind KIND] [--tags a,b] [--slug S]
+  python gbrain_cli.py get <slug> [--ns NS]
+  python gbrain_cli.py search "<query>" [--ns NS] [--limit N] [--kind KIND]
+  python gbrain_cli.py link <from_slug> <to_slug> [--ns NS]
+  python gbrain_cli.py list [--ns NS]
+  python gbrain_cli.py clear [--ns NS]
+
+NS defaults to "default". Config (DigitalOcean + Neo4j) is read from the project .env.
+"""
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)  # allow sibling imports when run from anywhere
+
+from dotenv import load_dotenv
+load_dotenv(os.path.join(HERE, "..", "..", ".env"))
+
+# Keep CLI output clean — silence the chatty INFO logs / Neo4j notifications.
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger("neo4j").setLevel(logging.ERROR)
+
+from unified_database_manager import create_database_manager
+
+
+def _cfg():
+    return {
+        "uri": os.getenv("NEO4J_URI"),
+        "username": os.getenv("NEO4J_USERNAME") or os.getenv("NEO4J_USER"),
+        "password": os.getenv("NEO4J_PASSWORD"),
+        "database": os.getenv("NEO4J_DATABASE"),
+    }
+
+
+async def run(args) -> int:
+    mgr = create_database_manager(_cfg())
+    if not await mgr.connect():
+        print("ERROR: could not connect to Neo4j (check .env)")
+        return 1
+    try:
+        if args.cmd == "put":
+            tags = [t.strip() for t in args.tags.split(",") if t.strip()]
+            r = await mgr.put_page(title=args.title, body=args.body, namespace=args.ns,
+                                   slug=(args.slug or None), tags=tags, kind=args.kind)
+            print(json.dumps(r, indent=2))
+
+        elif args.cmd == "get":
+            r = await mgr.get_page(args.slug, namespace=args.ns)
+            print(json.dumps(r, indent=2) if r else f"(not found: {args.ns}::{args.slug})")
+
+        elif args.cmd == "search":
+            qv = mgr.indexer.create_text_embedding(args.query)
+            res = await mgr.search_pages(qv, namespace=args.ns, limit=args.limit,
+                                         kind=(args.kind or None))
+            for x in res:
+                print(f"  {x['similarity_score']:.3f}  {x['slug']:<28} [{x['kind']}]  {x['title']}")
+            if not res:
+                print(f"(no results in namespace '{args.ns}')")
+
+        elif args.cmd == "link":
+            print(json.dumps(await mgr.link_pages(args.from_slug, args.to_slug, namespace=args.ns)))
+
+        elif args.cmd == "list":
+            with mgr.driver.session(database=mgr.database) as s:
+                rows = list(s.run(
+                    "MATCH (p:Page {namespace:$ns}) "
+                    "RETURN p.slug AS slug, p.kind AS kind, p.title AS title, p.version AS v "
+                    "ORDER BY p.updated_at DESC", {"ns": args.ns}))
+            for r in rows:
+                print(f"  {r['slug']:<28} v{r['v']}  [{r['kind']}]  {r['title']}")
+            if not rows:
+                print(f"(no pages in namespace '{args.ns}')")
+
+        elif args.cmd == "clear":
+            with mgr.driver.session(database=mgr.database) as s:
+                n = s.run("MATCH (p:Page {namespace:$ns}) DETACH DELETE p RETURN count(*) AS c",
+                          {"ns": args.ns}).single()["c"]
+            print(f"deleted {n} pages from namespace '{args.ns}'")
+
+        elif args.cmd == "ingest":
+            with open(args.path, encoding="utf-8") as fh:
+                body = fh.read()
+            # title = first markdown H1, else the filename without extension
+            title = next((ln[2:].strip() for ln in body.splitlines() if ln.startswith("# ")),
+                         os.path.splitext(os.path.basename(args.path))[0])
+            r = await mgr.put_page(title=title, body=body, namespace=args.ns,
+                                   slug=(args.slug or None), kind=args.kind,
+                                   source=os.path.abspath(args.path))
+            print(json.dumps(r, indent=2))
+    finally:
+        await mgr.close()
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="gbrain", description="Finance GBrain CLI")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("put", help="create/update a page")
+    p.add_argument("title"); p.add_argument("body")
+    p.add_argument("--ns", default="default"); p.add_argument("--kind", default="knowledge")
+    p.add_argument("--tags", default=""); p.add_argument("--slug", default="")
+
+    g = sub.add_parser("get", help="fetch a page by slug")
+    g.add_argument("slug"); g.add_argument("--ns", default="default")
+
+    s = sub.add_parser("search", help="semantic search within a namespace")
+    s.add_argument("query"); s.add_argument("--ns", default="default")
+    s.add_argument("--limit", type=int, default=5); s.add_argument("--kind", default="")
+
+    l = sub.add_parser("link", help="link two pages (from -> to)")
+    l.add_argument("from_slug"); l.add_argument("to_slug"); l.add_argument("--ns", default="default")
+
+    ls = sub.add_parser("list", help="list pages in a namespace")
+    ls.add_argument("--ns", default="default")
+
+    cl = sub.add_parser("clear", help="delete all pages in a namespace")
+    cl.add_argument("--ns", default="default")
+
+    ig = sub.add_parser("ingest", help="add a markdown/text file as a page")
+    ig.add_argument("path")
+    ig.add_argument("--ns", default="default")
+    ig.add_argument("--kind", default="knowledge")
+    ig.add_argument("--slug", default="")
+
+    sys.exit(asyncio.run(run(ap.parse_args())))
+
+
+if __name__ == "__main__":
+    main()

--- a/FinAgents/memory/intelligent_memory_indexer.py
+++ b/FinAgents/memory/intelligent_memory_indexer.py
@@ -15,13 +15,17 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 import pickle
 import os
+import logging
+from pathlib import Path
 
-# Try to import sentence transformers for advanced embeddings
+# Try to import sentence transformers for advanced embeddings (local fallback)
 try:
     from sentence_transformers import SentenceTransformer
     TRANSFORMERS_AVAILABLE = True
 except ImportError:
     TRANSFORMERS_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 @dataclass
 class MemoryIndex:
@@ -42,40 +46,69 @@ class IntelligentMemoryIndexer:
     Advanced memory indexing system with semantic search capabilities
     """
     
-    def __init__(self, 
+    def __init__(self,
                  index_file: str = "memory_index.pkl",
-                 use_transformers: bool = True,
-                 model_name: str = "all-MiniLM-L6-v2"):
+                 embedding_backend: str = "digitalocean",
+                 model_name: str = "bge-m3",
+                 embedding_dim: int = 1024,
+                 use_transformers: bool = True):
         """
-        Initialize the intelligent memory indexer
-        
+        Initialize the intelligent memory indexer.
+
         Args:
             index_file: Path to store the memory index
-            use_transformers: Whether to use transformer models for embeddings
-            model_name: Name of the sentence transformer model
+            embedding_backend: "digitalocean" (default, OpenAI-compatible API),
+                "transformers" (local sentence-transformers), or "tfidf"
+            model_name: Embedding model id (DO default: "bge-m3", 1024-dim)
+            embedding_dim: Vector dimension produced by the model (must match the
+                Neo4j vector index; bge-m3 / gte-large-en-v1.5 / e5-large-v2 = 1024)
+            use_transformers: Allow falling back to local sentence-transformers
         """
         self.index_file = index_file
-        self.use_transformers = use_transformers and TRANSFORMERS_AVAILABLE
+        self.embedding_backend = embedding_backend
+        self.embedding_model_name = model_name
+        self.embedding_dim = embedding_dim
         self.memory_index: Dict[str, MemoryIndex] = {}
-        
-        # Initialize embedding models
-        if self.use_transformers:
+        self.do_client = None
+        self.use_transformers = False
+
+        # Primary backend: DigitalOcean Gradient AI embeddings via OpenAI SDK.
+        # Reads OPENAI_API_KEY + OPENAI_BASE_URL from the project .env.
+        if embedding_backend == "digitalocean":
             try:
-                self.transformer_model = SentenceTransformer(model_name)
-                print(f"✅ Loaded transformer model: {model_name}")
+                from dotenv import load_dotenv
+                load_dotenv(dotenv_path=Path(__file__).resolve().parents[2] / ".env")
+            except Exception:
+                pass
+            try:
+                import openai
+                self.do_client = openai.OpenAI()  # base_url/key from environment
+                logger.info(f"Using DigitalOcean embeddings: {model_name} (dim={embedding_dim})")
             except Exception as e:
-                print(f"⚠️ Failed to load transformer model: {e}")
-                self.use_transformers = False
-        
-        if not self.use_transformers:
+                logger.warning(f"Failed to init DigitalOcean embeddings client: {e}")
+                self.do_client = None
+
+        # Fallback 1: local sentence-transformers
+        if self.do_client is None and use_transformers and TRANSFORMERS_AVAILABLE \
+                and embedding_backend in ("digitalocean", "transformers"):
+            st_model = model_name if embedding_backend == "transformers" else "all-MiniLM-L6-v2"
+            try:
+                self.transformer_model = SentenceTransformer(st_model)
+                self.use_transformers = True
+                logger.info(f"Loaded transformer model: {st_model}")
+            except Exception as e:
+                logger.warning(f"Failed to load transformer model: {e}")
+
+        # Fallback 2: TF-IDF (always available)
+        if self.do_client is None and not self.use_transformers:
             self.tfidf_vectorizer = TfidfVectorizer(
                 max_features=1000,
                 stop_words='english',
                 ngram_range=(1, 2)
             )
             self.tfidf_fitted = False
-            print("✅ Using TF-IDF vectorizer for embeddings")
-        
+            logger.info("Using TF-IDF vectorizer for embeddings")
+
         # Load existing index
         self.load_index()
     
@@ -133,11 +166,27 @@ class IntelligentMemoryIndexer:
         return list(set(keywords))  # Remove duplicates
     
     def create_text_embedding(self, text: str) -> np.ndarray:
-        """Create text embedding using available model"""
+        """Create text embedding using the configured backend (DigitalOcean bge-m3 by default)."""
+        # Primary: DigitalOcean Gradient AI embeddings (OpenAI-compatible)
+        if self.do_client is not None:
+            try:
+                resp = self.do_client.embeddings.create(
+                    model=self.embedding_model_name,
+                    input=text or " "
+                )
+                return np.array(resp.data[0].embedding, dtype=np.float32)
+            except Exception as e:
+                logger.warning(f"DigitalOcean embedding call failed, using local fallback: {e}")
+
         if self.use_transformers:
             return self.transformer_model.encode([text])[0]
         else:
-            # Use TF-IDF
+            # Use TF-IDF (lazily initialize if a higher-priority backend was active)
+            if not hasattr(self, "tfidf_vectorizer"):
+                self.tfidf_vectorizer = TfidfVectorizer(
+                    max_features=1000, stop_words='english', ngram_range=(1, 2)
+                )
+                self.tfidf_fitted = False
             if not self.tfidf_fitted:
                 # Need to fit on existing texts first
                 all_texts = [text]
@@ -246,11 +295,11 @@ class IntelligentMemoryIndexer:
             # Save index
             await self.save_index()
             
-            print(f"✅ Indexed memory {memory_id[:8]}... with {len(keywords)} keywords")
+            logger.debug(f"Indexed memory {memory_id[:8]}... with {len(keywords)} keywords")
             return True
             
         except Exception as e:
-            print(f"❌ Failed to index memory {memory_id}: {e}")
+            logger.warning(f"Failed to index memory {memory_id}: {e}")
             return False
     
     def semantic_search(self, 
@@ -395,7 +444,7 @@ class IntelligentMemoryIndexer:
             with open(self.index_file, 'wb') as f:
                 pickle.dump(self.memory_index, f)
         except Exception as e:
-            print(f"⚠️ Failed to save index: {e}")
+            logger.warning(f"Failed to save index: {e}")
     
     def load_index(self):
         """Load memory index from disk"""
@@ -403,9 +452,9 @@ class IntelligentMemoryIndexer:
             if os.path.exists(self.index_file):
                 with open(self.index_file, 'rb') as f:
                     self.memory_index = pickle.load(f)
-                print(f"✅ Loaded {len(self.memory_index)} indexed memories")
+                logger.info(f"Loaded {len(self.memory_index)} indexed memories")
         except Exception as e:
-            print(f"⚠️ Failed to load index: {e}")
+            logger.warning(f"Failed to load index: {e}")
             self.memory_index = {}
     
     def get_index_stats(self) -> Dict[str, Any]:

--- a/FinAgents/memory/interface.py
+++ b/FinAgents/memory/interface.py
@@ -190,7 +190,7 @@ async def run_conversation_with_tools(user_prompt: str, mcp_session: ClientSessi
         try:
             print("💬 [CLIENT] Sending request to OpenAI...")
             response = client.chat.completions.create(
-                model="gpt-4o", 
+                model="openai-gpt-oss-120b", 
                 messages=messages,
                 tools=tools_definition,
                 tool_choice="auto", 

--- a/FinAgents/memory/llm_research_service.py
+++ b/FinAgents/memory/llm_research_service.py
@@ -307,7 +307,7 @@ Memory {i+1}:
         """Call OpenAI API asynchronously."""
         try:
             # Try different models in order of preference
-            models_to_try = ["o4-mini", "gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4-turbo-preview"]
+            models_to_try = ["openai-gpt-oss-120b"]
             
             for model in models_to_try:
                 try:

--- a/FinAgents/memory/memory_server.py
+++ b/FinAgents/memory/memory_server.py
@@ -31,6 +31,11 @@ from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
+import functools
+
+# Route this module's diagnostic banners to stderr. In stdio MCP mode, stdout IS
+# the JSON-RPC protocol channel — anything printed to stdout would corrupt it.
+print = functools.partial(print, file=sys.stderr, flush=True)
 
 # Import unified components
 try:
@@ -41,6 +46,11 @@ except ImportError:
     # Fallback to original database for compatibility
     from database import TradingGraphMemory
     UNIFIED_COMPONENTS_AVAILABLE = False
+    # Define names so module-level annotations below don't raise NameError
+    UnifiedDatabaseManager = None
+    UnifiedInterfaceManager = None
+    create_database_manager = None
+    create_interface_manager = None
 
 # Import intelligent indexer and stream processor
 try:
@@ -48,20 +58,30 @@ try:
     INTELLIGENT_INDEXER_AVAILABLE = True
 except ImportError:
     INTELLIGENT_INDEXER_AVAILABLE = False
+    IntelligentMemoryIndexer = None
 
 try:
     from realtime_stream_processor import StreamProcessor, ReactiveMemoryManager
     STREAM_PROCESSOR_AVAILABLE = True
 except ImportError:
     STREAM_PROCESSOR_AVAILABLE = False
+    StreamProcessor = None
+    ReactiveMemoryManager = None
 
 # ═══════════════════════════════════════════════════════════════════════════════════
 # CONFIGURATION AND GLOBAL VARIABLES
 # ═══════════════════════════════════════════════════════════════════════════════════
 
-NEO4J_URI = "bolt://localhost:7687"
-NEO4J_USER = "neo4j"
-NEO4J_PASSWORD = "finagent123"
+try:
+    from dotenv import load_dotenv
+    load_dotenv(dotenv_path=Path(__file__).resolve().parents[2] / ".env")
+except ImportError:
+    pass
+
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+NEO4J_USER = os.getenv("NEO4J_USERNAME") or os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "finagent123")
+NEO4J_DATABASE = os.getenv("NEO4J_DATABASE", "neo4j")
 
 # Global instances for unified architecture
 UNIFIED_DATABASE_MANAGER: Optional[UnifiedDatabaseManager] = None
@@ -105,7 +125,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[None]:
                 "uri": NEO4J_URI,
                 "username": NEO4J_USER,
                 "password": NEO4J_PASSWORD,
-                "database": "neo4j"
+                "database": NEO4J_DATABASE
             }
             
             UNIFIED_DATABASE_MANAGER = create_database_manager(database_config)
@@ -196,9 +216,9 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[None]:
             await GRAPH_DB_INSTANCE.close()
             print("✅ [SERVER] Legacy database connection closed")
             
-        if STREAM_PROCESSOR:
-            await STREAM_PROCESSOR.shutdown()
-            print("✅ [SERVER] Stream processor shut down")
+        if STREAM_PROCESSOR and hasattr(STREAM_PROCESSOR, "stop_processing"):
+            await STREAM_PROCESSOR.stop_processing()
+            print("✅ [SERVER] Stream processor stopped")
             
         print("🛑 [SERVER] Memory server shutdown complete")
 
@@ -252,7 +272,7 @@ async def store_graph_memory(
                 print(f"   ✅ [SERVER] {message}")
                 
                 # Publish to stream processor if available
-                if REACTIVE_MANAGER:
+                if REACTIVE_MANAGER and hasattr(REACTIVE_MANAGER, "handle_memory_event"):
                     await REACTIVE_MANAGER.handle_memory_event({
                         "event_type": "memory_stored",
                         "memory_id": stored_data.get("memory_id"),
@@ -615,53 +635,47 @@ async def semantic_search_memories(
         raise Exception("No database connection available for semantic search.")
 
     try:
-        # Get memories for semantic search
-        if UNIFIED_DATABASE_MANAGER:
-            all_memories = await UNIFIED_DATABASE_MANAGER.retrieve_memory("", limit=1000)
-        else:
-            all_memories = await GRAPH_DB_INSTANCE.retrieve_memory("", limit=1000)
-        
-        if not all_memories:
+        # Vector search requires the unified manager (Neo4j native vector index).
+        if not UNIFIED_DATABASE_MANAGER:
             return json.dumps({
-                "status": "success",
-                "results": [],
-                "message": "No memories found in database for semantic search."
+                "status": "error",
+                "message": "Vector search requires the unified database manager.",
+                "search_type": "semantic"
             })
 
-        # Perform semantic search using intelligent indexer
-        search_results = INTELLIGENT_INDEXER.semantic_search(
-            query=query,
-            memories=all_memories,
-            top_k=limit,
-            similarity_threshold=similarity_threshold
+        # Embed the query with the same model used at write time (bge-m3, 1024-dim),
+        # then query the Neo4j vector index — no in-process scan of all memories.
+        embedder = INTELLIGENT_INDEXER or getattr(UNIFIED_DATABASE_MANAGER, "indexer", None)
+        if not embedder:
+            return json.dumps({
+                "status": "error",
+                "message": "No embedding backend available to embed the query.",
+                "search_type": "semantic"
+            })
+
+        query_embedding = embedder.create_text_embedding(query)
+        results = await UNIFIED_DATABASE_MANAGER.vector_search(
+            query_embedding, limit=limit, similarity_threshold=similarity_threshold
         )
-        
-        # Process results and handle numpy types
-        processed_results = []
-        for result in search_results:
-            processed_result = dict(result)
-            if 'similarity_score' in processed_result:
-                processed_result['similarity_score'] = float(processed_result['similarity_score'])
-            processed_results.append(processed_result)
-        
-        print(f"   ✅ [SERVER] Semantic search returned {len(processed_results)} results.")
-        
+
+        print(f"   ✅ [SERVER] Vector search returned {len(results)} results.")
+
         # Publish search event to stream processor
-        if REACTIVE_MANAGER:
+        if REACTIVE_MANAGER and hasattr(REACTIVE_MANAGER, "handle_search_event"):
             await REACTIVE_MANAGER.handle_search_event({
                 "query": query,
-                "results_count": len(processed_results),
+                "results_count": len(results),
                 "timestamp": datetime.utcnow().isoformat(),
                 "search_type": "semantic"
             })
-        
+
         response_data = {
             "status": "success",
-            "results": processed_results,
+            "results": results,
             "query": query,
             "similarity_threshold": similarity_threshold,
-            "architecture": "unified" if UNIFIED_DATABASE_MANAGER else "legacy",
-            "search_type": "semantic"
+            "architecture": "unified",
+            "search_type": "vector_index"
         }
         return json.dumps(response_data)
         
@@ -672,6 +686,66 @@ async def semantic_search_memories(
             "message": f"Semantic search failed: {str(e)}",
             "search_type": "semantic"
         })
+
+@mcp.tool(name="put_page",
+          description="Create or update a knowledge page (gbrain). Upserts by (namespace, slug); embeds title+body for semantic search; bumps version on update.")
+async def put_page(title: str, body: str, namespace: str = "default", slug: str = "",
+                   tags: Optional[List[str]] = None, kind: str = "knowledge",
+                   links: Optional[List[str]] = None, source: str = "", trust: str = "trusted"):
+    print(f"🛠️ [SERVER] TOOL: put_page ns={namespace} slug={slug or '(auto)'}")
+    if not UNIFIED_DATABASE_MANAGER:
+        return json.dumps({"status": "error", "message": "put_page requires the unified database manager."})
+    try:
+        r = await UNIFIED_DATABASE_MANAGER.put_page(
+            title=title, body=body, namespace=namespace, slug=(slug or None),
+            tags=tags, kind=kind, links=links, source=(source or None), trust=trust)
+        return json.dumps(r)
+    except Exception as e:
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool(name="get_page",
+          description="Fetch a knowledge page by (namespace, slug), including its outgoing links.")
+async def get_page(slug: str, namespace: str = "default"):
+    print(f"🛠️ [SERVER] TOOL: get_page ns={namespace} slug={slug}")
+    if not UNIFIED_DATABASE_MANAGER:
+        return json.dumps({"status": "error", "message": "get_page requires the unified database manager."})
+    page = await UNIFIED_DATABASE_MANAGER.get_page(slug, namespace=namespace)
+    return json.dumps(page if page else {"status": "not_found", "slug": slug, "namespace": namespace})
+
+
+@mcp.tool(name="search",
+          description="Semantic search over knowledge pages within a namespace (optionally filtered by kind).")
+async def search(query: str, namespace: str = "default", limit: int = 10,
+                 kind: str = "", similarity_threshold: float = 0.0):
+    print(f"🛠️ [SERVER] TOOL: search ns={namespace} q={query[:60]!r}")
+    if not UNIFIED_DATABASE_MANAGER:
+        return json.dumps({"status": "error", "message": "search requires the unified database manager."})
+    embedder = INTELLIGENT_INDEXER or getattr(UNIFIED_DATABASE_MANAGER, "indexer", None)
+    if not embedder:
+        return json.dumps({"status": "error", "message": "No embedding backend available to embed the query."})
+    try:
+        qv = embedder.create_text_embedding(query)
+        results = await UNIFIED_DATABASE_MANAGER.search_pages(
+            qv, namespace=namespace, limit=limit, kind=(kind or None),
+            similarity_threshold=similarity_threshold)
+        return json.dumps({"status": "success", "query": query, "namespace": namespace, "results": results})
+    except Exception as e:
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool(name="create_link",
+          description="Create a directed link between two pages in a namespace (from_slug -> to_slug).")
+async def create_link(from_slug: str, to_slug: str, namespace: str = "default"):
+    print(f"🛠️ [SERVER] TOOL: create_link ns={namespace} {from_slug} -> {to_slug}")
+    if not UNIFIED_DATABASE_MANAGER:
+        return json.dumps({"status": "error", "message": "create_link requires the unified database manager."})
+    try:
+        r = await UNIFIED_DATABASE_MANAGER.link_pages(from_slug, to_slug, namespace=namespace)
+        return json.dumps({"status": "success", **r})
+    except Exception as e:
+        return json.dumps({"status": "error", "message": str(e)})
+
 
 @mcp.tool(name="get_trending_keywords",
           description="Extracts and analyzes trending keywords from recent memories using intelligent text processing.")
@@ -1162,5 +1236,18 @@ if __name__ == "__main__":
     print(f"   👤 Neo4j User: {NEO4J_USER}")
     print(f"   🏷️  Server Name: FinAgentMemoryServer")
     print("\n🚀 Starting FinAgent Memory Server...")
-    print("   Use uvicorn to run: uvicorn memory_server:app --host 0.0.0.0 --port 8000")
     print("="*80)
+
+    # stdio is the default transport (gbrain model): one long-lived process per
+    # client, all sharing the always-on Neo4j Aura brain. In stdio mode the lifespan
+    # runs once for the whole process, so init is effectively a startup singleton.
+    # HTTP (MCP_TRANSPORT=http) is for the hosted headless fleet.
+    transport = os.getenv("MCP_TRANSPORT", "stdio").lower()
+    if transport in ("http", "streamable-http"):
+        import uvicorn
+        port = int(os.getenv("PORT", "8000"))
+        print(f"🚀 Launching MemoryAgent over HTTP on 0.0.0.0:{port}")
+        uvicorn.run(app, host="0.0.0.0", port=port)
+    else:
+        print("🚀 Launching MemoryAgent over stdio MCP")
+        mcp.run(transport="stdio")

--- a/FinAgents/memory/unified_database_manager.py
+++ b/FinAgents/memory/unified_database_manager.py
@@ -38,17 +38,25 @@ except ImportError:
 
 # Intelligent indexer imports
 try:
-    from .intelligent_memory_indexer import IntelligentMemoryIndexer
+    from intelligent_memory_indexer import IntelligentMemoryIndexer
     INDEXER_AVAILABLE = True
 except ImportError:
-    INDEXER_AVAILABLE = False
+    try:
+        from .intelligent_memory_indexer import IntelligentMemoryIndexer
+        INDEXER_AVAILABLE = True
+    except ImportError:
+        INDEXER_AVAILABLE = False
 
 # Stream processor imports  
 try:
-    from .realtime_stream_processor import StreamProcessor, ReactiveMemoryManager
+    from realtime_stream_processor import StreamProcessor, ReactiveMemoryManager
     STREAM_PROCESSOR_AVAILABLE = True
 except ImportError:
-    STREAM_PROCESSOR_AVAILABLE = False
+    try:
+        from .realtime_stream_processor import StreamProcessor, ReactiveMemoryManager
+        STREAM_PROCESSOR_AVAILABLE = True
+    except ImportError:
+        STREAM_PROCESSOR_AVAILABLE = False
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -220,8 +228,8 @@ class UnifiedDatabaseManager:
                 logger.info("✅ Neo4j connection closed")
             
             # Close stream processor if available
-            if self.stream_processor:
-                await self.stream_processor.shutdown()
+            if self.stream_processor and hasattr(self.stream_processor, "stop_processing"):
+                await self.stream_processor.stop_processing()
                 
         except Exception as e:
             logger.error(f"❌ Error closing connections: {e}")
@@ -292,13 +300,31 @@ class UnifiedDatabaseManager:
                     session_id: $session_id,
                     correlation_id: $correlation_id,
                     created_at: datetime(),
-                    lookup_count: 0
+                    lookup_count: 0,
+                    embedding: $embedding,
+                    embedding_model: $embedding_model,
+                    embedding_dim: $embedding_dim,
+                    needs_embedding: $needs_embedding
                 })
                 RETURN m.memory_id as stored_id
                 """
                 
                 # Prepare searchable text
                 content_text = f"{query} {summary} {' '.join(keywords)}".lower()
+
+                # Embed on write (bge-m3 via the indexer). On failure, store the node
+                # anyway and flag needs_embedding=true for a later backfill pass.
+                embedding = None
+                embedding_model = getattr(self.indexer, "embedding_model_name", None) if self.indexer else None
+                embedding_dim = getattr(self.indexer, "embedding_dim", 0) if self.indexer else 0
+                needs_embedding = True
+                if self.indexer:
+                    try:
+                        vec = self.indexer.create_text_embedding(content_text)
+                        embedding = [float(x) for x in vec]
+                        needs_embedding = False
+                    except Exception as e:
+                        logger.warning(f"⚠️ Embed-on-write failed (stored without vector): {e}")
                 
                 result = session.run(memory_query, {
                     "memory_id": memory_id,
@@ -312,7 +338,11 @@ class UnifiedDatabaseManager:
                     "event_type": event_type,
                     "log_level": log_level,
                     "session_id": session_id,
-                    "correlation_id": correlation_id
+                    "correlation_id": correlation_id,
+                    "embedding": embedding,
+                    "embedding_model": embedding_model,
+                    "embedding_dim": embedding_dim,
+                    "needs_embedding": needs_embedding
                 })
                 
                 stored_id = result.single()["stored_id"]
@@ -323,12 +353,11 @@ class UnifiedDatabaseManager:
                 # Find and link similar memories
                 linked_memories = await self._find_and_link_similar_memories(session, memory_id, keywords, summary)
                 
-                # Index memory for intelligent search
-                if self.indexer:
-                    self.indexer.index_memory(memory_id, memory_content)
+                # Embeddings are persisted on the node (embed-on-write) and searched via the
+                # Neo4j vector index — the in-process pickle index is retired as the search path.
                 
                 # Publish memory event to stream processor
-                if self.reactive_manager:
+                if self.reactive_manager and hasattr(self.reactive_manager, "handle_memory_event"):
                     await self.reactive_manager.handle_memory_event({
                         "event_type": "memory_stored",
                         "memory_id": memory_id,
@@ -350,6 +379,169 @@ class UnifiedDatabaseManager:
         except Exception as e:
             logger.error(f"❌ Failed to store memory: {e}")
             raise Exception(f"Memory storage failed: {str(e)}")
+
+    async def vector_search(self, query_embedding, limit: int = 10,
+                            similarity_threshold: float = 0.0) -> List[Dict[str, Any]]:
+        """Semantic search via the Neo4j native vector index (cosine, 1024-dim)."""
+        if not self.is_connected:
+            raise Exception("Database not connected")
+        vec = [float(x) for x in query_embedding]
+        cypher = """
+        CALL db.index.vector.queryNodes('memory_embedding_index', $k, $vec)
+        YIELD node, score
+        WHERE score >= $threshold
+        RETURN node.memory_id AS memory_id, node.agent_id AS agent_id,
+               node.summary AS summary, node.content AS content,
+               node.keywords AS keywords, node.event_type AS event_type,
+               node.timestamp AS timestamp, score AS similarity_score
+        ORDER BY score DESC
+        """
+        results: List[Dict[str, Any]] = []
+        with self.driver.session(database=self.database) as session:
+            for r in session.run(cypher, {"k": int(limit), "vec": vec,
+                                          "threshold": float(similarity_threshold)}):
+                results.append({
+                    "memory_id": r["memory_id"],
+                    "agent_id": r["agent_id"],
+                    "summary": r["summary"],
+                    "content": json.loads(r["content"]) if r.get("content") else {},
+                    "keywords": r["keywords"],
+                    "event_type": r["event_type"],
+                    "timestamp": r["timestamp"].isoformat() if r.get("timestamp") else None,
+                    "similarity_score": float(r["similarity_score"]),
+                })
+        self.operation_count += 1
+        return results
+
+    # ═══════════════════════════════════════════════════════════════════════════════════
+    # GBRAIN GENERALIZATION — domain-agnostic :Page nodes (Phase 2)
+    # ═══════════════════════════════════════════════════════════════════════════════════
+
+    @staticmethod
+    def _slugify(title: str) -> str:
+        s = "".join(c if c.isalnum() else "-" for c in (title or "").lower())
+        s = "-".join(filter(None, s.split("-")))[:80]
+        return s or str(uuid.uuid4())
+
+    async def put_page(self, title: str, body: str, namespace: str = "default",
+                       slug: Optional[str] = None, tags: Optional[List[str]] = None,
+                       kind: str = "knowledge", links: Optional[List[str]] = None,
+                       written_by: Optional[str] = None, agent_type: Optional[str] = None,
+                       agent_instance_id: Optional[str] = None, source: Optional[str] = None,
+                       trust: str = "trusted") -> Dict[str, Any]:
+        """Upsert a knowledge page (gbrain put_page). Embeds title+body; bumps version on update."""
+        if not self.is_connected:
+            raise Exception("Database not connected")
+        tags = tags or []
+        links = links or []
+        slug = slug or self._slugify(title)
+        page_key = f"{namespace}::{slug}"
+
+        text = f"{title}\n\n{body}".strip()
+        embedding = None
+        needs_embedding = True
+        embedding_model = getattr(self.indexer, "embedding_model_name", None) if self.indexer else None
+        embedding_dim = getattr(self.indexer, "embedding_dim", 0) if self.indexer else 0
+        if self.indexer:
+            try:
+                v = self.indexer.create_text_embedding(text)
+                embedding = [float(x) for x in v]
+                needs_embedding = False
+            except Exception as e:
+                logger.warning(f"⚠️ Page embed-on-write failed (stored without vector): {e}")
+
+        cypher = """
+        MERGE (p:Page {page_key: $page_key})
+        ON CREATE SET p.id = $id, p.created_at = datetime(), p.version = 1
+        ON MATCH  SET p.version = coalesce(p.version, 0) + 1
+        SET p.namespace = $namespace, p.slug = $slug, p.title = $title, p.body = $body,
+            p.tags = $tags, p.kind = $kind, p.embedding = $embedding,
+            p.embedding_model = $embedding_model, p.embedding_dim = $embedding_dim,
+            p.needs_embedding = $needs_embedding, p.written_by = $written_by,
+            p.agent_type = $agent_type, p.agent_instance_id = $agent_instance_id,
+            p.source = $source, p.trust = $trust, p.updated_at = datetime()
+        RETURN p.id AS id, p.version AS version, p.namespace AS namespace, p.slug AS slug
+        """
+        with self.driver.session(database=self.database) as session:
+            rec = session.run(cypher, {
+                "page_key": page_key, "id": str(uuid.uuid4()), "namespace": namespace,
+                "slug": slug, "title": title, "body": body, "tags": tags, "kind": kind,
+                "embedding": embedding, "embedding_model": embedding_model,
+                "embedding_dim": embedding_dim, "needs_embedding": needs_embedding,
+                "written_by": written_by, "agent_type": agent_type,
+                "agent_instance_id": agent_instance_id, "source": source, "trust": trust,
+            }).single()
+            for tgt in links:
+                session.run(
+                    "MATCH (a:Page {page_key:$a}), (b:Page {page_key:$b}) MERGE (a)-[:LINKS_TO]->(b)",
+                    {"a": page_key, "b": f"{namespace}::{tgt}"})
+        self.operation_count += 1
+        return {"id": rec["id"], "namespace": rec["namespace"], "slug": rec["slug"],
+                "version": rec["version"], "needs_embedding": needs_embedding, "status": "success"}
+
+    async def get_page(self, slug: str, namespace: str = "default") -> Optional[Dict[str, Any]]:
+        """Fetch a page by (namespace, slug) with its outgoing links."""
+        if not self.is_connected:
+            raise Exception("Database not connected")
+        cypher = """
+        MATCH (p:Page {page_key: $k})
+        OPTIONAL MATCH (p)-[:LINKS_TO]->(t:Page)
+        RETURN p AS page, collect(t.slug) AS links
+        """
+        with self.driver.session(database=self.database) as session:
+            rec = session.run(cypher, {"k": f"{namespace}::{slug}"}).single()
+        if not rec:
+            return None
+        p = rec["page"]
+        return {
+            "id": p.get("id"), "namespace": p.get("namespace"), "slug": p.get("slug"),
+            "title": p.get("title"), "body": p.get("body"), "tags": p.get("tags"),
+            "kind": p.get("kind"), "version": p.get("version"),
+            "source": p.get("source"), "trust": p.get("trust"),
+            "links": [l for l in rec["links"] if l],
+            "updated_at": p.get("updated_at").isoformat() if p.get("updated_at") else None,
+        }
+
+    async def search_pages(self, query_embedding, namespace: str = "default", limit: int = 10,
+                          kind: Optional[str] = None, similarity_threshold: float = 0.0) -> List[Dict[str, Any]]:
+        """Semantic search over :Page via the Neo4j vector index, scoped to a namespace (and optional kind)."""
+        if not self.is_connected:
+            raise Exception("Database not connected")
+        vec = [float(x) for x in query_embedding]
+        fetch = max(int(limit) * 5, 20)  # over-fetch, then filter by namespace/kind
+        cypher = """
+        CALL db.index.vector.queryNodes('page_embedding_index', $fetch, $vec)
+        YIELD node, score
+        WHERE node.namespace = $ns AND ($kind IS NULL OR node.kind = $kind) AND score >= $th
+        RETURN node.slug AS slug, node.title AS title, node.kind AS kind,
+               node.tags AS tags, node.namespace AS namespace, score AS similarity_score
+        ORDER BY score DESC
+        LIMIT $limit
+        """
+        results: List[Dict[str, Any]] = []
+        with self.driver.session(database=self.database) as session:
+            for r in session.run(cypher, {"fetch": fetch, "vec": vec, "ns": namespace,
+                                          "kind": kind, "th": float(similarity_threshold),
+                                          "limit": int(limit)}):
+                results.append({"slug": r["slug"], "title": r["title"], "kind": r["kind"],
+                                "tags": r["tags"], "namespace": r["namespace"],
+                                "similarity_score": float(r["similarity_score"])})
+        return results
+
+    async def link_pages(self, from_slug: str, to_slug: str, namespace: str = "default") -> Dict[str, Any]:
+        """Create a (:Page)-[:LINKS_TO]->(:Page) edge within a namespace."""
+        if not self.is_connected:
+            raise Exception("Database not connected")
+        cypher = """
+        MATCH (a:Page {page_key:$a}), (b:Page {page_key:$b})
+        MERGE (a)-[:LINKS_TO]->(b)
+        RETURN count(*) AS linked
+        """
+        with self.driver.session(database=self.database) as session:
+            rec = session.run(cypher, {"a": f"{namespace}::{from_slug}",
+                                       "b": f"{namespace}::{to_slug}"}).single()
+        return {"linked": rec["linked"] if rec else 0, "from": from_slug,
+                "to": to_slug, "namespace": namespace}
 
     async def store_memories_batch(self, events: List[Dict[str, Any]]) -> int:
         """
@@ -847,7 +1039,44 @@ class UnifiedDatabaseManager:
                         session.run(constraint)
                     except Exception as e:
                         logger.debug(f"Constraint note: {e}")
-                
+
+                # Vector index for semantic search (Neo4j 5.x native vector index).
+                # Dimension/similarity are LOCKED to the embedding model: bge-m3 = 1024, cosine.
+                # Switching to any other 1024-dim model (gte-large-en-v1.5, e5-large-v2,
+                # qwen3-embedding-0.6b) requires only re-embedding, not an index rebuild.
+                try:
+                    session.run(
+                        """
+                        CREATE VECTOR INDEX memory_embedding_index IF NOT EXISTS
+                        FOR (m:Memory) ON (m.embedding)
+                        OPTIONS { indexConfig: {
+                            `vector.dimensions`: 1024,
+                            `vector.similarity_function`: 'cosine'
+                        }}
+                        """
+                    )
+                    logger.info("✅ Vector index (1024-dim, cosine) ensured on :Memory(embedding)")
+                except Exception as e:
+                    logger.warning(f"Vector index note (requires Neo4j 5.x): {e}")
+
+                # :Page (gbrain generalization) — synthetic composite key (namespace::slug) for
+                # portability across Neo4j editions, plus its own 1024/cosine vector index.
+                try:
+                    session.run("CREATE CONSTRAINT page_key_unique IF NOT EXISTS FOR (p:Page) REQUIRE p.page_key IS UNIQUE")
+                    session.run(
+                        """
+                        CREATE VECTOR INDEX page_embedding_index IF NOT EXISTS
+                        FOR (p:Page) ON (p.embedding)
+                        OPTIONS { indexConfig: {
+                            `vector.dimensions`: 1024,
+                            `vector.similarity_function`: 'cosine'
+                        }}
+                        """
+                    )
+                    logger.info("✅ :Page constraint + vector index (1024, cosine) ensured")
+                except Exception as e:
+                    logger.warning(f"Page schema note: {e}")
+
                 # Create indexes
                 await self.create_memory_index()
                 await self.create_structured_indexes()

--- a/FinAgents/memory_testing/accuracy_testing.py
+++ b/FinAgents/memory_testing/accuracy_testing.py
@@ -11,7 +11,7 @@ except KeyError:
     exit()
 
 
-MODEL = "gpt-4o-mini"
+MODEL = "openai-gpt-oss-120b"
 DATA_FILE_PATH = "sp500_headlines_2008_2024.csv"
 CONTEXT_TOKEN_LIMIT = 120000
 

--- a/FinAgents/memory_testing/latency_test.py
+++ b/FinAgents/memory_testing/latency_test.py
@@ -11,7 +11,7 @@ except KeyError:
     exit()
 
 
-MODEL = "gpt-4o-mini"
+MODEL = "openai-gpt-oss-120b"
 NUM_ROWS_TO_TEST = [50, 100, 200, 400, 800, 1200]
 NUM_RUNS_PER_SIZE = 3 
 DATA_FILE_PATH = "sp500_headlines_2008_2024.csv"

--- a/FinAgents/orchestrator/core/llm_integration.py
+++ b/FinAgents/orchestrator/core/llm_integration.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class LLMConfig:
     """Configuration for LLM integration"""
     provider: str = "openai"  # openai, anthropic, local
-    model: str = "gpt-4"
+    model: str = "openai-gpt-oss-120b"
     api_key: Optional[str] = None
     base_url: Optional[str] = None
     temperature: float = 0.7
@@ -411,7 +411,7 @@ if __name__ == "__main__":
         # Initialize LLM config
         config = LLMConfig(
             provider="openai",
-            model="gpt-4",
+            model="openai-gpt-oss-120b",
             temperature=0.7
         )
         

--- a/FinAgents/orchestrator/core/mcp_nl_interface.py
+++ b/FinAgents/orchestrator/core/mcp_nl_interface.py
@@ -31,7 +31,7 @@ class MCPNaturalLanguageInterface:
         # Initialize LLM integration
         llm_config = LLMConfig(
             provider=self.config.get("llm", {}).get("provider", "openai"),
-            model=self.config.get("llm", {}).get("model", "gpt-4"),
+            model=self.config.get("llm", {}).get("model", "openai-gpt-oss-120b"),
             temperature=self.config.get("llm", {}).get("temperature", 0.7)
         )
         
@@ -453,7 +453,7 @@ async def main():
         },
         "llm": {
             "provider": "openai",
-            "model": "gpt-4",
+            "model": "openai-gpt-oss-120b",
             "temperature": 0.7
         }
     }

--- a/FinAgents/orchestrator/core/orchestrator.py
+++ b/FinAgents/orchestrator/core/orchestrator.py
@@ -5,7 +5,7 @@ CAPITAL = 100000
 
 orchestrator = create_supervisor(
     agents=[], #TODO: add agent pool A2A protocol interaction here
-    model=ChatOpenAI(model="gpt-4o"),
+    model=ChatOpenAI(model="openai-gpt-oss-120b"),
     prompt=(
         f'''
         You are the supervisor of an end-to-end automated trading system.

--- a/FinAgents/orchestrator/finagent_cli.py
+++ b/FinAgents/orchestrator/finagent_cli.py
@@ -72,7 +72,7 @@ Type 'help' for available commands or 'quit' to exit.
             },
             "llm": {
                 "provider": "openai",
-                "model": "gpt-4",
+                "model": "openai-gpt-oss-120b",
                 "temperature": 0.7
             }
         }
@@ -88,7 +88,7 @@ Type 'help' for available commands or 'quit' to exit.
             # Initialize LLM components
             llm_config = LLMConfig(
                 provider=self.config.get("llm", {}).get("provider", "openai"),
-                model=self.config.get("llm", {}).get("model", "gpt-4"),
+                model=self.config.get("llm", {}).get("model", "openai-gpt-oss-120b"),
                 temperature=self.config.get("llm", {}).get("temperature", 0.7)
             )
             

--- a/FinAgents/orchestrator_demo/orchestrator.py
+++ b/FinAgents/orchestrator_demo/orchestrator.py
@@ -69,9 +69,9 @@ class Orchestrator:
             
         # Initialize Sub-Agents
         # Updated to use GPT-4o as requested
-        self.alpha_agent = AlphaSignalAgent(name="AlphaCore", model="gpt-4o")
-        self.risk_agent = RiskSignalAgent(name="RiskCore", model="gpt-4o")
-        self.portfolio_agent = PortfolioAgent(name="PortfolioCore", model="gpt-4o")
+        self.alpha_agent = AlphaSignalAgent(name="AlphaCore", model="openai-gpt-oss-120b")
+        self.risk_agent = RiskSignalAgent(name="RiskCore", model="openai-gpt-oss-120b")
+        self.portfolio_agent = PortfolioAgent(name="PortfolioCore", model="openai-gpt-oss-120b")
         
         self.execution_agent = ExecutionAgent(
             alpaca_api_key=self.api_key, 
@@ -546,7 +546,7 @@ class Orchestrator:
         if hasattr(target_agent, 'client') and target_agent.client:
             try:
                 response = target_agent.client.chat.completions.create(
-                    model="gpt-4o", # Use strong model for optimization
+                    model="openai-gpt-oss-120b", # Use strong model for optimization
                     messages=[{"role": "user", "content": meta_prompt}]
                 )
                 new_instructions = response.choices[0].message.content

--- a/Plan.md
+++ b/Plan.md
@@ -1,0 +1,136 @@
+# Plan — Finance GBrain Layer 1 (Hosted MemoryAgent + L2/L3 seams)
+
+Build order for a **research-demo-grade, always-reachable MemoryAgent** that also ships
+the **interface seams** Layers 2 and 3 need (see `Architecture.md` §9). Scope is Layer 1:
+we build the *primitives*, not the agent loops or the supervisor.
+
+Legend: ✅ done · 🔜 next · ⛔ blocked-on-prereq · ⬜ todo · 🔌 seam for L2/L3
+
+---
+
+## Phase 0 — Foundation (DONE)
+
+- ✅ Migrate LLM provider OpenAI → DigitalOcean; standardize on `openai-gpt-oss-120b`.
+- ✅ Env-driven `OPENAI_*` + `NEO4J_*`; Aura `52b4f6d4` wired & verified.
+- ✅ Embeddings default = DO `bge-m3` (1024-dim) with local fallbacks.
+- ✅ Vector index `memory_embedding_index` (1024/cosine) ensured at startup.
+- ✅ Transport → **stdio-default** (HTTP opt-in via `MCP_TRANSPORT=http`); fixed lifespan teardown
+  crash; diagnostics routed to stderr (clean stdio protocol channel). Verified locally vs Aura.
+
+---
+
+## Phase 1 — DB-backed semantic search (✅ CORE DONE — cleanup pending)
+
+- ✅ **Write path:** embed `content_text` via bge-m3 in `store_memory`; `SET m.embedding`, `embedding_model`, `embedding_dim`.
+- ✅ **Resilience:** on embed failure, store node + `needs_embedding=true` (write never fails).
+- ✅ **Query path:** new `UnifiedDatabaseManager.vector_search()` → `db.index.vector.queryNodes('memory_embedding_index', …)`; `semantic_search_memories` tool rewritten to use it.
+- ✅ Retire `memory_index.pkl` as the search path (removed the in-process `index_memory` call).
+- ✅ Latent bugs fixed (surfaced once components were enabled): relative-import fallbacks for
+  indexer/stream in `unified_database_manager`; `StreamProcessor.stop_processing()` (was `.shutdown()`)
+  in both `close()` and the lifespan; `hasattr` guards on the not-yet-implemented reactive event calls.
+- ✅ Acceptance MET: stored docs return correctly cosine-ranked from Neo4j (moat query → moat docs; crypto query → BTC).
+- ⬜ Cron backfill for `needs_embedding=true` (deferred — for re-embedding pre-existing nodes).
+- ⬜ Drop `scikit-learn` / `scipy` (deferred cleanup — requires making the indexer's sklearn imports lazy).
+
+---
+
+## Phase 2 — GBrain generalization (✅ DONE — `:Page` + neutral tools)
+
+- ✅ `:Page` with `page_key` (=`namespace::slug`) uniqueness constraint (edition-portable) + a
+  dedicated 1024/cosine vector index `page_embedding_index`.
+- ✅ Seam-ready fields on every page: `kind`, `version` (bumped on upsert), `written_by`,
+  `agent_type`, `agent_instance_id`, `source`, `trust` (🔌 enables L2/L3 + injection boundary).
+- ✅ Manager methods + MCP tools:
+  - `put_page(title, body, namespace, slug?, tags, kind, links, source, trust)` → upsert via MERGE on `page_key`, embeds title+body.
+  - `get_page(slug, namespace)` → page + outgoing links.
+  - `search(query, namespace, limit, kind?)` → namespace-scoped vector search.
+  - `create_link(from_slug, to_slug, namespace)` → `(:Page)-[:LINKS_TO]->(:Page)`.
+- ✅ `namespace` threaded through every query — **isolation verified** (demo vs other don't bleed).
+- ✅ Acceptance MET: generic page round-trips; per-namespace + per-kind search; version bumps; links traverse.
+
+---
+
+## Phase 3 — Security (must precede public exposure)
+
+- ⬜ Bearer-token middleware on the Starlette `app`.
+- ⬜ Scopes: **read-only** (search/get) · **read-write** (put/link/prune).
+- 🔌 ⬜ **Per-agent identity:** tokens map to an identity → stamped into `written_by` (enables L3 attribution).
+- ⬜ Tokens from env; 401 on missing/invalid; `/health` stays unauthenticated.
+- ✅ Acceptance: unauth → 401; ro can't write; rw can; writes record `written_by`.
+
+---
+
+## Phase 4 — L2/L3 interface seams (the forward-compat layer)
+
+Build the **primitives** only; consumers come in Layers 2/3.
+
+- 🔌 ⬜ **Config-as-pages (L2):** support `kind="strategy"|"config"`; `get_page` serves an
+  agent's current behavior by stable slug.
+- 🔌 ⬜ **Compare-and-set (L2/L3):** `put_page(expected_version=N)` → bump `version`, return
+  **409** on mismatch (atomic swap / safe multi-writer).
+- 🔌 ⬜ **Change events (L2/L3):** publish-on-write to a durable `:Event` log; expose
+  **poll-based** `get_events(namespace, since_cursor)` — NOT WebSocket push (simpler, stateless-
+  friendly, curl-debuggable, drops the `websockets` dep). Backed by Neo4j.
+- 🔌 ⬜ **Claim / lease (L3):** atomic `claim(key, owner, ttl)` + `release(key, owner)` via
+  single-transaction MERGE on `:Lease`; TTL expiry.
+- ⬜ Constraints for `:Event`/`:Lease` added to idempotent startup schema-init.
+- ✅ Acceptance: CAS rejects stale writes (409); a subscriber receives an event on `put_page`;
+  two concurrent `claim` calls — exactly one wins.
+
+> Why in Layer 1: these are *store-level contracts*. Adding `version`/`kind`/events/leases
+> after the graph is populated is a painful migration; adding them now is nearly free.
+
+---
+
+## Phase 5 — Containerize & deploy (see `Deploy.md`)
+
+- ⬜ Dockerfile (uvicorn `memory_server:app`, port 8000; light image — embeddings via API).
+- ⛔ Provision hosting (Fly.io account + CLI) — **user prerequisite**.
+- ⬜ Push host secrets (`OPENAI_*`, `NEO4J_*`, `MEMORY_API_TOKEN_*`, per-agent tokens).
+- ⬜ Deploy; point MCP client at `https://<host>/mcp`.
+- ✅ Neo4j always-on strategy decided: **Aura Free + keep-alive ping** (Phase 6 cron required).
+- ⚠️ **Single instance only** until the event/lease seams are confirmed durable across replicas.
+- ✅ Acceptance: `/health` green; remote `search` works with a token.
+
+---
+
+## Phase 6 — Durability & ops
+
+- ⬜ Keep-alive cron (anti Aura-Free pause).
+- ⛔ Weekly backup cron → private git repo or object storage — **user provides destination**.
+- ⬜ Minimal structured logging for store/search/events; surface in `/health`.
+
+---
+
+## Milestones
+
+1. **M1 — Local semantic brain:** Phases 1–2 (DB-backed search + `:Page` tools). ✅ DONE +
+   validated via a real MCP **stdio handshake** (`initialize` + `tools/list` + `tools/call`).
+2. **M2 — Secured + seam-ready:** Phases 3–4 (auth + CAS/events/leases/attribution).
+3. **M3 — Live demo:** Phase 5 (always-reachable hosted MemoryAgent).
+4. **M4 — Durable:** Phase 6.
+
+After M2, Layer 2 can be built **without touching Layer 1**: an agent loop just calls
+`get_page(kind=strategy)` + `subscribe()`; Layer 3 just calls `claim()` + CAS + per-agent tokens.
+
+---
+
+## Cost (research-demo MVP)
+
+| | Shoestring (recommended) | Solid always-on |
+|---|---|---|
+| Compute | Fly.io ~$3/mo | Render $7/mo |
+| Neo4j | Aura **Free $0** + keep-alive | Aura Pro ~$65/mo |
+| Tokens (embeddings + LLM) | **< $1/mo** | **< $5/mo** |
+| **Total** | **≈ $3–5 / month** | **≈ $70 / month** |
+
+Tokens are not the Layer 1 cost driver; the always-on database is.
+
+---
+
+## Explicitly out of scope (consumers of the seams — built in L2/L3)
+
+- Agent control loops that hot-reload behavior from `subscribe()` / `get_page()`.
+- The behavior-swap policy, rollback orchestration.
+- Process spawning/supervision; how many instances per type; work-partitioning policy.
+- Full version history, reranking, chunking, horizontal **server** replicas, RBAC beyond scopes+identity.

--- a/README.md
+++ b/README.md
@@ -259,24 +259,38 @@ git clone https://github.com/Open-Finance-Lab/AgenticTrading.git
 cd AgenticTrading
 ```
 
-2. **Install dependencies**:
+2. **Create and activate a virtual environment**:
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+3. **Install dependencies**:
 ```bash
 pip install -r requirements.txt
 ```
 
-3. **Set up Neo4j database**:
+4. **Set up Neo4j database**:
 ```bash
 python scripts/setup_neo4j.py
 ```
 
-4. **Configure environment variables**:
+5. **Configure environment variables**:
 ```bash
-# Create .env file with your API keys
-OPENAI_API_KEY=your_openai_api_key
+# Create .env file with your API keys.
+# LLM calls use DigitalOcean Gradient AI's OpenAI-compatible serverless
+# inference endpoint. The OpenAI SDK reads OPENAI_API_KEY + OPENAI_BASE_URL
+# automatically, so no code change is needed to switch providers.
+OPENAI_API_KEY=your_digitalocean_model_access_key   # doo_v1_...
+OPENAI_BASE_URL=https://inference.do-ai.run/v1
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=your_password
 ```
+
+> Models are referenced by their DigitalOcean ids (e.g. `openai-gpt-oss-120b`).
+> List the models your access key can reach with:
+> `curl https://inference.do-ai.run/v1/models -H "Authorization: Bearer $OPENAI_API_KEY"`
 
 ### Quick Start
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,133 @@
+# GBrain Tutorial — basic commands
+
+A hands-on quickstart for the Finance GBrain MemoryAgent (Layer 1): a persistent,
+semantic-search knowledge store backed by Neo4j Aura + DigitalOcean `bge-m3` embeddings.
+
+You interact with it two ways:
+- **CLI** (`gbrain_cli.py`) — quickest way to poke at the brain from a terminal.
+- **MCP** — register it with Claude Code so the tools show up natively.
+
+Config is read from the project `.env` (DigitalOcean + Neo4j). Nothing else to set up.
+
+---
+
+## Core concepts (30 seconds)
+
+- **Page** — the unit of knowledge: `title`, `body`, `tags`, plus a `kind`.
+- **slug** — the page's address within a namespace (auto-derived from the title, e.g.
+  "Buffett moat checklist" → `buffett-moat-checklist`).
+- **namespace** — an isolation boundary (e.g. `default`, `research`, `strategies`).
+  Search and get are scoped to one namespace; they never bleed across.
+- **kind** — `knowledge` (default), `strategy`, or `config`. Search can filter by it.
+- **version** — bumps automatically each time you re-`put` the same slug.
+- **links** — directed `LINKS_TO` edges between pages (the graph part).
+
+---
+
+## CLI quickstart
+
+Run from the repo (uses the project venv):
+
+```bash
+cd FinAgents/memory
+PY=../../.venv/bin/python   # or: python3
+```
+
+### 1. Put a page
+```bash
+$PY gbrain_cli.py put "Buffett moat checklist" \
+  "Durable competitive advantage, pricing power, consistently high ROE across periods." \
+  --ns demo --kind strategy --tags buffett,moat
+```
+→ returns JSON: `{ "slug": "buffett-moat-checklist", "version": 1, ... }`
+
+```bash
+$PY gbrain_cli.py put "Owner earnings" \
+  "Net income + D&A - maintenance capex - working capital changes." \
+  --ns demo --kind knowledge
+```
+
+### 2. List what's in a namespace
+```bash
+$PY gbrain_cli.py list --ns demo
+#   owner-earnings           v1  [knowledge]  Owner earnings
+#   buffett-moat-checklist   v1  [strategy]   Buffett moat checklist
+```
+
+### 3. Link two pages
+```bash
+$PY gbrain_cli.py link buffett-moat-checklist owner-earnings --ns demo
+# {"linked": 1, ...}
+```
+
+### 4. Semantic search (by meaning, not keywords)
+```bash
+$PY gbrain_cli.py search "pricing power and competitive advantage" --ns demo
+#   0.829  buffett-moat-checklist   [strategy]   Buffett moat checklist
+#   0.733  owner-earnings           [knowledge]  Owner earnings
+```
+Filter by kind:
+```bash
+$PY gbrain_cli.py search "valuation" --ns demo --kind knowledge --limit 3
+```
+
+### 5. Fetch one page (with its links)
+```bash
+$PY gbrain_cli.py get buffett-moat-checklist --ns demo
+# { "slug": ..., "kind": "strategy", "version": 1, "links": ["owner-earnings"], ... }
+```
+
+### 6. Versioning — re-put the same slug
+```bash
+$PY gbrain_cli.py put "Buffett moat checklist" "UPDATED: also require operating margin stability." --ns demo --kind strategy
+# version -> 2
+```
+
+### 7. Clean up a namespace
+```bash
+$PY gbrain_cli.py clear --ns demo
+# deleted N pages from namespace 'demo'
+```
+
+> All command output is plain JSON / text on **stdout**; diagnostics go to **stderr**.
+
+---
+
+## Inspect in Neo4j Browser
+
+Open the Aura console for instance `52b4f6d4`, make sure the **database selector shows
+`52b4f6d4`** (not the default `neo4j` — it doesn't exist on this instance), then:
+
+```cypher
+MATCH (p:Page {namespace:'demo'}) RETURN p
+```
+Confirm the vectors are stored:
+```cypher
+MATCH (p:Page {namespace:'demo'})
+RETURN p.slug, size(p.embedding) AS dims, p.embedding_model   // dims = 1024, bge-m3
+```
+
+---
+
+## Use it from Claude Code (MCP)
+
+Register the stdio MCP server once:
+```bash
+claude mcp add memory -- python FinAgents/memory/memory_server.py
+```
+Now `put_page`, `get_page`, `search`, and `create_link` are first-class tools in any
+Claude Code session — backed by the same always-on Aura brain. (Diagnostics stay on
+stderr, so the stdio protocol channel is clean.)
+
+---
+
+## Command reference
+
+| CLI | MCP tool | Purpose |
+|---|---|---|
+| `put "<title>" "<body>" [--ns --kind --tags --slug]` | `put_page` | create/update a page (upsert, embeds, bumps version) |
+| `get <slug> [--ns]` | `get_page` | fetch a page + its links |
+| `search "<query>" [--ns --kind --limit]` | `search` | namespace-scoped semantic search |
+| `link <from> <to> [--ns]` | `create_link` | directed page→page link |
+| `list [--ns]` | — | list pages in a namespace (CLI helper) |
+| `clear [--ns]` | — | delete all pages in a namespace (CLI helper) |

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,26 @@
+# fly.toml — agentictrading (Finance GBrain Layer 1 MemoryAgent)
+app = 'agentictrading'
+primary_region = 'sjc'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[http_service]
+  internal_port = 8000          # uvicorn binds 8000 (see Dockerfile CMD)
+  force_https = true
+  auto_stop_machines = 'off'    # always-on brain — do not scale to zero
+  auto_start_machines = true
+  min_machines_running = 1      # single instance (in-memory stream state not replica-safe yet)
+  processes = ['app']
+
+  # Platform health check — keep unauthenticated (see Phase 3)
+  [[http_service.checks]]
+    method = 'get'
+    path = '/health'
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '25s'        # app connects to Neo4j Aura on startup
+
+[[vm]]
+  memory = '1gb'
+  cpus = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,5 @@ requires-python = ">=3.12"
 dependencies = [
     "a2a-sdk>=0.2.4",
     "mcp[cli]>=1.9.1",
+    "neo4j>=5.28.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ jsonschema-specifications==2025.4.1
 mcp==1.13.1
 networkx==3.5
 numpy==2.3.2
+neo4j==5.28.1
 openai==1.101.0
 pandas==2.3.2
 platformdirs==4.3.7
@@ -40,3 +41,9 @@ typing_extensions==4.14.1
 tzdata==2025.2
 uvicorn==0.35.0
 virtualenv==20.29.3
+# Memory indexer: semantic-search math + TF-IDF fallback (DO bge-m3 is primary backend)
+scikit-learn==1.8.0
+scipy==1.17.1
+joblib==1.5.3
+# Real-time stream processor (event seam backbone)
+websockets==16.0

--- a/scripts/setup_neo4j.py
+++ b/scripts/setup_neo4j.py
@@ -34,6 +34,12 @@ project_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(project_root))
 
 try:
+    from dotenv import load_dotenv
+    load_dotenv(dotenv_path=project_root / ".env")
+except ImportError:
+    pass
+
+try:
     from neo4j import GraphDatabase
     from neo4j.exceptions import ServiceUnavailable, AuthError
     NEO4J_AVAILABLE = True
@@ -346,15 +352,16 @@ async def main():
         default="init",
         help="Action to perform"
     )
-    parser.add_argument("--uri", default="bolt://localhost:7687", help="Neo4j URI")
-    parser.add_argument("--username", default="neo4j", help="Neo4j username")
-    parser.add_argument("--password", default="password", help="Neo4j password")
-    parser.add_argument("--database", default="finagent", help="Database name")
-    
+    # Defaults come from the environment (.env) so the script targets the
+    # configured instance out of the box; CLI flags still override.
+    parser.add_argument("--uri", default=os.getenv("NEO4J_URI", "bolt://localhost:7687"), help="Neo4j URI")
+    parser.add_argument("--username", default=os.getenv("NEO4J_USERNAME") or os.getenv("NEO4J_USER", "neo4j"), help="Neo4j username")
+    parser.add_argument("--password", default=os.getenv("NEO4J_PASSWORD", "password"), help="Neo4j password")
+    parser.add_argument("--database", default=os.getenv("NEO4J_DATABASE", "neo4j"), help="Database name")
+
     args = parser.parse_args()
-    
-    # Get password from environment if available
-    password = os.getenv("NEO4J_PASSWORD", args.password)
+
+    password = args.password
     
     print("\n" + "="*80)
     print("🗄️  FinAgent Neo4j Database Setup")


### PR DESCRIPTION
## Summary
Migrates LLM/embeddings from OpenAI to **DigitalOcean Gradient AI** (OpenAI-compatible) and builds **Layer 1 of a persistent "finance gbrain"** — a semantic-search knowledge store on Neo4j Aura, usable from a CLI and as MCP tools in Claude Code.

## What changed
**Provider migration**
- Standardize chat model on `openai-gpt-oss-120b` across ~25 files (the DO subscription tier 403s proprietary `gpt-4o`/Anthropic models).
- Env-driven `OPENAI_*` / `NEO4J_*` config; `memory_server.py` and `scripts/setup_neo4j.py` load `.env`.
- Embeddings default to DO `bge-m3` (1024-dim) with local sentence-transformers / TF-IDF fallbacks. Adds `neo4j`, `scikit-learn`, `scipy` deps.

**Layer 1 gbrain (Neo4j-backed, MCP)**
- Embed-on-write + Neo4j **native vector index** (1024/cosine) → real DB-backed semantic search (previously in-process over a pickle).
- `:Page` generalization: namespaces, `kind`, `version` (bumped on upsert), `LINKS_TO` edges, and provenance/`trust` fields (seams for future Layers 2/3).
- MCP tools: `put_page`, `get_page`, `search`, `create_link`.
- **stdio-default transport** (the gbrain model); diagnostics routed to `stderr` so the stdio JSON-RPC channel stays clean (indexer converted `print()` → `logging`).
- Fixes latent bugs surfaced once components were actually enabled: package-relative-import fallbacks in `unified_database_manager`, `StreamProcessor.stop_processing()` (was a non-existent `.shutdown()`), and `hasattr`-guarded reactive event calls.
- `FinAgents/memory/gbrain_cli.py` (put/get/search/link/list/clear/ingest), a `/gbrain` Claude command, and markdown-file ingestion.

**Docs & deploy**
- `Architecture.md`, `Plan.md`, `Deploy.md`, `TUTORIAL.md` (scope = Layer 1 + the seams Layers 2/3 will need).
- `Dockerfile`, `.dockerignore`, `fly.toml` for the HTTP/fleet path (stdio is the default for local/Claude-Code use).

## Reviewer notes
- **No secrets committed** — the DO key, Neo4j password, and API tokens live only in the gitignored `.env`; verified by scanning the tree.
- **Intentionally excluded:** `Procfile` (generic `gunicorn app:app` leftover from `fly launch`, wrong for our Dockerfile/uvicorn), `.github/workflows/fly-deploy.yml` (auto-deploy-on-push; needs a `FLY_API_TOKEN` secret), `.DS_Store`, and `.claude/settings.local.json`.
- **Verified** end-to-end against live Aura: embed-on-write + vector search ranking, namespace isolation, versioning, links, and a full MCP **stdio handshake** (`initialize` + `tools/list` + `tools/call`).
- **Scope:** this is the memory layer only. Turning a strategy doc (e.g. `buffett.md`) into a *running* orchestrated agent is the deferred Layer 2/3 work (control loop, fundamentals data tools, evaluation engine).

## Test plan
- [ ] `pip install -r requirements.txt`
- [ ] Set `.env` (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NEO4J_*`)
- [ ] `python scripts/setup_neo4j.py --action init`
- [ ] `cd FinAgents/memory && python gbrain_cli.py put "..." "..." --ns demo && python gbrain_cli.py search "..." --ns demo`
- [ ] (optional) `claude mcp add memory -- python FinAgents/memory/memory_server.py` and use `/gbrain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)