### PR TITLE
Edit Website UI

### DIFF
--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -32,6 +32,7 @@ class CreateAgentBody(BaseModel):
     model_name: str = Field(default="local-model", max_length=100)
     agent_type: str = Field(default="external", max_length=20)
     description: Optional[str] = Field(default=None, max_length=280)
+    cash_allocation: Optional[float] = Field(default=None, ge=0, le=3000)
 
 
 class PipelineStep(BaseModel):
@@ -50,6 +51,7 @@ class UpdateAgentBody(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
     description: Optional[str] = Field(default=None, max_length=280)
     pipeline: Optional[List[PipelineStep]] = Field(default=None, max_length=50)
+    cash_allocation: Optional[float] = Field(default=None, ge=0, le=3000)
 
 
 @router.post("")
@@ -73,6 +75,7 @@ async def create_agent(
         owner_browser_session=ctx["browser_session"],
         agent_type=agent_type,
         description=(body.description.strip() if body.description else None),
+        cash_allocation=body.cash_allocation,
     )
     return {
         "agent": agent_service.agent_with_stats(agent),
@@ -227,7 +230,8 @@ async def update_agent(
     _require_agent_access(agent_id, ctx, reclaim_on_session_match=True)
     fields_set = body.model_fields_set
     pipeline_provided = "pipeline" in fields_set
-    if body.name is None and body.description is None and not pipeline_provided:
+    cash_allocation_provided = "cash_allocation" in fields_set
+    if body.name is None and body.description is None and not pipeline_provided and not cash_allocation_provided:
         raise HTTPException(status_code=400, detail="No fields to update")
 
     if pipeline_provided:
@@ -239,12 +243,15 @@ async def update_agent(
     else:
         pipeline_arg = _UNSET
 
+    cash_allocation_arg = body.cash_allocation if cash_allocation_provided else _UNSET
+
     try:
         agent = agent_service.update_agent(
             agent_id,
             name=body.name.strip() if body.name is not None else None,
             description=body.description,
             pipeline=pipeline_arg,
+            cash_allocation=cash_allocation_arg,
         )
     except AgentNotFoundError:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/dashboard/backend/domain/agents/repository.py
+++ b/dashboard/backend/domain/agents/repository.py
@@ -62,6 +62,7 @@ def _public_agent(row: sqlite3.Row | Dict[str, Any]) -> Dict[str, Any]:
         "agent_type": data.get("agent_type") or "external",
         "description": data.get("description"),
         "pipeline": _parse_pipeline(data.get("pipeline_config")),
+        "cash_allocation": data.get("cash_allocation"),
         "api_key_prefix": data.get("api_key_prefix") or "",
         "owner_user_id": data.get("owner_user_id"),
         "scopes": [s for s in str(raw_scopes).split(",") if s],
@@ -134,6 +135,10 @@ class AgentStore:
             cursor.execute(
                 "ALTER TABLE external_agents ADD COLUMN pipeline_config TEXT"
             )
+        if "cash_allocation" not in existing_columns:
+            cursor.execute(
+                "ALTER TABLE external_agents ADD COLUMN cash_allocation REAL"
+            )
         if "scopes" not in existing_columns:
             cursor.execute(
                 "ALTER TABLE external_agents ADD COLUMN scopes TEXT "
@@ -159,6 +164,7 @@ class AgentStore:
         session_id: Optional[str] = None,
         agent_type: str = "external",
         description: Optional[str] = None,
+        cash_allocation: Optional[float] = None,
     ) -> Dict[str, Any]:
         agent_id = f"agent_{uuid.uuid4().hex[:12]}"
         session_id = session_id or str(uuid.uuid4())
@@ -173,9 +179,9 @@ class AgentStore:
             """
             INSERT INTO external_agents (
                 agent_id, name, session_id, api_key_hash, api_key_prefix,
-                model_name, agent_type, description,
+                model_name, agent_type, description, cash_allocation,
                 owner_user_id, owner_browser_session, created_at, last_used_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 agent_id,
@@ -186,6 +192,7 @@ class AgentStore:
                 model_name.strip() or "local-model",
                 (agent_type or "external").strip() or "external",
                 (description or None),
+                cash_allocation,
                 owner_user_id,
                 owner_browser_session,
                 now,
@@ -452,6 +459,7 @@ class AgentStore:
         name: Optional[str] = None,
         description: Optional[str] = None,
         pipeline: Any = _UNSET,
+        cash_allocation: Any = _UNSET,
     ) -> Optional[Dict[str, Any]]:
         """Update display fields for an agent. Returns the updated record or None.
 
@@ -470,6 +478,9 @@ class AgentStore:
         if pipeline is not _UNSET:
             sets.append("pipeline_config = ?")
             params.append(json.dumps(pipeline) if pipeline else None)
+        if cash_allocation is not _UNSET:
+            sets.append("cash_allocation = ?")
+            params.append(cash_allocation)
         if not sets:
             return self.get_agent(agent_id)
         sets.append("last_used_at = ?")

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -183,9 +183,14 @@ class AgentService:
         name: Optional[str] = None,
         description: Optional[str] = None,
         pipeline: Any = _UNSET,
+        cash_allocation: Any = _UNSET,
     ) -> Dict[str, Any]:
         agent = self.agents.update_agent(
-            agent_id, name=name, description=description, pipeline=pipeline
+            agent_id,
+            name=name,
+            description=description,
+            pipeline=pipeline,
+            cash_allocation=cash_allocation,
         )
         if not agent:
             raise AgentNotFoundError()
@@ -200,6 +205,7 @@ class AgentService:
         owner_browser_session: Optional[str],
         agent_type: str = "external",
         description: Optional[str] = None,
+        cash_allocation: Optional[float] = None,
     ) -> Dict[str, Any]:
         return self.agents.create_agent(
             name=name,
@@ -208,6 +214,7 @@ class AgentService:
             owner_browser_session=owner_browser_session,
             agent_type=agent_type,
             description=description,
+            cash_allocation=cash_allocation,
         )
 
     def list_builtin_agents_with_stats(self) -> List[Dict[str, Any]]:

--- a/dashboard/backend/tests/domain/agents/test_repository_move.py
+++ b/dashboard/backend/tests/domain/agents/test_repository_move.py
@@ -73,7 +73,7 @@ def test_create_agent_schema(store):
     agent = store.create_agent(name="My Agent", model_name="gpt-x", owner_user_id=7)
     assert set(agent.keys()) == {
         "agent_id", "name", "session_id", "model_name", "agent_type",
-        "description", "api_key_prefix", "owner_user_id", "scopes",
+        "description", "pipeline", "cash_allocation", "api_key_prefix", "owner_user_id", "scopes",
         "created_at", "last_used_at", "api_key",
     }
     assert agent["name"] == "My Agent"

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=13">
+    <link rel="stylesheet" href="styles.css?v=14">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=9">
+    <link rel="stylesheet" href="styles.css?v=13">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -102,6 +102,10 @@
     </svg>
     <!-- Header -->
     <header class="header">
+        <a class="header-left header-github-link" href="https://github.com/Open-Finance-Lab/AgenticTrading" target="_blank" rel="noopener noreferrer" aria-label="AgenticTrading on GitHub">
+            <svg class="ui-icon header-github-icon" aria-hidden="true"><use href="#icon-github"/></svg>
+            <span class="header-github-name">AgenticTrading</span>
+        </a>
         <a class="header-brand" href="/?stay=1" aria-label="Agentic Trading Lab home">
             <div class="logo-container">
                 <img src="images/atltransparent.png" alt="" class="logo-icon">
@@ -491,11 +495,11 @@
                 <section class="home-resources">
                     <h3 class="home-section-title home-resources-heading">Resources</h3>
                     <div class="home-resources-grid">
-                        <a class="home-resource-card" href="https://finagent-orchestration.readthedocs.io/en/latest/" target="_blank" rel="noopener noreferrer">
-                            <span class="icon-shell icon-shell--sm"><svg class="ui-icon"><use href="#icon-book"/></svg></span>
+                        <a class="home-resource-card" href="https://github.com/Open-Finance-Lab/AgenticTrading" target="_blank" rel="noopener noreferrer">
+                            <span class="icon-shell icon-shell--sm icon-shell--muted"><svg class="ui-icon"><use href="#icon-github"/></svg></span>
                             <span class="home-resource-copy">
-                                <span class="home-resource-title">Documentation</span>
-                                <span class="home-resource-subtitle">Guides and API reference</span>
+                                <span class="home-resource-title">GitHub</span>
+                                <span class="home-resource-subtitle">Open source and examples</span>
                             </span>
                             <svg class="ui-icon home-resource-arrow" aria-hidden="true"><use href="#icon-external-link"/></svg>
                         </a>
@@ -515,11 +519,11 @@
                             </span>
                             <svg class="ui-icon home-resource-arrow" aria-hidden="true"><use href="#icon-arrow-right"/></svg>
                         </button>
-                        <a class="home-resource-card" href="https://github.com/Allan-Feng/AgenticTrading" target="_blank" rel="noopener noreferrer">
-                            <span class="icon-shell icon-shell--sm icon-shell--muted"><svg class="ui-icon"><use href="#icon-github"/></svg></span>
+                        <a class="home-resource-card" href="https://finagent-orchestration.readthedocs.io/en/latest/" target="_blank" rel="noopener noreferrer">
+                            <span class="icon-shell icon-shell--sm"><svg class="ui-icon"><use href="#icon-book"/></svg></span>
                             <span class="home-resource-copy">
-                                <span class="home-resource-title">GitHub</span>
-                                <span class="home-resource-subtitle">Open source and examples</span>
+                                <span class="home-resource-title">Documentation</span>
+                                <span class="home-resource-subtitle">Guides and API reference</span>
                             </span>
                             <svg class="ui-icon home-resource-arrow" aria-hidden="true"><use href="#icon-external-link"/></svg>
                         </a>
@@ -581,6 +585,11 @@
                     <span>Model name (optional)</span>
                     <input id="externalAgentModel" type="text" maxlength="100" placeholder="gpt-4 / rule-based" autocomplete="off">
                 </label>
+                <label class="auth-field">
+                    <span>Initial cash (max $3,000)</span>
+                    <input id="externalAgentCashAllocation" type="number" min="0" max="3000" step="1" value="1000" required aria-describedby="externalAgentCashHint">
+                </label>
+                <p id="externalAgentCashHint" class="credential-hint">Starting capital budget for this agent's backtests and trading sessions.</p>
                 <p id="createExternalAgentError" class="auth-error" hidden></p>
                 <button id="createExternalAgentSubmit" class="auth-submit-btn" type="submit">Create agent</button>
             </form>
@@ -613,6 +622,11 @@
                     <span>Description (optional)</span>
                     <input id="builtinAgentDescription" type="text" maxlength="280" placeholder="What is this agent's edge?" autocomplete="off">
                 </label>
+                <label class="auth-field">
+                    <span>Initial cash (max $3,000)</span>
+                    <input id="builtinAgentCashAllocation" type="number" min="0" max="3000" step="1" value="1000" required aria-describedby="builtinAgentCashHint">
+                </label>
+                <p id="builtinAgentCashHint" class="credential-hint">Starting capital budget for this agent's backtests and trading sessions.</p>
                 <p id="createBuiltinAgentError" class="auth-error" hidden></p>
                 <button id="createBuiltinAgentSubmit" class="auth-submit-btn" type="submit">Create built-in agent</button>
             </form>
@@ -698,12 +712,27 @@
                         </div>
                     </div>
                 </section>
+                <section class="section-card allocation-card">
+                    <h3 class="allocation-title">Agent Allocation</h3>
+                    <div class="allocation-body">
+                        <div class="allocation-chart-wrap">
+                            <canvas id="agentAllocationChart"></canvas>
+                        </div>
+                        <div class="allocation-detail">
+                            <div class="allocation-total" id="agentAllocationTotal"></div>
+                            <ul class="allocation-legend" id="agentAllocationLegend"></ul>
+                        </div>
+                    </div>
+                </section>
             </div>
 
             <!-- My Agents -->
             <div class="agents-section">
                 <div class="agents-section-head">
-                    <h2 class="page-title">My Agents</h2>
+                    <div class="agents-section-title-row">
+                        <h2 class="page-title">My Agents</h2>
+                        <a id="agentsSectionDiscordBtn" class="discord-nav-btn discord-nav-btn-sm" href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">Open Discord</a>
+                    </div>
                     <div class="agent-toolbar">
                         <select id="agentFilterSelect" class="agent-toolbar-select" aria-label="Filter agents">
                             <option value="all">All Agents</option>
@@ -744,6 +773,10 @@
                 <input id="agentEditorNameInput" class="agent-editor-name-input" type="text" maxlength="100" placeholder="Agent name" aria-label="Agent name" autocomplete="off">
                 <p id="agentEditorMeta" class="agent-editor-meta"></p>
                 <textarea id="agentEditorDescription" class="agent-editor-description" rows="2" maxlength="280" placeholder="Optional description for this agent…" aria-label="Agent description"></textarea>
+                <label class="agent-editor-cash-field" for="agentEditorCashAllocation">
+                    <span class="agent-editor-cash-label">Initial cash (max $3,000)</span>
+                    <input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="3000" step="1" placeholder="0" aria-label="Initial cash">
+                </label>
             </div>
             <div class="agent-editor-header-actions">
                 <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -713,7 +713,7 @@
                     </div>
                 </section>
                 <section class="section-card allocation-card">
-                    <h3 class="allocation-title">Agent Allocation</h3>
+                    <h3 class="allocation-title">Capital Allocation by Agent</h3>
                     <div class="allocation-body">
                         <div class="allocation-chart-wrap">
                             <canvas id="agentAllocationChart"></canvas>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -230,21 +230,15 @@ const MOCK_AGENTS = [
 // Holds the most recently loaded agents so the toolbar can re-filter without refetching.
 let allAgents = [];
 let agentViewMode = 'grid';
-let runningBacktestAgentId = null;
-
-function setBacktestRunningForAgent(agentId, running) {
-  runningBacktestAgentId = running ? agentId : null;
-  if (allAgents.length) {
-    applyAgentFilters();
+function resolveAgentStatusBadge(agent) {
+  if (agent.is_live === true || agent.deployment_status === 'live') {
+    return { label: 'Live', className: 'live' };
   }
-}
-
-function resolveAgentDeploymentBadge(agent) {
-  if (runningBacktestAgentId && agent.agent_id === runningBacktestAgentId) {
-    return { label: 'Backtesting', className: 'backtesting' };
+  const runCount = Number(agent.run_count) || (Array.isArray(agent.runs) ? agent.runs.length : 0);
+  if (runCount > 0) {
+    return { label: 'Backtested', className: 'backtested' };
   }
-  // Future: Paper trading / Live trading states when per-agent deployment exists.
-  return { label: 'Not live', className: 'not-live' };
+  return { label: 'Draft', className: 'draft' };
 }
 
 // Demo/mock agents (MOCK_AGENTS) have no database row, so renames made in the editor
@@ -366,7 +360,7 @@ function renderAgentsGrid(agents) {
 
   agents.forEach((agent) => {
     const isBuiltin = agent.agent_type === 'builtin';
-    const deploymentBadge = resolveAgentDeploymentBadge(agent);
+    const statusBadge = resolveAgentStatusBadge(agent);
     const card = document.createElement('div');
     card.className = `section-card agent-card agent-card--compact${isBuiltin ? ' agent-card-builtin' : ''}`;
 
@@ -385,7 +379,7 @@ function renderAgentsGrid(agents) {
     card.innerHTML = `
       <div class="agent-card-head">
         <h3 class="agent-name">${escapeHtml(agent.name)}</h3>
-        <span class="status-badge ${deploymentBadge.className}">${deploymentBadge.label}</span>
+        <span class="status-badge ${statusBadge.className}">${statusBadge.label}</span>
       </div>
       <div class="agent-meta">
         <span>${escapeHtml(agent.model_name || 'local-model')}</span>
@@ -2614,7 +2608,6 @@ async function runBacktest() {
             });
             btn.textContent = '❌ Error - Try Again';
             btn.disabled = false;
-            setBacktestRunningForAgent(null, false);
             setTimeout(() => {
                 btn.textContent = '▶ Run Backtest';
                 showBacktestRunProgress(false);
@@ -2623,9 +2616,6 @@ async function runBacktest() {
         }
         
         console.log('✅ Backtest started:', data.message);
-        if (activeAgent?.agent_id) {
-            setBacktestRunningForAgent(activeAgent.agent_id, true);
-        }
         
         // Poll for status (now session-aware)
         await pollBacktestStatus(btn);
@@ -2639,7 +2629,6 @@ async function runBacktest() {
         });
         btn.textContent = '❌ Error - Try Again';
         btn.disabled = false;
-        setBacktestRunningForAgent(null, false);
         setTimeout(() => {
             btn.textContent = '▶ Run Backtest';
             showBacktestRunProgress(false);
@@ -2693,7 +2682,6 @@ async function pollBacktestStatus(btn) {
                     isComplete = true;
                     clearInterval(interval);
                     liveBacktestChartActive = false;
-                    setBacktestRunningForAgent(null, false);
                     
                     if (status.error) {
                         console.error('❌ Backtest error:', status.error);

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -129,6 +129,48 @@ function formatTokenCount(value) {
 // unavailable). Lets the redesigned My Agents page render without a backend.
 // TODO: Replace mock agent data with backend API data later.
 // ============================================================================
+const MAX_AGENT_CASH_ALLOCATION = 3000;
+const AGENT_CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
+
+function formatAgentCashAllocation(value) {
+  if (value == null || value === '') return '—';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(Number(value));
+}
+
+function parseAgentCashAllocationInput(raw) {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Initial cash must be between $0 and $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
+  }
+  if (value > MAX_AGENT_CASH_ALLOCATION) {
+    throw new Error(`Initial cash cannot exceed $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
+  }
+  return Math.round(value);
+}
+
+function applyAgentCashAllocationOverride(agent) {
+  if (!agent?.agent_id) return agent;
+  if (agent.cash_allocation != null) return agent;
+  try {
+    const raw = localStorage.getItem(`${AGENT_CASH_OVERRIDE_PREFIX}${agent.agent_id}`);
+    if (raw == null) return agent;
+    const value = Number(raw);
+    if (!Number.isFinite(value)) return agent;
+    return { ...agent, cash_allocation: value };
+  } catch (e) {
+    return agent;
+  }
+}
+
+function decorateAgent(agent) {
+  return applyAgentCashAllocationOverride(applyAgentNameOverride(agent));
+}
+
 const MOCK_AGENTS = [
   {
     agent_id: 'mock-test-agent-2', name: 'test agent 2', agent_type: 'builtin',
@@ -188,6 +230,22 @@ const MOCK_AGENTS = [
 // Holds the most recently loaded agents so the toolbar can re-filter without refetching.
 let allAgents = [];
 let agentViewMode = 'grid';
+let runningBacktestAgentId = null;
+
+function setBacktestRunningForAgent(agentId, running) {
+  runningBacktestAgentId = running ? agentId : null;
+  if (allAgents.length) {
+    applyAgentFilters();
+  }
+}
+
+function resolveAgentDeploymentBadge(agent) {
+  if (runningBacktestAgentId && agent.agent_id === runningBacktestAgentId) {
+    return { label: 'Backtesting', className: 'backtesting' };
+  }
+  // Future: Paper trading / Live trading states when per-agent deployment exists.
+  return { label: 'Not live', className: 'not-live' };
+}
 
 // Demo/mock agents (MOCK_AGENTS) have no database row, so renames made in the editor
 // are stored locally under `agent-name-override:{id}`. Real agents use the same key
@@ -213,7 +271,7 @@ function applyAgentFilters() {
   const query = (document.getElementById('agentSearchInput')?.value || '').trim().toLowerCase();
   const activeId = localStorage.getItem(ACTIVE_AGENT_KEY);
 
-  let list = allAgents.map(applyAgentNameOverride);
+  let list = allAgents.map(decorateAgent);
   if (filter === 'builtin') {
     list = list.filter((a) => a.agent_type === 'builtin');
   } else if (filter === 'external') {
@@ -306,14 +364,9 @@ function renderAgentsGrid(agents) {
   }
   if (empty) empty.hidden = true;
 
-  const activeId = localStorage.getItem(ACTIVE_AGENT_KEY);
-
   agents.forEach((agent) => {
-    const latest = agent.latest_run || {};
-    const totalReturn = latest.total_return;
-    const sharpe = latest.sharpe_ratio;
-    const isActive = agent.is_active === true || agent.agent_id === activeId;
     const isBuiltin = agent.agent_type === 'builtin';
+    const deploymentBadge = resolveAgentDeploymentBadge(agent);
     const card = document.createElement('div');
     card.className = `section-card agent-card agent-card--compact${isBuiltin ? ' agent-card-builtin' : ''}`;
 
@@ -321,33 +374,25 @@ function renderAgentsGrid(agents) {
       ? '<span class="status-badge builtin">Built-in</span>'
       : '<span class="agent-discord connected">External agent</span>';
 
-    const discordButton = isBuiltin
-      ? `<a class="agent-action-btn agent-action-discord" href="${DISCORD_SERVER_URL}" target="_blank" rel="noopener noreferrer">Chat on Discord</a>`
-      : '';
     const apiKeyButton = isBuiltin
       ? ''
       : `<button class="agent-action-btn agent-action-secondary agent-rotate-key-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">New API key</button>`;
 
+    const cashBadge = agent.cash_allocation != null
+      ? `<span class="agent-cash-allocation" title="Starting capital budget for this agent">Initial cash: ${formatAgentCashAllocation(agent.cash_allocation)}</span>`
+      : '';
+
     card.innerHTML = `
       <div class="agent-card-head">
         <h3 class="agent-name">${escapeHtml(agent.name)}</h3>
-        <span class="status-badge ${isActive ? 'live' : 'baseline'}">${isActive ? 'Active' : 'Registered'}</span>
+        <span class="status-badge ${deploymentBadge.className}">${deploymentBadge.label}</span>
       </div>
       <div class="agent-meta">
         <span>${escapeHtml(agent.model_name || 'local-model')}</span>
         ${typeBadge}
+        ${cashBadge}
       </div>
       ${isBuiltin && agent.description ? `<p class="agent-description">${escapeHtml(agent.description)}</p>` : ''}
-      <div class="agent-metrics">
-        <div class="agent-metric">
-          <span class="metric-label">Return</span>
-          <span class="metric-value ${totalReturn >= 0 ? 'positive' : ''}">${formatAgentReturn(totalReturn)}</span>
-        </div>
-        <div class="agent-metric">
-          <span class="metric-label">Sharpe</span>
-          <span class="metric-value">${sharpe != null ? Number(sharpe).toFixed(2) : '—'}</span>
-        </div>
-      </div>
       <div class="agent-meta">
         <span>${agent.run_count || 0} backtest run(s)</span>
         ${renderAgentTokenCost(agent)}
@@ -356,9 +401,8 @@ function renderAgentsGrid(agents) {
       <div class="agent-card-actions">
         <button class="agent-action-btn agent-edit-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">Edit</button>
         <button class="agent-action-btn agent-select-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">View in Playground</button>
-        ${discordButton}
         ${apiKeyButton}
-        <button class="agent-action-btn agent-action-secondary agent-delete-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">Remove</button>
+        <button class="agent-action-btn agent-delete-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">Delete</button>
       </div>
     `;
     grid.appendChild(card);
@@ -419,7 +463,7 @@ function renderAgentsGrid(agents) {
   grid.querySelectorAll('.agent-delete-btn').forEach((btn) => {
     btn.addEventListener('click', async () => {
       const agentId = btn.dataset.agentId;
-      if (!agentId || !confirm('Remove this agent? Backtest history stays in the database.')) return;
+      if (!agentId || !confirm('Delete this agent? Backtest history stays in the database.')) return;
       try {
         if (isDemoAgent(agentId)) {
           hideDemoAgent(agentId);
@@ -437,7 +481,7 @@ function renderAgentsGrid(agents) {
         }
         await loadAgents();
       } catch (error) {
-        alert(error.message || 'Failed to remove agent');
+        alert(error.message || 'Failed to delete agent');
       }
     });
   });
@@ -588,6 +632,9 @@ async function loadAgents() {
     allAgents = agents;
     applyAgentFilters();
     populateBacktestAgentSelect();
+    if (typeof window.updateAgentAllocationFromAgents === 'function') {
+      window.updateAgentAllocationFromAgents(allAgents.map(decorateAgent));
+    }
   } catch (error) {
     console.warn('Failed to load agents:', error.message);
     if (isDemoMode()) {
@@ -644,7 +691,19 @@ async function submitCreateBuiltinAgent(event) {
   const name = nameInput?.value?.trim();
   const model_name = modelInput?.value?.trim() || 'anthropic/claude-haiku-4-5';
   const description = descInput?.value?.trim() || null;
+  const cashInput = document.getElementById('builtinAgentCashAllocation');
   if (!name) return;
+
+  let cash_allocation;
+  try {
+    cash_allocation = parseAgentCashAllocationInput(cashInput?.value);
+  } catch (error) {
+    if (errorEl) {
+      errorEl.textContent = error.message;
+      errorEl.hidden = false;
+    }
+    return;
+  }
 
   if (errorEl) errorEl.hidden = true;
   if (submitBtn) submitBtn.disabled = true;
@@ -655,6 +714,7 @@ async function submitCreateBuiltinAgent(event) {
       model_name,
       agent_type: 'builtin',
       description,
+      cash_allocation,
     });
     closeCreateBuiltinAgentModal();
     if (data.agent) applyActiveAgent(data.agent);
@@ -735,13 +795,25 @@ async function submitCreateExternalAgent(event) {
 
   const name = nameInput?.value?.trim();
   const model_name = modelInput?.value?.trim() || 'local-model';
+  const cashInput = document.getElementById('externalAgentCashAllocation');
   if (!name) return;
+
+  let cash_allocation;
+  try {
+    cash_allocation = parseAgentCashAllocationInput(cashInput?.value);
+  } catch (error) {
+    if (errorEl) {
+      errorEl.textContent = error.message;
+      errorEl.hidden = false;
+    }
+    return;
+  }
 
   if (errorEl) errorEl.hidden = true;
   if (submitBtn) submitBtn.disabled = true;
 
   try {
-    const data = await API.post(`${API_BASE}/api/v1/agents`, { name, model_name });
+    const data = await API.post(`${API_BASE}/api/v1/agents`, { name, model_name, cash_allocation });
     closeCreateExternalAgentModal();
     applyActiveAgent(data.agent);
     await loadAgents();
@@ -2542,6 +2614,7 @@ async function runBacktest() {
             });
             btn.textContent = '❌ Error - Try Again';
             btn.disabled = false;
+            setBacktestRunningForAgent(null, false);
             setTimeout(() => {
                 btn.textContent = '▶ Run Backtest';
                 showBacktestRunProgress(false);
@@ -2550,6 +2623,9 @@ async function runBacktest() {
         }
         
         console.log('✅ Backtest started:', data.message);
+        if (activeAgent?.agent_id) {
+            setBacktestRunningForAgent(activeAgent.agent_id, true);
+        }
         
         // Poll for status (now session-aware)
         await pollBacktestStatus(btn);
@@ -2563,6 +2639,7 @@ async function runBacktest() {
         });
         btn.textContent = '❌ Error - Try Again';
         btn.disabled = false;
+        setBacktestRunningForAgent(null, false);
         setTimeout(() => {
             btn.textContent = '▶ Run Backtest';
             showBacktestRunProgress(false);
@@ -2616,6 +2693,7 @@ async function pollBacktestStatus(btn) {
                     isComplete = true;
                     clearInterval(interval);
                     liveBacktestChartActive = false;
+                    setBacktestRunningForAgent(null, false);
                     
                     if (status.error) {
                         console.error('❌ Backtest error:', status.error);
@@ -2796,7 +2874,7 @@ function showPlaygroundPanel(tab) {
         loadPaperTradingData();
     } else {
         currentMode = 'agents';
-        if (typeof renderPortfolio === 'function') renderPortfolio();
+        if (typeof renderPortfolio === 'function') renderPortfolio(allAgents.map(decorateAgent));
         loadAgents();
     }
 

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -7,6 +7,7 @@
 
   const STORAGE_PREFIX = 'agent-pipeline-config:';
   const NAME_OVERRIDE_PREFIX = 'agent-name-override:';
+  const CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
   const API_BASE = window.location.origin;
 
   // Demo/mock agents (see MOCK_AGENTS in app.js) only exist in the frontend —
@@ -161,9 +162,22 @@
   function getEditorState() {
     const nameInput = document.getElementById('agentEditorNameInput');
     const descInput = document.getElementById('agentEditorDescription');
+    const cashInput = document.getElementById('agentEditorCashAllocation');
+    let cash_allocation = null;
+    if (cashInput && cashInput.value !== '') {
+      const value = Number(cashInput.value);
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error('Initial cash must be zero or greater.');
+      }
+      if (value > 3000) {
+        throw new Error('Initial cash cannot exceed $3,000.');
+      }
+      cash_allocation = Math.round(value);
+    }
     return {
       name: nameInput ? nameInput.value.trim() : '',
       description: descInput ? descInput.value.trim() : '',
+      cash_allocation,
       subAgents: collectPipelineFromDom(),
     };
   }
@@ -378,10 +392,14 @@
   function fillHeader(agent) {
     const nameInput = document.getElementById('agentEditorNameInput');
     const descInput = document.getElementById('agentEditorDescription');
+    const cashInput = document.getElementById('agentEditorCashAllocation');
     const meta = document.getElementById('agentEditorMeta');
 
     if (nameInput) nameInput.value = agent.name || '';
     if (descInput) descInput.value = agent.description || '';
+    if (cashInput) {
+      cashInput.value = agent.cash_allocation != null ? String(agent.cash_allocation) : '';
+    }
     if (meta) {
       const type = agent.agent_type === 'builtin' ? 'Built-in' : 'External';
       meta.textContent = `${agent.model_name || 'local-model'} · ${type}`;
@@ -398,11 +416,12 @@
     }));
   }
 
-  async function patchAgent(agent, name, description, pipeline) {
+  async function patchAgent(agent, name, description, pipeline, cash_allocation) {
     const payload = {
       name,
       description: description || null,
       pipeline: serializePipeline(pipeline),
+      cash_allocation,
     };
     const endpoint = `${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`;
 
@@ -593,7 +612,14 @@
   async function save() {
     if (!currentAgent) return;
 
-    const state = getEditorState();
+    let state;
+    try {
+      state = getEditorState();
+    } catch (error) {
+      showSaveStatus(error.message, true);
+      document.getElementById('agentEditorCashAllocation')?.focus();
+      return;
+    }
     if (!state.name) {
       showSaveStatus('Agent name is required', true);
       document.getElementById('agentEditorNameInput')?.focus();
@@ -615,7 +641,17 @@
           `${NAME_OVERRIDE_PREFIX}${currentAgent.agent_id}`,
           JSON.stringify({ name: state.name, description: state.description })
         );
-        currentAgent = { ...currentAgent, name: state.name, description: state.description };
+        if (state.cash_allocation != null) {
+          localStorage.setItem(`${CASH_OVERRIDE_PREFIX}${currentAgent.agent_id}`, String(state.cash_allocation));
+        } else {
+          localStorage.removeItem(`${CASH_OVERRIDE_PREFIX}${currentAgent.agent_id}`);
+        }
+        currentAgent = {
+          ...currentAgent,
+          name: state.name,
+          description: state.description,
+          cash_allocation: state.cash_allocation,
+        };
         savePipelineLocal(currentAgent.agent_id, subAgents);
         if (localStorage.getItem('active-agent-id') === currentAgent.agent_id) {
           localStorage.setItem('active-agent-name', state.name);
@@ -639,7 +675,8 @@
         currentAgent,
         state.name,
         state.description,
-        subAgents
+        subAgents,
+        state.cash_allocation
       );
       currentAgent = { ...currentAgent, ...updated, pipeline: subAgents };
       savePipelineLocal(currentAgent.agent_id, subAgents);

--- a/dashboard/frontend/js/portfolio.js
+++ b/dashboard/frontend/js/portfolio.js
@@ -1,7 +1,7 @@
 /*
  * portfolio.js — "My Portfolio" section for the My Agents page.
  *
- * Renders four summary cards and three allocation donut charts using the
+ * Renders four summary cards and four allocation donut charts using the
  * existing Chart.js library (loaded in index.html). Everything here is a
  * static, frontend-only mockup — no API, database, broker, or auth calls.
  *
@@ -51,6 +51,14 @@ const PORTFOLIO_MOCK = {
                 { label: 'ADA',   pct: 6.1,  value: 2078.43,  color: '#3b82f6' },
                 { label: 'DOT',   pct: 4.2,  value: 1424.50,  color: '#ec4899' },
                 { label: 'Other', pct: 3.7,  value: 1269.99,  color: '#475569' },
+            ],
+        },
+        agent: {
+            total: 7500,
+            slices: [
+                { label: 'Momentum Alpha', pct: 40.0, value: 3000, color: '#22d3ee' },
+                { label: 'test discord bot', pct: 33.3, value: 2500, color: '#a855f7' },
+                { label: 'Risk Parity Bot', pct: 26.7, value: 2000, color: '#34d399' },
             ],
         },
     },
@@ -219,15 +227,47 @@ function renderAllocationChart(key, data) {
 }
 
 // ---------------------------------------------------------------------------
+// Agent allocation (mock by default; can refresh from loaded agents)
+// ---------------------------------------------------------------------------
+const AGENT_ALLOCATION_COLORS = ['#22d3ee', '#a855f7', '#34d399', '#fbbf24', '#f87171', '#c084fc', '#475569'];
+
+function buildAgentAllocationData(agents) {
+    const withCash = (agents || []).filter(
+        (agent) => agent.cash_allocation != null && Number(agent.cash_allocation) > 0,
+    );
+    if (!withCash.length) {
+        return PORTFOLIO_MOCK.allocations.agent;
+    }
+
+    const total = withCash.reduce((sum, agent) => sum + Number(agent.cash_allocation), 0);
+    const slices = withCash.map((agent, index) => {
+        const value = Number(agent.cash_allocation);
+        return {
+            label: agent.name || 'Agent',
+            value,
+            pct: total > 0 ? Math.round((value / total) * 1000) / 10 : 0,
+            color: AGENT_ALLOCATION_COLORS[index % AGENT_ALLOCATION_COLORS.length],
+        };
+    });
+    return { total, slices };
+}
+
+function updateAgentAllocationFromAgents(agents) {
+    renderAllocationChart('agent', buildAgentAllocationData(agents));
+}
+
+// ---------------------------------------------------------------------------
 // Public entry point — called when the My Agents tab becomes visible.
 // ---------------------------------------------------------------------------
-function renderPortfolio() {
+function renderPortfolio(agents) {
     // TODO: Replace mock portfolio data with backend API data later.
     const data = PORTFOLIO_MOCK;
     renderPortfolioSummary(data.summary);
     renderAllocationChart('asset', data.allocations.asset);
     renderAllocationChart('stock', data.allocations.stock);
     renderAllocationChart('crypto', data.allocations.crypto);
+    renderAllocationChart('agent', buildAgentAllocationData(agents));
 }
 
 window.renderPortfolio = renderPortfolio;
+window.updateAgentAllocationFromAgents = updateAgentAllocationFromAgents;

--- a/dashboard/frontend/js/portfolio.js
+++ b/dashboard/frontend/js/portfolio.js
@@ -53,14 +53,6 @@ const PORTFOLIO_MOCK = {
                 { label: 'Other', pct: 3.7,  value: 1269.99,  color: '#475569' },
             ],
         },
-        agent: {
-            total: 7500,
-            slices: [
-                { label: 'Momentum Alpha', pct: 40.0, value: 3000, color: '#22d3ee' },
-                { label: 'test discord bot', pct: 33.3, value: 2500, color: '#a855f7' },
-                { label: 'Risk Parity Bot', pct: 26.7, value: 2000, color: '#34d399' },
-            ],
-        },
     },
 };
 
@@ -194,7 +186,10 @@ function renderAllocationChart(key, data) {
                     callbacks: {
                         label: (ctx) => {
                             const slice = data.slices[ctx.dataIndex];
-                            return `${slice.label}: ${slice.pct}% · ${pfMoney(slice.value)}`;
+                            const amount = slice.assignedCapital != null
+                                ? slice.assignedCapital
+                                : slice.value;
+                            return `${slice.label}: ${slice.pct}% · ${pfMoney(amount)}`;
                         },
                     },
                 },
@@ -211,15 +206,18 @@ function renderAllocationChart(key, data) {
     if (legendEl) {
         const rows = data.slices
             .map(
-                (s) => `
+                (s) => {
+                    const displayValue = s.assignedCapital != null ? s.assignedCapital : s.value;
+                    return `
             <li class="allocation-legend-row">
                 <span class="allocation-legend-name">
                     <span class="allocation-legend-dot" style="background:${s.color}"></span>
                     ${s.label}
                 </span>
                 <span class="allocation-legend-pct">${s.pct}%</span>
-                <span class="allocation-legend-value">${pfMoney(s.value)}</span>
-            </li>`,
+                <span class="allocation-legend-value">${pfMoney(displayValue)}</span>
+            </li>`;
+                },
             )
             .join('');
         legendEl.innerHTML = rows;
@@ -227,33 +225,92 @@ function renderAllocationChart(key, data) {
 }
 
 // ---------------------------------------------------------------------------
-// Agent allocation (mock by default; can refresh from loaded agents)
+// Capital allocation by agent (portfolio-wide: assigned + unassigned)
 // ---------------------------------------------------------------------------
-const AGENT_ALLOCATION_COLORS = ['#22d3ee', '#a855f7', '#34d399', '#fbbf24', '#f87171', '#c084fc', '#475569'];
+const AGENT_SLICE_COLORS = ['#22d3ee', '#a855f7', '#34d399', '#fbbf24', '#f87171', '#c084fc', '#38bdf8', '#2dd4bf'];
+const UNASSIGNED_SLICE_COLOR = '#64748b';
 
-function buildAgentAllocationData(agents) {
-    const withCash = (agents || []).filter(
+function portfolioPct(value, totalPortfolioValue) {
+    const total = Number(totalPortfolioValue) || 0;
+    if (total <= 0) return 0;
+    return Math.round((Number(value) / total) * 1000) / 10;
+}
+
+function getTotalPortfolioValue() {
+    return Number(PORTFOLIO_MOCK.summary.totalValue) || 0;
+}
+
+function buildAgentAllocationData(agents, totalPortfolioValue) {
+    const total = Number(totalPortfolioValue) || 0;
+
+    const assignedAgents = (agents || []).filter(
         (agent) => agent.cash_allocation != null && Number(agent.cash_allocation) > 0,
     );
-    if (!withCash.length) {
-        return PORTFOLIO_MOCK.allocations.agent;
+
+    if (total <= 0) {
+        return {
+            total: 0,
+            slices: [{ label: 'Unassigned', value: 0, pct: 0, color: UNASSIGNED_SLICE_COLOR }],
+        };
     }
 
-    const total = withCash.reduce((sum, agent) => sum + Number(agent.cash_allocation), 0);
-    const slices = withCash.map((agent, index) => {
-        const value = Number(agent.cash_allocation);
+    if (!assignedAgents.length) {
         return {
-            label: agent.name || 'Agent',
-            value,
-            pct: total > 0 ? Math.round((value / total) * 1000) / 10 : 0,
-            color: AGENT_ALLOCATION_COLORS[index % AGENT_ALLOCATION_COLORS.length],
+            total,
+            slices: [{
+                label: 'Unassigned',
+                value: total,
+                pct: 100,
+                color: UNASSIGNED_SLICE_COLOR,
+            }],
         };
+    }
+
+    const assignedTotal = assignedAgents.reduce(
+        (sum, agent) => sum + Number(agent.cash_allocation),
+        0,
+    );
+    const unassigned = Math.max(total - assignedTotal, 0);
+    const overAllocated = assignedTotal > total;
+    const chartScale = overAllocated && assignedTotal > 0 ? total / assignedTotal : 1;
+
+    const slices = [];
+
+    if (unassigned > 0) {
+        slices.push({
+            label: 'Unassigned',
+            value: unassigned,
+            pct: portfolioPct(unassigned, total),
+            color: UNASSIGNED_SLICE_COLOR,
+        });
+    }
+
+    assignedAgents.forEach((agent, index) => {
+        const assignedCapital = Number(agent.cash_allocation);
+        const chartValue = assignedCapital * chartScale;
+        slices.push({
+            label: agent.name || 'Agent',
+            value: chartValue,
+            assignedCapital,
+            pct: portfolioPct(assignedCapital, total),
+            color: AGENT_SLICE_COLORS[index % AGENT_SLICE_COLORS.length],
+        });
     });
-    return { total, slices };
+
+    if (!slices.length) {
+        slices.push({
+            label: 'Unassigned',
+            value: total,
+            pct: 100,
+            color: UNASSIGNED_SLICE_COLOR,
+        });
+    }
+
+    return { total, slices, overAllocated };
 }
 
 function updateAgentAllocationFromAgents(agents) {
-    renderAllocationChart('agent', buildAgentAllocationData(agents));
+    renderAllocationChart('agent', buildAgentAllocationData(agents, getTotalPortfolioValue()));
 }
 
 // ---------------------------------------------------------------------------
@@ -266,7 +323,7 @@ function renderPortfolio(agents) {
     renderAllocationChart('asset', data.allocations.asset);
     renderAllocationChart('stock', data.allocations.stock);
     renderAllocationChart('crypto', data.allocations.crypto);
-    renderAllocationChart('agent', buildAgentAllocationData(agents));
+    renderAllocationChart('agent', buildAgentAllocationData(agents, getTotalPortfolioValue()));
 }
 
 window.renderPortfolio = renderPortfolio;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -73,8 +73,7 @@ body {
     gap: 20px;
 }
 
-.header-brand,
-.header-left {
+.header-brand {
     grid-column: 2;
     justify-self: center;
     display: flex;
@@ -84,6 +83,34 @@ body {
     text-decoration: none;
     color: inherit;
     cursor: pointer;
+}
+
+.header-left {
+    grid-column: 1;
+    justify-self: start;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    text-decoration: none;
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 600;
+    transition: color 0.15s ease;
+}
+
+.header-github-link:hover {
+    color: var(--text-primary);
+}
+
+.header-github-icon {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+}
+
+.header-github-name {
+    white-space: nowrap;
 }
 
 a.header-brand:hover .title-section h1 {
@@ -179,7 +206,7 @@ a.header-brand:hover .title-section h1 {
     justify-self: end;
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 14px;
     min-width: 0;
 }
 
@@ -403,15 +430,16 @@ a.header-brand:hover .title-section h1 {
 
 .mode-toggle {
     display: flex;
-    gap: 2px;
+    gap: 4px;
     background-color: var(--bg-card);
-    padding: 3px;
-    border-radius: 4px;
+    padding: 4px;
+    border-radius: 6px;
     border: 1px solid var(--border-color);
+    flex-shrink: 0;
 }
 
 .mode-btn {
-    padding: 5px 12px;
+    padding: 6px 14px;
     border: none;
     background-color: transparent;
     color: var(--text-secondary);
@@ -1993,16 +2021,27 @@ a.header-brand:hover .title-section h1 {
     }
 }
 
+@media (max-width: 700px) {
+    .header-github-name {
+        display: none;
+    }
+}
+
 @media (max-width: 900px) {
     .header {
         grid-template-columns: 1fr;
         gap: 10px;
     }
 
-    .header-brand,
+    .header-brand {
+        grid-column: 1;
+        justify-self: center;
+    }
+
     .header-left {
         grid-column: 1;
         justify-self: center;
+        order: -1;
     }
 
     .header-right {
@@ -2984,6 +3023,16 @@ a.header-brand:hover .title-section h1 {
 .status-badge.baseline {
     background-color: rgba(200, 200, 81, 0.15);
     color: #c8c851;
+}
+
+.status-badge.not-live {
+    background-color: rgba(107, 114, 128, 0.15);
+    color: var(--text-muted);
+}
+
+.status-badge.backtesting {
+    background-color: rgba(34, 211, 238, 0.12);
+    color: #67e8f9;
 }
 
 .leaderboard-footer {
@@ -4636,6 +4685,18 @@ a.header-brand:hover .title-section h1 {
     background: var(--bg-hover);
 }
 
+.agent-delete-btn {
+    border-color: rgba(248, 113, 113, 0.55);
+    background: rgba(248, 113, 113, 0.1);
+    color: #f87171;
+}
+
+.agent-delete-btn:hover {
+    border-color: #f87171;
+    background: rgba(248, 113, 113, 0.2);
+    color: #fca5a5;
+}
+
 .agent-action-discord {
     display: inline-flex;
     align-items: center;
@@ -4745,7 +4806,7 @@ a.header-brand:hover .title-section h1 {
 /* Allocation charts */
 .allocation-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 12px;
     margin-bottom: 24px;
 }
@@ -4873,6 +4934,13 @@ a.header-brand:hover .title-section h1 {
 
 .agents-section-head .page-title {
     margin: 0;
+}
+
+.agents-section-title-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
 .agent-toolbar {
@@ -5094,19 +5162,19 @@ a.header-brand:hover .title-section h1 {
 
 .subtab-bar {
     display: flex;
-    gap: 4px;
+    gap: 6px;
     margin-bottom: 12px;
-    padding: 3px;
+    padding: 4px;
     background: var(--bg-card);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: 6px;
     width: fit-content;
     max-width: 100%;
     flex-wrap: wrap;
 }
 
 .subtab-btn {
-    padding: 6px 14px;
+    padding: 7px 16px;
     border: none;
     background: transparent;
     color: var(--text-secondary);
@@ -5336,6 +5404,52 @@ body.agent-editor-open {
 .agent-editor-description:focus {
     outline: none;
     border-color: rgba(34, 211, 238, 0.4);
+}
+
+.agent-editor-cash-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 10px;
+    max-width: 220px;
+}
+
+.agent-editor-cash-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.agent-editor-cash-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--bg-input);
+    color: var(--text-primary);
+    font-size: 14px;
+    font-family: var(--font-mono);
+}
+
+.agent-editor-cash-input:focus {
+    outline: none;
+    border-color: rgba(34, 211, 238, 0.4);
+}
+
+.agent-cash-allocation {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(34, 211, 238, 0.1);
+    border: 1px solid rgba(34, 211, 238, 0.25);
+    color: #67e8f9;
+    font-size: 11px;
+    font-weight: 700;
 }
 
 .agent-editor-header-actions {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -3030,7 +3030,7 @@ a.header-brand:hover .title-section h1 {
     color: var(--text-muted);
 }
 
-.status-badge.backtesting {
+.status-badge.backtested {
     background-color: rgba(34, 211, 238, 0.12);
     color: #67e8f9;
 }


### PR DESCRIPTION
**Summary**
Navigation & branding
- Point all dashboard GitHub links to Open-Finance-Lab/AgenticTrading (header + Home resources)
- Add GitHub icon + AgenticTrading repo link in the top-left header
- Reorder Home Resources: GitHub first, Documentation last
- Improve primary nav and sub-tab spacing at 100% zoom (more padding/gap)
My Portfolio
- Add Agent Allocation donut chart (mock by default; updates from agents with cash_allocation when present)
- Expand allocation grid from 3 → 4 columns (responsive layout preserved)
Per-agent initial cash (backend + UI)
- Add cash_allocation column to external_agents (SQLite migration, max $3,000)
- Expose on create (POST /api/v1/agents) and update (PATCH /api/v1/agents/{id})
- Prompt for initial cash when creating built-in or external agents
- Show Initial cash on agent cards and in the agent editor (editable on save)
- Update repository test schema for new cash_allocation field
Agent card redesign
- Replace Active / Registered with deployment-oriented badges:
- Not live (default)
- Backtesting (while a backtest is running for that agent)
- Rename Cash → Initial cash across cards, modals, and editor
- Remove card-level Return and Sharpe metrics (performance stays on backtest run rows)
- Rename Remove → Delete with red destructive styling
- Remove per-card Chat on Discord; add Open Discord next to the My Agents section title
