### PR TITLE
ci: auto-deploy prod via Render Deploy Hook after backend tests pass on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
 # Runs the backend and packaging test suites on every push and PR to main.
+# On pushes to main (and manual dispatch), additionally triggers a Render
+# prod deploy via the service's Deploy Hook once backend tests pass — the
+# service's native autoDeploy never fires for this repo (Render's GitHub App
+# isn't authorized on the org), so this workflow IS the deploy path.
 
 on:
   push:
@@ -9,6 +13,9 @@ on:
   pull_request:
     branches:
       - main
+  # Manual escape hatch: re-fire the deploy without a new commit
+  # (e.g. right after the RENDER_DEPLOY_HOOK_URL secret is first added).
+  workflow_dispatch:
 
 jobs:
   backend-tests:
@@ -53,3 +60,41 @@ jobs:
       - name: Run packaging tests
         working-directory: packaging/agentictrading
         run: pytest tests/ -p no:cacheprovider
+
+  deploy-prod:
+    name: Trigger Render prod deploy
+    # Deploy only from main pushes (or a manual dispatch on main), and only
+    # after the backend suite is green. packaging-tests is deliberately NOT a
+    # gate: it covers the PyPI SDK, which isn't part of the Render service —
+    # an SDK-only failure shouldn't block shipping a backend fix.
+    needs: backend-tests
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    # Serialize deploy triggers so rapid merges don't race; never cancel an
+    # in-flight trigger (the hook call is near-instant anyway).
+    concurrency:
+      group: render-prod-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Fire Render deploy hook
+        env:
+          # Repo secret holding the full Deploy Hook URL
+          # (https://api.render.com/deploy/srv-...?key=...). The URL itself is
+          # the credential — scoped to "trigger a deploy of this one service",
+          # unlike an account-wide API key.
+          DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          # Fail loudly (red main) when the secret is missing: a silent
+          # non-deploy is exactly the failure mode this job exists to fix.
+          if [ -z "$DEPLOY_HOOK_URL" ]; then
+            echo "::error::RENDER_DEPLOY_HOOK_URL secret is not set — prod deploy NOT triggered." \
+                 "Add the service's Deploy Hook URL as an Actions secret (repo Settings → Secrets and variables → Actions)."
+            exit 1
+          fi
+          # --fail: any non-2xx response fails the job; --retry: rides out
+          # transient network/5xx hiccups (Render dedupes rapid re-triggers).
+          curl --fail --silent --show-error --retry 3 -X POST "$DEPLOY_HOOK_URL"
+          echo
+          echo "Render deploy triggered."


### PR DESCRIPTION
## Why

Merging to `main` does not deploy to prod, and never has. The Render service's `autoDeploy: yes` setting is **inert** — the Render GitHub App isn't authorized on the Open-Finance-Lab org, so Render never receives push events from this repo. Verified via the Render API on 2026-07-11: PRs #91–#94 merged over a ~3.5h window produced **zero** deploys; every deploy in the service's history has `trigger=deploy_hook` or `trigger=manual`. Prod only updates when someone remembers to trigger it by hand.

## What

Adds a `deploy-prod` job to the existing CI workflow:

- **Trigger**: pushes to `main` (plus a `workflow_dispatch` escape hatch to fire a deploy without a new commit).
- **Gate**: `needs: backend-tests` — prod deploys only happen on a green backend suite, a CI gate the native autoDeploy path never had. `packaging-tests` is deliberately *not* a gate: it covers the PyPI SDK, which isn't part of the Render service, so an SDK-only failure can't block a backend fix.
- **Action**: `curl --fail --retry 3 -X POST` to the service's Deploy Hook URL, read from the `RENDER_DEPLOY_HOOK_URL` Actions secret. The secret never appears in `run:` interpolation (env-var only) and GitHub masks it in logs.
- **Fail-loud by design**: a missing secret or a non-2xx response turns the job red. A silent non-deploy is exactly the failure mode this change eliminates, so it must never fail quietly.

Fork PRs can't reach the secret: secrets aren't exposed to `pull_request` runs from forks, and the job is additionally fenced to `refs/heads/main`.

## One-time setup required after merge (@Allan-Feng)

1. **Copy the Deploy Hook URL**: Render dashboard → `AgenticTrading` service → **Settings → Deploy Hook** → copy the URL (`https://api.render.com/deploy/srv-...?key=...`). It is not retrievable via the Render API — dashboard only.
2. **Add it as a repo secret** (needs repo admin on this repo): GitHub → **Settings → Secrets and variables → Actions → New repository secret**, name `RENDER_DEPLOY_HOOK_URL`, value = the full URL. Paste it directly into GitHub rather than sending it over chat — the URL alone grants deploy-trigger access (nothing else: no env-var reads, no service mutation, and it's instantly revocable by regenerating the hook in Render).
3. **Fire the first deploy**: Actions tab → CI → **Run workflow** (or re-run the red `deploy-prod` job from the merge commit).

Until step 2 lands, the `deploy-prod` job will show a red ❌ on `main` pushes with an explicit error annotation — that's intentional (fail-loud), and disappears as soon as the secret is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)