### PR TITLE
docs(plans): Agentic FinSearch as leaderboard agent — spec + impl plan

### DIFF
--- a/docs/superpowers/plans/2026-07-13-finsearch-leaderboard-agent.md
+++ b/docs/superpowers/plans/2026-07-13-finsearch-leaderboard-agent.md
@@ -4,7 +4,7 @@
 
 **Goal:** Put Agentic FinSearch on the leaderboard exactly like the other model entries — AF-side professional-trader persona (direct, tools-off path, structurally guarded), ATL-side `finsearch` provider shim, config entry, pricing, then the contest run + seed refresh.
 
-**Architecture:** Task 1 lands in the **Agentic-FinSearch repo** (persona prompt files + config-driven direct path closing all four buffet-literal gates plus the research-mode dispatch gap). Tasks 2–5 land in **ATL** (provider module over the already-pinned `openai` SDK following the PR #96 pattern, leaderboard.json entry, pricing row, env docs). Task 6 is the run itself (smoke → budget gate → full window → seed-DB commit → budget revert).
+**Architecture:** Task 1 lands in the **Agentic-FinSearch repo** (persona prompt files + config-driven direct path: the tools-bypass and persona gates generalize, Buffet's HF-endpoint gates stay literal, and the unguarded research dispatch gains a direct-model guard). Tasks 2–5 land in **ATL** (provider module over the already-pinned `openai` SDK following the PR #96 pattern, leaderboard.json entry, pricing row, env docs). Task 6 is the run itself (smoke → budget gate → full window → seed-DB commit → budget revert).
 
 **Tech Stack:** Django + OpenAI-compatible view (AF), `openai==1.101.0` SDK shim returning Anthropic-shaped objects (ATL), `deploy_leaderboard_model.py` (run), SQLite seed DB commit.
 
@@ -30,7 +30,7 @@
 **Files:**
 - Create: `Main/backend/prompts/personas/trader.md` (persona text: spec §4.2 — the authoritative copy)
 - Create: `Main/backend/prompts/personas/buffett.md` (migrate `BUFFETT_INSTRUCTION` text verbatim)
-- Modify: `Main/backend/datascraper/datascraper.py` — persona loader (same idiom as `_load_security_fragment`, `datascraper.py:66-75`); replace **all four** `provider == "buffet"` literals (`:284` `_prepare_messages`, `:531` `create_response`, `:1015` `create_agent_response`, `:1259` `create_agent_response_stream`) with config-driven `direct`/`persona`; add the research-mode dispatch guard in `create_advanced_response` (direct models short-circuit to the direct path before any tool machinery)
+- Modify: `Main/backend/datascraper/datascraper.py` — persona loader (same idiom as `_load_security_fragment`, `datascraper.py:66-75`); generalize the **tools-bypass** gates (`:1015` `create_agent_response`, `:1259` `create_agent_response_stream` — direct models route to the generic non-agent path) and **persona** selection (`:284` `_prepare_messages`) to config-driven `direct`/`persona`; add the research-mode dispatch guard in `create_advanced_response`. **Do NOT touch the `provider == "buffet"` checks inside `create_response` (`:531`) or its streaming twin** — those select Buffet's dedicated HF Inference Endpoint transport (`_call_buffet_agent`), and generalizing them would misroute every direct model into Buffet's fine-tuned endpoint instead of its own provider client (spec §3)
 - Modify: `Main/backend/datascraper/models_config.py` — add the `FinSearch-Trader` entry **exactly as spec §4.1** (`model_name`/`streaming` keys); add `"direct": True, "persona": "buffett"` to `Buffet-Agent`
 - Modify: `Docs/source/api_reference.rst` (model table row)
 - Test: `Main/backend/tests/test_trader_persona.py` (new)
@@ -78,18 +78,20 @@ def test_buffet_still_uses_buffett_instruction():
     assert "Warren Buffett" in joined
 
 
-def test_direct_models_never_reach_tool_paths():
+def test_direct_models_never_reach_tool_paths_or_buffet_endpoint():
     """Routing matrix: FinSearch-Trader x {normal, thinking, research} must
-    take the direct path (no agent/tool machinery). Assert via the same seam
-    the existing buffet tests use (patch create_response / the agent runner
-    and check which one is invoked)."""
+    reach the GENERIC provider dispatch — assert at the provider-client seam,
+    NOT by patching create_response (which would hide misrouting inside it)."""
     # for each mode in ("normal", "thinking", "research"):
-    #     patch ds.create_response and the agent-path entrypoint;
+    #     patch (a) the agent-path entrypoint, (b) ds._call_buffet_agent,
+    #     and (c) the provider client seam (the `clients` dict / the
+    #     google/openai client's chat-completions call);
     #     call the mode's dispatch with model="FinSearch-Trader";
-    #     assert create_response called, agent path NOT called.
+    #     assert: provider client seam WAS hit; agent path NOT hit;
+    #             _call_buffet_agent NOT hit.
 ```
 
-(The routing-matrix test body follows whatever seam `tests/test_openai_api.py` already patches for the buffet skip-agent case — reuse that fixture pattern; the invariant is the assertion, and it must cover the **research** dispatch too, which today has no direct check at all.)
+(Reuse the fixture pattern of `tests/test_openai_api.py`'s buffet cases, but the assertion seam must be the provider client / `_call_buffet_agent` level — a re-review of this plan caught that patching `create_response` itself would mask the exact misrouting bug the test exists to prevent. It must cover the **research** dispatch too, which today has no direct check at all.)
 
 - [ ] **Step 2: Run to verify failure** — `cd Main/backend && uv run pytest tests/test_trader_persona.py -v` → FAIL (`KeyError: 'FinSearch-Trader'`).
 
@@ -119,7 +121,7 @@ In `_prepare_messages` (`:281-291`) replace the buffet literal with:
             logging.info("[PERSONA] Using %s system prompt", persona)
 ```
 
-In `create_agent_response` (`:1015`), `create_response` (`:531`), `create_agent_response_stream` (`:1259`): replace `provider == "buffet"` with `model_config.get("direct")` (config now carries it for buffet — no dead `or` disjunct). In `create_advanced_response`: add the guard at entry — `if model_config.get("direct"): return await/call the direct path` — before any research/tool machinery. `models_config.py` per spec §4.1.
+In `create_agent_response` (`:1015`) and `create_agent_response_stream` (`:1259`): replace `provider == "buffet"` with `model_config.get("direct")`, routing to the **generic non-agent path** (`create_response`/its streaming twin) — config now carries `direct: True` for buffet, no dead `or` disjunct. **Leave `create_response`'s internal `provider == "buffet"` branch (`:531`) and its streaming twin untouched** — inside `create_response`, that literal selects Buffet's HF endpoint transport; direct models with provider `google`/`openai` must fall through to the generic `clients.get(provider)` dispatch. In `create_advanced_response`: add the guard at entry — direct models return via the non-agent path before any research/tool machinery. `models_config.py` per spec §4.1.
 
 - [ ] **Step 4: Run the new tests + the existing OpenAI-API suite**
 
@@ -348,7 +350,7 @@ def test_finsearch_trader_priced():
 **Files:**
 - Modify: `dashboard/config/leaderboard.json` — append the entry **exactly as spec §5** (the authoritative copy; note the `model` display string must name the underlying model + "tools off")
 - Modify: `.env.example` — add `FINSEARCH_BASE_URL=` beside the OpenRouter block (`FINGPT_API_KEY` is added by Plan 1's Task 7; if that hasn't merged yet, add it here). **No `FINSEARCH_MODE`/`FINSEARCH_MODEL` vars** — deliberately not knobs.
-- Modify: `dashboard/scripts/deploy_leaderboard_model.py` docstring (`:12-21`) — the required-secrets list gains `FINGPT_API_KEY` for `finsearch`
+- Modify: `dashboard/scripts/deploy_leaderboard_model.py` docstring (the required-secrets parenthetical at `:22-23` — lines 12-21 are the usage examples) — gains `FINGPT_API_KEY` for `finsearch`
 
 - [ ] **Step 1: Apply the three edits.**
 - [ ] **Step 2: Sanity test** — `python3 dashboard/scripts/deploy_leaderboard_model.py --entry agentic_finsearch --list` (**`--entry` is `required=True`** at `deploy_leaderboard_model.py:55` — bare `--list` exits 2 before listing) shows the entry with integration `finsearch`; `pytest dashboard/backend/tests/domain/leaderboard/ -v` → PASS.

--- a/docs/superpowers/plans/2026-07-13-finsearch-leaderboard-agent.md
+++ b/docs/superpowers/plans/2026-07-13-finsearch-leaderboard-agent.md
@@ -1,0 +1,369 @@
+# Agentic FinSearch as a Leaderboard Trading Agent — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Put Agentic FinSearch on the leaderboard exactly like the other model entries — AF-side professional-trader persona (direct, tools-off path), ATL-side `finsearch` provider shim, config entry, pricing, then the contest run + seed refresh.
+
+**Architecture:** Task 1 lands in the **Agentic-FinSearch repo** (persona + config-driven direct path, generalizing the existing buffet branch). Tasks 2–5 land in **ATL** (provider module following the PR #96 OpenRouter pattern, leaderboard.json entry, pricing row, env docs). Task 6 is the run itself (smoke → full window → seed-DB commit) — the same recipe the six existing LLM entries used.
+
+**Tech Stack:** Django + OpenAI-compatible view (AF), `requests` shim returning Anthropic-shaped objects (ATL), `deploy_leaderboard_model.py` (run), SQLite seed DB commit.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md`.
+
+## Global Constraints
+
+- **No look-ahead:** the leaderboard entry must only ever call AF's direct, tools-off path (`FinSearch-Trader`). Never point `FINSEARCH_MODE`/model at a tool-attached mode for a backtest run.
+- **Never pass `--allow-fallback`** to the deploy script — H6 exists to stop exactly that.
+- ATL provider contract (from `providers/__init__.py:1-13`): module exposes `INTEGRATION_ID`, `DEFAULT_MODEL`, `default_model_name()`, `make_client(anthropic_cls)`; `make_client` returns `None` on missing key (printed warning, never raises); registered in `PROVIDERS`; never auto-selected.
+- Seed-DB commits: regenerate via the deploy script, snapshot with `VACUUM INTO` from an isolated git worktree (WAL mode), commit the binary + config diffs together. Always set `DATABASE_PATH` when smoke-testing so the committed seed stays clean.
+- AF repo tests run via `cd Main/backend && uv run pytest`; ATL tests via `pytest dashboard/backend/tests/ -v` from the repo root.
+- `CommonStack` hijack gotcha: `resolve_integration()` prefers CommonStack when `COMMONSTACK_API_KEY` is set and no integration is explicit — the leaderboard entry sets `"integration": "finsearch"` explicitly, so this cannot bite; do not remove that field.
+
+---
+
+### Task 1 (Agentic-FinSearch repo): trader persona + config-driven direct path
+
+**Repo:** `/mnt/d/FinGPT/Github/fingpt_rcos` — own branch + PR there (reference this plan in the PR body).
+
+**Files:**
+- Modify: `Main/backend/datascraper/datascraper.py` (persona registry near `BUFFETT_INSTRUCTION` at `:101-111`; direct-path branch at `:1015-1021`; instruction selection in `_prepare_messages` at `:281-291`)
+- Modify: `Main/backend/datascraper/models_config.py:6-40` (new `FinSearch-Trader` entry; add `"direct": True, "persona": "buffett"` to `Buffet-Agent`)
+- Test: `Main/backend/tests/test_trader_persona.py` (new; mirror the buffet cases in `tests/test_openai_api.py`)
+
+**Interfaces:**
+- Produces: `MODELS_CONFIG["FinSearch-Trader"]` reachable via `POST /v1/chat/completions {"model": "FinSearch-Trader", "mode": "normal", ...}`; response is standard OpenAI shape (no tools ever invoked); `TRADER_INSTRUCTION` and `PERSONA_INSTRUCTIONS` constants.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Main/backend/tests/test_trader_persona.py
+from datascraper.models_config import MODELS_CONFIG
+from datascraper import datascraper as ds
+
+
+def test_finsearch_trader_registered():
+    cfg = MODELS_CONFIG["FinSearch-Trader"]
+    assert cfg["direct"] is True
+    assert cfg["persona"] == "trader"
+
+
+def test_persona_registry_selects_trader():
+    assert ds.PERSONA_INSTRUCTIONS["trader"] is ds.TRADER_INSTRUCTION
+    assert ds.PERSONA_INSTRUCTIONS["buffett"] is ds.BUFFETT_INSTRUCTION
+
+
+def test_prepare_messages_uses_trader_instruction():
+    # real signature: _prepare_messages(message_list, user_input, model=None)
+    # -> (msgs, system_message)   (datascraper.py:245-297)
+    msgs, _system = ds._prepare_messages([], "What do you do?",
+                                         model="FinSearch-Trader")
+    joined = " ".join(m.get("content", "") for m in msgs)
+    assert "FinSearch Trader" in joined          # persona applied
+    assert "Warren Buffett" not in joined
+
+
+def test_buffet_still_uses_buffett_instruction():
+    msgs, _system = ds._prepare_messages([], "hi", model="Buffet-Agent")
+    joined = " ".join(m.get("content", "") for m in msgs)
+    assert "Warren Buffett" in joined
+```
+
+- [ ] **Step 2: Run to verify failure** — `cd Main/backend && uv run pytest tests/test_trader_persona.py -v` → FAIL (`KeyError: 'FinSearch-Trader'`).
+
+- [ ] **Step 3: Implement**
+
+```python
+# datascraper.py — beside BUFFETT_INSTRUCTION
+TRADER_INSTRUCTION = (
+    "You are FinSearch Trader, a disciplined professional equities trader. "
+    "You manage positions with a risk-first process: capital preservation precedes "
+    "return-seeking; you size positions to conviction and cut losers rather than "
+    "average down into a failing thesis. You reason strictly from the evidence you "
+    "are given — prices, technical indicators, portfolio state, and any provided "
+    "news — and you never invent data you were not shown. When evidence is mixed "
+    "you prefer holding over churning, and you can say why in one or two sentences. "
+    "When a request specifies an output format or schema, you follow it exactly: "
+    "no extra prose, no markdown fences, no disclaimers."
+)
+
+PERSONA_INSTRUCTIONS = {
+    "buffett": BUFFETT_INSTRUCTION,
+    "trader": TRADER_INSTRUCTION,
+}
+```
+
+- In `_prepare_messages` (`:281-291`, the exact current selection is
+  `instruction = INSTRUCTION`; `if model:` → `get_model_config(model)` → `if model_config and model_config.get("provider") == "buffet": instruction = BUFFETT_INSTRUCTION`):
+  replace the provider check with
+  `instruction = PERSONA_INSTRUCTIONS.get(model_config.get("persona"), INSTRUCTION) if model_config else INSTRUCTION`
+  and generalize the log line (`logging.info("[PERSONA] Using %s system prompt", persona)`).
+- In `create_agent_response` (`:1015-1021`): replace `provider == "buffet"` with
+  `model_config.get("direct") or provider == "buffet"` (belt-and-suspenders; config now carries `direct: True` for buffet too).
+- `models_config.py`: add the `FinSearch-Trader` entry exactly as in spec §4.1 (provider `google` / `gemini-3-flash-preview`; **verify at impl time that the direct path's google client works — if flaky, the sanctioned fallback is provider `openai` / `gpt-5.1-chat-latest`**), and add `"direct": True, "persona": "buffett"` to `Buffet-Agent`.
+
+- [ ] **Step 4: Run the new tests + the existing OpenAI-API suite**
+
+Run: `cd Main/backend && uv run pytest tests/test_trader_persona.py tests/test_openai_api.py -v`
+Expected: PASS (buffet behavior unchanged; `/v1/models` test may need its expected-count updated — that update belongs in this task).
+
+- [ ] **Step 5: One manual live check** (needs env keys): `curl -s -X POST http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"FinSearch-Trader","mode":"normal","messages":[{"role":"user","content":"Reply with exactly the JSON {\"ok\": true} and nothing else."}]}'` → `choices[0].message.content` is exactly `{"ok": true}` (format-compliance clause working).
+
+- [ ] **Step 6: Docs + commit + PR.** Add the model row to `Docs/source/api_reference.rst`'s model table. Commit, push branch `feat/trader-persona`, open PR against the repo's current working convention (recent precedent: PRs to `main`), body references this plan. Review before merging (loop protocol).
+
+---
+
+### Task 2 (ATL): `finsearch` provider module
+
+**Files:**
+- Create: `dashboard/backend/infrastructure/llm/providers/finsearch.py`
+- Modify: `dashboard/backend/infrastructure/llm/providers/__init__.py:31-35` (register in `PROVIDERS`)
+- Test: `dashboard/backend/tests/llm/test_providers.py` (extend — the provider-contract cases added by PR #96 are the template)
+
+**Interfaces:**
+- Consumes: nothing from other tasks (independent of Task 1 until the run).
+- Produces: `INTEGRATION_ID = "finsearch"`; `make_client(anthropic_cls) -> FinSearchClient | None`; `FinSearchClient.messages.create(model, max_tokens, messages, system=None, **kw)` returning an object with `.content` (list of one `type="text"` block) and `.usage.input_tokens/.output_tokens`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to dashboard/backend/tests/llm/test_providers.py
+from types import SimpleNamespace
+
+from dashboard.backend.infrastructure.llm.providers import (PROVIDERS,
+                                                            resolve_integration)
+from dashboard.backend.infrastructure.llm.providers import finsearch
+
+
+def test_finsearch_registered():
+    assert PROVIDERS["finsearch"] is finsearch
+    assert finsearch.DEFAULT_MODEL == "FinSearch-Trader"
+    assert finsearch.default_model_name() == "FinSearch-Trader"
+
+
+def test_finsearch_never_auto_selected(monkeypatch):
+    monkeypatch.delenv("COMMONSTACK_API_KEY", raising=False)
+    assert resolve_integration(None) != "finsearch"
+
+
+def test_finsearch_client_none_without_key(monkeypatch, capsys):
+    monkeypatch.delenv("FINGPT_API_KEY", raising=False)
+    assert finsearch.make_client(object) is None
+    assert "FINGPT_API_KEY" in capsys.readouterr().out
+
+
+def test_finsearch_messages_create_shapes_anthropic_response(monkeypatch):
+    monkeypatch.setenv("FINGPT_API_KEY", "k")
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured.update(url=url, json=json, headers=headers, timeout=timeout)
+        return SimpleNamespace(
+            status_code=200,
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "choices": [{"message": {"role": "assistant",
+                                         "content": '{"actions": []}'},
+                             "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 100, "completion_tokens": 8,
+                          "total_tokens": 108},
+            },
+        )
+
+    monkeypatch.setattr(finsearch, "_post", fake_post)
+    client = finsearch.make_client(object)
+    resp = client.messages.create(
+        model="FinSearch-Trader", max_tokens=2000,
+        messages=[{"role": "user", "content": "prompt"}], system="sys",
+    )
+    assert captured["json"]["model"] == "FinSearch-Trader"
+    assert captured["json"]["mode"] == "normal"
+    assert captured["json"]["messages"][0] == {"role": "system", "content": "sys"}
+    assert captured["headers"]["Authorization"] == "Bearer k"
+    assert resp.content[0].type == "text"
+    assert resp.content[0].text == '{"actions": []}'
+    assert resp.usage.input_tokens == 100 and resp.usage.output_tokens == 8
+```
+
+- [ ] **Step 2: Run to verify failure** — `pytest dashboard/backend/tests/llm/test_providers.py -v -k finsearch` → FAIL (import error).
+
+- [ ] **Step 3: Implement**
+
+```python
+# dashboard/backend/infrastructure/llm/providers/finsearch.py
+"""Agentic FinSearch gateway — Anthropic-shaped shim over AF's OpenAI-compatible /v1.
+
+Contract asymmetries (accepted): AF ignores max_tokens/temperature (LLM_MAX_OUTPUT_TOKENS
+is a no-op here); AF's usage tokens are char-count estimates (len//4), so costs are
+approximate; AF requires a `mode` field — the shim supplies FINSEARCH_MODE (default
+"normal"). Leaderboard runs must target the direct, tools-off FinSearch-Trader model:
+tool-attached modes would look ahead in a backtest.
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import requests
+
+INTEGRATION_ID = "finsearch"
+DEFAULT_MODEL = "FinSearch-Trader"
+DEFAULT_BASE_URL = "https://agenticfinsearch.org"
+_TIMEOUT_SECONDS = 150  # AF's gunicorn kills at 120s; margin classifies failures client-side
+
+
+def default_model_name() -> str:
+    return os.environ.get("FINSEARCH_MODEL", DEFAULT_MODEL)
+
+
+def _post(url, json=None, headers=None, timeout=None):
+    return requests.post(url, json=json, headers=headers, timeout=timeout)
+
+
+class _FinSearchMessages:
+    def create(self, *, model, max_tokens=None, messages=None, system=None, **_):
+        url = os.environ.get("FINSEARCH_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+        payload_messages = list(messages or [])
+        if system:
+            payload_messages.insert(0, {"role": "system", "content": system})
+        resp = _post(
+            f"{url}/v1/chat/completions",
+            json={
+                "model": model or default_model_name(),
+                "mode": os.environ.get("FINSEARCH_MODE", "normal"),
+                "messages": payload_messages,
+            },
+            headers={"Authorization": f"Bearer {os.environ['FINGPT_API_KEY']}"},
+            timeout=_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        text = body["choices"][0]["message"]["content"]
+        usage = body.get("usage") or {}
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text=text)],
+            usage=SimpleNamespace(
+                input_tokens=int(usage.get("prompt_tokens", 0)),
+                output_tokens=int(usage.get("completion_tokens", 0)),
+            ),
+        )
+
+
+class FinSearchClient:
+    def __init__(self):
+        self.messages = _FinSearchMessages()
+
+
+def make_client(anthropic_cls):
+    if not os.environ.get("FINGPT_API_KEY"):
+        print("[finsearch] FINGPT_API_KEY not set — finsearch integration unavailable")
+        return None
+    return FinSearchClient()
+```
+
+Register in `providers/__init__.py` `PROVIDERS` dict (import the module, add `finsearch.INTEGRATION_ID: finsearch`).
+
+- [ ] **Step 4: Run** — `pytest dashboard/backend/tests/llm/test_providers.py -v` → PASS (including the pre-existing provider-contract sweep, which iterates `PROVIDERS` — the new module must satisfy it).
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(llm): finsearch provider — Anthropic shim over AF /v1 (tools-off trader model)"`.
+
+---
+
+### Task 3 (ATL): pricing row
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/token_cost.py:27-58` (`_PRICING_TABLE`)
+- Test: `dashboard/backend/tests/llm/` (wherever token-cost cases live — Grep `estimate_cost_usd` under tests)
+
+- [ ] **Step 1: Failing test** — `estimate_cost_usd("FinSearch-Trader", 1_000_000, 1_000_000)` equals the underlying model's list price sum, not the `(1.0, 5.0)` default.
+
+```python
+def test_finsearch_trader_priced():
+    from dashboard.backend.infrastructure.llm.token_cost import estimate_cost_usd
+    cost = estimate_cost_usd("FinSearch-Trader", 1_000_000, 1_000_000)
+    assert cost != 6.0  # not the default (1.0 + 5.0) — a real row must match first
+```
+
+- [ ] **Step 2: Add the row** — `("FinSearch-Trader", <in>, <out>)` at the underlying foundation model's **current list price** (verify gemini-3-flash-preview's published rate at impl time; if Task 1 fell back to `gpt-5.1-chat-latest`, use that model's rate). Comment the row with the upstream model + verification date.
+- [ ] **Step 3: Run + commit** — `pytest dashboard/backend/tests/llm/ -v` → PASS; `git commit -m "feat(llm): FinSearch-Trader pricing row (approx upstream spend)"`.
+
+---
+
+### Task 4 (ATL): leaderboard entry + env docs
+
+**Files:**
+- Modify: `dashboard/config/leaderboard.json` (append to `strategies` after the Nemotron entry at `:127-139`)
+- Modify: `.env.example` (add `FINSEARCH_BASE_URL=`, `FINSEARCH_MODE=normal`, `FINSEARCH_MODEL=` beside the OpenRouter block; `FINGPT_API_KEY` is added by Plan 1's Task 7 — if that hasn't merged yet, add it here)
+
+- [ ] **Step 1: Add the entry**
+
+```json
+{
+  "id": "agentic_finsearch",
+  "name": "Agentic FinSearch",
+  "label": "Model",
+  "model": "FinSearch Trader",
+  "provider": "SecureFinAI Lab",
+  "strategy": "llm_agent",
+  "integration": "finsearch",
+  "model_id": "FinSearch-Trader",
+  "mode": "safe_trading",
+  "symbols": [],
+  "auto_compute": false
+}
+```
+
+- [ ] **Step 2: Sanity test** — `python3 dashboard/scripts/deploy_leaderboard_model.py --list` shows the entry with integration `finsearch`; `pytest dashboard/backend/tests/domain/leaderboard/ -v` → PASS (config-shape guards).
+- [ ] **Step 3: Commit** — `git commit -m "feat(leaderboard): Agentic FinSearch entry (finsearch integration, manual deploy)"`.
+
+---
+
+### Task 5 (ops): environment for the run
+
+Manual checklist (no code):
+
+- [ ] AF droplet: raise `AGENT_DAILY_RUN_BUDGET` to `500` for the run window (env for the `fingpt-api` unit; the deploy-owned env file — same place `FINGPT_API_KEY`/`REQUIRE_FINGPT_API_KEY` live). Revert after the run if desired.
+- [ ] Local ATL `dashboard/.env`: `FINGPT_API_KEY=<the FinSearch backend key>`; optionally `FINSEARCH_BASE_URL` if targeting staging.
+- [ ] Confirm AF prod is serving `FinSearch-Trader` (Task 1 merged + deployed): the Step-5 curl from Task 1, against `https://agenticfinsearch.org`.
+
+---
+
+### Task 6: smoke run → full run → seed refresh
+
+- [ ] **Step 1: Smoke (1 trading day, costs cents)**
+
+```bash
+DATABASE_PATH=/tmp/atl-smoke.db python3 dashboard/scripts/deploy_leaderboard_model.py \
+  --entry agentic_finsearch --start 2026-04-15 --end 2026-04-16
+```
+
+Expected: exits 0; printed coverage 100% (or ≥95%); no `LeaderboardFallbackError`. If it exits 2, diagnose (auth? model key? JSON compliance?) — do NOT proceed to the full window.
+
+- [ ] **Step 2: Full contest window** (161 steps; direct path ≈ seconds/call → well under an hour)
+
+```bash
+python3 dashboard/scripts/deploy_leaderboard_model.py --entry agentic_finsearch
+```
+
+Expected: exits 0, H6 passes, run row written to `dashboard/storage/data/backtest.db`.
+
+- [ ] **Step 3: Seed refresh commit** (worktree + VACUUM INTO pattern)
+
+```bash
+sqlite3 dashboard/storage/data/backtest.db "VACUUM INTO '/tmp/backtest-snapshot.db'"
+git worktree add /tmp/atl-seed-refresh main
+cp /tmp/backtest-snapshot.db /tmp/atl-seed-refresh/dashboard/storage/data/backtest.db
+# commit there alongside the leaderboard.json/provider diffs if not already merged
+```
+
+- [ ] **Step 4: Verify display** — locally: `uvicorn dashboard.backend.app:app` → `/app` → Competition → Leaderboard shows "Agentic FinSearch" with curve, return, Sharpe (zero frontend edits). After merge: prod auto-deploys (PR #95 hook) → `GET /api/v1/leaderboard?refresh=true` → verify live.
+- [ ] **Step 5: `/code-review` + merge** per the loop protocol.
+
+---
+
+## Verification (whole plan)
+
+1. AF: `uv run pytest` green including new persona tests; live curl proves format compliance.
+2. ATL: `pytest dashboard/backend/tests/ -v` fully green.
+3. H6 guard passes on the real full-window run — **the** acceptance gate.
+4. Leaderboard page renders the entry with no frontend diff (`git diff --stat` shows none under `dashboard/frontend/`).
+5. Both repos' PRs self-reviewed before merge.

--- a/docs/superpowers/plans/2026-07-13-finsearch-leaderboard-agent.md
+++ b/docs/superpowers/plans/2026-07-13-finsearch-leaderboard-agent.md
@@ -2,36 +2,41 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Put Agentic FinSearch on the leaderboard exactly like the other model entries — AF-side professional-trader persona (direct, tools-off path), ATL-side `finsearch` provider shim, config entry, pricing, then the contest run + seed refresh.
+**Goal:** Put Agentic FinSearch on the leaderboard exactly like the other model entries — AF-side professional-trader persona (direct, tools-off path, structurally guarded), ATL-side `finsearch` provider shim, config entry, pricing, then the contest run + seed refresh.
 
-**Architecture:** Task 1 lands in the **Agentic-FinSearch repo** (persona + config-driven direct path, generalizing the existing buffet branch). Tasks 2–5 land in **ATL** (provider module following the PR #96 OpenRouter pattern, leaderboard.json entry, pricing row, env docs). Task 6 is the run itself (smoke → full window → seed-DB commit) — the same recipe the six existing LLM entries used.
+**Architecture:** Task 1 lands in the **Agentic-FinSearch repo** (persona prompt files + config-driven direct path closing all four buffet-literal gates plus the research-mode dispatch gap). Tasks 2–5 land in **ATL** (provider module over the already-pinned `openai` SDK following the PR #96 pattern, leaderboard.json entry, pricing row, env docs). Task 6 is the run itself (smoke → budget gate → full window → seed-DB commit → budget revert).
 
-**Tech Stack:** Django + OpenAI-compatible view (AF), `requests` shim returning Anthropic-shaped objects (ATL), `deploy_leaderboard_model.py` (run), SQLite seed DB commit.
+**Tech Stack:** Django + OpenAI-compatible view (AF), `openai==1.101.0` SDK shim returning Anthropic-shaped objects (ATL), `deploy_leaderboard_model.py` (run), SQLite seed DB commit.
 
-**Spec:** `docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md`.
+**Spec:** `docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md` — the spec's code/config blocks (§4.1 config, §4.2 persona text, §5 leaderboard entry) are the **single authoritative copies**; this plan references them instead of duplicating.
 
 ## Global Constraints
 
-- **No look-ahead:** the leaderboard entry must only ever call AF's direct, tools-off path (`FinSearch-Trader`). Never point `FINSEARCH_MODE`/model at a tool-attached mode for a backtest run.
+- **No look-ahead, structurally:** the shim hardcodes `mode: "normal"` (no env knob can select a tool-attached mode) and raises on any response with non-empty `sources` (AF's tool paths populate it; the direct path leaves it empty). AF-side, `direct: True` must route to the direct path for **every** mode and transport (spec §3).
 - **Never pass `--allow-fallback`** to the deploy script — H6 exists to stop exactly that.
-- ATL provider contract (from `providers/__init__.py:1-13`): module exposes `INTEGRATION_ID`, `DEFAULT_MODEL`, `default_model_name()`, `make_client(anthropic_cls)`; `make_client` returns `None` on missing key (printed warning, never raises); registered in `PROVIDERS`; never auto-selected.
-- Seed-DB commits: regenerate via the deploy script, snapshot with `VACUUM INTO` from an isolated git worktree (WAL mode), commit the binary + config diffs together. Always set `DATABASE_PATH` when smoke-testing so the committed seed stays clean.
+- **MODELS_CONFIG schema:** the model field key is **`model_name`** (read at `datascraper.py:219,524,1012`) and the streaming flag is **`streaming`** (read at `:1384`). Copy the spec §4.1 block exactly — earlier drafts with `model`/`supports_streaming` keys would make every call send `model=None`.
+- ATL provider contract (from `providers/__init__.py:1-13` + the three existing modules): expose `INTEGRATION_ID`, `DEFAULT_MODEL`, `default_model_name()`, `make_client(anthropic_cls)`; `make_client` returns `None` and never raises when the key is absent (the existing providers do this silently; finsearch additionally prints a hint — its own choice, not a contract requirement); registered in `PROVIDERS`; never auto-selected.
+- **Golden-set tests:** registering a provider changes `KNOWN_INTEGRATIONS` — `tests/llm/test_providers.py::test_known_integrations_are_parallel_siblings` (`:19-23`) hardcodes the integration set and must be updated in the same commit (same staleness family as the route-contract freezes that blocked PRs #88–#91).
+- Seed-DB commits: regenerate via the deploy script, snapshot with `VACUUM INTO` from an isolated **detached** worktree, commit the binary + config diffs together. Always set `DATABASE_PATH` when smoke-testing so the committed seed stays clean.
 - AF repo tests run via `cd Main/backend && uv run pytest`; ATL tests via `pytest dashboard/backend/tests/ -v` from the repo root.
 - `CommonStack` hijack gotcha: `resolve_integration()` prefers CommonStack when `COMMONSTACK_API_KEY` is set and no integration is explicit — the leaderboard entry sets `"integration": "finsearch"` explicitly, so this cannot bite; do not remove that field.
 
 ---
 
-### Task 1 (Agentic-FinSearch repo): trader persona + config-driven direct path
+### Task 1 (Agentic-FinSearch repo): trader persona + structurally-guarded direct path
 
-**Repo:** `/mnt/d/FinGPT/Github/fingpt_rcos` — own branch + PR there (reference this plan in the PR body).
+**Repo:** `/mnt/d/FinGPT/Github/fingpt_rcos` — branch `flymiss_trader-persona`, PR per spec §4.3's branching note (default: PR to `main` per operational precedent #338/#354–#356; Felix may retarget to the CONTRIBUTING.md staging chain).
 
 **Files:**
-- Modify: `Main/backend/datascraper/datascraper.py` (persona registry near `BUFFETT_INSTRUCTION` at `:101-111`; direct-path branch at `:1015-1021`; instruction selection in `_prepare_messages` at `:281-291`)
-- Modify: `Main/backend/datascraper/models_config.py:6-40` (new `FinSearch-Trader` entry; add `"direct": True, "persona": "buffett"` to `Buffet-Agent`)
-- Test: `Main/backend/tests/test_trader_persona.py` (new; mirror the buffet cases in `tests/test_openai_api.py`)
+- Create: `Main/backend/prompts/personas/trader.md` (persona text: spec §4.2 — the authoritative copy)
+- Create: `Main/backend/prompts/personas/buffett.md` (migrate `BUFFETT_INSTRUCTION` text verbatim)
+- Modify: `Main/backend/datascraper/datascraper.py` — persona loader (same idiom as `_load_security_fragment`, `datascraper.py:66-75`); replace **all four** `provider == "buffet"` literals (`:284` `_prepare_messages`, `:531` `create_response`, `:1015` `create_agent_response`, `:1259` `create_agent_response_stream`) with config-driven `direct`/`persona`; add the research-mode dispatch guard in `create_advanced_response` (direct models short-circuit to the direct path before any tool machinery)
+- Modify: `Main/backend/datascraper/models_config.py` — add the `FinSearch-Trader` entry **exactly as spec §4.1** (`model_name`/`streaming` keys); add `"direct": True, "persona": "buffett"` to `Buffet-Agent`
+- Modify: `Docs/source/api_reference.rst` (model table row)
+- Test: `Main/backend/tests/test_trader_persona.py` (new)
 
 **Interfaces:**
-- Produces: `MODELS_CONFIG["FinSearch-Trader"]` reachable via `POST /v1/chat/completions {"model": "FinSearch-Trader", "mode": "normal", ...}`; response is standard OpenAI shape (no tools ever invoked); `TRADER_INSTRUCTION` and `PERSONA_INSTRUCTIONS` constants.
+- Produces: `MODELS_CONFIG["FinSearch-Trader"]` reachable via `POST /v1/chat/completions {"model": "FinSearch-Trader", "mode": "normal", ...}` on the direct path for every mode/transport; response is standard OpenAI shape with empty `sources`; `load_persona_instruction(name) -> str` loader.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -41,15 +46,20 @@ from datascraper.models_config import MODELS_CONFIG
 from datascraper import datascraper as ds
 
 
-def test_finsearch_trader_registered():
+def test_finsearch_trader_registered_with_real_schema_keys():
     cfg = MODELS_CONFIG["FinSearch-Trader"]
     assert cfg["direct"] is True
     assert cfg["persona"] == "trader"
+    assert cfg["model_name"]            # the key every read site uses
+    assert cfg["streaming"] is False    # the key datascraper.py:1384 reads
+    assert "model" not in cfg or cfg.get("model_name")  # no dead 'model' key
 
 
-def test_persona_registry_selects_trader():
-    assert ds.PERSONA_INSTRUCTIONS["trader"] is ds.TRADER_INSTRUCTION
-    assert ds.PERSONA_INSTRUCTIONS["buffett"] is ds.BUFFETT_INSTRUCTION
+def test_persona_loader_reads_prompt_files():
+    trader = ds.load_persona_instruction("trader")
+    buffett = ds.load_persona_instruction("buffett")
+    assert "FinSearch Trader" in trader
+    assert "Warren Buffett" in buffett
 
 
 def test_prepare_messages_uses_trader_instruction():
@@ -66,49 +76,59 @@ def test_buffet_still_uses_buffett_instruction():
     msgs, _system = ds._prepare_messages([], "hi", model="Buffet-Agent")
     joined = " ".join(m.get("content", "") for m in msgs)
     assert "Warren Buffett" in joined
+
+
+def test_direct_models_never_reach_tool_paths():
+    """Routing matrix: FinSearch-Trader x {normal, thinking, research} must
+    take the direct path (no agent/tool machinery). Assert via the same seam
+    the existing buffet tests use (patch create_response / the agent runner
+    and check which one is invoked)."""
+    # for each mode in ("normal", "thinking", "research"):
+    #     patch ds.create_response and the agent-path entrypoint;
+    #     call the mode's dispatch with model="FinSearch-Trader";
+    #     assert create_response called, agent path NOT called.
 ```
+
+(The routing-matrix test body follows whatever seam `tests/test_openai_api.py` already patches for the buffet skip-agent case — reuse that fixture pattern; the invariant is the assertion, and it must cover the **research** dispatch too, which today has no direct check at all.)
 
 - [ ] **Step 2: Run to verify failure** — `cd Main/backend && uv run pytest tests/test_trader_persona.py -v` → FAIL (`KeyError: 'FinSearch-Trader'`).
 
-- [ ] **Step 3: Implement**
+- [ ] **Step 3: Implement.** Persona files per spec §4.2; loader:
 
 ```python
-# datascraper.py — beside BUFFETT_INSTRUCTION
-TRADER_INSTRUCTION = (
-    "You are FinSearch Trader, a disciplined professional equities trader. "
-    "You manage positions with a risk-first process: capital preservation precedes "
-    "return-seeking; you size positions to conviction and cut losers rather than "
-    "average down into a failing thesis. You reason strictly from the evidence you "
-    "are given — prices, technical indicators, portfolio state, and any provided "
-    "news — and you never invent data you were not shown. When evidence is mixed "
-    "you prefer holding over churning, and you can say why in one or two sentences. "
-    "When a request specifies an output format or schema, you follow it exactly: "
-    "no extra prose, no markdown fences, no disclaimers."
-)
+_PERSONA_DIR = Path(__file__).resolve().parent.parent / "prompts" / "personas"
+_PERSONA_FALLBACKS = {"buffett": BUFFETT_INSTRUCTION}  # in-code fallback if file missing
 
-PERSONA_INSTRUCTIONS = {
-    "buffett": BUFFETT_INSTRUCTION,
-    "trader": TRADER_INSTRUCTION,
-}
+def load_persona_instruction(name: str) -> str:
+    path = _PERSONA_DIR / f"{name}.md"
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return _PERSONA_FALLBACKS.get(name, INSTRUCTION)
 ```
 
-- In `_prepare_messages` (`:281-291`, the exact current selection is
-  `instruction = INSTRUCTION`; `if model:` → `get_model_config(model)` → `if model_config and model_config.get("provider") == "buffet": instruction = BUFFETT_INSTRUCTION`):
-  replace the provider check with
-  `instruction = PERSONA_INSTRUCTIONS.get(model_config.get("persona"), INSTRUCTION) if model_config else INSTRUCTION`
-  and generalize the log line (`logging.info("[PERSONA] Using %s system prompt", persona)`).
-- In `create_agent_response` (`:1015-1021`): replace `provider == "buffet"` with
-  `model_config.get("direct") or provider == "buffet"` (belt-and-suspenders; config now carries `direct: True` for buffet too).
-- `models_config.py`: add the `FinSearch-Trader` entry exactly as in spec §4.1 (provider `google` / `gemini-3-flash-preview`; **verify at impl time that the direct path's google client works — if flaky, the sanctioned fallback is provider `openai` / `gpt-5.1-chat-latest`**), and add `"direct": True, "persona": "buffett"` to `Buffet-Agent`.
+In `_prepare_messages` (`:281-291`) replace the buffet literal with:
+
+```python
+    instruction = INSTRUCTION
+    if model:
+        model_config = get_model_config(model)
+        persona = (model_config or {}).get("persona")
+        if persona:
+            instruction = load_persona_instruction(persona)
+            logging.info("[PERSONA] Using %s system prompt", persona)
+```
+
+In `create_agent_response` (`:1015`), `create_response` (`:531`), `create_agent_response_stream` (`:1259`): replace `provider == "buffet"` with `model_config.get("direct")` (config now carries it for buffet — no dead `or` disjunct). In `create_advanced_response`: add the guard at entry — `if model_config.get("direct"): return await/call the direct path` — before any research/tool machinery. `models_config.py` per spec §4.1.
 
 - [ ] **Step 4: Run the new tests + the existing OpenAI-API suite**
 
 Run: `cd Main/backend && uv run pytest tests/test_trader_persona.py tests/test_openai_api.py -v`
-Expected: PASS (buffet behavior unchanged; `/v1/models` test may need its expected-count updated — that update belongs in this task).
+Expected: PASS (buffet behavior unchanged; `/v1/models` count assertions updated in this task if they pin a count).
 
-- [ ] **Step 5: One manual live check** (needs env keys): `curl -s -X POST http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"FinSearch-Trader","mode":"normal","messages":[{"role":"user","content":"Reply with exactly the JSON {\"ok\": true} and nothing else."}]}'` → `choices[0].message.content` is exactly `{"ok": true}` (format-compliance clause working).
+- [ ] **Step 5: One manual live check** (needs env keys): `curl -s -X POST http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"FinSearch-Trader","mode":"normal","messages":[{"role":"user","content":"Reply with exactly the JSON {\"ok\": true} and nothing else."}]}'` → `choices[0].message.content` is exactly `{"ok": true}` (format compliance) and `sources` is `[]` (direct path). This is also the moment to verify provider `google` works on the direct path; if not, flip the entry to the sanctioned openai fallback (spec §9.1) and update the leaderboard `model` display string (spec §5).
 
-- [ ] **Step 6: Docs + commit + PR.** Add the model row to `Docs/source/api_reference.rst`'s model table. Commit, push branch `feat/trader-persona`, open PR against the repo's current working convention (recent precedent: PRs to `main`), body references this plan. Review before merging (loop protocol).
+- [ ] **Step 6: Docs + commit + PR.** Push `flymiss_trader-persona`, open the PR (body references this plan + spec), review before merging (loop protocol).
 
 ---
 
@@ -117,17 +137,19 @@ Expected: PASS (buffet behavior unchanged; `/v1/models` test may need its expect
 **Files:**
 - Create: `dashboard/backend/infrastructure/llm/providers/finsearch.py`
 - Modify: `dashboard/backend/infrastructure/llm/providers/__init__.py:31-35` (register in `PROVIDERS`)
-- Test: `dashboard/backend/tests/llm/test_providers.py` (extend — the provider-contract cases added by PR #96 are the template)
+- Modify: `dashboard/backend/tests/llm/test_providers.py` — new finsearch cases **and** update `test_known_integrations_are_parallel_siblings` (`:19-23`) to the four-member set
 
 **Interfaces:**
 - Consumes: nothing from other tasks (independent of Task 1 until the run).
-- Produces: `INTEGRATION_ID = "finsearch"`; `make_client(anthropic_cls) -> FinSearchClient | None`; `FinSearchClient.messages.create(model, max_tokens, messages, system=None, **kw)` returning an object with `.content` (list of one `type="text"` block) and `.usage.input_tokens/.output_tokens`.
+- Produces: `INTEGRATION_ID = "finsearch"`; `make_client(anthropic_cls) -> FinSearchClient | None`; `FinSearchClient.messages.create(model, max_tokens, messages, system=None, **kw)` returning an object with `.content` (one `type="text"` block) and `.usage.input_tokens/.output_tokens`; raises `LookAheadTripwire` on non-empty `sources`.
 
 - [ ] **Step 1: Write the failing tests**
 
 ```python
 # append to dashboard/backend/tests/llm/test_providers.py
 from types import SimpleNamespace
+
+import pytest
 
 from dashboard.backend.infrastructure.llm.providers import (PROVIDERS,
                                                             resolve_integration)
@@ -151,38 +173,58 @@ def test_finsearch_client_none_without_key(monkeypatch, capsys):
     assert "FINGPT_API_KEY" in capsys.readouterr().out
 
 
+def _fake_completion(content='{"actions": []}', sources=None):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(
+            content=content, sources=sources), finish_reason="stop")],
+        usage=SimpleNamespace(prompt_tokens=100, completion_tokens=8),
+        sources=sources or [],
+    )
+
+
+class _FakeSDK:
+    def __init__(self):
+        self.calls = []
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+        self._response = _fake_completion()
+
+    def _create(self, **kw):
+        self.calls.append(kw)
+        return self._response
+
+
 def test_finsearch_messages_create_shapes_anthropic_response(monkeypatch):
     monkeypatch.setenv("FINGPT_API_KEY", "k")
-    captured = {}
-
-    def fake_post(url, json=None, headers=None, timeout=None):
-        captured.update(url=url, json=json, headers=headers, timeout=timeout)
-        return SimpleNamespace(
-            status_code=200,
-            raise_for_status=lambda: None,
-            json=lambda: {
-                "choices": [{"message": {"role": "assistant",
-                                         "content": '{"actions": []}'},
-                             "finish_reason": "stop"}],
-                "usage": {"prompt_tokens": 100, "completion_tokens": 8,
-                          "total_tokens": 108},
-            },
-        )
-
-    monkeypatch.setattr(finsearch, "_post", fake_post)
+    fake = _FakeSDK()
+    monkeypatch.setattr(finsearch, "_make_sdk_client", lambda: fake)
     client = finsearch.make_client(object)
     resp = client.messages.create(
         model="FinSearch-Trader", max_tokens=2000,
         messages=[{"role": "user", "content": "prompt"}], system="sys",
     )
-    assert captured["json"]["model"] == "FinSearch-Trader"
-    assert captured["json"]["mode"] == "normal"
-    assert captured["json"]["messages"][0] == {"role": "system", "content": "sys"}
-    assert captured["headers"]["Authorization"] == "Bearer k"
+    call = fake.calls[0]
+    assert call["model"] == "FinSearch-Trader"
+    assert call["extra_body"] == {"mode": "normal"}   # hardcoded, no env knob
+    assert call["messages"][0] == {"role": "system", "content": "sys"}
     assert resp.content[0].type == "text"
     assert resp.content[0].text == '{"actions": []}'
     assert resp.usage.input_tokens == 100 and resp.usage.output_tokens == 8
+
+
+def test_finsearch_sources_tripwire(monkeypatch):
+    """Non-empty sources == AF's tool path ran == look-ahead in a backtest.
+    The shim must raise, never return tool-derived content as a decision."""
+    monkeypatch.setenv("FINGPT_API_KEY", "k")
+    fake = _FakeSDK()
+    fake._response = _fake_completion(sources=[{"url": "https://example.com"}])
+    monkeypatch.setattr(finsearch, "_make_sdk_client", lambda: fake)
+    client = finsearch.make_client(object)
+    with pytest.raises(finsearch.LookAheadTripwire):
+        client.messages.create(model="FinSearch-Trader", max_tokens=10,
+                               messages=[{"role": "user", "content": "p"}])
 ```
+
+Also update `test_known_integrations_are_parallel_siblings` to `{"commonstack", "openrouter", "anthropic", "finsearch"}`.
 
 - [ ] **Step 2: Run to verify failure** — `pytest dashboard/backend/tests/llm/test_providers.py -v -k finsearch` → FAIL (import error).
 
@@ -192,18 +234,21 @@ def test_finsearch_messages_create_shapes_anthropic_response(monkeypatch):
 # dashboard/backend/infrastructure/llm/providers/finsearch.py
 """Agentic FinSearch gateway — Anthropic-shaped shim over AF's OpenAI-compatible /v1.
 
-Contract asymmetries (accepted): AF ignores max_tokens/temperature (LLM_MAX_OUTPUT_TOKENS
-is a no-op here); AF's usage tokens are char-count estimates (len//4), so costs are
-approximate; AF requires a `mode` field — the shim supplies FINSEARCH_MODE (default
-"normal"). Leaderboard runs must target the direct, tools-off FinSearch-Trader model:
-tool-attached modes would look ahead in a backtest.
+Transport is the already-pinned `openai` SDK (base_url + api_key + retries for
+free); this module only translates shapes. Contract asymmetries (accepted):
+AF ignores max_tokens/temperature (LLM_MAX_OUTPUT_TOKENS is a no-op here);
+AF's usage tokens are char-count estimates (len//4), so costs are approximate;
+AF requires a `mode` field — hardcoded to "normal" (the tools-off invariant
+must not be one env var away from violation). Non-empty `sources` in the
+response means AF's tool path ran (look-ahead in a backtest) -> raise.
+Note: make_llm_client() in providers/__init__.py gates on the `anthropic`
+package importing BEFORE any provider dispatch, so this integration still
+transitively needs anthropic installed even though the shim never uses it.
 """
 from __future__ import annotations
 
 import os
 from types import SimpleNamespace
-
-import requests
 
 INTEGRATION_ID = "finsearch"
 DEFAULT_MODEL = "FinSearch-Trader"
@@ -211,39 +256,47 @@ DEFAULT_BASE_URL = "https://agenticfinsearch.org"
 _TIMEOUT_SECONDS = 150  # AF's gunicorn kills at 120s; margin classifies failures client-side
 
 
+class LookAheadTripwire(RuntimeError):
+    """AF returned tool-derived sources on a path that must be tools-off."""
+
+
 def default_model_name() -> str:
-    return os.environ.get("FINSEARCH_MODEL", DEFAULT_MODEL)
+    return DEFAULT_MODEL
 
 
-def _post(url, json=None, headers=None, timeout=None):
-    return requests.post(url, json=json, headers=headers, timeout=timeout)
+def _make_sdk_client():
+    from openai import OpenAI  # pinned in requirements.txt (1.101.0)
+    base = os.environ.get("FINSEARCH_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+    return OpenAI(base_url=f"{base}/v1",
+                  api_key=os.environ["FINGPT_API_KEY"],
+                  timeout=_TIMEOUT_SECONDS, max_retries=1)
 
 
 class _FinSearchMessages:
+    def __init__(self):
+        self._sdk = _make_sdk_client()
+
     def create(self, *, model, max_tokens=None, messages=None, system=None, **_):
-        url = os.environ.get("FINSEARCH_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
-        payload_messages = list(messages or [])
+        payload = list(messages or [])
         if system:
-            payload_messages.insert(0, {"role": "system", "content": system})
-        resp = _post(
-            f"{url}/v1/chat/completions",
-            json={
-                "model": model or default_model_name(),
-                "mode": os.environ.get("FINSEARCH_MODE", "normal"),
-                "messages": payload_messages,
-            },
-            headers={"Authorization": f"Bearer {os.environ['FINGPT_API_KEY']}"},
-            timeout=_TIMEOUT_SECONDS,
+            payload.insert(0, {"role": "system", "content": system})
+        resp = self._sdk.chat.completions.create(
+            model=model or DEFAULT_MODEL,
+            messages=payload,
+            extra_body={"mode": "normal"},  # hardcoded: see module docstring
         )
-        resp.raise_for_status()
-        body = resp.json()
-        text = body["choices"][0]["message"]["content"]
-        usage = body.get("usage") or {}
+        sources = getattr(resp, "sources", None) or []
+        if sources:
+            raise LookAheadTripwire(
+                f"finsearch returned {len(sources)} tool-derived sources on a "
+                "tools-off path — refusing to use the response")
+        text = resp.choices[0].message.content or ""
+        usage = getattr(resp, "usage", None)
         return SimpleNamespace(
             content=[SimpleNamespace(type="text", text=text)],
             usage=SimpleNamespace(
-                input_tokens=int(usage.get("prompt_tokens", 0)),
-                output_tokens=int(usage.get("completion_tokens", 0)),
+                input_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+                output_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
             ),
         )
 
@@ -262,9 +315,11 @@ def make_client(anthropic_cls):
 
 Register in `providers/__init__.py` `PROVIDERS` dict (import the module, add `finsearch.INTEGRATION_ID: finsearch`).
 
-- [ ] **Step 4: Run** — `pytest dashboard/backend/tests/llm/test_providers.py -v` → PASS (including the pre-existing provider-contract sweep, which iterates `PROVIDERS` — the new module must satisfy it).
+Implementation note: AF returns `sources` as a top-level response extension — verify at impl time whether the openai SDK surfaces it as an attribute or requires `resp.model_extra`/`resp.to_dict()`; the tripwire must read wherever it actually lands.
 
-- [ ] **Step 5: Commit** — `git commit -m "feat(llm): finsearch provider — Anthropic shim over AF /v1 (tools-off trader model)"`.
+- [ ] **Step 4: Run** — `pytest dashboard/backend/tests/llm/test_providers.py -v` → PASS (including the updated `test_known_integrations_are_parallel_siblings`).
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(llm): finsearch provider — openai-SDK shim, tools-off tripwire"`.
 
 ---
 
@@ -283,36 +338,20 @@ def test_finsearch_trader_priced():
     assert cost != 6.0  # not the default (1.0 + 5.0) — a real row must match first
 ```
 
-- [ ] **Step 2: Add the row** — `("FinSearch-Trader", <in>, <out>)` at the underlying foundation model's **current list price** (verify gemini-3-flash-preview's published rate at impl time; if Task 1 fell back to `gpt-5.1-chat-latest`, use that model's rate). Comment the row with the upstream model + verification date.
+- [ ] **Step 2: Add the row** — `("FinSearch-Trader", <in>, <out>)` at the underlying foundation model's **current list price** (verify the shipped model's published rate at impl time — gemini-3-flash-preview, or gpt-5.1-chat-latest if Task 1 fell back). Comment the row with the upstream model + verification date.
 - [ ] **Step 3: Run + commit** — `pytest dashboard/backend/tests/llm/ -v` → PASS; `git commit -m "feat(llm): FinSearch-Trader pricing row (approx upstream spend)"`.
 
 ---
 
-### Task 4 (ATL): leaderboard entry + env docs
+### Task 4 (ATL): leaderboard entry + env + script docs
 
 **Files:**
-- Modify: `dashboard/config/leaderboard.json` (append to `strategies` after the Nemotron entry at `:127-139`)
-- Modify: `.env.example` (add `FINSEARCH_BASE_URL=`, `FINSEARCH_MODE=normal`, `FINSEARCH_MODEL=` beside the OpenRouter block; `FINGPT_API_KEY` is added by Plan 1's Task 7 — if that hasn't merged yet, add it here)
+- Modify: `dashboard/config/leaderboard.json` — append the entry **exactly as spec §5** (the authoritative copy; note the `model` display string must name the underlying model + "tools off")
+- Modify: `.env.example` — add `FINSEARCH_BASE_URL=` beside the OpenRouter block (`FINGPT_API_KEY` is added by Plan 1's Task 7; if that hasn't merged yet, add it here). **No `FINSEARCH_MODE`/`FINSEARCH_MODEL` vars** — deliberately not knobs.
+- Modify: `dashboard/scripts/deploy_leaderboard_model.py` docstring (`:12-21`) — the required-secrets list gains `FINGPT_API_KEY` for `finsearch`
 
-- [ ] **Step 1: Add the entry**
-
-```json
-{
-  "id": "agentic_finsearch",
-  "name": "Agentic FinSearch",
-  "label": "Model",
-  "model": "FinSearch Trader",
-  "provider": "SecureFinAI Lab",
-  "strategy": "llm_agent",
-  "integration": "finsearch",
-  "model_id": "FinSearch-Trader",
-  "mode": "safe_trading",
-  "symbols": [],
-  "auto_compute": false
-}
-```
-
-- [ ] **Step 2: Sanity test** — `python3 dashboard/scripts/deploy_leaderboard_model.py --list` shows the entry with integration `finsearch`; `pytest dashboard/backend/tests/domain/leaderboard/ -v` → PASS (config-shape guards).
+- [ ] **Step 1: Apply the three edits.**
+- [ ] **Step 2: Sanity test** — `python3 dashboard/scripts/deploy_leaderboard_model.py --entry agentic_finsearch --list` (**`--entry` is `required=True`** at `deploy_leaderboard_model.py:55` — bare `--list` exits 2 before listing) shows the entry with integration `finsearch`; `pytest dashboard/backend/tests/domain/leaderboard/ -v` → PASS.
 - [ ] **Step 3: Commit** — `git commit -m "feat(leaderboard): Agentic FinSearch entry (finsearch integration, manual deploy)"`.
 
 ---
@@ -321,13 +360,13 @@ def test_finsearch_trader_priced():
 
 Manual checklist (no code):
 
-- [ ] AF droplet: raise `AGENT_DAILY_RUN_BUDGET` to `500` for the run window (env for the `fingpt-api` unit; the deploy-owned env file — same place `FINGPT_API_KEY`/`REQUIRE_FINGPT_API_KEY` live). Revert after the run if desired.
+- [ ] AF droplet: raise `AGENT_DAILY_RUN_BUDGET` to **1000** for the run window (env for the `fingpt-api` unit — same env file as `FINGPT_API_KEY`/`REQUIRE_FINGPT_API_KEY`). Sized for the worst case: the no-text retry ladder can bill up to 5 calls/step × 161 steps = 805, and the budget cliff is deterministic — once exhausted, every remaining step is a contiguous rule-based block that guarantees H6 rejection. **Reverting is Task 6 Step 5, not optional.**
 - [ ] Local ATL `dashboard/.env`: `FINGPT_API_KEY=<the FinSearch backend key>`; optionally `FINSEARCH_BASE_URL` if targeting staging.
-- [ ] Confirm AF prod is serving `FinSearch-Trader` (Task 1 merged + deployed): the Step-5 curl from Task 1, against `https://agenticfinsearch.org`.
+- [ ] Confirm AF prod is serving `FinSearch-Trader` (Task 1 merged + deployed): the Step-5 curl from Task 1, against `https://agenticfinsearch.org` (check `sources: []` too).
 
 ---
 
-### Task 6: smoke run → full run → seed refresh
+### Task 6: smoke run → budget gate → full run → seed refresh → revert
 
 - [ ] **Step 1: Smoke (1 trading day, costs cents)**
 
@@ -336,34 +375,37 @@ DATABASE_PATH=/tmp/atl-smoke.db python3 dashboard/scripts/deploy_leaderboard_mod
   --entry agentic_finsearch --start 2026-04-15 --end 2026-04-16
 ```
 
-Expected: exits 0; printed coverage 100% (or ≥95%); no `LeaderboardFallbackError`. If it exits 2, diagnose (auth? model key? JSON compliance?) — do NOT proceed to the full window.
+Expected: exits 0; printed coverage 100% (or ≥95%); no `LeaderboardFallbackError`; **zero no-text retries in the output** (any retry = an AF-side format bug — fix there, don't tune ATL). If it exits 2, diagnose — do NOT proceed.
 
-- [ ] **Step 2: Full contest window** (161 steps; direct path ≈ seconds/call → well under an hour)
+- [ ] **Step 2: Budget gate, then the full window.** Confirm the droplet raise is live (`ssh finsearch` → check the env file / a test call), **then**:
 
 ```bash
 python3 dashboard/scripts/deploy_leaderboard_model.py --entry agentic_finsearch
 ```
 
-Expected: exits 0, H6 passes, run row written to `dashboard/storage/data/backtest.db`.
+(161 steps; direct path ≈ seconds/call plus per-call session setup AF-side — budget about an hour.) Expected: exits 0, H6 passes, run row written to `dashboard/storage/data/backtest.db`. The ~7-call smoke cannot catch a missing budget raise; skipping this gate deterministically fails H6 mid-run (contiguous 429 block).
 
-- [ ] **Step 3: Seed refresh commit** (worktree + VACUUM INTO pattern)
+- [ ] **Step 3: Seed refresh commit** (detached worktree + VACUUM INTO — `git worktree add /tmp/... main` fails whenever `main` is checked out in the primary working copy, which it normally is):
 
 ```bash
 sqlite3 dashboard/storage/data/backtest.db "VACUUM INTO '/tmp/backtest-snapshot.db'"
-git worktree add /tmp/atl-seed-refresh main
+git worktree add --detach /tmp/atl-seed-refresh origin/main
 cp /tmp/backtest-snapshot.db /tmp/atl-seed-refresh/dashboard/storage/data/backtest.db
-# commit there alongside the leaderboard.json/provider diffs if not already merged
+# branch + commit there alongside the leaderboard.json/provider diffs if not already merged
 ```
 
-- [ ] **Step 4: Verify display** — locally: `uvicorn dashboard.backend.app:app` → `/app` → Competition → Leaderboard shows "Agentic FinSearch" with curve, return, Sharpe (zero frontend edits). After merge: prod auto-deploys (PR #95 hook) → `GET /api/v1/leaderboard?refresh=true` → verify live.
-- [ ] **Step 5: `/code-review` + merge** per the loop protocol.
+The leaderboard write is **additive** (one new `agent_runs` row; the seed runs referenced by `dashboard/config/defaults.json` are untouched) — but per the CLAUDE.md gotcha, verify the `defaults.json`-referenced runs still resolve against the new DB before committing (open the app locally against the snapshot; the default dashboard views must still load).
+
+- [ ] **Step 4: Verify display** — locally: `uvicorn dashboard.backend.app:app` → `/app` → Competition → Leaderboard shows the entry (name "Agentic FinSearch", model string disclosing the underlying brain + tools-off) with curve, return, Sharpe — zero frontend edits. After merge: prod auto-deploys (PR #95 hook) → `GET /api/v1/leaderboard?refresh=true` → verify live.
+- [ ] **Step 5: Revert the droplet `AGENT_DAILY_RUN_BUDGET` raise** (mandatory — a standing 10× budget quietly raises the shared droplet's abuse ceiling indefinitely).
+- [ ] **Step 6: `/code-review` + merge** per the loop protocol.
 
 ---
 
 ## Verification (whole plan)
 
-1. AF: `uv run pytest` green including new persona tests; live curl proves format compliance.
-2. ATL: `pytest dashboard/backend/tests/ -v` fully green.
+1. AF: `uv run pytest` green including the routing-matrix tests; live curl proves format compliance AND `sources: []`.
+2. ATL: `pytest dashboard/backend/tests/ -v` fully green (including the updated `KNOWN_INTEGRATIONS` golden set).
 3. H6 guard passes on the real full-window run — **the** acceptance gate.
 4. Leaderboard page renders the entry with no frontend diff (`git diff --stat` shows none under `dashboard/frontend/`).
-5. Both repos' PRs self-reviewed before merge.
+5. Budget raise reverted; both repos' PRs self-reviewed before merge.

--- a/docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md
+++ b/docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md
@@ -29,7 +29,10 @@ AF's default `/v1` modes (`thinking`, `normal` — currently identical) attach t
 
 **The no-tools property is enforced structurally, not by operator discipline** — two independent guards:
 
-1. **AF-side dispatch guard:** `direct: True` models are routed to the direct path at the dispatch level for **every** mode and transport (`normal`/`thinking`/`research`, streaming and non-streaming). Today `provider == "buffet"` is checked at four separate sites (`create_agent_response` `datascraper.py:1015`, `create_response` `:531`, `create_agent_response_stream` `:1259`, `_prepare_messages` `:284`) and `create_advanced_response` (research) has **no** such check at all — a `mode: "research"` request against a direct model would silently reach the 46-tool pipeline. The generalization closes all of these: one config flag, honored everywhere, with a routing-matrix test (§4.3).
+1. **AF-side dispatch guard:** `direct: True` models bypass the agent/tool machinery at **every** dispatch site — but the four existing `provider == "buffet"` literals are two different mechanisms and only one generalizes:
+   - **Tools-bypass gates** — `create_agent_response` (`datascraper.py:1015`) gains `model_config.get("direct")` routing to the non-agent path; `create_agent_response_stream` (`:1259`) gains the same direct-model branch (routing to the generic non-agent path, **not** the buffet branch); `create_advanced_response` (research — today has **no** check at all, so a `mode: "research"` request would silently reach the 46-tool pipeline) gains an entry guard. Persona selection in `_prepare_messages` (`:284`) generalizes via the `persona` config key.
+   - **Buffet's HF-endpoint transport gates** — the `provider == "buffet"` checks inside `create_response` (`:531`) and its streaming twin select Buffet's *dedicated HuggingFace Inference Endpoint* (`_call_buffet_agent`, own API key/URL — nothing to do with tools-off). They **stay keyed on the provider literal**: generalizing them to `direct` would misroute every direct model into Buffet's fine-tuned endpoint instead of its own configured provider client (`clients["google"]`/`clients["openai"]`).
+   The routing-matrix test (§4.3) asserts at the provider-client seam — FinSearch-Trader must reach the generic provider dispatch, never `_call_buffet_agent`, never the agent runner — for every mode and transport.
 2. **ATL-side tripwire:** AF's tool-using paths populate the response's `sources` array; the direct path returns it empty. The finsearch shim **raises** if `sources` is non-empty — the step falls to rule-based fallback, coverage collapses, and H6 refuses to publish the run. A silent look-ahead curve cannot reach the board even if AF-side routing regresses.
 
 Guardrail (advisor memo, carried through the programme): **measurement, not alpha-seeking** — we are benchmarking an agent's trading behavior on the shared apparatus, not shipping a money-maker.
@@ -54,8 +57,8 @@ Guardrail (advisor memo, carried through the programme): **measurement, not alph
 },
 ```
 
-- **All four** `provider == "buffet"` literal checks become config-driven `model_config.get("direct")` / `model_config.get("persona")` (buffet's entry gains `direct: True, persona: "buffett"`; the literal checks are removed, not kept as a dead `or` — a dead disjunct would mask regressions in the config mechanism).
-- **Dispatch guard:** `create_advanced_response` (research mode) short-circuits `direct` models to the direct path before any tool/agent machinery, so no mode/transport combination can attach tools to a direct model.
+- The **tools-bypass** gates (`create_agent_response:1015`, its streaming twin `:1259`) and **persona** selection (`_prepare_messages:284`) become config-driven `direct`/`persona` (buffet's entry gains `direct: True, persona: "buffett"`; the replaced literals are removed, not kept as dead `or` disjuncts). The **Buffet HF-endpoint** gates inside `create_response:531`/its streaming twin stay `provider == "buffet"` — they select a transport, not a tools policy (§3).
+- **Dispatch guard:** `create_advanced_response` (research mode) short-circuits `direct` models to the non-agent path before any tool/agent machinery, so no mode/transport combination can attach tools to a direct model.
 
 ### 4.2 The persona text — a prompt file, not a Python constant
 
@@ -83,7 +86,7 @@ Design notes: the persona is **format-agnostic** (the last sentence defers to th
 
 ### 4.3 What the AF PR contains
 
-1. Persona files (`prompts/personas/{trader,buffett}.md`) + loader + config-driven `direct`/`persona` replacing all four buffet literals + the research-mode dispatch guard.
+1. Persona files (`prompts/personas/{trader,buffett}.md`) + loader + config-driven `direct`/`persona` on the tools-bypass and persona gates (Buffet's HF-endpoint gates stay literal — §4.1) + the research-mode dispatch guard.
 2. `MODELS_CONFIG["FinSearch-Trader"]` entry (§4.1).
 3. Tests: **routing matrix** — `FinSearch-Trader` × `{normal, thinking, research}` × `{stream, non-stream}` all take the direct path (no agent/tool machinery; assert via the same seam the buffet tests use); persona file loads and lands in the instruction payload; buffet behavior unchanged; `/v1/models` lists the new key (update the model-count assertion).
 4. Docs: `Docs/source/api_reference.rst` model table gains the entry.

--- a/docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md
+++ b/docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md
@@ -9,7 +9,7 @@
 
 ## 1. Goal
 
-Agentic FinSearch (AF) trades the leaderboard contest **exactly like the other model entries**: same `LLMAgentStrategy` loop, same prompt, same H6 integrity guard, same contest window (2026-04-15 → 2026-05-15, 161 hourly decision steps), same deploy path (`deploy_leaderboard_model.py` → seed-DB commit). Once the run lands, the frontend displays "Agentic FinSearch" with **zero frontend changes** (rendering is fully data-driven — verified: `leaderboard.js` has no name-keyed logic; unmatched labels get auto-assigned palette colors).
+Agentic FinSearch (AF) trades the leaderboard contest **exactly like the other model entries**: same `LLMAgentStrategy` loop, same prompt, same H6 integrity guard, same contest window (2026-04-15 → 2026-05-15, 161 hourly decision steps), same deploy path (`deploy_leaderboard_model.py` → seed-DB commit). Once the run lands, the frontend displays the entry with **zero frontend changes** (rendering is fully data-driven — verified: `leaderboard.js` has no name-keyed logic; unmatched labels get auto-assigned palette colors).
 
 AF today has no trading behavior and no "professional trader personality." Both are added: the personality lives in **AF's repo** (it is AF's product surface, reusable beyond ATL); the integration shim lives in **ATL** (a provider module, like OpenRouter's).
 
@@ -25,73 +25,84 @@ AF today has no trading behavior and no "professional trader personality." Both 
 
 AF's default `/v1` modes (`thinking`, `normal` — currently identical) attach the **full 46-tool live catalog** (yfinance, TradingView, SEC EDGAR, web scrape, Playwright) with `max_turns=30`. In a **backtest over past dates**, live tools are **structural look-ahead**: the agent can read July's prices/news while "trading" April 15th. Every other leaderboard model sees only the prompt's market snapshot; an AF entry with live tools could not honestly share their board.
 
-**Decision: the leaderboard entry runs AF's *direct, tools-off* path with the trader persona.** AF already has the exact precedent: `Buffet-Agent` skips the agent/tool machinery entirely (`create_agent_response` branches on the provider config) and applies a server-side persona (`BUFFETT_INSTRUCTION`). We generalize that mechanism (config-driven, buffet becomes its first user) and add a **`FinSearch-Trader`** model entry: AF's configured foundation model + AF's professional-trader persona + no tools. That is what "AF the trading agent" *can honestly mean under backtest rules*.
+**Decision: the leaderboard entry runs AF's *direct, tools-off* path with the trader persona.** AF already has the exact precedent: `Buffet-Agent` skips the agent/tool machinery entirely (`create_agent_response` branches on provider config) and applies a server-side persona (`BUFFETT_INSTRUCTION`). We generalize that mechanism (config-driven, buffet becomes its first user) and add a **`FinSearch-Trader`** model entry: AF's configured foundation model + AF's professional-trader persona + no tools. That is what "AF the trading agent" *can honestly mean under backtest rules*.
 
-The full agentic AF — tools, research, live data — is the **live paper-trading** story, where "now" data for "now" decisions is legitimate (and where Plan 1's signals feed into the context). That is the programme's stated future and stays out of scope here (§8).
+**The no-tools property is enforced structurally, not by operator discipline** — two independent guards:
+
+1. **AF-side dispatch guard:** `direct: True` models are routed to the direct path at the dispatch level for **every** mode and transport (`normal`/`thinking`/`research`, streaming and non-streaming). Today `provider == "buffet"` is checked at four separate sites (`create_agent_response` `datascraper.py:1015`, `create_response` `:531`, `create_agent_response_stream` `:1259`, `_prepare_messages` `:284`) and `create_advanced_response` (research) has **no** such check at all — a `mode: "research"` request against a direct model would silently reach the 46-tool pipeline. The generalization closes all of these: one config flag, honored everywhere, with a routing-matrix test (§4.3).
+2. **ATL-side tripwire:** AF's tool-using paths populate the response's `sources` array; the direct path returns it empty. The finsearch shim **raises** if `sources` is non-empty — the step falls to rule-based fallback, coverage collapses, and H6 refuses to publish the run. A silent look-ahead curve cannot reach the board even if AF-side routing regresses.
 
 Guardrail (advisor memo, carried through the programme): **measurement, not alpha-seeking** — we are benchmarking an agent's trading behavior on the shared apparatus, not shipping a money-maker.
 
+**Display honesty:** every other leaderboard row names its real driving model ("Claude Sonnet 4.6", "Gemini 3.1 Pro Preview"…). This entry does the same — the `model` display field names the underlying brain and the constraint, e.g. `"FinSearch Trader — Gemini 3 Flash (tools off)"` — so a viewer never mistakes the entry for the live-tool research agent. Zero frontend changes still hold (it's a data field).
+
 ## 4. AF-side design — the professional trader personality (own PR in Agentic-FinSearch)
 
-### 4.1 Persona mechanism (generalize the buffet branch)
+### 4.1 Persona + direct-path mechanism (generalize the buffet special case)
 
-- `MODELS_CONFIG` (`Main/backend/datascraper/models_config.py`) gains a new entry:
+- `MODELS_CONFIG` (`Main/backend/datascraper/models_config.py`) gains a new entry. **Field names verified against the real schema** (every entry uses `model_name`, read at `datascraper.py:219,524,1012`; the streaming flag is `streaming`, read at `:1384`):
 
 ```python
 "FinSearch-Trader": {
-    "provider": "google",                # same family as the FinGPT default (gemini-3-flash-preview);
-    "model": "gemini-3-flash-preview",   # final choice at impl time — must be a provider the direct
-    "direct": True,                      # (non-agent) path already supports
-    "persona": "trader",
-    "max_tokens": 1_048_576,
-    "supports_streaming": False,
+    "provider": "google",                     # same family as the FinGPT default;
+    "model_name": "gemini-3-flash-preview",   # provider "google" already works on the
+    "direct": True,                           # direct path (FinGPT uses it via
+    "persona": "trader",                      # create_response today) — verify live
+    "max_tokens": 1_048_576,                  # at impl time; sanctioned fallback:
+    "streaming": False,                       # provider "openai" / gpt-5.1-chat-latest
     "description": "Professional trader persona — direct path, no tools (backtest-safe)",
 },
 ```
 
-- `create_agent_response` (`datascraper.py:1015-1021`) currently branches `provider == "buffet"` → direct path. Generalize to `model_config.get("direct") or provider == "buffet"` (buffet keeps working, gains `direct: True` in config as cleanup).
-- `_prepare_messages` (`datascraper.py:281-291`) currently branches `provider == "buffet"` → `BUFFETT_INSTRUCTION`. Generalize to a persona registry: `PERSONA_INSTRUCTIONS = {"buffett": BUFFETT_INSTRUCTION, "trader": TRADER_INSTRUCTION}`, selected by `model_config.get("persona")`, falling back to the default `INSTRUCTION`.
+- **All four** `provider == "buffet"` literal checks become config-driven `model_config.get("direct")` / `model_config.get("persona")` (buffet's entry gains `direct: True, persona: "buffett"`; the literal checks are removed, not kept as a dead `or` — a dead disjunct would mask regressions in the config mechanism).
+- **Dispatch guard:** `create_advanced_response` (research mode) short-circuits `direct` models to the direct path before any tool/agent machinery, so no mode/transport combination can attach tools to a direct model.
 
-### 4.2 The persona text (draft — final wording in the AF PR)
+### 4.2 The persona text — a prompt file, not a Python constant
 
-```python
-TRADER_INSTRUCTION = (
-    "You are FinSearch Trader, a disciplined professional equities trader. "
-    "You manage positions with a risk-first process: capital preservation precedes "
-    "return-seeking; you size positions to conviction and cut losers rather than "
-    "average down into a failing thesis. You reason strictly from the evidence you "
-    "are given — prices, technical indicators, portfolio state, and any provided "
-    "news — and you never invent data you were not shown. When evidence is mixed "
-    "you prefer holding over churning, and you can say why in one or two sentences. "
-    "When a request specifies an output format or schema, you follow it exactly: "
-    "no extra prose, no markdown fences, no disclaimers."
-)
+AF already has the convention for canonical instruction text: markdown files under `prompts/` loaded by code (`datascraper.py::_load_security_fragment()` delegates the security rules to `prompts/_security.md` citing "single source of truth"; `PromptBuilder` hot-reloads `prompts/core.md` on mtime). The trader persona follows it:
+
+- **`Main/backend/prompts/personas/trader.md`** — the personality text (draft below; final wording in the AF PR).
+- **`Main/backend/prompts/personas/buffett.md`** — `BUFFETT_INSTRUCTION`'s text migrates here (behavior-preserving; completes the pattern instead of leaving a double-standard in the same file).
+- A small loader (same idiom as `_load_security_fragment`) resolves `model_config["persona"]` → `prompts/personas/<name>.md`, with the previous constants as in-code fallback if the file is missing.
+
+Draft persona text (`trader.md`):
+
+```
+You are FinSearch Trader, a disciplined professional equities trader. You manage
+positions with a risk-first process: capital preservation precedes return-seeking;
+you size positions to conviction and cut losers rather than average down into a
+failing thesis. You reason strictly from the evidence you are given — prices,
+technical indicators, portfolio state, and any provided news — and you never invent
+data you were not shown. When evidence is mixed you prefer holding over churning,
+and you can say why in one or two sentences. When a request specifies an output
+format or schema, you follow it exactly: no extra prose, no markdown fences, no
+disclaimers.
 ```
 
 Design notes: the persona is **format-agnostic** (the last sentence defers to the caller's requested schema rather than baking ATL's JSON contract into AF) — it stays reusable for any consumer. The "never invent data" clause is the persona-level echo of the no-look-ahead rule.
 
 ### 4.3 What the AF PR contains
 
-1. `TRADER_INSTRUCTION` + persona registry + `direct` config flag generalization (buffet migrated onto both, behavior-preserving).
-2. `MODELS_CONFIG["FinSearch-Trader"]` entry.
-3. Tests mirroring `tests/test_openai_api.py`: `/v1/models` lists the new key; a `FinSearch-Trader` chat completion takes the direct path (no agent/tools — assert via the same seam the buffet tests use), carries the persona, and honors a caller format request end-to-end.
+1. Persona files (`prompts/personas/{trader,buffett}.md`) + loader + config-driven `direct`/`persona` replacing all four buffet literals + the research-mode dispatch guard.
+2. `MODELS_CONFIG["FinSearch-Trader"]` entry (§4.1).
+3. Tests: **routing matrix** — `FinSearch-Trader` × `{normal, thinking, research}` × `{stream, non-stream}` all take the direct path (no agent/tool machinery; assert via the same seam the buffet tests use); persona file loads and lands in the instruction payload; buffet behavior unchanged; `/v1/models` lists the new key (update the model-count assertion).
 4. Docs: `Docs/source/api_reference.rst` model table gains the entry.
 
-**Not** in the AF PR: any ATL-specific trading schema, any new mode, any change to the agent/tool path.
+**Not** in the AF PR: any ATL-specific trading schema, any new mode, any change to the agent/tool path's behavior for non-direct models.
+
+**Branching:** AF's `CONTRIBUTING.md` documents a `fingpt_backend_dev → fingpt_backend_prod → main` staging chain with `[user]_[focus]` branch names; recent operational precedent (news-signals #338, endpoint-auth #354–#356 — all `Main/backend` changes) merged PRs to `main` directly. Default to the operational precedent (PR to `main`), name the branch `flymiss_trader-persona`, and let Felix retarget if he wants the formal chain.
 
 ## 5. ATL-side design — the `finsearch` provider
 
-New sibling module `dashboard/backend/infrastructure/llm/providers/finsearch.py`, registered in `PROVIDERS` (`providers/__init__.py:31-35`). Contract compliance (per `providers/__init__.py:1-13`):
+New sibling module `dashboard/backend/infrastructure/llm/providers/finsearch.py`, registered in `PROVIDERS` (`providers/__init__.py:31-35`). Contract compliance (per `providers/__init__.py:1-13`): expose `INTEGRATION_ID = "finsearch"`, `DEFAULT_MODEL = "FinSearch-Trader"`, `default_model_name()`, and `make_client(anthropic_cls)` that returns `None` (never raises) when `FINGPT_API_KEY` is unset.
 
-- `INTEGRATION_ID = "finsearch"`; `DEFAULT_MODEL = "FinSearch-Trader"`; `default_model_name()`.
-- `make_client(anthropic_cls)` → returns `None` (with printed warning, never raises) unless `FINGPT_API_KEY` is set; otherwise a **shim client** that ignores `anthropic_cls` entirely:
-  - `client.messages.create(model=…, max_tokens=…, messages=…, system=None, **_)` →
-    `POST {FINSEARCH_BASE_URL}/v1/chat/completions` with
-    `{"model": model, "mode": FINSEARCH_MODE (default "normal"), "messages": [system?, …messages]}`,
-    `Authorization: Bearer <FINGPT_API_KEY>`, `timeout=150` (AF's gunicorn kills at 120s; the extra margin only classifies the failure client-side).
-  - Response → Anthropic-shaped object: `content=[SimpleNamespace(type="text", text=choices[0].message.content)]`, `usage=SimpleNamespace(input_tokens=prompt_tokens, output_tokens=completion_tokens)` — exactly what `extract_response_text` (`backtest_harness.py:163-190`) and `extract_token_usage` (`:192-206`) read.
-- Env: `FINGPT_API_KEY` (shared with Plan 1 — one secret), `FINSEARCH_BASE_URL` (default `https://agenticfinsearch.org`), `FINSEARCH_MODE` (default `normal`), `FINSEARCH_MODEL` override. All documented in `.env.example`.
+- **Transport: the `openai` SDK, not hand-rolled HTTP.** `openai==1.101.0` is already pinned in `requirements.txt` (currently unused anywhere in `dashboard/`) — `OpenAI(base_url=f"{FINSEARCH_BASE_URL}/v1", api_key=FINGPT_API_KEY, timeout=150, max_retries=1)` provides auth, pooling, retries, and typed parsing for free; AF's required `mode` extension field rides in `extra_body`. The module's only real job is the **Anthropic-shape translation**: `content=[…type="text"…]` + `usage.input_tokens/output_tokens` — exactly what `extract_response_text` (`backtest_harness.py:163-190`) and `extract_token_usage` (`:192-206`) read.
+- **`mode` is hardcoded to `"normal"`.** No `FINSEARCH_MODE` env var: the tools-off invariant must not be one unreviewed env line away from violation (an operator copy-pasting `FINSEARCH_MODE=thinking` from a staging env would hand a backtest the 46-tool catalog, and H6 checks coverage, not look-ahead). Likewise no `FINSEARCH_MODEL` env knob — `leaderboard.json`'s `model_id` is the single source of truth and the harness always passes `model=` explicitly.
+- **`sources` tripwire (§3 guard 2):** if the response carries a non-empty `sources` array, raise — never return tool-derived content as a decision.
+- Env: `FINGPT_API_KEY` (shared with Plan 1 — one secret), `FINSEARCH_BASE_URL` (default `https://agenticfinsearch.org`). Documented in `.env.example`.
 - **Never auto-selected**: like OpenRouter, `resolve_integration()` only picks it when `integration: "finsearch"` is explicit.
+- **Known coupling:** `make_llm_client()` gates on the `anthropic` SDK importing (`providers/__init__.py:67-68`) before any provider dispatch — so the finsearch integration still transitively requires the anthropic package to import, even though the shim never uses it. Documented in the module docstring so a missing-anthropic failure isn't misdiagnosed as a key problem.
+- **Test obligations:** the new-module tests (mirror PR #96's additions in `tests/llm/test_providers.py`) **plus** updating the pre-existing golden-set assertion `test_known_integrations_are_parallel_siblings` (`test_providers.py:19-23` — a hardcoded `{"commonstack", "openrouter", "anthropic"}` set that fails the moment finsearch registers; same staleness family as the route-contract freezes that blocked PRs #88–#91).
 
 Known contract asymmetries, accepted and documented in the module docstring:
 - AF ignores `max_tokens`/`temperature` (not read by `/v1`); `LLM_MAX_OUTPUT_TOKENS` is a no-op for this provider.
@@ -99,28 +110,48 @@ Known contract asymmetries, accepted and documented in the module docstring:
 - AF requires `mode`; the shim supplies it (OpenAI clients don't send one).
 
 Config + pricing:
-- `dashboard/config/leaderboard.json` entry: `{"id": "agentic_finsearch", "name": "Agentic FinSearch", "label": "Model", "model": "FinSearch Trader", "provider": "SecureFinAI Lab", "strategy": "llm_agent", "integration": "finsearch", "model_id": "FinSearch-Trader", "mode": "safe_trading", "symbols": [], "auto_compute": false}`.
+- `dashboard/config/leaderboard.json` entry (the **only** authoritative copy of this block — the plan references it):
+
+```json
+{
+  "id": "agentic_finsearch",
+  "name": "Agentic FinSearch",
+  "label": "Model",
+  "model": "FinSearch Trader — Gemini 3 Flash (tools off)",
+  "provider": "SecureFinAI Lab",
+  "strategy": "llm_agent",
+  "integration": "finsearch",
+  "model_id": "FinSearch-Trader",
+  "mode": "safe_trading",
+  "symbols": [],
+  "auto_compute": false
+}
+```
+
+(If the AF PR lands on the openai fallback, the `model` display string changes to match — display honesty per §3.)
 - `token_cost.py` `_PRICING_TABLE` row for `"FinSearch-Trader"` at the underlying foundation model's list price (exact numbers verified at impl time), so `est_cost_usd` approximates AF's real upstream spend rather than falling to the `(1.0, 5.0)` default.
+- `deploy_leaderboard_model.py`'s docstring/help text lists the required secret per integration — add `FINGPT_API_KEY` for `finsearch` (today it names only COMMONSTACK/OPENROUTER/ANTHROPIC keys).
 
 ## 6. The run — ops constraints (all verified against current code)
 
 | Constraint | Value | Consequence |
 |---|---|---|
-| AF per-identity daily budget | `AGENT_DAILY_RUN_BUDGET = 100/day` per IP (`api/agent_budget.py:44-46`); **every** `/v1` call consumes a slot | 161 calls from one machine in one day **will be throttled at 100**. Ops task: raise the droplet env (e.g. `AGENT_DAILY_RUN_BUDGET=500`) for the run window, or accept a 2-day split. Budget raise is the recommendation — it's one env var, and the global 2000/day ceiling still protects the service. |
-| AF gunicorn timeout | 120s/request | Direct path is a single foundation-model call (no tools) — typically seconds. Ample headroom. |
-| ATL per-call resiliency | No retry on network/HTTP errors — first failure = rule-based fallback for that step (`portfolio_manager.py:468-471`) | H6 needs ≥95% of 161 steps model-driven → **≤8 failed steps total**. Direct-path reliability makes this realistic; the smoke test (below) is the gate. |
-| H6 guard | `llm_decisions / decision_steps ≥ 0.95` (`service.py:39`) | The persona's format-compliance clause + ATL's tolerant JSON extraction (`_parse_llm_response` finds the first `{...}`) are the two layers that keep steps parseable. Never pass `--allow-fallback`. |
-| Rate limit | 600/h per IP on AF | 161 calls spread over the run's wall-clock — no issue. |
+| AF per-identity daily budget | `AGENT_DAILY_RUN_BUDGET = 100/day` per IP (`api/agent_budget.py:44-46`); **every** `/v1` call consumes a slot | **The cliff is deterministic, not probabilistic:** once exhausted, every remaining call 429s and every remaining step falls back rule-based — a *contiguous* failure block that guarantees H6 rejection on a single-day full run. And the worst case is not 161 calls: the no-text retry ladder (below) can bill up to **5 calls per step** (805). Ops gate: raise the droplet env to **1000** for the run window; **confirming the raise is a hard precondition of the full-window run** (the 1-day smoke, ~7 calls, cannot catch it). Revert after the run (mandatory step, not a suggestion). |
+| ATL retry behavior | The only retry is the no-text ladder (`portfolio_manager.py:311-354`): up to 4 retries + 1 "rescue" per step, triggered solely by empty-text responses. Network/HTTP errors (429/5xx/timeout) skip it entirely → immediate rule-based fallback for that step (`:468-471`) | The rescue attempt force-sets `OPENROUTER_REASONING_EFFORT` — a no-op for finsearch, so all 5 attempts are byte-identical. The persona's format-compliance clause is the real mitigation for empty/miswrapped text; if the smoke run shows any no-text retries, treat it as an AF-side bug, don't tune ATL. (Pre-existing note: that rescue mutates process-global env — a shared-state hazard when v2 live calls interleave; not introduced or worsened by this plan, just inherited.) |
+| AF gunicorn timeout | 120s/request | Direct path is a single foundation-model call (no tools) — typically seconds. Ample headroom. Caveat on the wall-clock estimate: each `/v1` call also rebuilds a session context server-side (`openai_views.py:73-81,222-228`), so budget ~an hour for the full window, not minutes. |
+| H6 guard | `llm_decisions / decision_steps ≥ 0.95` (`service.py:39`) → ≤8 failed steps of 161 | The persona's format-compliance clause + ATL's tolerant JSON extraction (`_parse_llm_response` finds the first `{...}`) keep steps parseable. Never pass `--allow-fallback`. |
+| Rate limit | 600/h per IP on AF | 161–805 calls spread over the run's wall-clock — no issue. |
 
 **Run sequence** (identical to the six-LLM onboarding, per the recipe):
 1. Smoke: `python3 dashboard/scripts/deploy_leaderboard_model.py --entry agentic_finsearch --start 2026-04-15 --end 2026-04-16` — catches auth/model-key/JSON issues for cents.
-2. Full window: same command without dates (uses `leaderboard.json` window). Expect H6 to pass or fail loudly (exit 2).
-3. Seed refresh: commit the regenerated `dashboard/storage/data/backtest.db` from an isolated worktree (`VACUUM INTO` snapshot; WAL mode — never commit with a live handle open), alongside the config/provider diffs.
-4. Merge → CI deploys prod automatically (PR #95 deploy hook) → `GET /api/v1/leaderboard?refresh=true` → verify the entry renders.
+2. **Gate:** confirm the droplet `AGENT_DAILY_RUN_BUDGET` raise is live (a curl loop or the droplet env file), then run the full window: same command without dates. Expect H6 to pass or fail loudly (exit 2).
+3. Seed refresh: commit the regenerated `dashboard/storage/data/backtest.db` from an isolated worktree (`VACUUM INTO` snapshot; WAL mode — never commit with a live handle open), alongside the config/provider diffs. The leaderboard write is **additive** (a new `agent_runs` row) — the seed runs `dashboard/config/defaults.json` references are untouched, but per the CLAUDE.md gotcha, verify they still resolve before committing.
+4. Revert the budget raise (mandatory).
+5. Merge → CI deploys prod automatically (PR #95 deploy hook) → `GET /api/v1/leaderboard?refresh=true` → verify the entry renders.
 
 ## 7. Display
 
-No frontend work. Verified: the leaderboard table, chart, legend, and detail panel key on generic fields (`team_name`, `model`, `is_model`, `entry_type`, `equity_curve`); the only name-keyed logic is a cosmetic style preset for 5 baseline labels; new labels auto-assign palette colors (`leaderboard.js:25-31,40-64`). "Agentic FinSearch" appears exactly like the other six models once the run row exists.
+No frontend work. Verified: the leaderboard table, chart, legend, and detail panel key on generic fields (`team_name`, `model`, `is_model`, `entry_type`, `equity_curve`); the only name-keyed logic is a cosmetic style preset for 5 baseline labels; new labels auto-assign palette colors (`leaderboard.js:25-31,40-64`). The entry appears exactly like the other six models once the run row exists — with the underlying model disclosed in the `model` display string (§3).
 
 ## 8. Future work (explicit, out of scope)
 
@@ -130,6 +161,6 @@ No frontend work. Verified: the leaderboard table, chart, legend, and detail pan
 
 ## 9. Open questions flagged for Felix (non-blocking)
 
-1. **Underlying model for `FinSearch-Trader`**: spec says AF's default family (`gemini-3-flash-preview`, provider `google`) — if the direct path's google client proves flaky at impl time, `openai`/`gpt-5.1-chat-latest` is the sanctioned fallback. Either is honest as "AF's configured brain."
+1. **Underlying model for `FinSearch-Trader`**: provider `google` is confirmed workable on the direct path in principle (FinGPT itself runs provider `google` through `create_response`) — the impl-time task is a live verification; the sanctioned fallback is `openai`/`gpt-5.1-chat-latest`. Either is honest as "AF's configured brain" (and the leaderboard `model` string discloses whichever ships).
 2. **Cost display**: `est_cost_usd` will be an *approximation of AF's upstream spend* (char-estimate tokens × underlying list price). Alternative is displaying 0 (misleading) or omitting (inconsistent). Spec picks the approximation.
-3. **Budget raise vs 2-day run split** for the 161-call window (spec recommends the env raise).
+3. **AF branching**: PR to `main` per operational precedent, or the CONTRIBUTING.md staging chain (§4.3)?

--- a/docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md
+++ b/docs/superpowers/specs/2026-07-13-finsearch-leaderboard-agent-design.md
@@ -1,0 +1,135 @@
+# Agentic FinSearch as a Leaderboard Trading Agent (Plan 3) — Design Spec
+
+- **Date:** 2026-07-13
+- **Owner:** Felix (FlyMiss)
+- **Repos:** agent-trading-lab (provider + entry) **and** Agentic-FinSearch (trader personality)
+- **Status:** Design — written under the AFK planning loop; open forks decided with rationale below and flagged for Felix's review in the PR
+- **Programme:** Plan 3 of 3 (Plan 1 = news→signals, sibling spec `2026-07-13-finsearch-news-signals-panel-design.md`; Plan 2 = agent-API foundation, shipped)
+- **Precedent:** the six-LLM leaderboard onboarding (PRs #72/#74/#75) and the freshest add-a-model example, PR #96 (OpenRouter Nemotron) — this spec deliberately follows that recipe.
+
+## 1. Goal
+
+Agentic FinSearch (AF) trades the leaderboard contest **exactly like the other model entries**: same `LLMAgentStrategy` loop, same prompt, same H6 integrity guard, same contest window (2026-04-15 → 2026-05-15, 161 hourly decision steps), same deploy path (`deploy_leaderboard_model.py` → seed-DB commit). Once the run lands, the frontend displays "Agentic FinSearch" with **zero frontend changes** (rendering is fully data-driven — verified: `leaderboard.js` has no name-keyed logic; unmatched labels get auto-assigned palette colors).
+
+AF today has no trading behavior and no "professional trader personality." Both are added: the personality lives in **AF's repo** (it is AF's product surface, reusable beyond ATL); the integration shim lives in **ATL** (a provider module, like OpenRouter's).
+
+## 2. Approaches considered
+
+| Approach | Verdict | Why |
+|---|---|---|
+| **A. ATL provider module over AF's OpenAI-compatible `/v1/chat/completions`** | **Chosen** | "Just like other models" literally: a fourth sibling in `infrastructure/llm/providers/` (`commonstack`, `openrouter`, `anthropic` exist). Reuses the entire proven pipeline — prompt, parsing, counters, H6, deploy, display. Smallest new surface; PR #96 is a 1:1 template. |
+| B. AF as an external agent driving `/api/v2` protocol runs | Deferred (future benchmark phase) | This was Plan 3's original sketch, but v2 runs don't feed the leaderboard contest table, "like other models" points at the provider path, and the full agentic value of it only materializes with live/paper mode (Phase B — not built). Revisit when Phase B lands; see §8. |
+| C. Add AF's underlying foundation model directly via an existing provider | Rejected | Measures Gemini/GPT, not AF. No AF surface involved — defeats the goal. |
+
+## 3. The integrity fork (the one hard problem)
+
+AF's default `/v1` modes (`thinking`, `normal` — currently identical) attach the **full 46-tool live catalog** (yfinance, TradingView, SEC EDGAR, web scrape, Playwright) with `max_turns=30`. In a **backtest over past dates**, live tools are **structural look-ahead**: the agent can read July's prices/news while "trading" April 15th. Every other leaderboard model sees only the prompt's market snapshot; an AF entry with live tools could not honestly share their board.
+
+**Decision: the leaderboard entry runs AF's *direct, tools-off* path with the trader persona.** AF already has the exact precedent: `Buffet-Agent` skips the agent/tool machinery entirely (`create_agent_response` branches on the provider config) and applies a server-side persona (`BUFFETT_INSTRUCTION`). We generalize that mechanism (config-driven, buffet becomes its first user) and add a **`FinSearch-Trader`** model entry: AF's configured foundation model + AF's professional-trader persona + no tools. That is what "AF the trading agent" *can honestly mean under backtest rules*.
+
+The full agentic AF — tools, research, live data — is the **live paper-trading** story, where "now" data for "now" decisions is legitimate (and where Plan 1's signals feed into the context). That is the programme's stated future and stays out of scope here (§8).
+
+Guardrail (advisor memo, carried through the programme): **measurement, not alpha-seeking** — we are benchmarking an agent's trading behavior on the shared apparatus, not shipping a money-maker.
+
+## 4. AF-side design — the professional trader personality (own PR in Agentic-FinSearch)
+
+### 4.1 Persona mechanism (generalize the buffet branch)
+
+- `MODELS_CONFIG` (`Main/backend/datascraper/models_config.py`) gains a new entry:
+
+```python
+"FinSearch-Trader": {
+    "provider": "google",                # same family as the FinGPT default (gemini-3-flash-preview);
+    "model": "gemini-3-flash-preview",   # final choice at impl time — must be a provider the direct
+    "direct": True,                      # (non-agent) path already supports
+    "persona": "trader",
+    "max_tokens": 1_048_576,
+    "supports_streaming": False,
+    "description": "Professional trader persona — direct path, no tools (backtest-safe)",
+},
+```
+
+- `create_agent_response` (`datascraper.py:1015-1021`) currently branches `provider == "buffet"` → direct path. Generalize to `model_config.get("direct") or provider == "buffet"` (buffet keeps working, gains `direct: True` in config as cleanup).
+- `_prepare_messages` (`datascraper.py:281-291`) currently branches `provider == "buffet"` → `BUFFETT_INSTRUCTION`. Generalize to a persona registry: `PERSONA_INSTRUCTIONS = {"buffett": BUFFETT_INSTRUCTION, "trader": TRADER_INSTRUCTION}`, selected by `model_config.get("persona")`, falling back to the default `INSTRUCTION`.
+
+### 4.2 The persona text (draft — final wording in the AF PR)
+
+```python
+TRADER_INSTRUCTION = (
+    "You are FinSearch Trader, a disciplined professional equities trader. "
+    "You manage positions with a risk-first process: capital preservation precedes "
+    "return-seeking; you size positions to conviction and cut losers rather than "
+    "average down into a failing thesis. You reason strictly from the evidence you "
+    "are given — prices, technical indicators, portfolio state, and any provided "
+    "news — and you never invent data you were not shown. When evidence is mixed "
+    "you prefer holding over churning, and you can say why in one or two sentences. "
+    "When a request specifies an output format or schema, you follow it exactly: "
+    "no extra prose, no markdown fences, no disclaimers."
+)
+```
+
+Design notes: the persona is **format-agnostic** (the last sentence defers to the caller's requested schema rather than baking ATL's JSON contract into AF) — it stays reusable for any consumer. The "never invent data" clause is the persona-level echo of the no-look-ahead rule.
+
+### 4.3 What the AF PR contains
+
+1. `TRADER_INSTRUCTION` + persona registry + `direct` config flag generalization (buffet migrated onto both, behavior-preserving).
+2. `MODELS_CONFIG["FinSearch-Trader"]` entry.
+3. Tests mirroring `tests/test_openai_api.py`: `/v1/models` lists the new key; a `FinSearch-Trader` chat completion takes the direct path (no agent/tools — assert via the same seam the buffet tests use), carries the persona, and honors a caller format request end-to-end.
+4. Docs: `Docs/source/api_reference.rst` model table gains the entry.
+
+**Not** in the AF PR: any ATL-specific trading schema, any new mode, any change to the agent/tool path.
+
+## 5. ATL-side design — the `finsearch` provider
+
+New sibling module `dashboard/backend/infrastructure/llm/providers/finsearch.py`, registered in `PROVIDERS` (`providers/__init__.py:31-35`). Contract compliance (per `providers/__init__.py:1-13`):
+
+- `INTEGRATION_ID = "finsearch"`; `DEFAULT_MODEL = "FinSearch-Trader"`; `default_model_name()`.
+- `make_client(anthropic_cls)` → returns `None` (with printed warning, never raises) unless `FINGPT_API_KEY` is set; otherwise a **shim client** that ignores `anthropic_cls` entirely:
+  - `client.messages.create(model=…, max_tokens=…, messages=…, system=None, **_)` →
+    `POST {FINSEARCH_BASE_URL}/v1/chat/completions` with
+    `{"model": model, "mode": FINSEARCH_MODE (default "normal"), "messages": [system?, …messages]}`,
+    `Authorization: Bearer <FINGPT_API_KEY>`, `timeout=150` (AF's gunicorn kills at 120s; the extra margin only classifies the failure client-side).
+  - Response → Anthropic-shaped object: `content=[SimpleNamespace(type="text", text=choices[0].message.content)]`, `usage=SimpleNamespace(input_tokens=prompt_tokens, output_tokens=completion_tokens)` — exactly what `extract_response_text` (`backtest_harness.py:163-190`) and `extract_token_usage` (`:192-206`) read.
+- Env: `FINGPT_API_KEY` (shared with Plan 1 — one secret), `FINSEARCH_BASE_URL` (default `https://agenticfinsearch.org`), `FINSEARCH_MODE` (default `normal`), `FINSEARCH_MODEL` override. All documented in `.env.example`.
+- **Never auto-selected**: like OpenRouter, `resolve_integration()` only picks it when `integration: "finsearch"` is explicit.
+
+Known contract asymmetries, accepted and documented in the module docstring:
+- AF ignores `max_tokens`/`temperature` (not read by `/v1`); `LLM_MAX_OUTPUT_TOKENS` is a no-op for this provider.
+- AF's `usage` is a char-count estimate (`len//4`), not a tokenizer — cost figures are approximate.
+- AF requires `mode`; the shim supplies it (OpenAI clients don't send one).
+
+Config + pricing:
+- `dashboard/config/leaderboard.json` entry: `{"id": "agentic_finsearch", "name": "Agentic FinSearch", "label": "Model", "model": "FinSearch Trader", "provider": "SecureFinAI Lab", "strategy": "llm_agent", "integration": "finsearch", "model_id": "FinSearch-Trader", "mode": "safe_trading", "symbols": [], "auto_compute": false}`.
+- `token_cost.py` `_PRICING_TABLE` row for `"FinSearch-Trader"` at the underlying foundation model's list price (exact numbers verified at impl time), so `est_cost_usd` approximates AF's real upstream spend rather than falling to the `(1.0, 5.0)` default.
+
+## 6. The run — ops constraints (all verified against current code)
+
+| Constraint | Value | Consequence |
+|---|---|---|
+| AF per-identity daily budget | `AGENT_DAILY_RUN_BUDGET = 100/day` per IP (`api/agent_budget.py:44-46`); **every** `/v1` call consumes a slot | 161 calls from one machine in one day **will be throttled at 100**. Ops task: raise the droplet env (e.g. `AGENT_DAILY_RUN_BUDGET=500`) for the run window, or accept a 2-day split. Budget raise is the recommendation — it's one env var, and the global 2000/day ceiling still protects the service. |
+| AF gunicorn timeout | 120s/request | Direct path is a single foundation-model call (no tools) — typically seconds. Ample headroom. |
+| ATL per-call resiliency | No retry on network/HTTP errors — first failure = rule-based fallback for that step (`portfolio_manager.py:468-471`) | H6 needs ≥95% of 161 steps model-driven → **≤8 failed steps total**. Direct-path reliability makes this realistic; the smoke test (below) is the gate. |
+| H6 guard | `llm_decisions / decision_steps ≥ 0.95` (`service.py:39`) | The persona's format-compliance clause + ATL's tolerant JSON extraction (`_parse_llm_response` finds the first `{...}`) are the two layers that keep steps parseable. Never pass `--allow-fallback`. |
+| Rate limit | 600/h per IP on AF | 161 calls spread over the run's wall-clock — no issue. |
+
+**Run sequence** (identical to the six-LLM onboarding, per the recipe):
+1. Smoke: `python3 dashboard/scripts/deploy_leaderboard_model.py --entry agentic_finsearch --start 2026-04-15 --end 2026-04-16` — catches auth/model-key/JSON issues for cents.
+2. Full window: same command without dates (uses `leaderboard.json` window). Expect H6 to pass or fail loudly (exit 2).
+3. Seed refresh: commit the regenerated `dashboard/storage/data/backtest.db` from an isolated worktree (`VACUUM INTO` snapshot; WAL mode — never commit with a live handle open), alongside the config/provider diffs.
+4. Merge → CI deploys prod automatically (PR #95 deploy hook) → `GET /api/v1/leaderboard?refresh=true` → verify the entry renders.
+
+## 7. Display
+
+No frontend work. Verified: the leaderboard table, chart, legend, and detail panel key on generic fields (`team_name`, `model`, `is_model`, `entry_type`, `equity_curve`); the only name-keyed logic is a cosmetic style preset for 5 baseline labels; new labels auto-assign palette colors (`leaderboard.js:25-31,40-64`). "Agentic FinSearch" appears exactly like the other six models once the run row exists.
+
+## 8. Future work (explicit, out of scope)
+
+- **AF full-agentic benchmark** via `/api/v2` protocol runs in **live paper-trading** mode, where tools are legitimate — gated on Execution Phase B (`execution/paper_backend.py` is a stub today). This is where approach B comes back, and where Plan 1's signals (already in the v2 context envelope) meet Plan 3's agent.
+- Feeding `news_sentiment` into the **internal** leaderboard prompt (`portfolio_manager.py` snapshot) — would change what *all* entries see; a deliberate new-contest-season decision, not a rider on this work.
+- A `rationale`-aware trading log surface (the persona can say *why*; ATL persists `reasoning` per decision already).
+
+## 9. Open questions flagged for Felix (non-blocking)
+
+1. **Underlying model for `FinSearch-Trader`**: spec says AF's default family (`gemini-3-flash-preview`, provider `google`) — if the direct path's google client proves flaky at impl time, `openai`/`gpt-5.1-chat-latest` is the sanctioned fallback. Either is honest as "AF's configured brain."
+2. **Cost display**: `est_cost_usd` will be an *approximation of AF's upstream spend* (char-estimate tokens × underlying list price). Alternative is displaying 0 (misleading) or omitting (inconsistent). Spec picks the approximation.
+3. **Budget raise vs 2-day run split** for the 161-call window (spec recommends the env raise).


### PR DESCRIPTION
## What & why

Spec + implementation plan for **Plan 3**: Agentic FinSearch trades the leaderboard contest **exactly like the other model entries** — same `LLMAgentStrategy` loop, prompt, H6 guard, window, and deploy recipe (the six-LLM onboarding + PR #96's OpenRouter pattern is followed 1:1). Includes the **professional trader personality** design for AF's repo. Docs-only.

## Key decisions (full rationale in the spec)

- **Integration = a fourth provider module** (`infrastructure/llm/providers/finsearch.py`), an Anthropic-shaped shim over AF's OpenAI-compatible `/v1/chat/completions`. The v2-protocol route was considered and deferred to the future live-paper benchmark phase.
- **The integrity fork:** AF's default modes attach 46 live tools → structural look-ahead in a backtest over past dates. The entry therefore runs AF's **direct, tools-off path** with the trader persona — generalizing AF's existing Buffet-Agent mechanism (config-driven `direct` + persona registry). Full-agentic AF is explicitly the live paper-trading story (future, gated on Execution Phase B).
- **Persona lives in AF's repo** (own PR there; reusable product surface, format-agnostic wording so ATL's JSON contract isn't baked into AF).
- **Ops constraints verified in code:** AF's per-IP daily budget (100) < 161 calls → droplet env raise task; gunicorn 120s vs single-call direct path; H6 math (≤8 failed steps allowed); char-estimate usage → approximate cost display (flagged for Felix).
- **Zero frontend changes** — leaderboard rendering is fully data-driven (evidence in spec §7).

## Open questions flagged for Felix (spec §9)

Underlying model choice (gemini default vs openai fallback), cost-display approximation, budget raise vs 2-day run split.

## Test plan (of the plan)

- [x] Spec self-review (placeholders, consistency, scope, ambiguity)
- [x] AF-side task verified against real `datascraper.py` signatures (`_prepare_messages(message_list, user_input, model=None)` etc.)
- [x] 8-angle finder review before merge (same protocol as #98)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vt54RQvvdoiWo3BbXGBm1B