### PR TITLE
feat(discord): bind website accounts so /agent lists owned agents only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,17 @@ DISCORD_CHANNEL_ID=234567890123456789
 # so the bot can read plain messages in server channels.
 # Base URL of the backend API the bot calls (defaults to http://localhost:8000).
 ATL_API_BASE=http://localhost:8000
+# Shared secret: Discord bot → GET /api/v1/discord/agents (must match on API + bot).
+DISCORD_BOT_API_SECRET=generate_a_long_random_secret_here
+# Discord OAuth (same Discord Application as the bot). Used by website
+# "Open Discord" to link users.discord_user_id (scope=identify).
+DISCORD_CLIENT_ID=your_discord_oauth_client_id
+DISCORD_CLIENT_SECRET=your_discord_oauth_client_secret
+DISCORD_REDIRECT_URI=http://localhost:8000/api/auth/discord/callback
+# Channel/invite URL opened after a successful link (or when already linked).
+DISCORD_GUILD_CHANNEL_URL=https://discord.gg/9HnQ6XDG98
+# Optional: dashboard origin for OAuth redirects (defaults to /app on same host).
+# PUBLIC_APP_URL=http://localhost:8000
 
 # Database
 DATABASE_PATH=dashboard/storage/data/backtest.db

--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,8 @@ DISCORD_CLIENT_SECRET=your_discord_oauth_client_secret
 DISCORD_REDIRECT_URI=http://localhost:8000/api/auth/discord/callback
 # Channel/invite URL opened after a successful link (or when already linked).
 DISCORD_GUILD_CHANNEL_URL=https://discord.gg/9HnQ6XDG98
-# Optional: dashboard origin for OAuth redirects (defaults to /app on same host).
+# Optional: dashboard origin for OAuth redirects and Discord result deep links
+# (defaults to ATL_API_BASE / same host). Example: http://localhost:8000
 # PUBLIC_APP_URL=http://localhost:8000
 
 # Database

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,8 @@ DISCORD_CLIENT_SECRET=your_discord_oauth_client_secret
 DISCORD_REDIRECT_URI=http://localhost:8000/api/auth/discord/callback
 # Channel/invite URL opened after a successful link (or when already linked).
 DISCORD_GUILD_CHANNEL_URL=https://discord.gg/9HnQ6XDG98
+# Optional: signs the short-lived OAuth state token. Defaults to DISCORD_CLIENT_SECRET.
+# DISCORD_OAUTH_STATE_SECRET=another_long_random_secret
 # Optional: dashboard origin for OAuth redirects and Discord result deep links
 # (defaults to ATL_API_BASE / same host). Example: http://localhost:8000
 # PUBLIC_APP_URL=http://localhost:8000

--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from typing import Optional
 from urllib.parse import urlencode
@@ -152,9 +153,17 @@ async def discord_oauth_callback(code: Optional[str] = None, state: Optional[str
         return _app_redirect({"discord": "error", "reason": "invalid_state"})
 
     try:
-        access_token = discord_oauth.exchange_code_for_access_token(code)
-        discord_user = discord_oauth.fetch_discord_user(access_token)
-        user_store.link_discord_user(user_id, str(discord_user["id"]))
+        # These make blocking HTTP/DB calls; run them off the event loop so a slow
+        # Discord token exchange (up to ~40s) doesn't stall every other request.
+        access_token = await asyncio.to_thread(
+            discord_oauth.exchange_code_for_access_token, code
+        )
+        discord_user = await asyncio.to_thread(
+            discord_oauth.fetch_discord_user, access_token
+        )
+        await asyncio.to_thread(
+            user_store.link_discord_user, user_id, str(discord_user["id"])
+        )
     except ValueError as exc:
         reason = str(exc) if str(exc) in {"discord_already_linked", "user_not_found"} else "link_failed"
         return _app_redirect({"discord": "error", "reason": reason})

--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -1,11 +1,26 @@
+import os
 from typing import Optional
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field, field_validator
 
+from dashboard.backend.api import discord_oauth
 from dashboard.backend.users import public_user, user_store
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _app_redirect(query: dict[str, str]) -> RedirectResponse:
+    """Send the browser back to the dashboard after Discord OAuth."""
+    base = (os.getenv("PUBLIC_APP_URL") or "").rstrip("/")
+    if base:
+        if not base.endswith("/app"):
+            base = f"{base}/app"
+    else:
+        base = "/app"
+    return RedirectResponse(url=f"{base}?{urlencode(query)}", status_code=302)
 
 
 def _normalize_email(value: str) -> str:
@@ -98,3 +113,52 @@ async def logout(authorization: Optional[str] = Header(default=None)):
     if token:
         user_store.delete_session(token)
     return {"status": "ok"}
+
+
+@router.post("/discord/start")
+async def discord_oauth_start(current_user: dict = Depends(get_current_user)):
+    """Begin Discord OAuth linking for the logged-in website user."""
+    if not discord_oauth.oauth_configured():
+        raise HTTPException(
+            status_code=503,
+            detail="Discord OAuth is not configured on this server",
+        )
+    # Already linked → client can skip OAuth and open Discord directly.
+    if current_user.get("discord_user_id"):
+        return {
+            "already_linked": True,
+            "authorize_url": None,
+            "discord_url": discord_oauth.discord_guild_channel_url(),
+            "user": public_user(current_user),
+        }
+
+    state = discord_oauth.mint_oauth_state(int(current_user["id"]))
+    return {
+        "already_linked": False,
+        "authorize_url": discord_oauth.build_authorize_url(state),
+        "discord_url": discord_oauth.discord_guild_channel_url(),
+        "user": public_user(current_user),
+    }
+
+
+@router.get("/discord/callback")
+async def discord_oauth_callback(code: Optional[str] = None, state: Optional[str] = None):
+    """OAuth redirect target: exchange code, persist discord_user_id, return to /app."""
+    if not code or not state:
+        return _app_redirect({"discord": "error", "reason": "missing_params"})
+    try:
+        user_id = discord_oauth.parse_oauth_state(state)
+    except ValueError:
+        return _app_redirect({"discord": "error", "reason": "invalid_state"})
+
+    try:
+        access_token = discord_oauth.exchange_code_for_access_token(code)
+        discord_user = discord_oauth.fetch_discord_user(access_token)
+        user_store.link_discord_user(user_id, str(discord_user["id"]))
+    except ValueError as exc:
+        reason = str(exc) if str(exc) in {"discord_already_linked", "user_not_found"} else "link_failed"
+        return _app_redirect({"discord": "error", "reason": reason})
+    except Exception:
+        return _app_redirect({"discord": "error", "reason": "oauth_failed"})
+
+    return _app_redirect({"discord": "linked"})

--- a/dashboard/backend/api/discord_oauth.py
+++ b/dashboard/backend/api/discord_oauth.py
@@ -1,0 +1,156 @@
+"""Discord OAuth helpers for linking website accounts to Discord user ids."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+from typing import Any, Optional
+from urllib.parse import urlencode
+
+import httpx
+
+DISCORD_AUTHORIZE_URL = "https://discord.com/api/oauth2/authorize"
+DISCORD_TOKEN_URL = "https://discord.com/api/oauth2/token"
+DISCORD_ME_URL = "https://discord.com/api/users/@me"
+STATE_TTL_SECONDS = 600
+
+
+def discord_client_id() -> str:
+    return (os.getenv("DISCORD_CLIENT_ID") or "").strip()
+
+
+def discord_client_secret() -> str:
+    return (os.getenv("DISCORD_CLIENT_SECRET") or "").strip()
+
+
+def discord_redirect_uri() -> str:
+    return (os.getenv("DISCORD_REDIRECT_URI") or "").strip()
+
+
+def discord_guild_channel_url() -> str:
+    return (
+        os.getenv("DISCORD_GUILD_CHANNEL_URL")
+        or os.getenv("DISCORD_SERVER_URL")
+        or "https://discord.gg/9HnQ6XDG98"
+    ).strip()
+
+
+def discord_bot_api_secret() -> str:
+    return (os.getenv("DISCORD_BOT_API_SECRET") or "").strip()
+
+
+def oauth_configured() -> bool:
+    return bool(discord_client_id() and discord_client_secret() and discord_redirect_uri())
+
+
+def _state_signing_key() -> bytes:
+    raw = (
+        os.getenv("DISCORD_OAUTH_STATE_SECRET")
+        or discord_client_secret()
+        or "dev-discord-oauth-state"
+    )
+    return raw.encode("utf-8")
+
+
+def mint_oauth_state(user_id: int) -> str:
+    payload = {
+        "uid": int(user_id),
+        "exp": int(time.time()) + STATE_TTL_SECONDS,
+        "n": secrets.token_hex(8),
+    }
+    raw = base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+    raw = raw.rstrip("=")
+    sig = hmac.new(_state_signing_key(), raw.encode(), hashlib.sha256).hexdigest()
+    return f"{raw}.{sig}"
+
+
+def parse_oauth_state(state: str) -> int:
+    try:
+        raw, sig = state.rsplit(".", 1)
+    except ValueError as exc:
+        raise ValueError("invalid_state") from exc
+    expected = hmac.new(_state_signing_key(), raw.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, sig):
+        raise ValueError("invalid_state")
+    pad = "=" * (-len(raw) % 4)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(raw + pad).decode())
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid_state") from exc
+    if int(payload.get("exp") or 0) < int(time.time()):
+        raise ValueError("expired_state")
+    user_id = payload.get("uid")
+    if user_id is None:
+        raise ValueError("invalid_state")
+    return int(user_id)
+
+
+def build_authorize_url(state: str) -> str:
+    if not oauth_configured():
+        raise RuntimeError("discord_oauth_not_configured")
+    query = urlencode(
+        {
+            "client_id": discord_client_id(),
+            "response_type": "code",
+            "redirect_uri": discord_redirect_uri(),
+            "scope": "identify",
+            "state": state,
+            "prompt": "consent",
+        }
+    )
+    return f"{DISCORD_AUTHORIZE_URL}?{query}"
+
+
+def exchange_code_for_access_token(code: str) -> str:
+    if not oauth_configured():
+        raise RuntimeError("discord_oauth_not_configured")
+    data = {
+        "client_id": discord_client_id(),
+        "client_secret": discord_client_secret(),
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": discord_redirect_uri(),
+    }
+    with httpx.Client(timeout=20.0) as client:
+        resp = client.post(
+            DISCORD_TOKEN_URL,
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    if resp.status_code >= 400:
+        raise RuntimeError(f"discord_token_exchange_failed:{resp.status_code}")
+    body = resp.json()
+    token = body.get("access_token")
+    if not token:
+        raise RuntimeError("discord_token_missing")
+    return str(token)
+
+
+def fetch_discord_user(access_token: str) -> dict[str, Any]:
+    with httpx.Client(timeout=20.0) as client:
+        resp = client.get(
+            DISCORD_ME_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    if resp.status_code >= 400:
+        raise RuntimeError(f"discord_me_failed:{resp.status_code}")
+    body = resp.json()
+    if not body.get("id"):
+        raise RuntimeError("discord_user_id_missing")
+    return body
+
+
+def verify_bot_secret(provided: Optional[str]) -> bool:
+    expected = discord_bot_api_secret()
+    if not expected or not provided:
+        return False
+    # compare_digest on str rejects non-ASCII; always compare utf-8 bytes.
+    return hmac.compare_digest(
+        expected.encode("utf-8"),
+        provided.strip().encode("utf-8"),
+    )

--- a/dashboard/backend/api/discord_oauth.py
+++ b/dashboard/backend/api/discord_oauth.py
@@ -49,6 +49,9 @@ def oauth_configured() -> bool:
 
 
 def _state_signing_key() -> bytes:
+    # Prefer an explicit override, else the OAuth client secret (which
+    # ``oauth_configured()`` already requires for the flow to run at all, so the
+    # bare dev fallback below is only ever reached in an unconfigured dev box).
     raw = (
         os.getenv("DISCORD_OAUTH_STATE_SECRET")
         or discord_client_secret()

--- a/dashboard/backend/api/router.py
+++ b/dashboard/backend/api/router.py
@@ -4,6 +4,7 @@ from dashboard.backend.api.routers.agent_versions import router as agent_version
 from dashboard.backend.api.routers.agents import router as agents_router
 from dashboard.backend.api.routers.algo import router as algo_router
 from dashboard.backend.api.auth import router as auth_router
+from dashboard.backend.api.routers.discord import router as discord_router
 from dashboard.backend.api.routers.environments import router as environments_router
 from dashboard.backend.api.routers.external_backtest import router as external_backtest_router
 from dashboard.backend.api.health import router as health_router
@@ -17,6 +18,7 @@ api_router.include_router(health_router)
 api_router.include_router(auth_router)
 api_router.include_router(algo_router)
 api_router.include_router(agents_router)
+api_router.include_router(discord_router)
 api_router.include_router(agent_versions_router)
 api_router.include_router(external_backtest_router)
 api_router.include_router(runs_router)

--- a/dashboard/backend/api/routers/discord.py
+++ b/dashboard/backend/api/routers/discord.py
@@ -1,0 +1,75 @@
+"""Discord bot-facing endpoints (service-secret auth)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Header, HTTPException
+
+from dashboard.backend.api import discord_oauth
+from dashboard.backend.domain.agents.service import agent_service
+from dashboard.backend.users import user_store
+
+router = APIRouter(prefix="/v1/discord", tags=["discord"])
+
+
+def _require_bot_auth(
+    x_discord_bot_secret: Optional[str],
+    x_discord_user_id: Optional[str],
+) -> tuple[dict, str]:
+    if not discord_oauth.verify_bot_secret(x_discord_bot_secret):
+        raise HTTPException(status_code=401, detail="Invalid Discord bot secret")
+    discord_user_id = (x_discord_user_id or "").strip()
+    if not discord_user_id:
+        raise HTTPException(status_code=400, detail="X-Discord-User-Id is required")
+    user = user_store.get_user_by_discord_id(discord_user_id)
+    if not user:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "discord_not_linked", "message": "Discord account is not linked"},
+        )
+    return user, discord_user_id
+
+
+@router.get("/agents")
+async def list_discord_user_agents(
+    x_discord_bot_secret: Optional[str] = Header(default=None, alias="X-Discord-Bot-Secret"),
+    x_discord_user_id: Optional[str] = Header(default=None, alias="X-Discord-User-Id"),
+):
+    """List agents owned by the website user linked to this Discord id.
+
+    Called by the Discord bot only (shared ``DISCORD_BOT_API_SECRET``).
+    Built-in agents are sorted first so ``/agent`` can prefer selectable cards.
+    """
+    user, _discord_user_id = _require_bot_auth(x_discord_bot_secret, x_discord_user_id)
+    agents = agent_service.list_agents_with_stats(
+        owner_user_id=int(user["id"]),
+        owner_browser_session=None,
+        trading_session_id=None,
+    )
+
+    public = []
+    for agent in agents:
+        latest = agent.get("latest_run") or {}
+        public.append(
+            {
+                "agent_id": agent["agent_id"],
+                "name": agent["name"],
+                "agent_type": agent.get("agent_type") or "external",
+                "model_name": agent.get("model_name") or "local-model",
+                "description": agent.get("description"),
+                "run_count": agent.get("run_count", 0),
+                "latest_return": latest.get("total_return"),
+                "latest_sharpe": latest.get("sharpe_ratio"),
+            }
+        )
+
+    # Prefer builtins for Discord select (backtest agent_id path requires builtin).
+    public.sort(key=lambda a: (0 if a["agent_type"] == "builtin" else 1, a["name"].lower()))
+    return {
+        "user": {
+            "id": user["id"],
+            "display_name": user.get("display_name"),
+        },
+        "agents": public,
+    }

--- a/dashboard/backend/integrations/discord_bot.py
+++ b/dashboard/backend/integrations/discord_bot.py
@@ -6,6 +6,7 @@ import os
 import uuid
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlencode
 
 import discord
 import requests
@@ -64,6 +65,32 @@ _SESSION_NAMESPACE = uuid.UUID("8f1b2c3d-0000-4000-8000-a9b8c7d6e5f4")
 def api_base() -> str:
     """Base URL of the running Agentic Trading Lab backend."""
     return os.getenv("ATL_API_BASE", "http://localhost:8000").rstrip("/")
+
+
+def public_app_base() -> str:
+    """Origin (or /app URL) used for dashboard deep links in Discord messages."""
+    raw = (os.getenv("PUBLIC_APP_URL") or api_base()).rstrip("/")
+    if raw.endswith("/app"):
+        return raw
+    return f"{raw}/app"
+
+
+def dashboard_backtest_url(
+    *,
+    agent_id: Optional[str],
+    run_id: Optional[str],
+) -> Optional[str]:
+    """Build /app?view=backtest&agent_id=…&run_id=… for Discord result messages."""
+    if not agent_id or not run_id:
+        return None
+    query = urlencode(
+        {
+            "view": "backtest",
+            "agent_id": str(agent_id),
+            "run_id": str(run_id),
+        }
+    )
+    return f"{public_app_base()}?{query}"
 
 
 def _parse_id_list(raw: Optional[str]) -> list[int]:
@@ -521,16 +548,21 @@ async def execute_backtest(
         f"Max DD: {pct(m.get('max_drawdown'))}  ·  Trades: {m.get('num_trades', 0)}\n"
         f"Final equity: ${float(m.get('final_equity') or 0):,.0f}"
     )
-    if share_url:
+    run_id = m.get("run_id")
+    agent_id = selected.get("agent_id") if selected else None
+    dash_url = dashboard_backtest_url(agent_id=agent_id, run_id=run_id)
+    if dash_url:
+        summary += f"\nDashboard: {dash_url}"
+    elif share_url:
         summary += f"\nView: {share_url}"
     if selected and selected.get("name"):
         summary += (
-            f"\nSaved to **{selected['name']}**'s card — open *My Agents* on the "
-            "website to track the details."
+            f"\nSaved to **{selected['name']}**'s card"
+            + (" — open the Dashboard link above." if dash_url else
+               " — open *My Agents* on the website to track the details.")
         )
     await interaction.edit_original_response(content=summary)
 
-    run_id = m.get("run_id")
     if run_id:
         try:
             png = await api_get_bytes(f"/runs/{run_id}/plot.png", headers=headers)

--- a/dashboard/backend/integrations/discord_bot.py
+++ b/dashboard/backend/integrations/discord_bot.py
@@ -283,11 +283,13 @@ async def fetch_owned_agents(
     )
     if status == 404:
         detail = data.get("detail")
-        code = None
-        if isinstance(detail, dict):
-            code = detail.get("code")
-        if code == "discord_not_linked" or status == 404:
+        code = detail.get("code") if isinstance(detail, dict) else None
+        if code == "discord_not_linked":
             return [], "discord_not_linked"
+        # Any other 404 (misconfigured ATL_API_BASE, a route rename) is a real
+        # outage — don't tell the user their account "isn't linked".
+        print(f"Discord owned-agents fetch failed: HTTP 404 {data!r}")
+        return [], "fetch_failed"
     if status >= 400:
         print(f"Discord owned-agents fetch failed: HTTP {status} {data!r}")
         return [], "fetch_failed"
@@ -549,13 +551,16 @@ async def execute_backtest(
         f"Final equity: ${float(m.get('final_equity') or 0):,.0f}"
     )
     run_id = m.get("run_id")
-    agent_id = selected.get("agent_id") if selected else None
-    dash_url = dashboard_backtest_url(agent_id=agent_id, run_id=run_id)
+    # Only a builtin agent gets agent_id attached to the run (see payload above).
+    # Key the deep link + "saved to card" line off what was actually sent so we
+    # never claim a run landed on an agent's card when it didn't.
+    attached_agent_id = payload.get("agent_id")
+    dash_url = dashboard_backtest_url(agent_id=attached_agent_id, run_id=run_id)
     if dash_url:
         summary += f"\nDashboard: {dash_url}"
     elif share_url:
         summary += f"\nView: {share_url}"
-    if selected and selected.get("name"):
+    if attached_agent_id and selected and selected.get("name"):
         summary += (
             f"\nSaved to **{selected['name']}**'s card"
             + (" — open the Dashboard link above." if dash_url else

--- a/dashboard/backend/integrations/discord_bot.py
+++ b/dashboard/backend/integrations/discord_bot.py
@@ -204,6 +204,31 @@ def _http_get_bytes(path: str, *, headers: Optional[dict] = None, timeout: int =
     return resp.content
 
 
+def _http_get_status(
+    path: str,
+    *,
+    headers: Optional[dict] = None,
+    timeout: int = 30,
+) -> tuple[int, dict]:
+    """GET that returns (status_code, json_body) without raising on 4xx."""
+    resp = requests.get(f"{api_base()}{path}", headers=headers or {}, timeout=timeout)
+    try:
+        body = resp.json() if resp.content else {}
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+    return resp.status_code, body
+
+
+def bot_api_headers(discord_user_id: str) -> dict[str, str]:
+    """Service headers for Discord → backend identity calls."""
+    return {
+        "X-Discord-Bot-Secret": (os.getenv("DISCORD_BOT_API_SECRET") or "").strip(),
+        "X-Discord-User-Id": str(discord_user_id),
+    }
+
+
 async def api_post(path: str, *, json: dict[str, Any], headers: Optional[dict] = None, timeout: int = 30) -> dict:
     return await asyncio.to_thread(_http_post, path, json=json, headers=headers, timeout=timeout)
 
@@ -216,10 +241,31 @@ async def api_get_bytes(path: str, *, headers: Optional[dict] = None, timeout: i
     return await asyncio.to_thread(_http_get_bytes, path, headers=headers, timeout=timeout)
 
 
-async def fetch_builtin_agents() -> list[dict[str, Any]]:
-    """Fetch the platform's built-in agents from the backend (public endpoint)."""
-    data = await api_get("/api/v1/agents/builtin")
-    return data.get("agents", []) if isinstance(data, dict) else []
+async def fetch_owned_agents(
+    discord_user_id: str,
+) -> tuple[list[dict[str, Any]], Optional[str]]:
+    """Fetch agents owned by the website account linked to this Discord user.
+
+    Returns ``(agents, error_code)``. ``error_code`` is ``discord_not_linked``,
+    ``fetch_failed``, or ``None`` on success.
+    """
+    status, data = await asyncio.to_thread(
+        _http_get_status,
+        "/api/v1/discord/agents",
+        headers=bot_api_headers(discord_user_id),
+    )
+    if status == 404:
+        detail = data.get("detail")
+        code = None
+        if isinstance(detail, dict):
+            code = detail.get("code")
+        if code == "discord_not_linked" or status == 404:
+            return [], "discord_not_linked"
+    if status >= 400:
+        print(f"Discord owned-agents fetch failed: HTTP {status} {data!r}")
+        return [], "fetch_failed"
+    agents = data.get("agents", []) if isinstance(data, dict) else []
+    return (agents if isinstance(agents, list) else []), None
 
 
 async def deliver_agent_chat(
@@ -249,22 +295,23 @@ async def deliver_agent_chat(
 
 
 class AgentSelect(discord.ui.Select):
-    """Dropdown letting a user pick which built-in agent to talk to."""
+    """Dropdown letting a user pick one of their owned built-in agents."""
 
     def __init__(self, agents: list[dict[str, Any]]):
         options: list[discord.SelectOption] = []
         for agent in agents[:25]:  # Discord caps selects at 25 options.
             model = agent.get("model_name") or "local-model"
             run_count = agent.get("run_count") or 0
+            agent_type = agent.get("agent_type") or "builtin"
             options.append(
                 discord.SelectOption(
                     label=(agent.get("name") or "agent")[:100],
                     value=agent["agent_id"],
-                    description=f"{model} · {run_count} backtest(s)"[:100],
+                    description=f"{agent_type} · {model} · {run_count} run(s)"[:100],
                 )
             )
         super().__init__(
-            placeholder="Choose a built-in agent to talk to…",
+            placeholder="Choose one of your agents…",
             min_values=1,
             max_values=1,
             options=options,
@@ -285,6 +332,7 @@ class AgentSelect(discord.ui.Select):
             "name": agent.get("name") or "agent",
             "model_name": agent.get("model_name") or "local-model",
             "session_id": agent.get("session_id"),
+            "agent_type": agent.get("agent_type") or "builtin",
         }
 
         await interaction.response.edit_message(
@@ -384,7 +432,7 @@ async def execute_backtest(
         return
 
     payload: dict[str, Any] = {"strategy_prompt": strategy_prompt}
-    if selected:
+    if selected and (selected.get("agent_type") or "builtin") == "builtin":
         payload["agent_id"] = selected["agent_id"]
     model_override = _model_override(selected.get("model_name")) if selected else None
     if model_override:
@@ -826,38 +874,79 @@ async def reset(
 
 @bot.tree.command(
     name="agent",
-    description="List built-in agents and choose which one to talk to.",
+    description="List your linked website agents and choose which one to talk to.",
 )
 async def agent(
     interaction: discord.Interaction,
 ) -> None:
     await interaction.response.defer(thinking=True, ephemeral=True)
 
+    discord_user_id = str(interaction.user.id)
     try:
-        agents = await fetch_builtin_agents()
+        agents, err = await fetch_owned_agents(discord_user_id)
     except Exception as exc:
         print("Discord /agent fetch failed:", repr(exc))
         await interaction.edit_original_response(
             content=(
-                "Could not load built-in agents. Is the backend running at "
+                "Could not load your agents. Is the backend running at "
                 f"`{api_base()}`? (set ATL_API_BASE if not)"
             )
         )
         return
 
-    if not agents:
+    if err == "discord_not_linked":
         await interaction.edit_original_response(
             content=(
-                "No built-in agents yet. Create one on the website:\n"
-                "**My Agents → Add Agent → Create a Built-in Agent** — it will "
-                "then appear here for everyone to chat with."
+                "Your Discord account is not linked to the website yet.\n"
+                "On the lab site: **sign in → Open Discord** (authorize once). "
+                "Then run `/agent` again to see *your* agents."
             )
         )
         return
 
-    current = selected_agent_for(interaction.user.id)
-    lines = ["**Built-in agents**"]
-    for a in agents[:25]:
+    if err == "fetch_failed":
+        await interaction.edit_original_response(
+            content=(
+                "Could not load your agents (auth/config error). "
+                "Ask an admin to check `DISCORD_BOT_API_SECRET` on the API and bot."
+            )
+        )
+        return
+
+    # Backtest agent_id path requires builtin; keep externals visible but not selectable.
+    selectable = [
+        a for a in agents
+        if (a.get("agent_type") or "external") == "builtin" and a.get("agent_id")
+    ]
+
+    # Drop stale in-memory selection if the agent is no longer owned.
+    current = selected_agent_for(discord_user_id)
+    owned_ids = {a["agent_id"] for a in agents if a.get("agent_id")}
+    if current and current.get("agent_id") not in owned_ids:
+        _selected_agents.pop(discord_user_id, None)
+        current = None
+
+    if not selectable:
+        if agents:
+            await interaction.edit_original_response(
+                content=(
+                    "Your linked account has agents, but none are **built-in** "
+                    "(needed for Discord backtests).\n"
+                    "On the website: **My Agents → Add Agent → Create a Built-in Agent**."
+                )
+            )
+        else:
+            await interaction.edit_original_response(
+                content=(
+                    "No agents on your linked website account yet.\n"
+                    "Create one on the site: **My Agents → Add Agent → "
+                    "Create a Built-in Agent**, then run `/agent` again."
+                )
+            )
+        return
+
+    lines = ["**Your agents** (linked website account)"]
+    for a in selectable[:25]:
         marker = "✅ " if current and current["agent_id"] == a["agent_id"] else "• "
         lines.append(
             f"{marker}**{a.get('name')}** — `{a.get('model_name') or 'local-model'}` "
@@ -869,7 +958,7 @@ async def agent(
 
     await interaction.edit_original_response(
         content="\n".join(lines),
-        view=AgentSelectView(agents),
+        view=AgentSelectView(selectable),
     )
 
 

--- a/dashboard/backend/tests/domain/chat/test_discord_bot.py
+++ b/dashboard/backend/tests/domain/chat/test_discord_bot.py
@@ -5,6 +5,7 @@ module is skipped so the suite stays green on minimal interpreters. No real
 Discord connection or network call is made.
 """
 
+import asyncio
 import subprocess
 import sys
 import textwrap
@@ -115,6 +116,30 @@ def test_split_discord_message_splits_long_text():
     chunks = bot_mod.split_discord_message(text, limit=100)
     assert len(chunks) > 1
     assert all(len(chunk) <= 100 for chunk in chunks)
+
+
+def test_fetch_owned_agents_maps_not_linked_code(monkeypatch):
+    """A 404 carrying ``code=discord_not_linked`` is the unlinked case."""
+    monkeypatch.setattr(
+        bot_mod,
+        "_http_get_status",
+        lambda *a, **k: (404, {"detail": {"code": "discord_not_linked"}}),
+    )
+    agents, err = asyncio.run(bot_mod.fetch_owned_agents("123"))
+    assert agents == []
+    assert err == "discord_not_linked"
+
+
+def test_fetch_owned_agents_other_404_is_fetch_failed(monkeypatch):
+    """A bare 404 (bad ATL_API_BASE / route rename) must NOT read as 'unlinked'."""
+    monkeypatch.setattr(
+        bot_mod,
+        "_http_get_status",
+        lambda *a, **k: (404, {"detail": "Not Found"}),
+    )
+    agents, err = asyncio.run(bot_mod.fetch_owned_agents("123"))
+    assert agents == []
+    assert err == "fetch_failed"
 
 
 def test_discord_bot_imports_without_secrets():

--- a/dashboard/backend/tests/integrations/test_discord_wiring.py
+++ b/dashboard/backend/tests/integrations/test_discord_wiring.py
@@ -78,6 +78,14 @@ def test_bot_agent_uses_owned_discord_agents_endpoint():
     assert 'api_get("/api/v1/agents/builtin")' not in src
 
 
+def test_bot_builds_dashboard_backtest_deep_link():
+    src = _source()
+    assert "def dashboard_backtest_url(" in src
+    assert '"view": "backtest"' in src
+    assert "agent_id" in src and "run_id" in src
+    assert "Dashboard:" in src
+
+
 def test_bot_sends_per_user_id_on_strategy_post():
     """MEDIUM #4 — the bot must send a per-Discord-user X-Browser-Id when creating
     a strategy, else all Discord users share the bot process's single (IP) bucket

--- a/dashboard/backend/tests/integrations/test_discord_wiring.py
+++ b/dashboard/backend/tests/integrations/test_discord_wiring.py
@@ -63,6 +63,19 @@ def test_discord_dependency_is_declared():
 def test_bot_backtest_sends_agent_id_for_builtin_card():
     src = _source()
     assert 'payload["agent_id"] = selected["agent_id"]' in src
+    assert 'selected.get("agent_type") or "builtin") == "builtin"' in src
+
+
+def test_bot_agent_uses_owned_discord_agents_endpoint():
+    """Discord /agent must list the linked website user's agents, not the
+    public /agents/builtin catalog."""
+    src = _source()
+    assert "/api/v1/discord/agents" in src
+    assert "fetch_owned_agents" in src
+    assert "discord_not_linked" in src
+    # Public catalog must not be the /agent source of truth anymore.
+    assert "fetch_builtin_agents" not in src
+    assert 'api_get("/api/v1/agents/builtin")' not in src
 
 
 def test_bot_sends_per_user_id_on_strategy_post():
@@ -71,3 +84,5 @@ def test_bot_sends_per_user_id_on_strategy_post():
     on the server's write rate limiter."""
     src = _source()
     assert '"X-Browser-Id": f"discord:{discord_user_id}"' in src
+    assert "X-Discord-Bot-Secret" in src
+    assert "DISCORD_BOT_API_SECRET" in src

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -43,7 +43,6 @@ EXPECTED_BACKTESTS_ROUTES = {
     ("GET", "/runs/{run_id}/equity", "get_equity_curve"),
     ("GET", "/runs/{run_id}/trades", "get_run_trades"),
     ("GET", "/runs/{run_id}/plot.png", "get_run_plot"),
-    ("GET", "/runs/{run_id}/trades", "get_run_trades"),
     ("GET", "/compare", "compare_runs"),
 }
 

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -43,6 +43,7 @@ EXPECTED_BACKTESTS_ROUTES = {
     ("GET", "/runs/{run_id}/equity", "get_equity_curve"),
     ("GET", "/runs/{run_id}/trades", "get_run_trades"),
     ("GET", "/runs/{run_id}/plot.png", "get_run_plot"),
+    ("GET", "/runs/{run_id}/trades", "get_run_trades"),
     ("GET", "/compare", "compare_runs"),
 }
 
@@ -66,6 +67,8 @@ EXPECTED_FULL_CONTRACT = {
     ("POST", "/api/auth/logout"),
     ("GET", "/api/auth/me"),
     ("POST", "/api/auth/signup"),
+    ("GET", "/api/auth/discord/callback"),
+    ("POST", "/api/auth/discord/start"),
     ("GET", "/api/backtest/compare/latest"),
     ("GET", "/api/backtest/runs"),
     ("GET", "/api/backtest/{run_id}"),
@@ -78,6 +81,7 @@ EXPECTED_FULL_CONTRACT = {
     ("POST", "/api/v1/agents/claim-account"),
     ("POST", "/api/v1/agents/import-session"),
     ("GET", "/api/v1/agents/resolve"),
+    ("GET", "/api/v1/discord/agents"),
     ("DELETE", "/api/v1/agents/{agent_id}"),
     ("GET", "/api/v1/agents/{agent_id}"),
     ("PATCH", "/api/v1/agents/{agent_id}"),

--- a/dashboard/backend/tests/test_discord_linking.py
+++ b/dashboard/backend/tests/test_discord_linking.py
@@ -1,0 +1,215 @@
+"""Discord account linking + bot-owned agents API."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+from dashboard.backend.users import UserStore
+from dashboard.backend.api import discord_oauth
+
+
+@pytest.fixture
+def temp_user_store(tmp_path, monkeypatch):
+    store = UserStore(db_path=tmp_path / "discord_auth.db")
+    import dashboard.backend.users as users_module
+
+    monkeypatch.setattr(users_module, "user_store", store)
+    # discord router imports user_store at module level — re-bind it too
+    import dashboard.backend.api.routers.discord as discord_router_mod
+    import dashboard.backend.api.auth as auth_mod
+
+    monkeypatch.setattr(discord_router_mod, "user_store", store)
+    monkeypatch.setattr(auth_mod, "user_store", store)
+    return store
+
+
+@pytest.fixture
+def client(temp_user_store, monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_API_SECRET", "test-bot-secret")
+    monkeypatch.setenv("DISCORD_CLIENT_ID", "client-id")
+    monkeypatch.setenv("DISCORD_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv(
+        "DISCORD_REDIRECT_URI",
+        "http://testserver/api/auth/discord/callback",
+    )
+    monkeypatch.setenv("DISCORD_GUILD_CHANNEL_URL", "https://discord.gg/test-channel")
+    return TestClient(app)
+
+
+def _signup(client, email="alice@example.com", name="Alice"):
+    resp = client.post(
+        "/api/auth/signup",
+        json={"email": email, "display_name": name, "password": "securepass1"},
+    )
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def test_public_user_includes_discord_link_fields(client):
+    data = _signup(client)
+    user = data["user"]
+    assert user["discord_linked"] is False
+    assert user["discord_user_id"] is None
+
+    me = client.get("/api/auth/me", headers={"Authorization": f"Bearer {data['token']}"})
+    assert me.status_code == 200
+    assert me.json()["user"]["discord_linked"] is False
+
+
+def test_link_discord_user_and_conflict(temp_user_store):
+    a = temp_user_store.create_user("a@example.com", "A", "securepass1")
+    b = temp_user_store.create_user("b@example.com", "B", "securepass1")
+
+    linked = temp_user_store.link_discord_user(a["id"], "111")
+    assert linked["discord_linked"] is True
+    assert linked["discord_user_id"] == "111"
+
+    # Idempotent re-link for same user
+    again = temp_user_store.link_discord_user(a["id"], "111")
+    assert again["discord_user_id"] == "111"
+
+    with pytest.raises(ValueError, match="discord_already_linked"):
+        temp_user_store.link_discord_user(b["id"], "111")
+
+
+def test_discord_start_requires_auth(client):
+    assert client.post("/api/auth/discord/start").status_code == 401
+
+
+def test_discord_start_returns_authorize_url(client):
+    data = _signup(client)
+    resp = client.post(
+        "/api/auth/discord/start",
+        headers={"Authorization": f"Bearer {data['token']}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["already_linked"] is False
+    assert "client_id=client-id" in body["authorize_url"]
+    assert "scope=identify" in body["authorize_url"]
+    assert body["discord_url"] == "https://discord.gg/test-channel"
+
+
+def test_discord_start_already_linked(client, temp_user_store):
+    data = _signup(client)
+    temp_user_store.link_discord_user(data["user"]["id"], "999888")
+    resp = client.post(
+        "/api/auth/discord/start",
+        headers={"Authorization": f"Bearer {data['token']}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["already_linked"] is True
+    assert body["authorize_url"] is None
+    assert body["user"]["discord_linked"] is True
+
+
+def test_discord_oauth_callback_links_user(client, temp_user_store, monkeypatch):
+    data = _signup(client)
+    user_id = data["user"]["id"]
+    state = discord_oauth.mint_oauth_state(user_id)
+
+    monkeypatch.setattr(
+        discord_oauth,
+        "exchange_code_for_access_token",
+        lambda code: "access-token",
+    )
+    monkeypatch.setattr(
+        discord_oauth,
+        "fetch_discord_user",
+        lambda token: {"id": "discord-42", "username": "demo"},
+    )
+
+    resp = client.get(
+        "/api/auth/discord/callback",
+        params={"code": "abc", "state": state},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert "discord=linked" in resp.headers["location"]
+
+    linked = temp_user_store.get_user_by_discord_id("discord-42")
+    assert linked is not None
+    assert linked["id"] == user_id
+
+
+def test_discord_agents_requires_bot_secret(client):
+    resp = client.get(
+        "/api/v1/discord/agents",
+        headers={"X-Discord-User-Id": "123"},
+    )
+    assert resp.status_code == 401
+
+
+def test_discord_agents_not_linked(client):
+    resp = client.get(
+        "/api/v1/discord/agents",
+        headers={
+            "X-Discord-Bot-Secret": "test-bot-secret",
+            "X-Discord-User-Id": "no-such-user",
+        },
+    )
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["code"] == "discord_not_linked"
+
+
+def test_discord_agents_returns_only_owner_agents(client, temp_user_store):
+    alice = _signup(client, email="owner@example.com", name="Owner")
+    bob = _signup(client, email="other@example.com", name="Other")
+
+    temp_user_store.link_discord_user(alice["user"]["id"], "discord-alice")
+    temp_user_store.link_discord_user(bob["user"]["id"], "discord-bob")
+
+    browser = str(uuid.uuid4())
+    created = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "Alice Bot",
+            "agent_type": "builtin",
+            "model_name": "anthropic/claude-haiku-4-5",
+        },
+        headers={
+            "Authorization": f"Bearer {alice['token']}",
+            "X-Session-Id": browser,
+            "X-Browser-Id": browser,
+        },
+    )
+    assert created.status_code == 200
+    alice_agent_id = created.json()["agent"]["agent_id"]
+
+    bob_browser = str(uuid.uuid4())
+    client.post(
+        "/api/v1/agents",
+        json={"name": "Bob Bot", "agent_type": "builtin"},
+        headers={
+            "Authorization": f"Bearer {bob['token']}",
+            "X-Session-Id": bob_browser,
+            "X-Browser-Id": bob_browser,
+        },
+    )
+
+    listing = client.get(
+        "/api/v1/discord/agents",
+        headers={
+            "X-Discord-Bot-Secret": "test-bot-secret",
+            "X-Discord-User-Id": "discord-alice",
+        },
+    )
+    assert listing.status_code == 200
+    body = listing.json()
+    assert body["user"]["id"] == alice["user"]["id"]
+    ids = {a["agent_id"] for a in body["agents"]}
+    assert alice_agent_id in ids
+    assert all(a["name"] != "Bob Bot" for a in body["agents"])
+
+
+def test_oauth_state_roundtrip():
+    state = discord_oauth.mint_oauth_state(7)
+    assert discord_oauth.parse_oauth_state(state) == 7
+    with pytest.raises(ValueError):
+        discord_oauth.parse_oauth_state(state + "tampered")

--- a/dashboard/backend/users.py
+++ b/dashboard/backend/users.py
@@ -64,12 +64,15 @@ def verify_password(password: str, password_hash: str) -> bool:
 
 def public_user(row: sqlite3.Row | Dict[str, Any]) -> Dict[str, Any]:
     data = dict(row)
+    discord_user_id = data.get("discord_user_id")
     return {
         "id": data["id"],
         "email": data["email"],
         "display_name": data["display_name"],
         "role": data["role"],
         "created_at": data["created_at"],
+        "discord_linked": bool(discord_user_id),
+        "discord_user_id": str(discord_user_id) if discord_user_id else None,
     }
 
 
@@ -116,6 +119,20 @@ class UserStore:
             """
             CREATE INDEX IF NOT EXISTS idx_auth_sessions_user_id
             ON auth_sessions(user_id)
+            """
+        )
+        # Lazy migration: Discord OAuth link column (nullable unique).
+        cursor.execute("PRAGMA table_info(users)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if "discord_user_id" not in columns:
+            cursor.execute(
+                "ALTER TABLE users ADD COLUMN discord_user_id TEXT"
+            )
+        cursor.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_users_discord_user_id
+            ON users(discord_user_id)
+            WHERE discord_user_id IS NOT NULL
             """
         )
         conn.commit()
@@ -229,6 +246,67 @@ class UserStore:
         cursor.execute("DELETE FROM auth_sessions WHERE token = ?", (token,))
         conn.commit()
         conn.close()
+
+    def get_user_by_discord_id(self, discord_user_id: str) -> Optional[Dict[str, Any]]:
+        discord_id = str(discord_user_id).strip()
+        if not discord_id:
+            return None
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM users WHERE discord_user_id = ?",
+            (discord_id,),
+        )
+        row = cursor.fetchone()
+        conn.close()
+        return dict(row) if row else None
+
+    def link_discord_user(self, user_id: int, discord_user_id: str) -> Dict[str, Any]:
+        """Attach a Discord snowflake to a website user.
+
+        Raises ValueError('discord_already_linked') if another account owns it.
+        """
+        discord_id = str(discord_user_id).strip()
+        if not discord_id:
+            raise ValueError("invalid_discord_user_id")
+
+        existing = self.get_user_by_discord_id(discord_id)
+        if existing and int(existing["id"]) != int(user_id):
+            raise ValueError("discord_already_linked")
+
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                "UPDATE users SET discord_user_id = ? WHERE id = ?",
+                (discord_id, user_id),
+            )
+            conn.commit()
+        except sqlite3.IntegrityError as exc:
+            conn.close()
+            raise ValueError("discord_already_linked") from exc
+
+        cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+        row = cursor.fetchone()
+        conn.close()
+        if not row:
+            raise ValueError("user_not_found")
+        return public_user(row)
+
+    def unlink_discord_user(self, user_id: int) -> Dict[str, Any]:
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE users SET discord_user_id = NULL WHERE id = ?",
+            (user_id,),
+        )
+        conn.commit()
+        cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+        row = cursor.fetchone()
+        conn.close()
+        if not row:
+            raise ValueError("user_not_found")
+        return public_user(row)
 
 
 def _build_user_store():

--- a/dashboard/backend/users_postgres.py
+++ b/dashboard/backend/users_postgres.py
@@ -41,8 +41,23 @@ class PostgresUserStore:
                         display_name TEXT NOT NULL,
                         password_hash TEXT NOT NULL,
                         role TEXT NOT NULL DEFAULT 'user',
-                        created_at TEXT NOT NULL
+                        created_at TEXT NOT NULL,
+                        discord_user_id TEXT
                     )
+                    """
+                )
+                # Lazy migration for existing deployments created before Discord linking.
+                cur.execute(
+                    """
+                    ALTER TABLE users
+                    ADD COLUMN IF NOT EXISTS discord_user_id TEXT
+                    """
+                )
+                cur.execute(
+                    """
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_users_discord_user_id
+                    ON users(discord_user_id)
+                    WHERE discord_user_id IS NOT NULL
                     """
                 )
                 cur.execute(
@@ -159,3 +174,56 @@ class PostgresUserStore:
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute("DELETE FROM auth_sessions WHERE token = %s", (token,))
+
+    def get_user_by_discord_id(self, discord_user_id: str) -> Optional[Dict[str, Any]]:
+        discord_id = str(discord_user_id).strip()
+        if not discord_id:
+            return None
+        with self._get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM users WHERE discord_user_id = %s",
+                    (discord_id,),
+                )
+                row = cur.fetchone()
+        return dict(row) if row else None
+
+    def link_discord_user(self, user_id: int, discord_user_id: str) -> Dict[str, Any]:
+        """Attach a Discord snowflake to a website user.
+
+        Raises ValueError('discord_already_linked') if another account owns it.
+        """
+        discord_id = str(discord_user_id).strip()
+        if not discord_id:
+            raise ValueError("invalid_discord_user_id")
+
+        existing = self.get_user_by_discord_id(discord_id)
+        if existing and int(existing["id"]) != int(user_id):
+            raise ValueError("discord_already_linked")
+
+        try:
+            with self._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE users SET discord_user_id = %s WHERE id = %s RETURNING *",
+                        (discord_id, user_id),
+                    )
+                    row = cur.fetchone()
+        except psycopg.errors.UniqueViolation as exc:
+            raise ValueError("discord_already_linked") from exc
+
+        if not row:
+            raise ValueError("user_not_found")
+        return public_user(row)
+
+    def unlink_discord_user(self, user_id: int) -> Dict[str, Any]:
+        with self._get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE users SET discord_user_id = NULL WHERE id = %s RETURNING *",
+                    (user_id,),
+                )
+                row = cur.fetchone()
+        if not row:
+            raise ValueError("user_not_found")
+        return public_user(row)

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -27,6 +27,10 @@
                 contest: { page: 'competition', competitionTab: 'leaderboard' },
                 'my-algo': { page: 'playground', playgroundTab: 'agents' },
             };
+            // Discord / share deep links: open Playground backtest immediately.
+            if (params.get('agent_id') || params.get('run_id')) {
+                return { page: 'playground', playgroundTab: 'backtest' };
+            }
             if (legacy && legacyMap[legacy]) return legacyMap[legacy];
             try {
                 var saved = JSON.parse(localStorage.getItem(NAV_STATE_KEY) || 'null');

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -111,7 +111,7 @@
                 <svg class="ui-icon header-github-icon" aria-hidden="true"><use href="#icon-github"/></svg>
                 <span class="header-github-name">AgenticTrading</span>
             </a>
-            <a id="openDiscordBtn" class="header-discord-btn" href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">
+            <a id="openDiscordBtn" class="header-discord-btn" data-discord-link href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">
                 <svg class="header-discord-btn__icon" aria-hidden="true"><use href="#icon-discord"/></svg>
                 <span class="header-discord-btn__label">Discord Community</span>
                 <svg class="header-discord-btn__arrow" aria-hidden="true"><use href="#icon-chevron-right"/></svg>
@@ -738,7 +738,7 @@
                 <div class="agents-section-head">
                     <div class="agents-section-title-row">
                         <h2 class="page-title">My Agents</h2>
-                        <a id="agentsSectionDiscordBtn" class="discord-nav-btn discord-nav-btn-sm" href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">Open Discord</a>
+                        <a id="agentsSectionDiscordBtn" class="discord-nav-btn discord-nav-btn-sm" data-discord-link href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">Open Discord</a>
                     </div>
                     <div class="agent-toolbar">
                         <select id="agentFilterSelect" class="agent-toolbar-select" aria-label="Filter agents">

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1041,6 +1041,10 @@ const AuthAPI = {
   logout() {
     return this.request('/api/auth/logout', { method: 'POST' });
   },
+
+  discordStart() {
+    return this.request('/api/auth/discord/start', { method: 'POST' });
+  },
 };
 
 let authMode = 'login';
@@ -1181,6 +1185,95 @@ function closeAuthModal() {
   setAuthMode('login');
 }
 
+/**
+ * Open Discord with the current website account.
+ * Not logged in → login modal.
+ * Logged in, not linked → Discord OAuth.
+ * Already linked → open the guild/channel URL.
+ */
+async function openDiscordWithAccount(event) {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  const token = localStorage.getItem(AUTH_TOKEN_KEY);
+  if (!token || !getStoredAuthUser()) {
+    openAuthModal('login');
+    return;
+  }
+
+  try {
+    const data = await AuthAPI.discordStart();
+    const discordUrl = data.discord_url || DISCORD_SERVER_URL;
+    if (data.already_linked) {
+      window.open(discordUrl, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    if (data.authorize_url) {
+      window.location.href = data.authorize_url;
+      return;
+    }
+    window.open(discordUrl, '_blank', 'noopener,noreferrer');
+  } catch (error) {
+    console.warn('Discord link start failed:', error.message);
+    alert(error.message || 'Could not start Discord linking. Are you signed in?');
+  }
+}
+
+/** Handle /app?discord=linked|error after OAuth callback. */
+async function handleDiscordOAuthReturn() {
+  const params = new URLSearchParams(window.location.search);
+  const discord = (params.get('discord') || '').toLowerCase();
+  if (!discord) return;
+
+  const reason = params.get('reason') || '';
+  params.delete('discord');
+  params.delete('reason');
+  const clean = params.toString();
+  const next = `${window.location.pathname}${clean ? `?${clean}` : ''}${window.location.hash}`;
+  window.history.replaceState({}, '', next);
+
+  if (discord === 'linked') {
+    try {
+      await refreshAuthUser();
+    } catch (error) {
+      console.warn('Auth refresh after Discord link failed:', error.message);
+    }
+    try {
+      const data = await AuthAPI.discordStart();
+      window.open(data.discord_url || DISCORD_SERVER_URL, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      window.open(DISCORD_SERVER_URL, '_blank', 'noopener,noreferrer');
+    }
+    return;
+  }
+
+  if (discord === 'error') {
+    const messages = {
+      missing_params: 'Discord linking failed (missing OAuth params).',
+      invalid_state: 'Discord linking expired. Please try Open Discord again.',
+      discord_already_linked: 'That Discord account is already linked to another user.',
+      oauth_failed: 'Discord authorization failed. Please try again.',
+      link_failed: 'Could not link Discord to your account.',
+    };
+    alert(messages[reason] || `Discord linking failed${reason ? ` (${reason})` : ''}.`);
+  }
+}
+
+function wireDiscordAccountButtons() {
+  const ids = ['openDiscordBtn', 'agentsSectionDiscordBtn', 'homeConnectDiscordBtn'];
+  ids.forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener('click', openDiscordWithAccount);
+  });
+  document.querySelectorAll('a.discord-nav-btn').forEach((el) => {
+    if (ids.includes(el.id)) return;
+    el.addEventListener('click', openDiscordWithAccount);
+  });
+}
+
 async function refreshAuthUser() {
   const token = localStorage.getItem(AUTH_TOKEN_KEY);
   if (!token) {
@@ -1270,6 +1363,8 @@ function initAuthUI() {
   window.AUTH_USER = getStoredAuthUser();
   updateAuthUI();
   openAuthFromUrl();
+  handleDiscordOAuthReturn();
+  wireDiscordAccountButtons();
   refreshAuthUser();
 }
 
@@ -3029,10 +3124,7 @@ function initNavigation() {
             } else if (target === 'playground') {
                 navigateToPage('playground', { playgroundTab: 'agents' });
             } else if (target === 'discord') {
-                const discordUrl = document.getElementById('homeConnectDiscordBtn')?.href
-                    || document.getElementById('openDiscordBtn')?.href
-                    || 'https://discord.gg/9HnQ6XDG98';
-                window.open(discordUrl, '_blank', 'noopener,noreferrer');
+                openDiscordWithAccount();
             }
         });
     });

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1418,6 +1418,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await loadData();
     });
     await restoreActiveAgentSession();
+    await applyAgentRunDeepLink();
     const config = loadConfigFromURL();
     window.CURRENT_CONFIG = config;
     console.log('⚙️ Experiment config:', config);
@@ -2908,6 +2909,11 @@ function resolveInitialNavigation() {
         'my-algo': { page: 'playground', playgroundTab: 'agents' },
     };
 
+    // Discord / share deep links land on the backtest playground.
+    if (params.get('agent_id') || params.get('run_id')) {
+        return { page: 'playground', playgroundTab: 'backtest' };
+    }
+
     // An explicit URL view/hash always wins.
     if (legacy && legacyMap[legacy]) {
         return legacyMap[legacy];
@@ -2925,6 +2931,59 @@ function resolveInitialNavigation() {
     }
 
     return { page: 'home' };
+}
+
+/**
+ * Open a specific agent + backtest run from ?agent_id=&run_id= (Discord links).
+ */
+async function applyAgentRunDeepLink() {
+    const params = new URLSearchParams(window.location.search);
+    const agentId = (params.get('agent_id') || '').trim();
+    const runId = (params.get('run_id') || '').trim();
+    if (!agentId && !runId) return;
+
+    try {
+        await loadAgents();
+    } catch (error) {
+        console.warn('Deep link: loadAgents failed:', error.message);
+    }
+
+    let agent = agentId
+        ? (allAgents || []).find((a) => a.agent_id === agentId)
+        : null;
+    if (!agent && agentId) {
+        try {
+            const data = await API.get(`${API_BASE}/api/v1/agents/${encodeURIComponent(agentId)}`);
+            agent = data?.agent || null;
+        } catch (error) {
+            console.warn('Deep link: agent not accessible:', error.message);
+        }
+    }
+
+    if (agent) {
+        try {
+            await activateAgent(agent);
+        } catch (error) {
+            console.warn('Deep link: activateAgent failed:', error.message);
+        }
+    }
+
+    if (runId) {
+        localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, runId);
+    }
+
+    navigateToPage('playground', { playgroundTab: 'backtest' });
+    currentMode = 'backtest';
+    await loadData();
+
+    params.delete('agent_id');
+    params.delete('run_id');
+    if (!params.get('view') && !params.get('mode')) {
+        params.set('view', 'backtest');
+    }
+    const clean = params.toString();
+    const next = `${window.location.pathname}${clean ? `?${clean}` : ''}${window.location.hash}`;
+    window.history.replaceState({}, '', next);
 }
 
 function updatePlaygroundSubtabs() {

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1262,14 +1262,10 @@ async function handleDiscordOAuthReturn() {
 }
 
 function wireDiscordAccountButtons() {
-  const ids = ['openDiscordBtn', 'agentsSectionDiscordBtn', 'homeConnectDiscordBtn'];
-  ids.forEach((id) => {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.addEventListener('click', openDiscordWithAccount);
-  });
-  document.querySelectorAll('a.discord-nav-btn').forEach((el) => {
-    if (ids.includes(el.id)) return;
+  // Opt-in only: account-linking buttons carry data-discord-link. A plain
+  // "Join Discord" community invite (no marker) stays an ordinary link so
+  // logged-out visitors reach the server instead of a login modal.
+  document.querySelectorAll('[data-discord-link]').forEach((el) => {
     el.addEventListener('click', openDiscordWithAccount);
   });
 }
@@ -1350,6 +1346,12 @@ function initAuthUI() {
       setAuthState(data.user, data.token);
       await claimAgentsForUser();
       closeAuthModal();
+      // If we arrived here from a Discord deep link that needed this account
+      // (params were kept), retry it now that the owner is signed in.
+      const deepLinkParams = new URLSearchParams(window.location.search);
+      if (deepLinkParams.get('agent_id') || deepLinkParams.get('run_id')) {
+        applyAgentRunDeepLink();
+      }
     } catch (error) {
       if (errorEl) {
         errorEl.textContent = error.message;
@@ -2951,13 +2953,29 @@ async function applyAgentRunDeepLink() {
     let agent = agentId
         ? (allAgents || []).find((a) => a.agent_id === agentId)
         : null;
+    let agentAuthError = false;
     if (!agent && agentId) {
         try {
             const data = await API.get(`${API_BASE}/api/v1/agents/${encodeURIComponent(agentId)}`);
             agent = data?.agent || null;
         } catch (error) {
+            // The agent card is owner-gated (403). A Discord deep link is often
+            // opened on a different device/browser than the one that owns the
+            // agent, so surface it instead of silently landing on an empty session.
+            agentAuthError = error.status === 401 || error.status === 403;
             console.warn('Deep link: agent not accessible:', error.message);
         }
+    }
+
+    if (agentId && !agent && agentAuthError) {
+        const signedIn = !!(localStorage.getItem(AUTH_TOKEN_KEY) && getStoredAuthUser());
+        if (!signedIn) {
+            // Leave agent_id/run_id in the URL so a successful sign-in retries.
+            alert('Sign in with the account that owns this agent to open its backtest from Discord.');
+            openAuthModal('login');
+            return;
+        }
+        alert('This agent belongs to a different account. Sign in with the account that owns it to open its backtest.');
     }
 
     if (agent) {

--- a/docs/architecture/discord-to-backtest.md
+++ b/docs/architecture/discord-to-backtest.md
@@ -1,0 +1,58 @@
+# Discord → Backtest → Dashboard
+
+Short note for the Discord demo path ([Issue #79](https://github.com/Open-Finance-Lab/AgenticTrading/issues/79)). Backend layering: [`dashboard-target-structure.md`](./dashboard-target-structure.md).
+
+## Current workflow (user steps)
+
+Full path that lands a run on a website agent card and opens it in Playground:
+
+1. **Sign in** on the lab website and create at least one **built-in** agent (My Agents).
+2. Click **Open Discord** (header or My Agents). First time: authorize Discord OAuth once so the site stores `users.discord_user_id`.
+3. In the Discord bot channel, run **`/agent`** and pick one of your linked agents.
+4. Optional: **`/ask`** to brainstorm rules, then **`/strategy`** to save a reusable prompt (or skip straight to backtest).
+5. Run **`/backtest`** with either:
+   - `prompt: …` (inline strategy text), or
+   - `code: …` (saved strategy share code);
+   optional `start:` / `end:` dates.
+6. Wait for the bot reply: metrics summary + equity PNG. If an agent was selected, open the **Dashboard** deep link (`/app?view=backtest&agent_id=…&run_id=…`) to inspect the same run in Playground.
+
+Shortcut (no account link / no agent card): skip steps 1–3 and run `/backtest prompt:…` alone — results stay on the Discord session only.
+
+Operator cheat sheet: [`docs/discord-bot-instructions.md`](../discord-bot-instructions.md).
+
+### What happens behind those steps
+
+```text
+User steps above
+    │  /agent     →  GET /api/v1/discord/agents  (bot secret + Discord user id)
+    │  /ask|/strategy → chat / strategy APIs
+    │  /backtest  →  POST /backtest/run  (X-Session-Id)
+    ▼
+FastAPI (dashboard.backend.app)
+    │  hourly engine + Alpaca bars + hosted LLM
+    │  persist run (config, trades, equity, errors) in SQLite
+    ▼
+Discord: metrics + PNG + Dashboard deep link → Playground
+```
+
+| Piece | Role today |
+| --- | --- |
+| **Account link** | **Open Discord** → OAuth `identify` → `users.discord_user_id`. `/agent` lists that account’s agents only. |
+| **Entrypoint** | `dashboard/backend/integrations/discord_bot.py` — HTTP client to the same API the website uses. |
+| **Run** | `POST /backtest/run` + poll `GET /backtest/status`; builtin `agent_id` attaches the run to that agent’s card. |
+| **Record** | Unique `run_id`; equity/metrics/plot via `/runs/...`. |
+| **Hand-off** | Selected agent → Playground deep link in the bot reply. |
+
+`/api/v1` is the compatibility surface the bot uses. New agent-facing work should prefer `/api/v2`; migrating Discord onto v2 is future work, not required for this demo.
+
+## Future: paper trading from Discord
+
+Paper trading already exists on the website (`/paper/*` → Alpaca paper via `domain/trading` + `infrastructure/brokers/alpaca_paper.py`). It is **not** wired into the Discord bot yet.
+
+Intended direction (when Phase B lands):
+
+1. Reuse the same account-link + agent selection path.
+2. Drive live/paper steps through the v2 `ExecutionBackend` (`execution/paper_backend.py` is still a stub).
+3. Keep Discord as a thin client: start/status/summary + a dashboard deep link into the paper session, same pattern as backtest — do not embed a second broker stack in the bot.
+
+Until then, Discord remains **backtest-only**; paper stays on the web UI.

--- a/docs/discord-bot-instructions.md
+++ b/docs/discord-bot-instructions.md
@@ -1,0 +1,55 @@
+# Discord Bot Instructions
+
+Talk to the Agentic Trading Lab bot in Discord. Chat about strategies, save a prompt, and run a real backtest (Alpaca bars + hosted model) without leaving Discord.
+
+Invite: [discord.gg/9HnQ6XDG98](https://discord.gg/9HnQ6XDG98)
+
+---
+
+## Link your website account (required for `/agent`)
+
+`/agent` shows **your** agents from the lab website — not everyone else's.
+
+1. Sign in on the website.
+2. Click **Open Discord** (header or My Agents). The first time, Discord asks you to authorize once.
+3. After linking, run `/agent` in Discord to pick one of your built-in agents.
+
+Until you link, `/backtest prompt:…` still works (results stay on a Discord session, not an agent card).
+
+---
+
+## Fastest path: one command, no extra clicks
+
+```
+/backtest prompt: Buy the Magnificent 7 equally when the market is calm; cut exposure when volatility spikes.
+```
+
+Optional dates: `start:YYYY-MM-DD` `end:YYYY-MM-DD`.
+
+---
+
+## Full workflow
+
+1. `/agent` — pick a linked website agent (after Open Discord / OAuth)
+2. `/ask` — brainstorm rules (or type in the bot channel)
+3. `/strategy` — save a reusable prompt (+ optional **Run backtest** button)
+4. `/backtest` — run on real Alpaca data (`prompt:` or `code:`)
+
+---
+
+## Commands
+
+- **`/agent`** — list *your* linked agents and select one
+- **`/ask`** — chat with the selected (or default) agent
+- **`/strategy`** — synthesize and save a strategy prompt
+- **`/prompt`** — show a saved strategy by share code
+- **`/backtest`** — start a backtest (`prompt` or `code`, optional dates)
+- **`/reset`** — clear temporary chat memory
+
+---
+
+## Tips
+
+- Only one backtest runs on the server at a time.
+- Prefer **built-in** agents for Discord backtests (results land on that agent's website card).
+- If `/agent` says you are not linked, use **Open Discord** on the site while signed in.

--- a/docs/discord-bot-instructions.md
+++ b/docs/discord-bot-instructions.md
@@ -35,6 +35,8 @@ Optional dates: `start:YYYY-MM-DD` `end:YYYY-MM-DD`.
 3. `/strategy` — save a reusable prompt (+ optional **Run backtest** button)
 4. `/backtest` — run on real Alpaca data (`prompt:` or `code:`)
 
+When a backtest finishes for a selected agent, the bot includes a **Dashboard** link that opens Playground → Backtest for that agent and run (`/app?view=backtest&agent_id=…&run_id=…`).
+
 ---
 
 ## Commands

--- a/docs/source/lab/architecture.rst
+++ b/docs/source/lab/architecture.rst
@@ -55,4 +55,7 @@ LLM integration example code lives in ``dashboard/backend/llm_integration_exampl
 Related documentation
 ---------------------
 
-Multi-agent orchestration, agent pools, and DAG workflows are documented under :doc:`../orchestration/index`.
+* Discord → backtest → dashboard workflow (and future paper trading from Discord):
+  ``docs/architecture/discord-to-backtest.md``
+* Multi-agent orchestration, agent pools, and DAG workflows:
+  :doc:`../orchestration/index`.

--- a/render-discord-bot.yaml
+++ b/render-discord-bot.yaml
@@ -29,6 +29,8 @@ services:
         sync: false
       - key: DISCORD_CHANNEL_ID
         sync: false
+      - key: DISCORD_BOT_API_SECRET
+        sync: false
       - key: ANTHROPIC_API_KEY
         sync: false
       - key: COMMONSTACK_API_KEY

--- a/render.yaml
+++ b/render.yaml
@@ -22,6 +22,18 @@ services:
         value: 3.13.5
       - key: DATABASE_PATH
         value: /data/backtest.db
+      - key: DISCORD_BOT_API_SECRET
+        sync: false
+      - key: DISCORD_CLIENT_ID
+        sync: false
+      - key: DISCORD_CLIENT_SECRET
+        sync: false
+      - key: DISCORD_REDIRECT_URI
+        sync: false
+      - key: DISCORD_GUILD_CHANNEL_URL
+        sync: false
+      - key: PUBLIC_APP_URL
+        sync: false
     
     # Health check
     healthCheckPath: /health


### PR DESCRIPTION
## Summary
- Bind Discord users to website accounts via Discord OAuth (`identify`) from the dashboard **Open Discord** button (login → authorize once → open guild/channel).
- Add `GET /api/v1/discord/agents` (bot secret + Discord user id) so `/agent` returns only that account’s agents (builtins first), instead of the public `/agents/builtin` catalog.
- Persist `users.discord_user_id` (SQLite + Postgres), document the flow, and wire Render env placeholders for OAuth + `DISCORD_BOT_API_SECRET`.
- Add Discord backtest → Playground deep links (`/app?view=backtest&agent_id=…&run_id=…`) and keep the address bar in sync when selecting runs.
- a short description to current architechture and workflow: docs/discord-bot-instructions.md

## Test plan
- [ ] Local: set `DISCORD_CLIENT_*`, `DISCORD_REDIRECT_URI=http://localhost:8000/api/auth/discord/callback`, `DISCORD_BOT_API_SECRET`; restart API + bot
- [ ] Sign in → create built-in agent → **Open Discord** → authorize → `/agent` shows only that user’s agents
- [ ] `curl /api/v1/discord/agents` with bot secret + Discord user id returns owned agents; wrong secret → 401
- [ ] Unlinked Discord user → `/agent` prompts to link on the website
- [ ] After `/backtest`, open the Dashboard deep link and confirm Playground loads that agent/run
- [ ] Prod: add production redirect URI in Discord Portal; set matching env on API + Discord worker; only one bot process online

Closes #79
