### PR TITLE
chore(backtest): drop dead TOP_10/TOP_10_STOCKS alias from hourly agent script

### DIFF
--- a/dashboard/scripts/backtest_hourly_agent.py
+++ b/dashboard/scripts/backtest_hourly_agent.py
@@ -47,7 +47,7 @@ from dashboard.backend.paths import CREDENTIALS_DIR
 from dashboard.backend.database import db
 import dashboard.backend.infrastructure.llm.token_cost as token_cost
 from dashboard.backend.baseline_generator import generate_baselines
-from dashboard.backend.infrastructure.llm.validator import create_safe_prompt, create_prompt, validate_llm_response, LLMTradingDecision, TOP_10_STOCKS, DJIA_30
+from dashboard.backend.infrastructure.llm.validator import create_safe_prompt, create_prompt, validate_llm_response, LLMTradingDecision, DJIA_30
 
 # Optional: LLM integration. Phase 2C2 moved the Anthropic SDK import, the
 # default model name, and the LLM request/parse workflow into the canonical
@@ -84,8 +84,8 @@ from dashboard.backend.infrastructure.llm.decision_parsing import fix_json_forma
 from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
 from dashboard.backend.domain.backtesting.constants import INITIAL_CAPITAL
 
-# DJIA_30 and TOP_10_STOCKS both imported from validator to keep them in sync
-TOP_10 = TOP_10_STOCKS
+# DJIA_30 is imported from validator (the single source of truth, guarded by
+# tests/test_djia30_universe.py) rather than redefined here.
 
 # ============================================================================
 # JSON Parsing Utilities


### PR DESCRIPTION
## What

Removes dead `TOP_10 = TOP_10_STOCKS` plumbing from `dashboard/scripts/backtest_hourly_agent.py`:

- Drops the unused `TOP_10` module-level alias.
- Drops `TOP_10_STOCKS` from the `validator` import (it was imported *only* to build that alias).

Net change is 3 lines in a single file.

## Why it's dead (and why the constant itself stays)

`TOP_10` in the script is assigned but **never read** anywhere below its definition — a leftover from before the buy-and-hold baseline logic moved into `domain/backtesting/engine.py`.

The **live** consumer is `engine.py`, which imports the constant directly (`from ...validator import ... TOP_10_STOCKS as TOP_10`) and feeds it to `generate_baselines(..., symbols_list=TOP_10)` inside `run_buyhold_baseline()` — a method called from `external_run_service.py`. So `TOP_10_STOCKS` **stays put in `validator.py`**; only the orphaned *script* alias and its now-unused import go away.

`DJIA_30` remains imported in the script (used in the run banner and part of the tested `bha.*` public surface).

## Safety

- **Compatibility surface intact.** `TOP_10`/`TOP_10_STOCKS` are *not* in `test_backtest_compatibility.py::PUBLIC_SURFACE` (which lists `DJIA_30`, kept). Verified `bha` still imports and exposes `DJIA_30`.
- **No route/schema/contract impact** — this touches a script constant only, so route-contract freezes are unaffected.
- **Full backend suite green:** `883 passed, 2 skipped`.

Follow-up cleanup split out of the DJIA-30 universe fix (#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)