### PR TITLE
feat: FinSearch news & signals home panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ DEEPSEEK_API_KEY=your_deepseek_key_here
 COMMONSTACK_API_KEY=your_commonstack_key_here
 COMMONSTACK_BASE_URL=https://api.commonstack.ai
 
+# Agentic FinSearch news-signals producer (bearer key, same value as the
+# FinSearch backend). Required for the Home news panel and backtest
+# news_sentiment to populate; leave unset and the panel shows "unavailable"
+# and backtests fail closed to an empty {} slot.
+FINGPT_API_KEY=your_fingpt_api_key_here
+# Optional override of the FinSearch producer base URL (defaults to the live
+# endpoint). Point at a local fixture/staging server for dev.
+# FINSEARCH_SIGNALS_URL=http://localhost:9000
+
 # OpenRouter multi-provider gateway (Anthropic Messages skin).
 # Leaderboard entries with "integration": "openrouter" route through this
 # (e.g. nvidia/nemotron-3-nano-30b-a3b). Opt-in only — never auto-selected.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ AgenticTrading/
 ## Future Roadmap
 
 - Leaderboard backed by real multi-agent runs (replace mock data)
-- Sentiment analysis (Reddit, news APIs)
+- News sentiment is live via Agentic FinSearch (Home panel + v2 agent context); Reddit/social sentiment still planned
 - Monte Carlo simulation baselines
 - Production-ready Docker image (frontend + data included)
 

--- a/dashboard/backend/api/router.py
+++ b/dashboard/backend/api/router.py
@@ -8,6 +8,7 @@ from dashboard.backend.api.routers.environments import router as environments_ro
 from dashboard.backend.api.routers.external_backtest import router as external_backtest_router
 from dashboard.backend.api.health import router as health_router
 from dashboard.backend.api.routers.leaderboard import router as leaderboard_router
+from dashboard.backend.api.routers.news import router as news_router
 from dashboard.backend.api.routers.runs import router as runs_router
 from dashboard.backend.api.routers.strategies import router as strategies_router
 from dashboard.backend.api.v2.router import v2_router
@@ -23,4 +24,5 @@ api_router.include_router(runs_router)
 api_router.include_router(environments_router)
 api_router.include_router(leaderboard_router)
 api_router.include_router(strategies_router)
+api_router.include_router(news_router)
 api_router.include_router(v2_router)

--- a/dashboard/backend/api/routers/news.py
+++ b/dashboard/backend/api/routers/news.py
@@ -1,0 +1,44 @@
+"""Panel proxy for FinSearch news signals — keeps FINGPT_API_KEY server-side."""
+import threading
+
+from fastapi import APIRouter
+
+from dashboard.backend.cache import (CACHE_KEY_NEWS_SIGNALS, TTL_NEWS,
+                                     TTL_NEWS_UNAVAILABLE, shared_ttl_cache)
+from dashboard.backend.infrastructure.llm.validator import DJIA_30
+from dashboard.backend.integrations import news_sentiment
+
+router = APIRouter(prefix="/news", tags=["news"])
+
+# Single-flight: concurrent cold-cache requests share one upstream fetch
+# instead of stampeding the bearer-gated producer at every TTL boundary.
+_fetch_lock = threading.Lock()
+
+
+# Deliberately sync `def`: FastAPI runs it in the threadpool, so the blocking
+# requests.get inside the adapter cannot stall the event loop. Do NOT convert
+# to `async def` without moving the HTTP call off the loop.
+@router.get("/signals")
+def latest_news_signals():
+    cached = shared_ttl_cache.get(CACHE_KEY_NEWS_SIGNALS)
+    if cached is not None:
+        return cached
+    with _fetch_lock:
+        cached = shared_ttl_cache.get(CACHE_KEY_NEWS_SIGNALS)  # re-check after the wait
+        if cached is not None:
+            return cached
+        try:
+            payload = news_sentiment.get_latest_panel_payload(list(DJIA_30))
+        except Exception:
+            payload = dict(news_sentiment.UNAVAILABLE_PAYLOAD)
+        # Negative-cache failures BRIEFLY. get_latest_panel_payload already returns
+        # UNAVAILABLE_PAYLOAD (not raises) on producer failure, so unavailable results
+        # reach here on the normal path too. Caching them (short TTL) is what stops a
+        # sustained outage from serializing every request through _fetch_lock at
+        # ~10s/attempt; the short TTL (vs TTL_NEWS) also lets the panel recover within
+        # ~30s of the producer coming back instead of showing stale "unavailable" for
+        # the full 420s.
+        ttl = (TTL_NEWS_UNAVAILABLE
+               if payload.get("status") == "unavailable" else TTL_NEWS)
+        shared_ttl_cache.set(CACHE_KEY_NEWS_SIGNALS, payload, ttl_seconds=ttl)
+    return payload

--- a/dashboard/backend/api/routers/news.py
+++ b/dashboard/backend/api/routers/news.py
@@ -1,6 +1,4 @@
 """Panel proxy for FinSearch news signals — keeps FINGPT_API_KEY server-side."""
-import threading
-
 from fastapi import APIRouter
 
 from dashboard.backend.cache import (CACHE_KEY_NEWS_SIGNALS, TTL_NEWS,
@@ -10,9 +8,14 @@ from dashboard.backend.integrations import news_sentiment
 
 router = APIRouter(prefix="/news", tags=["news"])
 
-# Single-flight: concurrent cold-cache requests share one upstream fetch
-# instead of stampeding the bearer-gated producer at every TTL boundary.
-_fetch_lock = threading.Lock()
+
+def _fetch_panel() -> dict:
+    # get_latest_panel_payload already fails closed to UNAVAILABLE_PAYLOAD; the
+    # except is a belt-and-braces guard so a bug can't leak a 500 to the panel.
+    try:
+        return news_sentiment.get_latest_panel_payload(list(DJIA_30))
+    except Exception:
+        return dict(news_sentiment.UNAVAILABLE_PAYLOAD)
 
 
 # Deliberately sync `def`: FastAPI runs it in the threadpool, so the blocking
@@ -20,25 +23,18 @@ _fetch_lock = threading.Lock()
 # to `async def` without moving the HTTP call off the loop.
 @router.get("/signals")
 def latest_news_signals():
-    cached = shared_ttl_cache.get(CACHE_KEY_NEWS_SIGNALS)
-    if cached is not None:
-        return cached
-    with _fetch_lock:
-        cached = shared_ttl_cache.get(CACHE_KEY_NEWS_SIGNALS)  # re-check after the wait
-        if cached is not None:
-            return cached
-        try:
-            payload = news_sentiment.get_latest_panel_payload(list(DJIA_30))
-        except Exception:
-            payload = dict(news_sentiment.UNAVAILABLE_PAYLOAD)
-        # Negative-cache failures BRIEFLY. get_latest_panel_payload already returns
-        # UNAVAILABLE_PAYLOAD (not raises) on producer failure, so unavailable results
-        # reach here on the normal path too. Caching them (short TTL) is what stops a
-        # sustained outage from serializing every request through _fetch_lock at
-        # ~10s/attempt; the short TTL (vs TTL_NEWS) also lets the panel recover within
-        # ~30s of the producer coming back instead of showing stale "unavailable" for
-        # the full 420s.
-        ttl = (TTL_NEWS_UNAVAILABLE
-               if payload.get("status") == "unavailable" else TTL_NEWS)
-        shared_ttl_cache.set(CACHE_KEY_NEWS_SIGNALS, payload, ttl_seconds=ttl)
-    return payload
+    # Single-flight lives in the cache primitive: one leader hits the producer,
+    # concurrent callers return the cached value (or a brief UNAVAILABLE) WITHOUT
+    # blocking a worker behind the ~10s upstream call — so a cold-cache burst of
+    # Home polls can't starve the shared threadpool that also serves the
+    # deadline-sensitive /api/v1/runs/* endpoints. A short negative-cache TTL
+    # (vs TTL_NEWS) also lets the panel recover within ~30s of the producer
+    # coming back instead of pinning "unavailable" for the full 420s.
+    return shared_ttl_cache.get_or_fetch(
+        CACHE_KEY_NEWS_SIGNALS,
+        _fetch_panel,
+        ttl_seconds=TTL_NEWS,
+        negative_ttl_seconds=TTL_NEWS_UNAVAILABLE,
+        is_negative=lambda payload: payload.get("status") == "unavailable",
+        default=dict(news_sentiment.UNAVAILABLE_PAYLOAD),
+    )

--- a/dashboard/backend/api/v2/models.py
+++ b/dashboard/backend/api/v2/models.py
@@ -24,6 +24,7 @@ class NewsSentimentEntry(BaseModel):
     url: str
     age_hours: float = Field(ge=0.0)
     n_articles: int = Field(ge=0)
+    rationale: Optional[str] = None  # producer's one-line directional reasoning (additive, 2026-07-13)
 
 
 class PortfolioState(BaseModel):

--- a/dashboard/backend/cache.py
+++ b/dashboard/backend/cache.py
@@ -92,3 +92,17 @@ TTL_POSITIONS = 30        # Positions update on trades
 TTL_TRADES = 60           # Trade history changes infrequently
 TTL_PORTFOLIO_HISTORY = 120  # Portfolio history very stable
 TTL_BASELINES = 3600      # Baselines update daily (1 hour cache)
+
+# Alias: the class is a generic TTL cache; paper trading was merely its first
+# consumer — new non-paper consumers use this name.
+shared_ttl_cache = paper_trading_cache
+
+CACHE_KEY_NEWS_SIGNALS = "news:signals"  # namespaced like the `paper:` keys
+
+# Deliberately above the frontend's 300s poll so a client's own re-poll lands
+# inside the cached window instead of always missing at the boundary.
+TTL_NEWS = 420
+# Short negative-cache TTL: an outage must not serialize every request through
+# _fetch_lock at ~10s/attempt, but the panel must also recover within ~30s of
+# the producer returning, not stay "unavailable" for the full 420s.
+TTL_NEWS_UNAVAILABLE = 30

--- a/dashboard/backend/cache.py
+++ b/dashboard/backend/cache.py
@@ -5,7 +5,7 @@ Reduces redundant API calls to Alpaca.
 
 import json
 import time
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Callable, Set
 from datetime import datetime, timedelta
 from threading import Lock
 
@@ -35,7 +35,59 @@ class PaperTradingCache:
     def __init__(self):
         self.cache: Dict[str, CachedData] = {}
         self.lock = Lock()
-    
+        # Single-flight coordination for get_or_fetch. Kept separate from
+        # `lock` (which guards `cache`) so a leader never holds `lock` across
+        # the blocking fetch_fn.
+        self._leader_lock = Lock()
+        self._inflight: Set[str] = set()
+
+    def get_or_fetch(
+        self,
+        key: str,
+        fetch_fn: Callable[[], Any],
+        *,
+        ttl_seconds: int,
+        negative_ttl_seconds: Optional[int] = None,
+        is_negative: Optional[Callable[[Any], bool]] = None,
+        default: Any = None,
+    ) -> Any:
+        """Single-flight read-through cache.
+
+        Returns the cached value if fresh. Otherwise exactly ONE caller (the
+        leader) runs ``fetch_fn`` and caches the result; concurrent callers
+        (followers) neither run ``fetch_fn`` nor block on it — they return the
+        freshest value available (``default`` on a cold cache). This bounds both
+        ``fetch_fn`` invocations AND blocked threadpool workers to ~1 per key
+        per refresh, so a burst of cold-cache requests can't pile up behind one
+        slow (~10s) upstream call inside FastAPI's bounded threadpool.
+
+        If ``is_negative(result)`` is truthy, the result is cached for
+        ``negative_ttl_seconds`` (a short outage-throttle window) instead of
+        ``ttl_seconds``. A ``None`` result is treated as absent (not cached).
+        """
+        cached = self.get(key)
+        if cached is not None:
+            return cached
+        with self._leader_lock:
+            cached = self.get(key)  # re-check: a leader may have just filled it
+            if cached is not None:
+                return cached
+            if key in self._inflight:
+                return default  # follower: do not fetch, do not block
+            self._inflight.add(key)
+        try:
+            value = fetch_fn()
+            if value is not None:
+                ttl = ttl_seconds
+                if (negative_ttl_seconds is not None and is_negative is not None
+                        and is_negative(value)):
+                    ttl = negative_ttl_seconds
+                self.set(key, value, ttl_seconds=ttl)
+            return value if value is not None else default
+        finally:
+            with self._leader_lock:
+                self._inflight.discard(key)
+
     def get(self, key: str) -> Optional[Any]:
         """Get cached value if not expired."""
         with self.lock:

--- a/dashboard/backend/integrations/news_sentiment.py
+++ b/dashboard/backend/integrations/news_sentiment.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 import requests
 
@@ -21,6 +22,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_BASE_URL = "https://agenticfinsearch.org/api/signals/news/"
 _TIMEOUT_SECONDS = 10
 _MAX_CACHE_ENTRIES = 64  # bounded — a long-lived server must not grow monotonically
+# Short throttle window for today/latest *failures* (outage/config errors), so a
+# producer outage can't re-hit the bearer-gated endpoint on every step or poll.
+# Mirrors cache.TTL_NEWS_UNAVAILABLE; kept local so the adapter stays usable
+# independently of the router's cache module.
+_NEGATIVE_TTL_SECONDS = 30
 
 UNAVAILABLE_PAYLOAD = {
     "status": "unavailable", "status_reason": None, "generated_at": None,
@@ -28,13 +34,23 @@ UNAVAILABLE_PAYLOAD = {
 }
 
 _lock = threading.Lock()
-# key: (as_of or "", tickers_key) -> {"etag": str|None, "body": dict|None}
+# key: (as_of or "", tickers_key) -> {"etag": str|None, "body": dict|None,
+#                                     "expires_at": float|None}
+# expires_at is a time.monotonic() deadline set ONLY on today/latest negative
+# entries (the outage throttle). None means "no throttle": positive bodies,
+# immutable past gaps, and today's 404-waiting-for-heartbeat gaps.
 _CACHE: Dict[Tuple[str, str], Dict[str, Any]] = {}
+# Keys with a leader currently hitting the producer (single-flight). Concurrent
+# callers read the freshest cached body instead of stampeding the producer or
+# blocking a threadpool worker behind the leader's ~10s call.
+_inflight: Set[Tuple[str, str]] = set()
+_MISS = object()  # sentinel: a cached None body (a served gap) is a real hit
 
 
 def clear_cache() -> None:
     with _lock:
         _CACHE.clear()
+        _inflight.clear()
 
 
 def _base_url() -> str:
@@ -59,7 +75,9 @@ def _coerce_timestamp(timestamp: Union[str, datetime, None]) -> Optional[datetim
         return None
     if isinstance(timestamp, str):
         try:
-            timestamp = datetime.fromisoformat(timestamp)
+            # Mirror equity_plot.parse_equity_timestamp: bare fromisoformat can't
+            # parse a trailing "Z", so normalize it to an explicit UTC offset.
+            timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
         except ValueError:
             logger.error("news_sentiment: unparseable timestamp %r", timestamp)
             return None
@@ -68,50 +86,53 @@ def _coerce_timestamp(timestamp: Union[str, datetime, None]) -> Optional[datetim
     return timestamp
 
 
-def fetch_signals(*, as_of: Optional[str], tickers: Tuple[str, ...]) -> Optional[dict]:
-    """Fetch one signals artifact; None on any failure (fail closed, log loud).
+def _write(key, *, etag, body, expires_at) -> None:
+    """Store a cache entry (caller holds _lock). Bounded, oldest-inserted evicted."""
+    _CACHE[key] = {"etag": etag, "body": body, "expires_at": expires_at}
+    while len(_CACHE) > _MAX_CACHE_ENTRIES:
+        _CACHE.pop(next(iter(_CACHE)))  # evict oldest-inserted
 
-    Memo policy: keys dated STRICTLY BEFORE today (UTC) are served from the
-    memo without HTTP once any result — including a config-error None — is
-    cached (past days are immutable for our purposes, and a 401 must not turn
-    a 161-step backtest into 161 live calls). Keys for today, and the
-    `as_of=None` "latest" read, always revalidate (ETag/If-None-Match), so a
-    404 seen before the daily heartbeat lands never sticks. A transport
-    failure NEVER serves a cached body — stale data presented as fresh is
-    worse than an honest gap.
-    """
-    key = (as_of or "", ",".join(tickers))
-    today = datetime.now(timezone.utc).date().isoformat()
-    with _lock:
-        cached = _CACHE.get(key)
-    if cached is not None and as_of and as_of < today:  # ISO dates sort lexically
-        return cached["body"]
-    params: Dict[str, str] = {}
-    if as_of:
-        params["as_of"] = as_of
-    if tickers:
-        params["tickers"] = ",".join(tickers)
-    headers = _headers()
-    if cached and cached.get("etag"):
-        headers["If-None-Match"] = cached["etag"]
-    try:
-        resp = _http_get(params=params, headers=headers)
-    except Exception as exc:  # network/timeout: fail closed, never stale
-        logger.warning("news_sentiment: fetch failed: %s", exc)
+
+def _serve_from_memo(cached, is_past):
+    """Whether a cached entry can be served without an HTTP call (caller holds
+    _lock). Returns _MISS when a (re)fetch is required."""
+    if cached is None:
+        return _MISS
+    if is_past:
+        return cached["body"]  # immutable past: positive body OR honest gap
+    # today/latest: positive bodies always revalidate (ETag), 404 gaps keep
+    # re-checking for the heartbeat; only a *throttled* negative entry serves.
+    exp = cached.get("expires_at")
+    if cached["body"] is None and exp is not None and time.monotonic() < exp:
         return None
-    if resp.status_code == 304 and cached:
-        return cached["body"]
-    body: Optional[dict] = None
+    return _MISS
+
+
+def _store_response(key, is_past, *, etag, body, is_404) -> None:
+    """Cache an HTTP result (caller holds _lock), applying the negative-cache
+    policy: throttle only today/latest OUTAGE gaps; never throttle a 404
+    (waiting for the heartbeat) or an immutable past gap."""
+    if body is not None or is_past or is_404:
+        expires_at = None
+    else:
+        expires_at = time.monotonic() + _NEGATIVE_TTL_SECONDS
+    _write(key, etag=etag, body=body, expires_at=expires_at)
+
+
+def _parse_response(resp, as_of) -> Optional[dict]:
+    """Extract the usable body from a producer response (None on any non-200 or
+    unusable body), logging each failure class."""
     if resp.status_code == 200:
         try:
             body = resp.json()
         except ValueError:
             logger.error("news_sentiment: unparseable producer body")
-        else:
-            if body.get("status") == "degraded":
-                logger.warning("news_sentiment: degraded artifact: %s",
-                               body.get("status_reason"))
-    elif resp.status_code == 401:
+            return None
+        if body.get("status") == "degraded":
+            logger.warning("news_sentiment: degraded artifact: %s",
+                           body.get("status_reason"))
+        return body
+    if resp.status_code == 401:
         logger.error("news_sentiment: 401 from producer — missing/wrong FINGPT_API_KEY")
     elif resp.status_code == 503:
         logger.error("news_sentiment: 503 — producer auth misconfigured server-side")
@@ -121,20 +142,87 @@ def fetch_signals(*, as_of: Optional[str], tickers: Tuple[str, ...]) -> Optional
         pass  # no artifact at/before as_of: normal for early steps
     else:
         logger.warning("news_sentiment: unexpected status %s", resp.status_code)
+    return None
+
+
+def fetch_signals(*, as_of: Optional[str], tickers: Tuple[str, ...]) -> Optional[dict]:
+    """Fetch one signals artifact; None on any failure (fail closed, log loud).
+
+    Memo policy: keys dated STRICTLY BEFORE today (UTC) are served from the
+    memo without HTTP once any result — including a config-error None — is
+    cached (past days are immutable, and a 401/timeout must not turn a 161-step
+    backtest into 161 live calls). Keys for today, and the `as_of=None` "latest"
+    read, always revalidate (ETag/If-None-Match), EXCEPT an outage/config
+    failure is negative-cached for _NEGATIVE_TTL_SECONDS so a sustained outage
+    is throttled there too; a 404 is never throttled (it must pick up the daily
+    heartbeat promptly). A transport failure NEVER serves a previously cached
+    body — stale data presented as fresh is worse than an honest gap.
+
+    Single-flight: exactly one leader per key hits the producer; concurrent
+    callers return the freshest cached body without blocking, so a burst can't
+    stampede the producer or pile up threadpool workers behind one ~10s call.
+    """
+    key = (as_of or "", ",".join(tickers))
+    today = datetime.now(timezone.utc).date().isoformat()
+    is_past = bool(as_of) and as_of < today  # ISO dates sort lexically
+
     with _lock:
-        _CACHE[key] = {"etag": resp.headers.get("ETag"), "body": body}
-        while len(_CACHE) > _MAX_CACHE_ENTRIES:
-            _CACHE.pop(next(iter(_CACHE)))  # evict oldest-inserted
-    return body
+        cached = _CACHE.get(key)
+        served = _serve_from_memo(cached, is_past)
+        if served is not _MISS:
+            return served
+        if key in _inflight:
+            # Follower: a leader is already fetching this key. Do not hit the
+            # producer and do not block on it — return the freshest body we have.
+            return cached["body"] if cached else None
+        _inflight.add(key)
+
+    try:
+        params: Dict[str, str] = {}
+        if as_of:
+            params["as_of"] = as_of
+        if tickers:
+            params["tickers"] = ",".join(tickers)
+        headers = _headers()
+        if cached and cached.get("etag"):
+            headers["If-None-Match"] = cached["etag"]
+        try:
+            resp = _http_get(params=params, headers=headers)
+        except Exception as exc:  # network/timeout: fail closed, never stale
+            logger.warning("news_sentiment: fetch failed: %s", exc)
+            with _lock:
+                # Memoize the gap so an outage can't re-hit every step: permanent
+                # for immutable past dates; a short throttle for today/latest, but
+                # never clobber an existing good body (keep it to revalidate later).
+                if is_past:
+                    _write(key, etag=None, body=None, expires_at=None)
+                elif cached is None or cached["body"] is None:
+                    _write(key, etag=None, body=None,
+                           expires_at=time.monotonic() + _NEGATIVE_TTL_SECONDS)
+            return None
+        if resp.status_code == 304 and cached:
+            return cached["body"]
+        body = _parse_response(resp, as_of)
+        with _lock:
+            _store_response(key, is_past, etag=resp.headers.get("ETag"),
+                            body=body, is_404=(resp.status_code == 404))
+        return body
+    finally:
+        with _lock:
+            _inflight.discard(key)
+
+
+def _story_fields(sig: dict) -> dict:
+    """Shared story projection (headline/source/url) used by BOTH the per-step
+    backtest entry and the panel feed, so the field list lives in one place."""
+    return {"headline": sig["headline"], "source": sig["source"], "url": sig["url"]}
 
 
 def _project_entry(sig: dict, reference_ts: float) -> dict:
     return {
         "sentiment": sig["sentiment"],
         "score": sig["score"],
-        "headline": sig["headline"],
-        "source": sig["source"],
-        "url": sig["url"],
+        **_story_fields(sig),
         "n_articles": sig["n_articles"],
         "age_hours": max(0.0, (reference_ts - float(sig["published"])) / 3600.0),
         "rationale": sig.get("rationale"),
@@ -162,26 +250,38 @@ def get_news_sentiment(universe, timestamp) -> dict:
     return {"news_sentiment": out, "news_overview": body.get("news_overview")}
 
 
+def _feed_sort_key(item: dict) -> float:
+    """Sort by published epoch; a malformed/missing timestamp sinks to the
+    bottom instead of throwing and collapsing the whole feed."""
+    try:
+        return float(item["published"])
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def get_latest_panel_payload(tickers) -> dict:
     """Latest-artifact read for the Home panel (no as_of).
 
     `feed` is served backend-side even though Phase A derives it from
     `signals`, so the wire format (and the frontend) do not change when
-    Phase B swaps the feed source to the raw-items endpoint."""
+    Phase B swaps the feed source to the raw-items endpoint.
+
+    One malformed signal is dropped (logged) rather than collapsing the whole
+    panel: the producer is the trust boundary, but a single off-spec entry must
+    still degrade to partial rendering, not an outage."""
     body = fetch_signals(as_of=None, tickers=tuple(sorted(tickers or ())))
     if not body:
         return dict(UNAVAILABLE_PAYLOAD)
     signals = body.get("signals") or {}
-    feed = sorted(
-        (
-            {
-                "headline": s["headline"], "source": s["source"], "url": s["url"],
-                "published": s["published"], "ticker": sym,
-            }
-            for sym, s in signals.items()
-        ),
-        key=lambda item: item["published"], reverse=True,
-    )
+    feed = []
+    for sym, s in signals.items():
+        try:
+            story = _story_fields(s)  # requires headline/source/url
+        except (KeyError, TypeError):
+            logger.warning("news_sentiment: dropping malformed panel signal %r", sym)
+            continue
+        feed.append({**story, "published": s.get("published"), "ticker": sym})
+    feed.sort(key=_feed_sort_key, reverse=True)
     return {
         "status": body.get("status", "ok"),
         "status_reason": body.get("status_reason"),

--- a/dashboard/backend/integrations/news_sentiment.py
+++ b/dashboard/backend/integrations/news_sentiment.py
@@ -1,0 +1,193 @@
+"""FinSearch news-sentiment adapter (Plan 1).
+
+Consumers:
+- execution/backtest_backend.py::load_news_sentiment  (fail-closed, per-step as_of)
+- api/routers/news.py                                  (latest artifact, panel payload)
+
+Contract: docs/integrations/finsearch-news-sentiment.md
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple, Union
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://agenticfinsearch.org/api/signals/news/"
+_TIMEOUT_SECONDS = 10
+_MAX_CACHE_ENTRIES = 64  # bounded — a long-lived server must not grow monotonically
+
+UNAVAILABLE_PAYLOAD = {
+    "status": "unavailable", "status_reason": None, "generated_at": None,
+    "staleness_hours": None, "news_overview": None, "signals": {}, "feed": [],
+}
+
+_lock = threading.Lock()
+# key: (as_of or "", tickers_key) -> {"etag": str|None, "body": dict|None}
+_CACHE: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+
+def clear_cache() -> None:
+    with _lock:
+        _CACHE.clear()
+
+
+def _base_url() -> str:
+    return os.environ.get("FINSEARCH_SIGNALS_URL", DEFAULT_BASE_URL)
+
+
+def _headers() -> Dict[str, str]:
+    key = os.environ.get("FINGPT_API_KEY", "")
+    return {"Authorization": f"Bearer {key}"} if key else {}
+
+
+def _http_get(*, params: Dict[str, str], headers: Dict[str, str]):
+    return requests.get(_base_url(), params=params, headers=headers,
+                        timeout=_TIMEOUT_SECONDS)
+
+
+def _coerce_timestamp(timestamp: Union[str, datetime, None]) -> Optional[datetime]:
+    """The v2 step envelope serializes timestamps to ISO strings
+    (external_run_service.py:429-431), so the REAL backtest call site passes
+    str; direct callers may pass datetime. Returns tz-aware datetime or None."""
+    if timestamp is None:
+        return None
+    if isinstance(timestamp, str):
+        try:
+            timestamp = datetime.fromisoformat(timestamp)
+        except ValueError:
+            logger.error("news_sentiment: unparseable timestamp %r", timestamp)
+            return None
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp
+
+
+def fetch_signals(*, as_of: Optional[str], tickers: Tuple[str, ...]) -> Optional[dict]:
+    """Fetch one signals artifact; None on any failure (fail closed, log loud).
+
+    Memo policy: keys dated STRICTLY BEFORE today (UTC) are served from the
+    memo without HTTP once any result — including a config-error None — is
+    cached (past days are immutable for our purposes, and a 401 must not turn
+    a 161-step backtest into 161 live calls). Keys for today, and the
+    `as_of=None` "latest" read, always revalidate (ETag/If-None-Match), so a
+    404 seen before the daily heartbeat lands never sticks. A transport
+    failure NEVER serves a cached body — stale data presented as fresh is
+    worse than an honest gap.
+    """
+    key = (as_of or "", ",".join(tickers))
+    today = datetime.now(timezone.utc).date().isoformat()
+    with _lock:
+        cached = _CACHE.get(key)
+    if cached is not None and as_of and as_of < today:  # ISO dates sort lexically
+        return cached["body"]
+    params: Dict[str, str] = {}
+    if as_of:
+        params["as_of"] = as_of
+    if tickers:
+        params["tickers"] = ",".join(tickers)
+    headers = _headers()
+    if cached and cached.get("etag"):
+        headers["If-None-Match"] = cached["etag"]
+    try:
+        resp = _http_get(params=params, headers=headers)
+    except Exception as exc:  # network/timeout: fail closed, never stale
+        logger.warning("news_sentiment: fetch failed: %s", exc)
+        return None
+    if resp.status_code == 304 and cached:
+        return cached["body"]
+    body: Optional[dict] = None
+    if resp.status_code == 200:
+        try:
+            body = resp.json()
+        except ValueError:
+            logger.error("news_sentiment: unparseable producer body")
+        else:
+            if body.get("status") == "degraded":
+                logger.warning("news_sentiment: degraded artifact: %s",
+                               body.get("status_reason"))
+    elif resp.status_code == 401:
+        logger.error("news_sentiment: 401 from producer — missing/wrong FINGPT_API_KEY")
+    elif resp.status_code == 503:
+        logger.error("news_sentiment: 503 — producer auth misconfigured server-side")
+    elif resp.status_code == 400:
+        logger.error("news_sentiment: 400 bad_as_of — adapter bug (as_of=%r)", as_of)
+    elif resp.status_code == 404:
+        pass  # no artifact at/before as_of: normal for early steps
+    else:
+        logger.warning("news_sentiment: unexpected status %s", resp.status_code)
+    with _lock:
+        _CACHE[key] = {"etag": resp.headers.get("ETag"), "body": body}
+        while len(_CACHE) > _MAX_CACHE_ENTRIES:
+            _CACHE.pop(next(iter(_CACHE)))  # evict oldest-inserted
+    return body
+
+
+def _project_entry(sig: dict, reference_ts: float) -> dict:
+    return {
+        "sentiment": sig["sentiment"],
+        "score": sig["score"],
+        "headline": sig["headline"],
+        "source": sig["source"],
+        "url": sig["url"],
+        "n_articles": sig["n_articles"],
+        "age_hours": max(0.0, (reference_ts - float(sig["published"])) / 3600.0),
+        "rationale": sig.get("rationale"),
+    }
+
+
+def get_news_sentiment(universe, timestamp) -> dict:
+    """Contract interface for execution/backtest_backend.load_news_sentiment."""
+    empty = {"news_sentiment": {}, "news_overview": None}
+    ts = _coerce_timestamp(timestamp)
+    if ts is None:
+        return empty
+    as_of = ts.date().isoformat()
+    reference_ts = ts.timestamp()
+    tickers = tuple(sorted(universe or ()))
+    body = fetch_signals(as_of=as_of, tickers=tickers)
+    if not body:
+        return empty
+    wanted = set(tickers)
+    out = {
+        sym: _project_entry(sig, reference_ts)
+        for sym, sig in (body.get("signals") or {}).items()
+        if not wanted or sym in wanted
+    }
+    return {"news_sentiment": out, "news_overview": body.get("news_overview")}
+
+
+def get_latest_panel_payload(tickers) -> dict:
+    """Latest-artifact read for the Home panel (no as_of).
+
+    `feed` is served backend-side even though Phase A derives it from
+    `signals`, so the wire format (and the frontend) do not change when
+    Phase B swaps the feed source to the raw-items endpoint."""
+    body = fetch_signals(as_of=None, tickers=tuple(sorted(tickers or ())))
+    if not body:
+        return dict(UNAVAILABLE_PAYLOAD)
+    signals = body.get("signals") or {}
+    feed = sorted(
+        (
+            {
+                "headline": s["headline"], "source": s["source"], "url": s["url"],
+                "published": s["published"], "ticker": sym,
+            }
+            for sym, s in signals.items()
+        ),
+        key=lambda item: item["published"], reverse=True,
+    )
+    return {
+        "status": body.get("status", "ok"),
+        "status_reason": body.get("status_reason"),
+        "generated_at": body.get("generated_at"),
+        "staleness_hours": body.get("staleness_hours"),
+        "news_overview": body.get("news_overview"),
+        "signals": signals,
+        "feed": feed,
+    }

--- a/dashboard/backend/tests/fixtures/signals-fixture.json
+++ b/dashboard/backend/tests/fixtures/signals-fixture.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "profile": "default",
+  "generated_at": "2026-07-06T15:00:00+00:00",
+  "generator": "news_signals.py/2026-07-11.2",
+  "model": "gpt-4o-mini",
+  "prompt_version": 1,
+  "source_items": "items-fixture.jsonl",
+  "window_hours": 24,
+  "watchlist": [
+    "AAPL",
+    "GOOGL",
+    "MSFT",
+    "NVDA"
+  ],
+  "status": "ok",
+  "status_reason": null,
+  "news_overview": "Fixture batch: cloud strength at Microsoft and Nvidia; the rest of the tape is quiet.",
+  "diagnostics": {
+    "stories_total": 6,
+    "candidates_dropped_not_subject": 3,
+    "near_dups_collapsed": 1,
+    "candidates_selected": 3,
+    "tickers_with_candidates": 2,
+    "tickers_no_candidates": 2,
+    "tickers_capped": 0,
+    "tickers_omitted_by_llm": 0,
+    "tickers_dropped_guid_mismatch": 0,
+    "scores_damped": 1
+  },
+  "signals": {
+    "MSFT": {
+      "sentiment": "bullish",
+      "score": 0.5,
+      "rationale": "Two distinct outlets report upbeat Azure guidance.",
+      "headline": "Microsoft raises Azure guidance after record quarter",
+      "source": "Reuters",
+      "url": "https://example.com/msft-1",
+      "published": 1783335600.0,
+      "guid": "fix-msft-1",
+      "n_articles": 2
+    },
+    "NVDA": {
+      "sentiment": "bullish",
+      "score": 0.7,
+      "rationale": "Single story reports record datacenter orders.",
+      "headline": "Nvidia reports record datacenter orders",
+      "source": "CNBC",
+      "url": "https://example.com/nvda-1",
+      "published": 1783339200.0,
+      "guid": "fix-nvda-1",
+      "n_articles": 1
+    }
+  }
+}

--- a/dashboard/backend/tests/fixtures/signals-v1.schema.json
+++ b/dashboard/backend/tests/fixtures/signals-v1.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "signals-v1.schema.json",
+  "title": "FinSearch news signals artifact v1 (spec 2026-07-06 §4.2, amended)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "profile", "generated_at", "generator", "model",
+    "prompt_version", "source_items", "window_hours", "watchlist",
+    "status", "status_reason", "news_overview", "diagnostics", "signals"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "profile": { "type": "string" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "generator": { "type": "string" },
+    "model": { "type": "string" },
+    "prompt_version": { "type": "integer", "minimum": 1 },
+    "source_items": { "type": "string", "pattern": "^items-[^/\\\\]+\\.jsonl$" },
+    "window_hours": { "type": "integer", "minimum": 1 },
+    "watchlist": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[A-Z0-9.\\-]+$" },
+      "uniqueItems": true
+    },
+    "status": { "enum": ["ok", "degraded"] },
+    "status_reason": { "type": ["string", "null"], "maxLength": 200 },
+    "news_overview": { "type": ["string", "null"], "maxLength": 300 },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stories_total", "candidates_dropped_not_subject", "near_dups_collapsed",
+        "candidates_selected", "tickers_with_candidates", "tickers_no_candidates",
+        "tickers_capped", "tickers_omitted_by_llm",
+        "tickers_dropped_guid_mismatch", "scores_damped"
+      ],
+      "properties": {
+        "stories_total": { "type": "integer", "minimum": 0 },
+        "candidates_dropped_not_subject": { "type": "integer", "minimum": 0 },
+        "near_dups_collapsed": { "type": "integer", "minimum": 0 },
+        "candidates_selected": { "type": "integer", "minimum": 0 },
+        "tickers_with_candidates": { "type": "integer", "minimum": 0 },
+        "tickers_no_candidates": { "type": "integer", "minimum": 0 },
+        "tickers_capped": { "type": "integer", "minimum": 0 },
+        "tickers_omitted_by_llm": { "type": "integer", "minimum": 0 },
+        "tickers_dropped_guid_mismatch": { "type": "integer", "minimum": 0 },
+        "scores_damped": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "signals": {
+      "type": "object",
+      "propertyNames": { "pattern": "^[A-Z0-9.\\-]+$" },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "sentiment", "score", "rationale", "headline", "source", "url",
+          "published", "guid", "n_articles"
+        ],
+        "properties": {
+          "sentiment": { "enum": ["bullish", "bearish", "neutral"] },
+          "score": { "type": "number", "minimum": -1, "maximum": 1 },
+          "rationale": { "type": "string", "maxLength": 280 },
+          "headline": { "type": "string", "maxLength": 500 },
+          "source": { "type": "string", "maxLength": 200 },
+          "url": { "type": "string", "maxLength": 2000 },
+          "published": { "type": "number" },
+          "guid": { "type": "string" },
+          "n_articles": { "type": "integer", "minimum": 1 }
+        }
+      }
+    }
+  }
+}

--- a/dashboard/backend/tests/fixtures/signals-wire-fixture.json
+++ b/dashboard/backend/tests/fixtures/signals-wire-fixture.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "profile": "default",
+  "generated_at": "2026-07-06T15:00:00+00:00",
+  "source_items": "items-fixture.jsonl",
+  "window_hours": 24,
+  "watchlist": [
+    "AAPL",
+    "GOOGL",
+    "MSFT",
+    "NVDA"
+  ],
+  "status": "ok",
+  "status_reason": null,
+  "news_overview": "Fixture batch: cloud strength at Microsoft and Nvidia; the rest of the tape is quiet.",
+  "diagnostics": {
+    "stories_total": 6,
+    "candidates_dropped_not_subject": 3,
+    "near_dups_collapsed": 1,
+    "candidates_selected": 3,
+    "tickers_with_candidates": 2,
+    "tickers_no_candidates": 2,
+    "tickers_capped": 0,
+    "tickers_omitted_by_llm": 0,
+    "tickers_dropped_guid_mismatch": 0,
+    "scores_damped": 1
+  },
+  "signals": {
+    "MSFT": {
+      "sentiment": "bullish",
+      "score": 0.5,
+      "rationale": "Two distinct outlets report upbeat Azure guidance.",
+      "headline": "Microsoft raises Azure guidance after record quarter",
+      "source": "Reuters",
+      "url": "https://example.com/msft-1",
+      "published": 1783335600.0,
+      "guid": "fix-msft-1",
+      "n_articles": 2
+    },
+    "NVDA": {
+      "sentiment": "bullish",
+      "score": 0.7,
+      "rationale": "Single story reports record datacenter orders.",
+      "headline": "Nvidia reports record datacenter orders",
+      "source": "CNBC",
+      "url": "https://example.com/nvda-1",
+      "published": 1783339200.0,
+      "guid": "fix-nvda-1",
+      "n_articles": 1
+    }
+  },
+  "staleness_hours": 2.5
+}

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -71,6 +71,7 @@ EXPECTED_FULL_CONTRACT = {
     ("GET", "/api/backtest/{run_id}"),
     ("GET", "/api/backtest/{run_id}/chart-data"),
     ("GET", "/api/health"),
+    ("GET", "/api/news/signals"),
     ("GET", "/api/v1/agent-versions/{agent_version_id}"),
     ("GET", "/api/v1/agents"),
     ("POST", "/api/v1/agents"),

--- a/dashboard/backend/tests/test_cache_get_or_fetch.py
+++ b/dashboard/backend/tests/test_cache_get_or_fetch.py
@@ -1,0 +1,78 @@
+"""Single-flight read-through primitive (PaperTradingCache.get_or_fetch).
+
+Centralizes the outage-throttle + stampede protection the news router used to
+hand-roll as a global lock held across a ~10s upstream call. The follower test
+is the one that matters: a concurrent cold-cache caller must return WITHOUT
+running the fetch and WITHOUT blocking a threadpool worker behind the leader."""
+import threading
+
+from dashboard.backend.cache import PaperTradingCache
+
+
+def test_leader_caches_and_followers_reuse():
+    c = PaperTradingCache()
+    calls = []
+
+    def fetch():
+        calls.append(1)
+        return {"v": 1}
+
+    a = c.get_or_fetch("k", fetch, ttl_seconds=60)
+    b = c.get_or_fetch("k", fetch, ttl_seconds=60)
+    assert a == b == {"v": 1}
+    assert len(calls) == 1  # second served from cache, fetch not re-run
+
+
+def test_negative_result_uses_short_ttl():
+    c = PaperTradingCache()
+    seen = {}
+    real_set = c.set
+
+    def spy_set(key, value, ttl_seconds=30):
+        seen["ttl"] = ttl_seconds
+        return real_set(key, value, ttl_seconds=ttl_seconds)
+
+    c.set = spy_set
+    c.get_or_fetch(
+        "k", lambda: {"status": "unavailable"},
+        ttl_seconds=420, negative_ttl_seconds=30,
+        is_negative=lambda v: v.get("status") == "unavailable",
+    )
+    assert seen["ttl"] == 30  # negative branch, not the 420 positive TTL
+
+
+def test_none_result_is_not_cached():
+    c = PaperTradingCache()
+    calls = []
+
+    def fetch():
+        calls.append(1)
+        return None
+
+    assert c.get_or_fetch("k", fetch, ttl_seconds=60, default={"d": 1}) == {"d": 1}
+    c.get_or_fetch("k", fetch, ttl_seconds=60, default={"d": 1})
+    assert len(calls) == 2  # None never cached -> re-fetched
+
+
+def test_follower_returns_default_without_fetching_or_blocking():
+    c = PaperTradingCache()
+    started, release, calls = threading.Event(), threading.Event(), []
+
+    def slow():
+        calls.append(1)
+        started.set()
+        release.wait(2.0)
+        return {"v": 1}
+
+    out = {}
+    leader = threading.Thread(
+        target=lambda: out.__setitem__(
+            "leader", c.get_or_fetch("k", slow, ttl_seconds=60, default={"d": 1})))
+    leader.start()
+    assert started.wait(2.0)                       # leader is mid-fetch, holds _inflight
+    out["follower"] = c.get_or_fetch("k", slow, ttl_seconds=60, default={"d": 1})
+    assert out["follower"] == {"d": 1}             # returned immediately, no block
+    assert len(calls) == 1                         # follower did not run slow()
+    release.set()
+    leader.join(2.0)
+    assert out["leader"] == {"v": 1}

--- a/dashboard/backend/tests/test_execution_backends.py
+++ b/dashboard/backend/tests/test_execution_backends.py
@@ -26,9 +26,14 @@ from dashboard.backend.api.v2.models import ContextEnvelope, SubmitAck
 
 
 def test_news_sentiment_fail_closed_when_plan1_absent(monkeypatch):
-    # No integrations.news_sentiment module → slot present, empty, overview None.
+    """Module absent -> loader degrades to ({}, None). Simulated absence:
+    a None entry in sys.modules makes the in-function import raise ImportError."""
+    import sys
+    monkeypatch.setitem(sys.modules,
+                        "dashboard.backend.integrations.news_sentiment", None)
     sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
-    assert sentiment == {} and overview is None
+    assert sentiment == {}
+    assert overview is None
 
 
 def _synthetic_bars(symbols, periods=40):

--- a/dashboard/backend/tests/test_news_router.py
+++ b/dashboard/backend/tests/test_news_router.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+from dashboard.backend import cache as cache_mod
+from dashboard.backend.integrations import news_sentiment as ns
+
+
+def test_news_signals_route_returns_payload(monkeypatch):
+    cache_mod.shared_ttl_cache.invalidate(cache_mod.CACHE_KEY_NEWS_SIGNALS)
+    fake = {"status": "ok", "status_reason": None, "generated_at": "2026-07-13T11:20:00+00:00",
+            "staleness_hours": 1.2, "news_overview": "calm", "signals": {}, "feed": []}
+    monkeypatch.setattr(ns, "get_latest_panel_payload", lambda tickers: fake)
+    client = TestClient(app)
+    resp = client.get("/api/news/signals")
+    assert resp.status_code == 200
+    assert resp.json()["news_overview"] == "calm"
+
+
+def test_news_signals_route_fail_closed(monkeypatch):
+    cache_mod.shared_ttl_cache.invalidate(cache_mod.CACHE_KEY_NEWS_SIGNALS)
+    def _boom(tickers):
+        raise RuntimeError("adapter exploded")
+    monkeypatch.setattr(ns, "get_latest_panel_payload", _boom)
+    client = TestClient(app)
+    resp = client.get("/api/news/signals")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "unavailable"
+
+
+def test_news_signals_route_caches(monkeypatch):
+    cache_mod.shared_ttl_cache.invalidate(cache_mod.CACHE_KEY_NEWS_SIGNALS)
+    calls = []
+    def _once(tickers):
+        calls.append(1)
+        return {"status": "ok", "status_reason": None, "generated_at": None,
+                "staleness_hours": None, "news_overview": None, "signals": {}, "feed": []}
+    monkeypatch.setattr(ns, "get_latest_panel_payload", _once)
+    client = TestClient(app)
+    client.get("/api/news/signals")
+    client.get("/api/news/signals")
+    assert len(calls) == 1
+
+
+def test_news_signals_route_negative_caches_failures(monkeypatch):
+    """The whole point of the short-TTL negative cache: a second failing request
+    within TTL_NEWS_UNAVAILABLE is served from cache, NOT re-run through the ~10s
+    adapter behind _fetch_lock (the outage-serialization fix). Without the negative
+    cache this asserts len(calls) == 2 — the regression the fix prevents."""
+    cache_mod.shared_ttl_cache.invalidate(cache_mod.CACHE_KEY_NEWS_SIGNALS)
+    calls = []
+    def _boom(tickers):
+        calls.append(1)
+        raise RuntimeError("adapter exploded")
+    monkeypatch.setattr(ns, "get_latest_panel_payload", _boom)
+    client = TestClient(app)
+    assert client.get("/api/news/signals").json()["status"] == "unavailable"
+    assert client.get("/api/news/signals").json()["status"] == "unavailable"
+    assert len(calls) == 1  # second request served from the negative cache

--- a/dashboard/backend/tests/test_news_sentiment_adapter.py
+++ b/dashboard/backend/tests/test_news_sentiment_adapter.py
@@ -127,3 +127,24 @@ def test_todays_404_not_hard_memoized(monkeypatch):
     second = ns.get_news_sentiment(["MSFT"], now)
     assert first["news_sentiment"] == {}
     assert second["news_overview"] is not None
+
+
+def test_panel_payload_shapes_feed_and_signals(monkeypatch):
+    body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    payload = ns.get_latest_panel_payload(["MSFT", "AAPL"])
+    assert payload["status"] in ("ok", "degraded")
+    assert payload["news_overview"] == body["news_overview"]
+    assert set(payload["signals"]) <= set(body["signals"])
+    pubs = [item["published"] for item in payload["feed"]]
+    assert pubs == sorted(pubs, reverse=True)
+    for item in payload["feed"]:
+        assert item["url"] and item["headline"] and item["source"]
+
+
+def test_panel_payload_unavailable_on_failure(monkeypatch):
+    def _boom(**kw):
+        raise OSError("down")
+    monkeypatch.setattr(ns, "_http_get", _boom)
+    payload = ns.get_latest_panel_payload(["MSFT"])
+    assert payload == ns.UNAVAILABLE_PAYLOAD  # single-sourced shape (router reuses it)

--- a/dashboard/backend/tests/test_news_sentiment_adapter.py
+++ b/dashboard/backend/tests/test_news_sentiment_adapter.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 import pytest
 
 from dashboard.backend.integrations import news_sentiment as ns
-from dashboard.backend.tests.test_news_sentiment_fixture import load_signals_fixture
+from dashboard.backend.tests.test_news_sentiment_fixture import (
+    load_signals_fixture,
+    load_signals_wire_fixture,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -148,3 +151,67 @@ def test_panel_payload_unavailable_on_failure(monkeypatch):
     monkeypatch.setattr(ns, "_http_get", _boom)
     payload = ns.get_latest_panel_payload(["MSFT"])
     assert payload == ns.UNAVAILABLE_PAYLOAD  # single-sourced shape (router reuses it)
+
+
+# --- Live wire-shape coverage (staleness_hours / degraded / 304) --------------
+# The vendored on-disk fixture omits `staleness_hours` and is `status: ok`, so
+# these branches are only reachable through the stripped-and-injected wire shape
+# (contract §"Producer response shape"). See signals-wire-fixture.json.
+
+
+def test_wire_shape_passes_staleness_hours_through(monkeypatch):
+    """The panel surfaces the server-injected `staleness_hours` verbatim — the
+    documented origin of the "Updated Xh ago" header. Unreachable via the
+    on-disk fixture, which has no such key."""
+    body = load_signals_wire_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    payload = ns.get_latest_panel_payload(["MSFT", "NVDA"])
+    assert payload["staleness_hours"] == body["staleness_hours"]
+    assert payload["staleness_hours"] is not None  # the whole point vs on-disk fixture
+
+
+def test_degraded_artifact_is_usable_projected_and_logged(monkeypatch, caplog):
+    """A `degraded` artifact is still usable (contract §"Error & degraded
+    handling"): the panel projects its signals and passes status/status_reason
+    through, and the adapter logs the reason so the run stays auditable."""
+    body = dict(load_signals_wire_fixture())
+    body["status"] = "degraded"
+    body["status_reason"] = "1 of 3 sources timed out"
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    with caplog.at_level("WARNING"):
+        payload = ns.get_latest_panel_payload(["MSFT", "NVDA"])
+    assert payload["signals"]                       # degraded != empty — still projected
+    assert payload["status"] == "degraded"
+    assert payload["status_reason"] == "1 of 3 sources timed out"
+    assert any("degraded" in r.getMessage() for r in caplog.records)
+
+
+def test_degraded_artifact_still_projects_in_backtest_path(monkeypatch):
+    """`get_news_sentiment` (the per-step backtest loader) does not branch on
+    status: a degraded-but-usable artifact still projects its signals rather
+    than collapsing to empty."""
+    body = dict(load_signals_wire_fixture())
+    body["status"] = "degraded"
+    body["status_reason"] = "partial feed"
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    ts = datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc)
+    out = ns.get_news_sentiment(["MSFT", "NVDA"], ts)
+    assert out["news_sentiment"]                    # non-empty: degraded is still projected
+    assert out["news_overview"] == body["news_overview"]
+
+
+def test_304_revalidation_serves_cached_body(monkeypatch):
+    """A conditional GET that returns 304 serves the previously cached body
+    (the latest-read path always sends If-None-Match). The on-disk fixture
+    tests never reach this branch."""
+    body = load_signals_wire_fixture()
+    responses = [
+        _fake_response(body=body, etag='"w1"'),
+        _fake_response(status=304, body={}, etag='"w1"'),
+    ]
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: responses.pop(0))
+    first = ns.get_latest_panel_payload(["MSFT"])
+    assert first["staleness_hours"] == body["staleness_hours"]
+    second = ns.get_latest_panel_payload(["MSFT"])   # 304 -> cached body reused, not refetched
+    assert second["staleness_hours"] == body["staleness_hours"]
+    assert not responses                             # both queued responses consumed

--- a/dashboard/backend/tests/test_news_sentiment_adapter.py
+++ b/dashboard/backend/tests/test_news_sentiment_adapter.py
@@ -1,0 +1,129 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from dashboard.backend.integrations import news_sentiment as ns
+from dashboard.backend.tests.test_news_sentiment_fixture import load_signals_fixture
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    ns.clear_cache()
+    yield
+    ns.clear_cache()
+
+
+def _fake_response(status=200, body=None, etag='"e1"'):
+    return SimpleNamespace(
+        status_code=status,
+        headers={"ETag": etag},
+        json=lambda: body if body is not None else load_signals_fixture(),
+    )
+
+
+def test_projection_maps_all_fields_including_rationale(monkeypatch):
+    body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    ts = datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc)
+    out = ns.get_news_sentiment(["MSFT", "AAPL"], ts)
+    sym, src = next(iter(body["signals"].items()))
+    entry = out["news_sentiment"].get(sym)
+    if entry is not None:  # fixture symbol may not be in the passed universe filter
+        assert entry["sentiment"] == src["sentiment"]
+        assert entry["rationale"] == src["rationale"]
+        assert entry["age_hours"] >= 0.0
+    assert out["news_overview"] == body["news_overview"]
+
+
+def test_age_hours_referenced_to_step_timestamp_not_wallclock(monkeypatch):
+    body = load_signals_fixture()
+    sym = next(iter(body["signals"]))
+    published = body["signals"][sym]["published"]
+    step_ts = datetime.fromtimestamp(published + 7200, tz=timezone.utc)  # 2h later
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    out = ns.get_news_sentiment([sym], step_ts)
+    assert abs(out["news_sentiment"][sym]["age_hours"] - 2.0) < 0.01
+
+
+def test_404_is_quiet_empty(monkeypatch):
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(status=404, body={}))
+    out = ns.get_news_sentiment(["MSFT"], datetime.now(timezone.utc))
+    assert out == {"news_sentiment": {}, "news_overview": None}
+
+
+def test_401_is_empty_and_logs_error(monkeypatch, caplog):
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(status=401, body={}))
+    with caplog.at_level("ERROR"):
+        out = ns.get_news_sentiment(["MSFT"], datetime.now(timezone.utc))
+    assert out["news_sentiment"] == {}
+    assert any("FINGPT_API_KEY" in r.message for r in caplog.records)
+
+
+def test_network_error_fails_closed_never_stale(monkeypatch):
+    """A transport failure returns unavailable — it must NOT serve the
+    previously cached body for the same key (stale data presented as fresh
+    during an outage)."""
+    body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    warm = ns.get_latest_panel_payload(["MSFT"])  # warms the ("", tickers) key
+    assert warm["status"] != "unavailable"
+
+    def _boom(**kw):
+        raise OSError("connection refused")
+    monkeypatch.setattr(ns, "_http_get", _boom)
+    out = ns.get_latest_panel_payload(["MSFT"])  # same key, latest path revalidates
+    assert out["status"] == "unavailable"
+
+
+def test_real_call_site_passes_iso_string(monkeypatch):
+    """The v2 step envelope serializes timestamp to an ISO STRING
+    (external_run_service.py:429-431) — the adapter must parse it, not crash
+    into the fail-closed loader."""
+    body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    out = ns.get_news_sentiment(["MSFT"], "2026-07-10T15:00:00+00:00")
+    assert out["news_overview"] == body["news_overview"]  # parsed, not swallowed
+
+
+def test_garbage_timestamp_fails_closed(monkeypatch):
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response())
+    out = ns.get_news_sentiment(["MSFT"], "not-a-date")
+    assert out == {"news_sentiment": {}, "news_overview": None}
+
+
+def test_past_as_of_memoized_one_call(monkeypatch):
+    calls = []
+    def _counting(**kw):
+        calls.append(kw)
+        return _fake_response()
+    monkeypatch.setattr(ns, "_http_get", _counting)
+    ts = datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc)  # strictly past date
+    ns.get_news_sentiment(["MSFT"], ts)
+    ns.get_news_sentiment(["MSFT"], ts.replace(hour=16))  # same date -> same as_of
+    assert len(calls) == 1
+
+
+def test_config_error_negative_cached_for_past_dates(monkeypatch):
+    """A 401 must not turn a 161-step backtest into 161 live calls."""
+    calls = []
+    def _unauth(**kw):
+        calls.append(1)
+        return _fake_response(status=401, body={})
+    monkeypatch.setattr(ns, "_http_get", _unauth)
+    ts = datetime(2026, 7, 1, 15, 0, tzinfo=timezone.utc)
+    ns.get_news_sentiment(["MSFT"], ts)
+    ns.get_news_sentiment(["MSFT"], ts)
+    assert len(calls) == 1
+
+
+def test_todays_404_not_hard_memoized(monkeypatch):
+    """A 404 seen before the daily heartbeat lands must not stick for the
+    process lifetime — today's key always revalidates."""
+    responses = [_fake_response(status=404, body={}), _fake_response()]
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: responses.pop(0))
+    now = datetime.now(timezone.utc)
+    first = ns.get_news_sentiment(["MSFT"], now)
+    second = ns.get_news_sentiment(["MSFT"], now)
+    assert first["news_sentiment"] == {}
+    assert second["news_overview"] is not None

--- a/dashboard/backend/tests/test_news_sentiment_adapter.py
+++ b/dashboard/backend/tests/test_news_sentiment_adapter.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -118,6 +119,100 @@ def test_config_error_negative_cached_for_past_dates(monkeypatch):
     ns.get_news_sentiment(["MSFT"], ts)
     ns.get_news_sentiment(["MSFT"], ts)
     assert len(calls) == 1
+
+
+def test_past_transport_failure_negative_cached_one_call(monkeypatch):
+    """A network outage on an immutable PAST date is memoized as an honest gap —
+    otherwise a 161-step backtest pays 161 live timeouts (the fix's whole point).
+    Distinct from test_config_error_negative_cached_for_past_dates, which covers
+    an HTTP 401; this covers a transport-layer failure (no response at all)."""
+    calls = []
+    def _boom(**kw):
+        calls.append(1)
+        raise OSError("connection refused")
+    monkeypatch.setattr(ns, "_http_get", _boom)
+    ts = datetime(2026, 7, 1, 15, 0, tzinfo=timezone.utc)  # strictly past
+    first = ns.get_news_sentiment(["MSFT"], ts)
+    second = ns.get_news_sentiment(["MSFT"], ts)
+    assert first == {"news_sentiment": {}, "news_overview": None}
+    assert second == {"news_sentiment": {}, "news_overview": None}
+    assert len(calls) == 1  # gap memoized; no second live timeout
+
+
+def test_today_outage_throttled_then_reattempts(monkeypatch):
+    """A today/latest OUTAGE is negative-cached briefly so it doesn't re-hit the
+    producer on every poll, then re-attempts once the window elapses."""
+    calls = []
+    def _boom(**kw):
+        calls.append(1)
+        raise OSError("down")
+    monkeypatch.setattr(ns, "_http_get", _boom)
+    now = datetime.now(timezone.utc)
+    ns.get_news_sentiment(["MSFT"], now)
+    ns.get_news_sentiment(["MSFT"], now)
+    assert len(calls) == 1  # second served from the short negative cache
+    # Expire the throttle entry (white-box, avoids a sleep) -> next call re-hits.
+    with ns._lock:
+        for entry in ns._CACHE.values():
+            if entry["expires_at"] is not None:
+                entry["expires_at"] = time.monotonic() - 1
+    ns.get_news_sentiment(["MSFT"], now)
+    assert len(calls) == 2
+
+
+def test_malformed_panel_signal_dropped_not_whole_panel(monkeypatch):
+    """One signal missing a required story field is dropped from the feed
+    (logged), not allowed to collapse the entire panel to unavailable."""
+    body = load_signals_fixture()
+    body["signals"]["BADD"] = {"sentiment": "bullish", "score": 0.1}  # no headline/url
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    payload = ns.get_latest_panel_payload(["MSFT", "NVDA", "BADD"])
+    assert payload["status"] != "unavailable"                 # panel survived
+    feed_tickers = {item["ticker"] for item in payload["feed"]}
+    assert "MSFT" in feed_tickers and "BADD" not in feed_tickers  # good kept, bad dropped
+
+
+def test_panel_signal_with_null_published_sinks_not_crashes(monkeypatch):
+    """An off-spec `published: null` must not throw inside the feed sort and
+    collapse the panel — the item sinks to the bottom instead."""
+    body = load_signals_fixture()
+    body["signals"]["MSFT"]["published"] = None
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    payload = ns.get_latest_panel_payload(["MSFT", "NVDA"])
+    assert payload["status"] != "unavailable"
+    assert any(item["ticker"] == "MSFT" for item in payload["feed"])  # sunk, not dropped
+
+
+def test_single_flight_follower_neither_hits_producer_nor_blocks(monkeypatch):
+    """Two concurrent callers on the same cold key: exactly one leader hits the
+    producer; the follower returns WITHOUT a second call and WITHOUT blocking
+    behind the leader's ~10s upstream call (the threadpool-starvation fix)."""
+    import threading as _threading
+    body = load_signals_fixture()
+    started, release, calls = _threading.Event(), _threading.Event(), []
+
+    def _slow(**kw):
+        calls.append(1)
+        started.set()          # leader is now inside the producer call
+        release.wait(2.0)      # hold until the follower has raced in
+        return _fake_response(body=body)
+
+    monkeypatch.setattr(ns, "_http_get", _slow)
+    results = {}
+    leader = _threading.Thread(
+        target=lambda: results.__setitem__("leader", ns.get_latest_panel_payload(["MSFT"])))
+    leader.start()
+    assert started.wait(2.0)   # leader is mid-fetch, holding _inflight
+    follower = _threading.Thread(
+        target=lambda: results.__setitem__("follower", ns.get_latest_panel_payload(["MSFT"])))
+    follower.start()
+    follower.join(2.0)
+    assert not follower.is_alive()                          # did not block behind the leader
+    assert results["follower"]["status"] == "unavailable"   # cold start: no body yet
+    release.set()
+    leader.join(2.0)
+    assert results["leader"]["status"] != "unavailable"     # leader got real data
+    assert len(calls) == 1                                  # follower never hit the producer
 
 
 def test_todays_404_not_hard_memoized(monkeypatch):

--- a/dashboard/backend/tests/test_news_sentiment_fixture.py
+++ b/dashboard/backend/tests/test_news_sentiment_fixture.py
@@ -39,3 +39,17 @@ def test_wire_fixture_reflects_public_projection():
     for stripped in ("generator", "model", "prompt_version"):
         assert stripped not in wire                        # dropped by _PUBLIC_STRIP
     assert isinstance(wire["signals"], dict) and wire["signals"]
+
+
+def test_wire_fixture_is_base_minus_strip_plus_staleness():
+    """Content-parity guard: the wire fixture must equal the on-disk fixture
+    modulo the documented transform (drop the three _PUBLIC_STRIP fields, append
+    `staleness_hours`). The `signals` blocks are byte-identical today; without
+    this assertion the two could silently diverge and quietly hollow out the
+    wire-shape coverage that depends on them matching."""
+    base = load_signals_fixture()
+    wire = load_signals_wire_fixture()
+    expected = {k: v for k, v in base.items()
+                if k not in ("generator", "model", "prompt_version")}
+    expected["staleness_hours"] = wire["staleness_hours"]
+    assert wire == expected

--- a/dashboard/backend/tests/test_news_sentiment_fixture.py
+++ b/dashboard/backend/tests/test_news_sentiment_fixture.py
@@ -8,6 +8,18 @@ def load_signals_fixture() -> dict:
     return json.loads((FIXTURES / "signals-fixture.json").read_text())
 
 
+def load_signals_wire_fixture() -> dict:
+    """The stripped-and-injected shape the bearer-gated HTTP endpoint returns,
+    as distinct from the raw on-disk artifact (`load_signals_fixture`). Per the
+    contract (docs/integrations/finsearch-news-sentiment.md §"Producer response
+    shape"): the view drops `generator`/`model`/`prompt_version` via
+    `_PUBLIC_STRIP` and appends a server-computed `staleness_hours` last. The
+    adapter reads this shape, so its `staleness_hours` / `degraded` branches are
+    only reachable through this fixture — the on-disk one omits `staleness_hours`
+    and is `status: ok`."""
+    return json.loads((FIXTURES / "signals-wire-fixture.json").read_text())
+
+
 def test_fixture_matches_contract_essentials():
     body = load_signals_fixture()
     assert body["schema_version"] == 1
@@ -16,3 +28,14 @@ def test_fixture_matches_contract_essentials():
     for field in ("sentiment", "score", "rationale", "headline", "source",
                   "url", "published", "guid", "n_articles"):
         assert field in sample
+
+
+def test_wire_fixture_reflects_public_projection():
+    """Guards the wire/on-disk distinction the adapter depends on: the wire
+    shape carries `staleness_hours` and omits the three fields `_PUBLIC_STRIP`
+    removes. If this drifts, the staleness/degraded coverage below goes hollow."""
+    wire = load_signals_wire_fixture()
+    assert wire["staleness_hours"] is not None            # injected on the wire
+    for stripped in ("generator", "model", "prompt_version"):
+        assert stripped not in wire                        # dropped by _PUBLIC_STRIP
+    assert isinstance(wire["signals"], dict) and wire["signals"]

--- a/dashboard/backend/tests/test_news_sentiment_fixture.py
+++ b/dashboard/backend/tests/test_news_sentiment_fixture.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def load_signals_fixture() -> dict:
+    return json.loads((FIXTURES / "signals-fixture.json").read_text())
+
+
+def test_fixture_matches_contract_essentials():
+    body = load_signals_fixture()
+    assert body["schema_version"] == 1
+    assert isinstance(body["signals"], dict) and body["signals"]
+    sample = next(iter(body["signals"].values()))
+    for field in ("sentiment", "score", "rationale", "headline", "source",
+                  "url", "published", "guid", "n_articles"):
+        assert field in sample

--- a/dashboard/backend/tests/test_router_move.py
+++ b/dashboard/backend/tests/test_router_move.py
@@ -22,6 +22,7 @@ from dashboard.backend.api.routers import algo as algo_canon
 from dashboard.backend.api.routers import environments as environments_canon
 from dashboard.backend.api.routers import external_backtest as external_backtest_canon
 from dashboard.backend.api.routers import leaderboard as leaderboard_canon
+from dashboard.backend.api.routers import news as news_canon
 from dashboard.backend.api.routers import paper_trading as paper_trading_canon
 from dashboard.backend.api.routers import runs as runs_canon
 from dashboard.backend.app import app
@@ -93,6 +94,10 @@ EXPECTED_ALGO_ROUTES = {
 
 EXPECTED_LEADERBOARD_ROUTES = {
     ("GET", "/v1/leaderboard", "api_get_leaderboard"),
+}
+
+EXPECTED_NEWS_ROUTES = {
+    ("GET", "/news/signals", "latest_news_signals"),
 }
 
 # Paper Trading routes are registered directly on the app (no /api prefix);
@@ -255,6 +260,14 @@ def test_leaderboard_router_route_contract_unchanged():
 def test_canonical_leaderboard_router_uses_canonical_service():
     modules = _all_imported_modules(leaderboard_canon.__file__)
     assert "dashboard.backend.domain.leaderboard.service" in modules
+
+
+# ---------------------------------------------------------------------------
+# News panel proxy router (Task 5)
+# ---------------------------------------------------------------------------
+
+def test_news_router_route_contract_unchanged():
+    assert _route_triples(news_canon.router) == EXPECTED_NEWS_ROUTES
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/test_v2_contracts.py
+++ b/dashboard/backend/tests/test_v2_contracts.py
@@ -76,3 +76,20 @@ def test_error_envelope_shape():
     err = ErrorEnvelope.model_validate({"error": {
         "code": "validation_failed", "message": "bad", "retryable": False}})
     assert err.error.code == "validation_failed"
+
+
+def test_news_sentiment_entry_accepts_rationale():
+    entry = NewsSentimentEntry(
+        sentiment="bullish", score=0.5, headline="h", source="s",
+        url="https://example.com", age_hours=1.0, n_articles=2,
+        rationale="Two outlets report upbeat guidance.",
+    )
+    assert entry.rationale == "Two outlets report upbeat guidance."
+
+
+def test_news_sentiment_entry_rationale_is_optional():
+    entry = NewsSentimentEntry(
+        sentiment="neutral", score=0.0, headline="h", source="s",
+        url="https://example.com", age_hours=0.0, n_articles=1,
+    )
+    assert entry.rationale is None

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -471,6 +471,23 @@
                     </div>
                 </section>
 
+                <section class="home-news-signals" id="homeNewsSignals" aria-label="News and signals">
+                    <div class="home-section-title-row">
+                        <h2 class="home-section-title">News &amp; Signals <span class="nns-source-tag">via Agentic FinSearch</span></h2>
+                        <span class="nns-updated" id="nnsUpdated"></span>
+                        <span class="nns-badge" id="nnsStatusBadge" hidden></span>
+                    </div>
+                    <p class="nns-overview" id="nnsOverview"></p>
+                    <div class="nns-split">
+                        <!-- Phase A honesty: the left column is the stories BEHIND today's signals
+                             (one representative story per signalled ticker), not the full fetched
+                             feed — Phase B renames this heading to "Latest news" when the
+                             raw-items endpoint powers it. -->
+                        <div class="nns-col" id="nnsFeed"><h3>Today's signal stories</h3><ul class="nns-list" id="nnsFeedList"></ul></div>
+                        <div class="nns-col" id="nnsSignals"><h3>Signals</h3><ul class="nns-list" id="nnsSignalsList"></ul></div>
+                    </div>
+                </section>
+
                 <section class="home-insights">
                     <h3 class="home-section-title home-insights-heading">Insights from the Lab</h3>
                     <div class="home-insights-grid">
@@ -1513,5 +1530,10 @@
     <script src="app.js?v=12"></script>
     <script src="js/leaderboard.js?v=11"></script>
     <script src="home-page.js"></script>
+    <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
+         market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),
+         both loaded above — not beside the market-events/* block, which loads
+         before app.js. -->
+    <script src="home-news-signals.js"></script>
 </body>
 </html>

--- a/dashboard/frontend/home-news-signals.js
+++ b/dashboard/frontend/home-news-signals.js
@@ -1,0 +1,75 @@
+// Home panel: FinSearch signal stories (left) + identified signals (right).
+// Data: GET /api/news/signals (server-side proxy; 420s TTL — above this 300s
+// poll, so a re-poll lands in-cache). Poll only while the Home view is visible.
+// Reuses app.js globals: escapeHtml (attribute-safe), API (fetch wrapper),
+// API_BASE; and market-events/marketEventRelativeTime.js for relative times.
+// Load order: this script tag must come after app.js and market-events/*.
+(function () {
+  const POLL_MS = 5 * 60 * 1000;
+  let timer = null;
+
+  // escapeHtml (app.js) neutralizes quotes/angle-brackets but does NOT scheme-validate
+  // a URL — a `javascript:` value would survive it unchanged and execute on click.
+  // The producer's clean_text does not validate scheme either, so this is the only
+  // guard: gate every outbound link to http(s) BEFORE it reaches an href.
+  function safeUrl(raw) {
+    const s = String(raw == null ? '' : raw).trim();
+    return /^https?:\/\//i.test(s) ? s : '#';
+  }
+
+  function relTime(publishedEpochSeconds) {
+    // Shared helper takes ms/Date-parseable input; producer sends epoch seconds.
+    return window.formatMarketEventRelativeTime
+      ? window.formatMarketEventRelativeTime(publishedEpochSeconds * 1000, new Date())
+      : '';
+  }
+
+  function render(payload) {
+    const updated = document.getElementById('nnsUpdated');
+    const badge = document.getElementById('nnsStatusBadge');
+    const overview = document.getElementById('nnsOverview');
+    const feedList = document.getElementById('nnsFeedList');
+    const sigList = document.getElementById('nnsSignalsList');
+    if (!feedList || !sigList) return;
+
+    if (payload.status === 'unavailable') {
+      overview.textContent = 'News signals are currently unavailable.';
+      feedList.innerHTML = sigList.innerHTML = '';
+      updated.textContent = '';
+      badge.hidden = true;
+      return;
+    }
+    updated.textContent = payload.staleness_hours != null
+      ? `Updated ${payload.staleness_hours.toFixed(1)}h ago` : '';
+    badge.hidden = payload.status !== 'degraded';
+    if (!badge.hidden) badge.textContent = `degraded: ${payload.status_reason || 'partial data'}`;
+    overview.textContent = payload.news_overview || '';
+
+    feedList.innerHTML = (payload.feed || []).map(item => `
+      <li class="nns-item">
+        <a href="${escapeHtml(safeUrl(item.url))}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.headline)}</a>
+        <span class="nns-meta">${escapeHtml(item.source)} · ${escapeHtml(item.ticker)} · ${relTime(item.published)}</span>
+      </li>`).join('') || '<li class="nns-empty">No qualifying news today.</li>';
+
+    sigList.innerHTML = Object.entries(payload.signals || {}).map(([sym, s]) => `
+      <li class="nns-item nns-signal nns-${escapeHtml(s.sentiment)}">
+        <span class="nns-chip">${escapeHtml(s.sentiment)}</span>
+        <strong>${escapeHtml(sym)}</strong> <span class="nns-score">${Number(s.score).toFixed(2)}</span>
+        <span class="nns-rationale">${escapeHtml(s.rationale || '')}</span>
+        <a class="nns-src" href="${escapeHtml(safeUrl(s.url))}" target="_blank" rel="noopener noreferrer">${escapeHtml(s.source)}</a>
+      </li>`).join('') || '<li class="nns-empty">No directional reads.</li>';
+  }
+
+  async function load() {
+    try {
+      render(await API.get(`${API_BASE}/api/news/signals`));
+    } catch (e) {
+      render({ status: 'unavailable' });
+    }
+  }
+
+  window.newsSignalsPanel = {
+    onShow() { load(); if (!timer) timer = setInterval(load, POLL_MS); },
+    onHide() { if (timer) { clearInterval(timer); timer = null; } },
+  };
+})();

--- a/dashboard/frontend/home-news-signals.js
+++ b/dashboard/frontend/home-news-signals.js
@@ -39,8 +39,12 @@
       badge.hidden = true;
       return;
     }
-    updated.textContent = payload.staleness_hours != null
-      ? `Updated ${payload.staleness_hours.toFixed(1)}h ago` : '';
+    // Coerce like the score below (line 57): the value is passed through from
+    // the producer unvalidated, so a string/non-number must not throw and mask
+    // an otherwise-valid payload as "unavailable". null stays "" as before.
+    const staleness = Number(payload.staleness_hours);
+    updated.textContent = (payload.staleness_hours != null && Number.isFinite(staleness))
+      ? `Updated ${staleness.toFixed(1)}h ago` : '';
     badge.hidden = payload.status !== 'degraded';
     if (!badge.hidden) badge.textContent = `degraded: ${payload.status_reason || 'partial data'}`;
     overview.textContent = payload.news_overview || '';

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -648,11 +648,13 @@ function initHomePage() {
 function onHomePageShow() {
     if (!homeMockLive) homeMockLive = useMockLiveEvents();
     homeMockLive.start();
+    window.newsSignalsPanel && window.newsSignalsPanel.onShow();
 }
 
 function onHomePageHide() {
     homeMockLive?.stop();
     hideLiveToast();
+    window.newsSignalsPanel && window.newsSignalsPanel.onHide();
 }
 
 window.initHomePage = initHomePage;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -4371,6 +4371,51 @@ a.header-brand:hover .title-section h1 {
 
 .home-highlight-positive { color: var(--home-positive-green); font-weight: 700; }
 
+/* News & signals panel (matches .home-dash-card chrome; full-width, not a grid item) */
+.home-news-signals {
+    padding: 18px 18px 16px; background: var(--home-surface-card);
+    border: 1px solid var(--home-border-card); border-radius: 12px; min-width: 0;
+}
+.home-section-title-row { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 8px; }
+.home-section-title-row .home-section-title { flex: 1; }
+.nns-source-tag { font-weight: 500; color: var(--text-muted); text-transform: none; letter-spacing: normal; margin-left: 4px; }
+.nns-updated { font-size: 11px; color: var(--text-muted); white-space: nowrap; }
+.nns-badge {
+    display: inline-block; padding: 4px 8px; border-radius: 3px;
+    font-size: 11px; font-weight: 600; text-transform: none;
+    background-color: rgba(245, 158, 11, 0.15); color: var(--home-warning-amber);
+}
+.nns-overview { margin: 0 0 14px; font-size: 13px; color: var(--text-secondary); line-height: 1.5; }
+
+.nns-split { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.nns-col h3 {
+    margin: 0 0 8px; font-size: 11px; font-weight: 700; letter-spacing: 0.1em;
+    text-transform: none; color: rgba(148,163,184,0.85);
+}
+.nns-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+.nns-item {
+    padding: 9px 0; border-bottom: 1px solid var(--home-border-subtle);
+    font-size: 12px; display: flex; flex-direction: column; gap: 3px;
+}
+.nns-list .nns-item:last-child { border-bottom: none; }
+.nns-item a { color: var(--text-primary); font-weight: 600; text-decoration: none; line-height: 1.4; overflow-wrap: anywhere; }
+.nns-item a:hover { color: var(--home-accent-cyan); text-decoration: underline; }
+.nns-meta { color: var(--text-muted); font-size: 11px; }
+.nns-empty { color: var(--text-muted); font-size: 12px; padding: 9px 0; }
+
+.nns-signal { gap: 4px; }
+.nns-chip {
+    display: inline-block; align-self: flex-start; padding: 2px 7px; border-radius: 999px;
+    font-size: 10px; font-weight: 700; text-transform: none; letter-spacing: 0.03em;
+}
+.nns-bullish .nns-chip { color: var(--home-positive-green); background: rgba(34,197,94,0.15); }
+.nns-bearish .nns-chip { color: var(--home-negative-red); background: rgba(239,68,68,0.15); }
+.nns-neutral .nns-chip { color: var(--text-muted); background: rgba(107,114,128,0.15); }
+.nns-score { color: var(--text-muted); font-size: 11px; }
+.nns-rationale { color: var(--text-secondary); font-size: 11px; line-height: 1.4; }
+.nns-src { align-self: flex-start; color: var(--home-accent-cyan); font-size: 11px; text-decoration: none; }
+.nns-src:hover { text-decoration: underline; }
+
 /* Timeline activity */
 .home-dash-card--activity .home-timeline {
     min-height: 300px;
@@ -4632,6 +4677,7 @@ a.header-brand:hover .title-section h1 {
 @media (max-width: 1200px) {
     .home-dashboard-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .home-hero-grid { grid-template-columns: 1fr; }
+    .nns-split { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 900px) {

--- a/docs/integrations/finsearch-news-sentiment.md
+++ b/docs/integrations/finsearch-news-sentiment.md
@@ -108,7 +108,8 @@ The producer artifact and the consumer type were designed independently and **do
 | `url` | `url` | passthrough |
 | `n_articles` | `n_articles` | passthrough |
 | `age_hours` | `published` (epoch) | **`max(0.0, (reference_ts − published) / 3600.0)`** |
-| — | `rationale`, `guid` | **dropped** — no slot in `NewsSentimentEntry` (see design note) |
+| `rationale` | `rationale` | passthrough — optional; the producer's one-line directional reasoning (see design note) |
+| — | `guid` | **dropped** — no slot in `NewsSentimentEntry` |
 
 And `news_overview` ← the top-level `news_overview` string (passthrough).
 
@@ -140,17 +141,17 @@ The consumer slot already defaults to empty, so every failure mode collapses saf
 
 ---
 
-## Design note — `rationale` / provenance (flag for the team)
+## Design note — `rationale` / provenance
 
-The producer emits a one-line **`rationale`** per ticker (why the read is bullish/bearish) plus the story `guid`. `NewsSentimentEntry` has **no slot for either**, so the adapter must currently drop them. That narrows the "auditable, sourced signal" thesis: `headline` + `source` + `url` still give provenance, but the *directional reasoning* is discarded before the agent ever sees it.
+The producer emits a one-line **`rationale`** per ticker (why the read is bullish/bearish) plus the story `guid`. `NewsSentimentEntry` now carries an **optional** `rationale: str | None = None` field (additive, 2026-07-13), so the agent can fold the sourced reasoning into the decision `reasoning` field that already persists. It is a forward-compatible, additive change (existing consumers ignore it) and it restores the "auditable, sourced signal" thesis: `headline` + `source` + `url` + `rationale` together give provenance and directional reasoning, instead of the reasoning being discarded before the agent ever sees it. The projecting adapter (see the Traceability section) is responsible for passing the producer's `rationale` through into this slot.
 
-Recommendation: add an **optional** `rationale: str | None = None` field to `NewsSentimentEntry`, so the agent can fold the sourced reasoning into the decision `reasoning` field that already persists. It is a forward-compatible, additive change (existing consumers ignore it) and it restores the audit trail the design intended. Raised here rather than silently decided — it is a contract change and belongs to whoever owns `api/v2/models.py`.
+`guid` has **no slot** and stays dropped — `headline`/`source`/`url` already give sufficient provenance without it, and there is no plan to add one.
 
 ---
 
 ## Reference sketch
 
-Not prescriptive — the projection above is the contract; degraded-handling and the `rationale` question are yours to decide.
+Not prescriptive — the projection above is the contract; degraded-handling is yours to decide (the `rationale` question is settled — see the design note above).
 
 ```python
 # dashboard/backend/integrations/news_sentiment.py
@@ -203,4 +204,4 @@ def get_news_sentiment(universe, timestamp):
 | Auth requirement | FinSearch `Docs/superpowers/plans/2026-07-12-endpoint-auth.md` (PRs #354/#355/#356); endpoint verified live 2026-07-13 |
 | `as_of`, Dow-30 reconcile | FinSearch PR #340 / #341; ATL #91 / #94 |
 
-**Deliberate deviation from the plan:** the plan's frozen sketch listed `rationale`/`published` on the injected entry; the shipped `NewsSentimentEntry` carries `age_hours`/`n_articles` instead and omits `rationale`. This doc documents the shipped contract and flags the `rationale` gap above rather than assuming the older sketch.
+**Deliberate deviation from the plan:** the plan's frozen sketch listed `rationale`/`published` on the injected entry; the shipped `NewsSentimentEntry` carries `age_hours`/`n_articles` instead of `published`, plus (as of 2026-07-13) an optional `rationale`. This doc documents the shipped contract rather than assuming the older sketch.

--- a/docs/integrations/finsearch-news-sentiment.md
+++ b/docs/integrations/finsearch-news-sentiment.md
@@ -34,6 +34,7 @@ No ATL-side contract change is needed — the `/api/v2` refactor shipped the who
   | `url` | str | |
   | `age_hours` | float | ≥ 0.0 |
   | `n_articles` | int | ≥ 0 |
+  | `rationale` | str \| None | optional — see design note |
 - **Universe:** the loader is called with `list(DJIA_30)` (the canonical current Dow-30 constant, `infrastructure/llm/validator.py`, reconciled in #91/#94 — the old `AMEX` typo is gone). Pass that straight through as the `?tickers=` filter.
 
 ---
@@ -109,7 +110,7 @@ The producer artifact and the consumer type were designed independently and **do
 | `n_articles` | `n_articles` | passthrough |
 | `age_hours` | `published` (epoch) | **`max(0.0, (reference_ts − published) / 3600.0)`** |
 | `rationale` | `rationale` | passthrough — optional; the producer's one-line directional reasoning (see design note) |
-| — | `guid` | **dropped** — no slot in `NewsSentimentEntry` |
+| — | `guid` | **dropped** — no slot in `NewsSentimentEntry` (see design note) |
 
 And `news_overview` ← the top-level `news_overview` string (passthrough).
 

--- a/docs/integrations/finsearch-news-sentiment.md
+++ b/docs/integrations/finsearch-news-sentiment.md
@@ -156,7 +156,8 @@ Not prescriptive — the projection above is the contract; degraded-handling is 
 
 ```python
 # dashboard/backend/integrations/news_sentiment.py
-import os, time, requests
+import os, requests
+from datetime import datetime, timezone
 
 _BASE = "https://agenticfinsearch.org/api/signals/news/"
 
@@ -164,7 +165,17 @@ def _headers():
     key = os.environ.get("FINGPT_API_KEY", "")
     return {"Authorization": f"Bearer {key}"} if key else {}
 
+def _coerce_timestamp(timestamp):
+    # The real call site (external_run_service.py:429-431) serializes the step
+    # timestamp to an ISO STRING, not a datetime — coerce, don't assume.
+    if isinstance(timestamp, str):
+        timestamp = datetime.fromisoformat(timestamp)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp
+
 def get_news_sentiment(universe, timestamp):
+    timestamp = _coerce_timestamp(timestamp)
     as_of = timestamp.date().isoformat()
     reference_ts = timestamp.timestamp()
     resp = requests.get(
@@ -185,6 +196,7 @@ def get_news_sentiment(universe, timestamp):
             "url": s["url"],
             "n_articles": s["n_articles"],
             "age_hours": max(0.0, (reference_ts - s["published"]) / 3600.0),
+            "rationale": s.get("rationale"),
         }
     return {"news_sentiment": out, "news_overview": body.get("news_overview")}
 

--- a/docs/source/lab/agent_api.rst
+++ b/docs/source/lab/agent_api.rst
@@ -36,8 +36,10 @@ Context envelope
 ``get_context`` returns a typed envelope: ``portfolio``, ``current_holdings``,
 ``recent_trades``, ``top_signals``, plus an explicit ``universe`` (DJIA-30), a
 ``loop`` field (``lockstep`` for backtest), and a guaranteed ``news_sentiment``
-slot (one aggregated entry per ticker; empty ``{}`` until the sentiment signal is
-wired). ``GET /api/v2/schema`` publishes the full schemas, error codes, and version.
+slot (one aggregated entry per ticker), populated by the Agentic FinSearch
+news-sentiment adapter when ``FINGPT_API_KEY`` is set, and left ``{}`` when the
+key is unset or the producer is unavailable. ``GET /api/v2/schema`` publishes
+the full schemas, error codes, and version.
 
 Decisions & idempotency
 ------------------------

--- a/docs/source/lab/agent_api.rst
+++ b/docs/source/lab/agent_api.rst
@@ -37,9 +37,11 @@ Context envelope
 ``recent_trades``, ``top_signals``, plus an explicit ``universe`` (DJIA-30), a
 ``loop`` field (``lockstep`` for backtest), and a guaranteed ``news_sentiment``
 slot (one aggregated entry per ticker), populated by the Agentic FinSearch
-news-sentiment adapter when ``FINGPT_API_KEY`` is set, and left ``{}`` when the
-key is unset or the producer is unavailable. ``GET /api/v2/schema`` publishes
-the full schemas, error codes, and version.
+news-sentiment adapter when ``FINGPT_API_KEY`` is set and the producer has an
+artifact at or before that step's date. It is left ``{}`` otherwise — the key
+unset, the producer unavailable, or (the common case for historical backtests)
+no artifact yet exists at or before that date (``404``). ``GET /api/v2/schema``
+publishes the full schemas, error codes, and version.
 
 Decisions & idempotency
 ------------------------


### PR DESCRIPTION
Plan 1 (Phase A) consumer half of the FinSearch news→sentiment→ATL bridge. Spec/plan: `docs/superpowers/{specs,plans}/2026-07-13-finsearch-news-signals-panel*`.

**Ships**
- `integrations/news_sentiment.py` — fail-closed adapter (shared HTTP core + memo policy: past-date hard-memo incl. negative-cached config errors, today/latest always ETag-revalidate, transport failure never serves stale). Populates the v2 `news_sentiment` envelope slot; ISO-string timestamp coercion (the real call site passes a string).
- `GET /api/news/signals` — sync proxy (single-flight lock, 420s TTL cache, 30s negative-cache), always 200 fail-closed. Bearer key stays server-side.
- Home panel (`#homeView`): latest stories (left) + identified signals (right), poll-while-visible, `safeUrl`-before-`escapeHtml` on every href.
- Additive optional `rationale` on `NewsSentimentEntry` (v2 contract) + normative-doc updates.
- `.env.example` (`FINGPT_API_KEY`, `FINSEARCH_SIGNALS_URL`), README roadmap + agent-API doc.

**Tests:** full suite **927 passed / 2 skipped / 0 failed**. Adapter/route/contract tests are offline (vendored fixture, no network, no key). Both route-contract freezes updated (no CI reddening).

**Review:** each task spec+quality reviewed with fixes applied; final whole-branch review = ready to merge, 0 Critical/0 Important. All four cross-task seams (payload shape adapter→route→frontend, fail-closed chain, key-never-crosses-browser, memo/TTL interaction) verified clean.

**Manual follow-ups (not in this PR)**
- Browser visual QA of the panel (code + server-side smoke verified; headless can't drive a browser).
- Set `FINGPT_API_KEY` in Render prod env (same value as the FinSearch backend).
- Phase B / Task 8 (cross-repo FinSearch raw-items endpoint + feed upgrade) is a separate PR.
- Non-blocking test-fidelity follow-up: add a stripped-wire-shape fixture (exercises `staleness_hours`) + a `degraded`-status branch test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
