### PR TITLE
fix(universe): collapse remaining Dow-ish copies onto canonical DJIA_30 (§PR-C.1 follow-up to #91)

### DIFF
--- a/dashboard/backend/domain/backtesting/baselines/paper.py
+++ b/dashboard/backend/domain/backtesting/baselines/paper.py
@@ -23,16 +23,11 @@ from dashboard.backend.paths import CREDENTIALS_DIR
 
 from dashboard.backend.database import db
 from dashboard.backend.infrastructure.brokers.alpaca_paper import AlpacaPaperTradingClient
+from dashboard.backend.infrastructure.llm.validator import DJIA_30, TOP_10_STOCKS
 
-
-DJIA_SYMBOLS = [
-    "AAPL", "MSFT", "JPM", "V", "JNJ",
-    "WMT", "PG", "UNH", "NVDA", "HD",
-    "KO", "IBM", "MCD", "CAT", "AXP",
-    "GS", "BA", "MMM", "AMGN", "INTC",
-    "VZ", "PFE", "MRK", "HON", "CSCO",
-    "NFLX", "TSLA", "CRM", "TRV", "DIS"
-]
+# Canonical Dow-30 (single source: validator.DJIA_30, guarded by
+# tests/test_djia30_universe.py), kept under the historical local name.
+DJIA_SYMBOLS = list(DJIA_30)
 
 
 class PaperTradingBaselineCalculator:
@@ -166,8 +161,8 @@ class PaperTradingBaselineCalculator:
         Calculate equal-weighted DJIA buy-and-hold for date range.
         """
         try:
-            # Use first 10 DJIA symbols (faster)
-            sample_symbols = DJIA_SYMBOLS[:10]
+            # Use the canonical 10-stock basket (faster than all 30)
+            sample_symbols = TOP_10_STOCKS
             all_bars = {}
             
             for symbol in sample_symbols:

--- a/dashboard/backend/tests/domain/backtesting/baselines/test_paper_baselines_move.py
+++ b/dashboard/backend/tests/domain/backtesting/baselines/test_paper_baselines_move.py
@@ -62,10 +62,10 @@ def calc():
 # Canonical surface
 # ---------------------------------------------------------------------------
 
-def test_djia_symbols_unchanged():
+def test_djia_symbols_track_canonical():
+    from dashboard.backend.infrastructure.llm.validator import DJIA_30
+    assert DJIA_SYMBOLS == list(DJIA_30)
     assert len(DJIA_SYMBOLS) == 30
-    assert DJIA_SYMBOLS[0] == "AAPL"
-    assert DJIA_SYMBOLS[-1] == "DIS"
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +128,7 @@ def test_fetch_djia_historical_empty_bars_returns_none(calc, fake_requests):
 # ---------------------------------------------------------------------------
 
 def test_fetch_buy_and_hold_schema(calc, fake_requests):
-    # 10 symbols requested (first 10 of DJIA_SYMBOLS); each returns 2 bars.
+    # 10 symbols requested (the canonical TOP_10_STOCKS basket); each returns 2 bars.
     fake_requests.responses = [
         _FakeResponse(200, {"bars": [
             {"t": "2024-01-01", "c": 10.0},

--- a/dashboard/backend/tests/test_djia30_universe.py
+++ b/dashboard/backend/tests/test_djia30_universe.py
@@ -11,6 +11,7 @@ derives from DJIA_30.
 Index verified 2026-07-10 (S&P DJI, effective 2026-06-29).
 """
 import ast
+import re
 from pathlib import Path
 
 from dashboard.backend.infrastructure.llm.validator import DJIA_30
@@ -95,3 +96,15 @@ def test_paper_baselines_track_canonical():
     from dashboard.backend.domain.backtesting.baselines.paper import DJIA_SYMBOLS
     assert list(DJIA_SYMBOLS) == list(DJIA_30)
     assert _module_dow_literal(_PAPER) is None
+
+
+_APP_JS = _REPO / "dashboard" / "frontend" / "app.js"
+
+
+def test_frontend_djia_preset_matches_canonical():
+    src = _APP_JS.read_text(encoding="utf-8")
+    m = re.search(r"djia:\s*\{[^{}]*?assets:\s*\[([^\]]*)\]", src, re.S)
+    assert m, "djia preset not found in ASSET_UNIVERSES in app.js"
+    assets = re.findall(r"'([A-Z.]+)'", m.group(1))
+    assert len(assets) == len(set(assets)), "duplicate tickers in djia preset"
+    assert set(assets) == EXPECTED

--- a/dashboard/backend/tests/test_djia30_universe.py
+++ b/dashboard/backend/tests/test_djia30_universe.py
@@ -1,9 +1,14 @@
-"""DJIA_30 single-source-of-truth guard (FinSearch↔ATL reconcile 2026-07-10).
+"""Dow-30 single-source-of-truth guard (FinSearch↔ATL reconcile 2026-07-10;
+copies collapsed 2026-07-11, §PR-C.1).
 
-validator.DJIA_30 is the one canonical Dow-30 for ATL: the backtest script and
-the v2 API contract import it. (The docs example on origin/main is a MAG7 demo
-with no Dow list — commit 13a2b64 — so there is nothing to guard there.)
-Verified 2026-07-10 (S&P DJI, effective 2026-06-29).
+validator.DJIA_30 is the one canonical Dow-30 for ATL. Every other Dow-ish
+list must import it (Python) or mirror it exactly (frontend, enforced
+textually below): the backtest scripts, the v2 API contract, the
+paper-trading baselines, and the app.js `djia` universe preset. The
+committee trading script (alpaca_trader_with_committee.py) is deliberately
+user-customizable (⭐ CUSTOMIZE) — the guard pins only its *default*, which
+derives from DJIA_30.
+Index verified 2026-07-10 (S&P DJI, effective 2026-06-29).
 """
 import ast
 from pathlib import Path
@@ -11,7 +16,12 @@ from pathlib import Path
 from dashboard.backend.infrastructure.llm.validator import DJIA_30
 
 _REPO = Path(__file__).resolve().parents[3]          # .../agent-trading-lab
-_BHA = _REPO / "dashboard" / "scripts" / "backtest_hourly_agent.py"
+_SCRIPTS = _REPO / "dashboard" / "scripts"
+_BHA = _SCRIPTS / "backtest_hourly_agent.py"
+_BACKTEST = _SCRIPTS / "backtest.py"
+_COMMITTEE = _SCRIPTS / "alpaca_trader_with_committee.py"
+_PAPER = (_REPO / "dashboard" / "backend" / "domain" / "backtesting"
+          / "baselines" / "paper.py")
 
 EXPECTED = {
     "AAPL", "AMGN", "AMZN", "AXP", "BA", "CAT", "CRM", "CSCO", "CVX", "DIS",
@@ -20,21 +30,40 @@ EXPECTED = {
 }
 FORBIDDEN = {"AMEX", "DOW", "INTC", "MA", "PFE", "WBA", "XOM", "VZ", "NFLX", "TSLA"}
 
+# Names under which Dow-ish copies have historically appeared.
+_DOW_NAMES = {"DJIA_30", "DJIA_SYMBOLS", "SYMBOLS"}
 
-def _module_djia30_literal(path):
-    """The set in a top-level `DJIA_30 = [...]` literal, or None if the module
-    has no such assignment (i.e. it imports the constant instead)."""
+
+def _module_dow_literal(path, names=frozenset(_DOW_NAMES)):
+    """The set in a top-level `<name> = [...]` list literal for any Dow-ish
+    name, or None if the module has no such literal (i.e. it imports or
+    derives the constant instead — `SYMBOLS = list(DJIA_30)` is not a
+    literal and passes)."""
     tree = ast.parse(path.read_text(encoding="utf-8"))
     for node in tree.body:
         if isinstance(node, ast.Assign):
-            for tgt in node.targets:
-                if isinstance(tgt, ast.Name) and tgt.id == "DJIA_30":
-                    return {ast.literal_eval(e) for e in node.value.elts}
-        elif isinstance(node, ast.AnnAssign):
-            tgt = node.target
-            if isinstance(tgt, ast.Name) and tgt.id == "DJIA_30" and node.value is not None:
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+        else:
+            continue
+        for tgt in targets:
+            if (isinstance(tgt, ast.Name) and tgt.id in names
+                    and isinstance(node.value, (ast.List, ast.Tuple, ast.Set))):
                 return {ast.literal_eval(e) for e in node.value.elts}
     return None
+
+
+def _imports_canonical(path):
+    """True if the module has `from ...infrastructure.llm.validator import
+    DJIA_30` (or TOP_10_STOCKS)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.ImportFrom) and node.module
+                and node.module.endswith("infrastructure.llm.validator")):
+            if any(a.name in {"DJIA_30", "TOP_10_STOCKS"} for a in node.names):
+                return True
+    return False
 
 
 def test_validator_is_the_current_index():
@@ -45,8 +74,10 @@ def test_validator_is_the_current_index():
 
 
 def test_backtest_script_imports_not_hardcodes():
-    # After the fix there is no local DJIA_30 = [...] literal — it imports it.
-    assert _module_djia30_literal(_BHA) is None
+    # No script carries its own Dow list literal — each imports the canonical.
+    for path in (_BHA, _BACKTEST, _COMMITTEE):
+        assert _module_dow_literal(path) is None, path.name
+        assert _imports_canonical(path), path.name
 
 
 def test_api_universe_tracks_validator():
@@ -58,3 +89,9 @@ def test_top10_is_subset_of_djia30():
     from dashboard.backend.infrastructure.llm.validator import TOP_10_STOCKS
     assert set(TOP_10_STOCKS) <= set(DJIA_30)
     assert len(TOP_10_STOCKS) == 10
+
+
+def test_paper_baselines_track_canonical():
+    from dashboard.backend.domain.backtesting.baselines.paper import DJIA_SYMBOLS
+    assert list(DJIA_SYMBOLS) == list(DJIA_30)
+    assert _module_dow_literal(_PAPER) is None

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1958,7 +1958,11 @@ function handleScenario(btn) {
 const ASSET_UNIVERSES = {
     djia: {
         name: 'DJIA',
-        assets: ['AAPL', 'MSFT', 'JPM', 'JNJ', 'V', 'PG', 'MRK', 'DIS', 'BA', 'HD', 'KO', 'AXP', 'GE', 'IBM', 'INTC']
+        // Canonical Dow-30 — must mirror backend validator.DJIA_30
+        // (pinned by dashboard/backend/tests/test_djia30_universe.py).
+        assets: ['AAPL', 'AMGN', 'AMZN', 'AXP', 'BA', 'CAT', 'CRM', 'CSCO', 'CVX', 'DIS',
+                 'GOOGL', 'GS', 'HD', 'HON', 'IBM', 'JNJ', 'JPM', 'KO', 'MCD', 'MMM',
+                 'MRK', 'MSFT', 'NKE', 'NVDA', 'PG', 'SHW', 'TRV', 'UNH', 'V', 'WMT']
     },
     mag7: {
         name: 'Magnificent 7',

--- a/dashboard/scripts/alpaca_trader_with_committee.py
+++ b/dashboard/scripts/alpaca_trader_with_committee.py
@@ -22,6 +22,7 @@ from _bootstrap import ensure_repo_root
 
 ensure_repo_root()
 from dashboard.backend.paths import DATA_DIR, DASHBOARD_DIR
+from dashboard.backend.infrastructure.llm.validator import DJIA_30
 
 LOG_FILE = DATA_DIR / "trading_log.json"
 SENTIMENT_FILE = DASHBOARD_DIR / "sentiment_scores.json"
@@ -29,15 +30,10 @@ SENTIMENT_FILE = DASHBOARD_DIR / "sentiment_scores.json"
 COMMITTEE_SCRIPT = Path(__file__).parent / "trading_committee.py"
 
 # Trading config
-# ⭐ CUSTOMIZE THIS LIST to change which stocks are scanned for trading
-SYMBOLS = [
-    "AAPL", "MSFT", "JPM", "V", "JNJ",
-    "WMT", "PG", "UNH", "NVDA", "HD",
-    "KO", "IBM", "MCD", "CAT", "AXP",
-    "GS", "BA", "MMM", "AMGN", "INTC",
-    "VZ", "PFE", "MRK", "HON", "CSCO",
-    "NFLX", "TSLA", "CRM", "TRV", "DIS"
-]  # DJIA Full 30 Stocks
+# ⭐ CUSTOMIZE THIS LIST to change which stocks are scanned for trading.
+# Defaults to the canonical Dow-30 (validator.DJIA_30) — replace with any
+# ticker list to customize.
+SYMBOLS = list(DJIA_30)
 
 MAX_SHARES_PER_SYMBOL = 5
 MIN_CASH_RESERVE = 5000

--- a/dashboard/scripts/backtest.py
+++ b/dashboard/scripts/backtest.py
@@ -47,19 +47,15 @@ from _bootstrap import ensure_repo_root
 ensure_repo_root()
 from dashboard.backend.paths import CREDENTIALS_DIR, DATA_DIR
 from dashboard.backend.database import db
+from dashboard.backend.infrastructure.llm.validator import DJIA_30, TOP_10_STOCKS
 
 # ============================================================================
 # Configuration
 # ============================================================================
 
-DJIA_SYMBOLS = [
-    "AAPL", "MSFT", "JPM", "V", "JNJ",
-    "WMT", "PG", "UNH", "NVDA", "HD",
-    "KO", "IBM", "MCD", "CAT", "AXP",
-    "GS", "BA", "MMM", "AMGN", "INTC",
-    "VZ", "PFE", "MRK", "HON", "CSCO",
-    "NFLX", "TSLA", "CRM", "TRV", "DIS"
-]
+# Canonical Dow-30 (single source: validator.DJIA_30, guarded by
+# tests/test_djia30_universe.py), kept under the historical local name.
+DJIA_SYMBOLS = list(DJIA_30)
 
 SCRIPT_DIR = Path(__file__).parent
 ALPACA_CLI = None  # Not used - we'll use yfinance instead
@@ -300,7 +296,7 @@ def run_backtest(start_date: str, end_date: str) -> Dict:
     
     # Initialize strategies
     clawdy_strategy = ClawdyStrategy(engine)
-    buy_hold_strategy = BuyHoldStrategy(engine, DJIA_SYMBOLS[:10])  # Top 10 for diversity
+    buy_hold_strategy = BuyHoldStrategy(engine, TOP_10_STOCKS)  # canonical top-10 basket
     djia_strategy = DJIAIndexStrategy(engine)
     
     # Fetch price data


### PR DESCRIPTION
Closes the §PR-C.1 deferred item from #91: every remaining Dow-ish ticker-list copy now derives from (or is pinned to) the canonical `validator.DJIA_30`.

## What changed

| Copy | Before | After |
|---|---|---|
| `baselines/paper.py` `DJIA_SYMBOLS` | old 30 incl. never-members NFLX/TSLA | `list(DJIA_30)` |
| `scripts/backtest.py` `DJIA_SYMBOLS` | same old 30 | `list(DJIA_30)` |
| `scripts/alpaca_trader_with_committee.py` `SYMBOLS` | old 30 literal labeled "DJIA Full 30" | defaults to `list(DJIA_30)`, still ⭐-customizable |
| `frontend/app.js` `djia` preset | stale 15-ticker subset incl. ex-members GE/INTC (card already promised "30 blue-chip companies") | canonical 30 |

Guard extension in `test_djia30_universe.py`: the AST check now rejects a top-level list literal under any Dow-ish name (`DJIA_30`/`DJIA_SYMBOLS`/`SYMBOLS`) in all three scripts + `paper.py`, requires each to import the canonical constant, value-pins `paper.DJIA_SYMBOLS == list(DJIA_30)`, and textually pins the JS preset (regex over `app.js`) to the canonical set.

## Intentional behavior changes

- The two 10-stock buy-and-hold baskets move from "first 10 of the old list" to canonical `TOP_10_STOCKS`: UNH/NVDA → AXP/DIS.
- The committee bot's default scan universe and the frontend DJIA preset move to the current index (eff. 2026-06-29).

## Verification

- Full backend suite at HEAD: **885 passed, 2 skipped, 0 failed** (Python 3.13, same gate as CI). TDD: each guard test was verified RED against the stale copies before the fix.
- `node --check` clean on `app.js`; both scripts AST-parse; `validator.py` untouched.
- Ship-gate review: READY TO MERGE, no Critical/Important findings. Two accepted Minors: the script guard is structural (a non-literal drift could evade it), and a user exercising the committee bot's ⭐-customize affordance with a literal list would fail the guard — both by design (the guard pins defaults, not customizations).

## Note for after merge

Prod (Render) still serves pre-#91 code as of 2026-07-11 09:45 UTC (`/api/v2/schema` returns MA/PFE/INTC/XOM). Once it redeploys, refresh the cached leaderboard baselines with `curl "https://agentictrading.onrender.com/api/v1/leaderboard?refresh=true"` — idempotent (INSERT OR REPLACE on deterministic run_ids). This PR doesn't gate that; the leaderboard strategies already import canonical `DJIA_30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JHuWqq62JsJtDFa64TT1X