### PR TITLE
Align preseason leaderboard UX and Discord dashboard deep links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,9 +60,12 @@ DISCORD_REDIRECT_URI=http://localhost:8000/api/auth/discord/callback
 DISCORD_GUILD_CHANNEL_URL=https://discord.gg/9HnQ6XDG98
 # Optional: signs the short-lived OAuth state token. Defaults to DISCORD_CLIENT_SECRET.
 # DISCORD_OAUTH_STATE_SECRET=another_long_random_secret
-# Optional: dashboard origin for OAuth redirects and Discord result deep links
-# (defaults to ATL_API_BASE / same host). Example: http://localhost:8000
+# Frontend origin for OAuth redirects and Discord result deep links.
+# Production Discord worker should use the Vercel app (not the Render API):
+#   PUBLIC_APP_URL=https://agentic-trading-lab.vercel.app
+# Local (API also serves /app):
 # PUBLIC_APP_URL=http://localhost:8000
+PUBLIC_APP_URL=https://agentic-trading-lab.vercel.app
 
 # Database
 DATABASE_PATH=dashboard/storage/data/backtest.db

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -415,22 +415,21 @@ def deploy_model_run(
     }
 
 
+def _rank_sort_key(entry: Dict[str, Any]) -> tuple:
+    """Official rank is by final portfolio value (nof1-style); tie-break on return."""
+    pv = entry.get("portfolio_value")
+    if pv is None:
+        # Unit tests / partial fixtures may omit dollars — fall back to return.
+        pv = entry.get("cumulative_return") or 0
+    return (-float(pv), -(entry.get("cumulative_return") or 0))
+
+
 def _rank_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Assign official ranks by final portfolio value (higher is better)."""
     if not entries:
         return entries
 
-    by_return = sorted(entries, key=lambda e: e.get("cumulative_return") or 0, reverse=True)
-    by_sharpe = sorted(entries, key=lambda e: e.get("sharpe_ratio") or 0, reverse=True)
-
-    rank_cr = {id(e): i + 1 for i, e in enumerate(by_return)}
-    rank_sr = {id(e): i + 1 for i, e in enumerate(by_sharpe)}
-
-    for entry in entries:
-        entry["rank_cr"] = rank_cr[id(entry)]
-        entry["rank_sr"] = rank_sr[id(entry)]
-        entry["final_score"] = (entry["rank_cr"] + entry["rank_sr"]) / 2
-
-    entries.sort(key=lambda e: (e["final_score"], -(e.get("cumulative_return") or 0)))
+    entries.sort(key=_rank_sort_key)
     for idx, entry in enumerate(entries):
         entry["rank"] = idx + 1
     return entries
@@ -446,31 +445,52 @@ def get_leaderboard(force_refresh: bool = False) -> Dict[str, Any]:
     strategy_by_id = {s["id"]: s for s in config.get("strategies", [])}
 
     entries: List[Dict[str, Any]] = []
+    display_capital = float(config.get("initial_capital", INITIAL_CAPITAL))
+
     for strategy in config.get("strategies", []):
         run = _find_cached_run(strategy["id"], start_date, end_date, session_id)
         if not run:
             continue
 
         equity_hourly = db.get_equity_curve(run["run_id"]) or []
-        initial_equity = run.get("initial_equity") or config.get("initial_capital", INITIAL_CAPITAL)
+        stored_initial = float(
+            run.get("initial_equity") or config.get("initial_capital", INITIAL_CAPITAL)
+        )
+        # Display capital may differ from the stored seed run (e.g. $100k seed
+        # shown as $1k). Scale dollar levels; returns / Sharpe stay unchanged.
+        scale = (display_capital / stored_initial) if stored_initial else 1.0
+        scaled_hourly = [
+            {
+                **pt,
+                "equity": float(pt.get("equity") or 0) * scale,
+                "cash": float(pt.get("cash") or 0) * scale,
+                "positions_value": float(pt.get("positions_value") or 0) * scale,
+            }
+            for pt in equity_hourly
+        ]
         equity_curve = chart_equity_curve(
-            equity_hourly,
-            initial_equity=float(initial_equity),
+            scaled_hourly,
+            initial_equity=display_capital,
             start_date=start_date,
         )
         strat = strategy_by_id.get(strategy["id"], strategy)
         is_model = strat.get("strategy") == "llm_agent" or strat.get("label") == "Model"
+        final_equity = run.get("final_equity")
+        if final_equity is None:
+            portfolio_value = display_capital
+        else:
+            portfolio_value = float(final_equity) * scale
 
         entries.append(
             {
                 "entry_id": strategy["id"],
                 "team_name": run["agent_name"],
-                "team_badge": strat.get("label", "Baseline"),
+                "team_badge": strat.get("label", "Baseline Strategy"),
                 "model": strat.get("model", "Baseline"),
                 "entry_type": "baseline",
                 "is_model": is_model,
-                "initial_equity": initial_equity,
-                "portfolio_value": run.get("final_equity") or config.get("initial_capital", INITIAL_CAPITAL),
+                "initial_equity": display_capital,
+                "portfolio_value": portfolio_value,
                 "cumulative_return": run.get("total_return") or 0,
                 "sharpe_ratio": run.get("sharpe_ratio") or 0,
                 "max_drawdown": run.get("max_drawdown") or 0,
@@ -491,7 +511,12 @@ def get_leaderboard(force_refresh: bool = False) -> Dict[str, Any]:
         entry["equity_curve"] = curve
 
     entries = _rank_entries(entries)
-    leader = entries[0]["team_name"] if entries else "—"
+    models = [e for e in entries if e.get("is_model")]
+    models.sort(key=lambda e: e.get("cumulative_return") or 0, reverse=True)
+    if models:
+        leader = models[0].get("model") or models[0].get("team_name") or "—"
+    else:
+        leader = entries[0]["team_name"] if entries else "—"
 
     return {
         "window": {
@@ -502,6 +527,7 @@ def get_leaderboard(force_refresh: bool = False) -> Dict[str, Any]:
         },
         "updated_at": meta.get("refreshed_at"),
         "total_entries": len(entries),
+        "display_capital": display_capital,
         "leader": leader,
         "entries": entries,
     }

--- a/dashboard/backend/integrations/discord_bot.py
+++ b/dashboard/backend/integrations/discord_bot.py
@@ -67,9 +67,25 @@ def api_base() -> str:
     return os.getenv("ATL_API_BASE", "http://localhost:8000").rstrip("/")
 
 
+# Production SPA (Vercel). The API often lives on Render; Discord deep links must
+# open the frontend, not the API host.
+_DEFAULT_PUBLIC_APP = "https://agentic-trading-lab.vercel.app"
+
+
 def public_app_base() -> str:
-    """Origin (or /app URL) used for dashboard deep links in Discord messages."""
-    raw = (os.getenv("PUBLIC_APP_URL") or api_base()).rstrip("/")
+    """Playground base URL for Discord Dashboard deep links.
+
+    Prefer ``PUBLIC_APP_URL``. If unset and ``ATL_API_BASE`` points at the
+    Render API, fall back to the Vercel app (not the API origin). Locally,
+    fall back to the API host (which also serves ``/app``).
+    """
+    raw = (os.getenv("PUBLIC_APP_URL") or "").rstrip("/")
+    if not raw:
+        api = api_base()
+        if "onrender.com" in api.lower():
+            raw = _DEFAULT_PUBLIC_APP
+        else:
+            raw = api
     if raw.endswith("/app"):
         return raw
     return f"{raw}/app"
@@ -77,20 +93,23 @@ def public_app_base() -> str:
 
 def dashboard_backtest_url(
     *,
-    agent_id: Optional[str],
-    run_id: Optional[str],
-) -> Optional[str]:
-    """Build /app?view=backtest&agent_id=…&run_id=… for Discord result messages."""
-    if not agent_id or not run_id:
-        return None
-    query = urlencode(
-        {
-            "view": "backtest",
-            "agent_id": str(agent_id),
-            "run_id": str(run_id),
-        }
-    )
-    return f"{public_app_base()}?{query}"
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> str:
+    """Build a Playground URL for Discord result messages.
+
+    Prefer ``/app?view=backtest&agent_id=…&run_id=…`` when both ids are known;
+    otherwise fall back to agent-only or the bare Playground URL so the reply
+    always includes a clickable dashboard link.
+    """
+    params: dict[str, str] = {"view": "backtest"}
+    if agent_id:
+        params["agent_id"] = str(agent_id)
+    if run_id:
+        params["run_id"] = str(run_id)
+    if len(params) == 1:
+        return public_app_base()
+    return f"{public_app_base()}?{urlencode(params)}"
 
 
 def _parse_id_list(raw: Optional[str]) -> list[int]:
@@ -555,16 +574,14 @@ async def execute_backtest(
     # Key the deep link + "saved to card" line off what was actually sent so we
     # never claim a run landed on an agent's card when it didn't.
     attached_agent_id = payload.get("agent_id")
+    # Always include a clickable Playground URL (Vercel in prod; full deep link when ids exist).
     dash_url = dashboard_backtest_url(agent_id=attached_agent_id, run_id=run_id)
-    if dash_url:
-        summary += f"\nDashboard: {dash_url}"
-    elif share_url:
+    summary += f"\nDashboard: {dash_url}"
+    if share_url:
         summary += f"\nView: {share_url}"
     if attached_agent_id and selected and selected.get("name"):
         summary += (
-            f"\nSaved to **{selected['name']}**'s card"
-            + (" — open the Dashboard link above." if dash_url else
-               " — open *My Agents* on the website to track the details.")
+            f"\nSaved to **{selected['name']}**'s card — open the Dashboard link above."
         )
     await interaction.edit_original_response(content=summary)
 

--- a/dashboard/backend/tests/domain/leaderboard/test_service_move.py
+++ b/dashboard/backend/tests/domain/leaderboard/test_service_move.py
@@ -93,23 +93,32 @@ def test_runtime_consumer_uses_canonical_import():
 # Ranking + tie ordering (pure function)
 # ---------------------------------------------------------------------------
 
-def test_rank_entries_orders_and_breaks_ties_by_return():
+def test_rank_entries_orders_by_portfolio_value():
     entries = [
-        {"entry_id": "A", "cumulative_return": 0.10, "sharpe_ratio": 1.0},
-        {"entry_id": "B", "cumulative_return": 0.05, "sharpe_ratio": 2.0},
-        {"entry_id": "C", "cumulative_return": 0.01, "sharpe_ratio": 0.5},
+        {"entry_id": "A", "portfolio_value": 110000, "cumulative_return": 0.10, "sharpe_ratio": 1.0},
+        {"entry_id": "B", "portfolio_value": 105000, "cumulative_return": 0.05, "sharpe_ratio": 2.0},
+        {"entry_id": "C", "portfolio_value": 101000, "cumulative_return": 0.01, "sharpe_ratio": 0.5},
     ]
     ranked = canon_service._rank_entries(entries)
     by_id = {e["entry_id"]: e for e in ranked}
 
-    # A and B tie on final_score (1.5); A wins the tie on higher cumulative_return.
-    assert by_id["A"]["final_score"] == 1.5
-    assert by_id["B"]["final_score"] == 1.5
+    # Official rank is by final portfolio value (higher Wins), not composite score.
     assert by_id["A"]["rank"] == 1
     assert by_id["B"]["rank"] == 2
     assert by_id["C"]["rank"] == 3
-    assert by_id["A"]["rank_cr"] == 1 and by_id["A"]["rank_sr"] == 2
-    assert by_id["B"]["rank_cr"] == 2 and by_id["B"]["rank_sr"] == 1
+    assert "final_score" not in by_id["A"]
+    assert "rank_cr" not in by_id["A"]
+
+
+def test_rank_entries_ties_break_on_return():
+    entries = [
+        {"entry_id": "A", "portfolio_value": 105000, "cumulative_return": 0.10},
+        {"entry_id": "B", "portfolio_value": 105000, "cumulative_return": 0.05},
+    ]
+    ranked = canon_service._rank_entries(entries)
+    assert ranked[0]["entry_id"] == "A"
+    assert ranked[0]["rank"] == 1
+    assert ranked[1]["entry_id"] == "B"
 
 
 def test_rank_entries_empty():
@@ -183,14 +192,18 @@ def test_get_leaderboard_schema_and_ranking(isolated_service):
     _seed(isolated_service, "spy_index", 0.03, 0.9)
 
     result = canon_service.get_leaderboard()
-    assert set(result.keys()) == {"window", "updated_at", "total_entries", "leader", "entries"}
+    assert set(result.keys()) == {
+        "window", "updated_at", "total_entries", "leader", "entries", "display_capital",
+    }
     assert result["total_entries"] == 2
     assert result["window"]["label"] == "2026-04-15 → 2026-05-15"
+    assert result["display_capital"] == 100000
 
     entries = result["entries"]
     # djia_index has higher return and sharpe → rank 1.
     assert entries[0]["entry_id"] == "djia_index"
     assert entries[0]["rank"] == 1
+    # No model entries in this fixture → leader falls back to overall rank-1 name.
     assert result["leader"] == "DJIA_INDEX"
 
     entry = entries[0]
@@ -198,8 +211,7 @@ def test_get_leaderboard_schema_and_ranking(isolated_service):
         "entry_id", "team_name", "team_badge", "model", "entry_type", "is_model",
         "initial_equity", "portfolio_value", "cumulative_return", "sharpe_ratio",
         "max_drawdown", "status", "run_id", "llm_calls", "input_tokens",
-        "output_tokens", "est_cost_usd", "equity_curve", "rank_cr", "rank_sr",
-        "final_score", "rank",
+        "output_tokens", "est_cost_usd", "equity_curve", "rank",
     }
     assert expected_fields.issubset(set(entry.keys()))
     assert "win_loss_ratio" not in entry
@@ -271,3 +283,36 @@ def test_get_leaderboard_equity_curve_is_hourly_with_open_tick(isolated_service)
     assert len(curve) >= 3
     assert any(str(p["timestamp"]).startswith("2026-04-15T14") for p in curve)
     assert any(str(p["timestamp"]).startswith("2026-04-15T15") for p in curve)
+
+
+def test_get_leaderboard_scales_to_display_capital_and_prefers_model_leader(
+    isolated_service, monkeypatch
+):
+    """$100k seed runs are rescaled when config.initial_capital is $1k."""
+    cfg = dict(_CONFIG)
+    cfg["initial_capital"] = 1000
+    cfg["strategies"] = [
+        {"id": "djia_index", "name": "DJIA", "label": "Index", "model": "DJIA", "strategy": "market_index"},
+        {
+            "id": "gpt_demo",
+            "name": "GPT Demo",
+            "label": "Model",
+            "model": "GPT Demo",
+            "strategy": "llm_agent",
+        },
+    ]
+    monkeypatch.setattr(canon_service, "load_leaderboard_config", lambda: cfg)
+
+    _seed(isolated_service, "djia_index", 0.10, 1.0)
+    _seed(isolated_service, "gpt_demo", 0.05, 0.8)
+
+    result = canon_service.get_leaderboard()
+    assert result["display_capital"] == 1000
+    by_id = {e["entry_id"]: e for e in result["entries"]}
+    assert by_id["djia_index"]["initial_equity"] == 1000
+    assert abs(by_id["djia_index"]["portfolio_value"] - 1100) < 1e-6
+    assert by_id["djia_index"]["cumulative_return"] == 0.10
+    assert by_id["gpt_demo"]["is_model"] is True
+    # Leader is best model even if an index outranks it overall.
+    assert result["leader"] == "GPT Demo"
+    assert by_id["gpt_demo"]["equity_curve"][0]["equity"] == 1000

--- a/dashboard/backend/tests/integrations/test_discord_wiring.py
+++ b/dashboard/backend/tests/integrations/test_discord_wiring.py
@@ -84,6 +84,9 @@ def test_bot_builds_dashboard_backtest_deep_link():
     assert '"view": "backtest"' in src
     assert "agent_id" in src and "run_id" in src
     assert "Dashboard:" in src
+    assert "agentic-trading-lab.vercel.app" in src
+    assert "onrender.com" in src  # prod API detection / never deep-link that host
+    assert "dashboard_backtest_url(agent_id=attached_agent_id, run_id=run_id)" in src
 
 
 def test_bot_sends_per_user_id_on_strategy_post():

--- a/dashboard/config/leaderboard.json
+++ b/dashboard/config/leaderboard.json
@@ -1,6 +1,6 @@
 {
   "session_id": "leaderboard-contest",
-  "initial_capital": 100000,
+  "initial_capital": 1000,
   "start_date": "2026-04-15",
   "end_date": "2026-05-15",
   "reference_start_date": "2026-03-15",
@@ -9,23 +9,27 @@
     {
       "id": "spy_index",
       "name": "Agentic Trading Lab",
-      "label": "Index",
+      "label": "Market Index",
       "model": "SPY",
       "strategy": "market_index",
-      "symbols": ["^GSPC"]
+      "symbols": [
+        "^GSPC"
+      ]
     },
     {
       "id": "djia_index",
       "name": "Agentic Trading Lab",
-      "label": "Index",
+      "label": "Market Index",
       "model": "DJIA",
       "strategy": "market_index",
-      "symbols": ["^DJI"]
+      "symbols": [
+        "^DJI"
+      ]
     },
     {
       "id": "buy_hold_djia",
       "name": "Agentic Trading Lab",
-      "label": "Strategy",
+      "label": "Baseline Strategy",
       "model": "Buy & Hold",
       "strategy": "equal_weight_buyhold",
       "symbols": []
@@ -33,7 +37,7 @@
     {
       "id": "mean_variance_djia",
       "name": "Agentic Trading Lab",
-      "label": "Strategy",
+      "label": "Baseline Strategy",
       "model": "Mean-Variance",
       "strategy": "mean_variance",
       "symbols": []
@@ -41,7 +45,7 @@
     {
       "id": "equal_weight_djia",
       "name": "Agentic Trading Lab",
-      "label": "Strategy",
+      "label": "Baseline Strategy",
       "model": "Equal-Weight",
       "strategy": "equal_weight_index",
       "symbols": []

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -180,7 +180,7 @@
     </div>
     <div class="ticker-info">
         <span class="ticker-source-label" title="Stock prices and daily % change from Yahoo Finance. Crypto uses CoinGecko when included.">Data: Yahoo Finance</span>
-        <span class="ticker-markets-open"><span class="ticker-markets-dot" aria-hidden="true"></span>Markets open</span>
+        <span id="tickerMarketsStatus" class="ticker-markets-open" role="status" aria-live="polite"><span class="ticker-markets-dot" aria-hidden="true"></span><span class="ticker-markets-label">Markets open</span></span>
     </div>
 
     <!-- Home -->
@@ -440,13 +440,13 @@
                         <h3 class="home-section-title">Current Season</h3>
                         <div class="home-season-head">
                             <div class="home-season-name">SecureFinAI Contest 2026</div>
-                            <span class="status-badge live">Live</span>
+                            <span class="status-badge upcoming">Upcoming</span>
                         </div>
                         <p class="home-season-window">Sep 1 – Oct 30, 2026</p>
-                        <p class="home-season-days tabular-nums">60 Days Left</p>
+                        <p class="home-season-days tabular-nums">Registration not open</p>
                         <div class="home-season-counts">
-                            <div class="home-season-count"><span class="metric-label">Teams</span><span class="metric-value tabular-nums">7 registered</span></div>
-                            <div class="home-season-count"><span class="metric-label">Agents</span><span class="metric-value tabular-nums">9 connected</span></div>
+                            <div class="home-season-count"><span class="metric-label">Phase</span><span class="metric-value">Preseason</span></div>
+                            <div class="home-season-count"><span class="metric-label">Status</span><span class="metric-value">Upcoming</span></div>
                         </div>
                         <div class="home-progress">
                             <div class="home-progress-labels">
@@ -1288,72 +1288,34 @@
     <div id="competitionView" class="page-view competition-view" style="display: none;">
         <div class="subtab-bar competition-subtabs">
             <button class="subtab-btn active" data-competition-tab="leaderboard">Leaderboard</button>
-            <button class="subtab-btn" data-competition-tab="participants">Participants</button>
+            <button class="subtab-btn" data-competition-tab="participants">Participating Teams</button>
             <button class="subtab-btn" data-competition-tab="about">About</button>
         </div>
-        <div id="competitionParticipantsPanel" class="competition-panel" style="display: none;">
-            <div class="participants-grid">
-                <div class="section-card participant-card">
-                    <div class="agent-card-head">
-                        <h3 class="agent-name">AlphaForge</h3>
-                        <span class="status-badge live">Live</span>
-                    </div>
-                    <p class="participant-desc">Claude Sonnet momentum strategy on DJIA universe</p>
-                    <div class="agent-metrics">
-                        <div class="agent-metric">
-                            <span class="metric-label">Return</span>
-                            <span class="metric-value positive">+18.2%</span>
-                        </div>
-                        <div class="agent-metric">
-                            <span class="metric-label">Rank</span>
-                            <span class="metric-value">#1</span>
-                        </div>
-                    </div>
-                </div>
-                <div class="section-card participant-card">
-                    <div class="agent-card-head">
-                        <h3 class="agent-name">QuantPulse</h3>
-                        <span class="status-badge live">Live</span>
-                    </div>
-                    <p class="participant-desc">Multi-signal agent with risk-adjusted position sizing</p>
-                    <div class="agent-metrics">
-                        <div class="agent-metric">
-                            <span class="metric-label">Return</span>
-                            <span class="metric-value positive">+14.7%</span>
-                        </div>
-                        <div class="agent-metric">
-                            <span class="metric-label">Rank</span>
-                            <span class="metric-value">#2</span>
-                        </div>
-                    </div>
-                </div>
-                <div class="section-card participant-card">
-                    <div class="agent-card-head">
-                        <h3 class="agent-name">Momentum Alpha</h3>
-                        <span class="status-badge live">Live</span>
-                    </div>
-                    <p class="participant-desc">Hourly LLM decisions on Magnificent 7 basket</p>
-                    <div class="agent-metrics">
-                        <div class="agent-metric">
-                            <span class="metric-label">Return</span>
-                            <span class="metric-value positive">+12.4%</span>
-                        </div>
-                        <div class="agent-metric">
-                            <span class="metric-label">Rank</span>
-                            <span class="metric-value">#3</span>
-                        </div>
-                    </div>
+        <div id="competitionParticipantsPanel" class="competition-panel participants-panel" style="display: none;">
+            <div class="participants-empty-wrap">
+                <div class="participants-empty" id="participantsEmptyState">
+                    <p class="participants-empty-title">Season hasn't started yet</p>
+                    <p class="participants-empty-text">Participating teams will appear here when the contest season opens. Preseason Standings on the Leaderboard are models and baselines only.</p>
                 </div>
             </div>
+            <div class="participants-grid" id="participantsGrid" hidden></div>
         </div>
         <div id="competitionAboutPanel" class="competition-panel" style="display: none;">
             <div class="about-grid">
                 <div class="section-card">
                     <h3 class="section-title">Competition Overview</h3>
-                    <p class="about-text">SecureFinAI Contest 2026 is a live-market paper trading competition where teams deploy LLM-powered trading agents and compete on standardized performance metrics.</p>
+                    <p class="about-text">SecureFinAI Contest 2026 is a paper-trading competition for LLM-powered agents. The contest is currently in <strong>Preseason</strong>. Participating teams join when the season starts (registration Aug 2026).</p>
+                </div>
+                <div class="section-card">
+                    <h3 class="section-title">Current Leaderboard</h3>
+                    <p class="about-text">Preseason Standings are a <strong>backtest leaderboard</strong>, not live trading. Each entry is an hourly backtest over <strong>2026-04-15 → 2026-05-15</strong> (one-month window), comparing provided LLM models, baseline strategies, and market indices. Official rank is by final portfolio value.</p>
                 </div>
                 <div class="section-card compact">
                     <h3 class="section-title">Schedule</h3>
+                    <div class="metric-row">
+                        <span class="metric-label">Phase</span>
+                        <span class="metric-value">Preseason</span>
+                    </div>
                     <div class="metric-row">
                         <span class="metric-label">Registration</span>
                         <span class="metric-value">Aug 1 – Aug 31</span>
@@ -1379,9 +1341,9 @@
                 <div class="section-card compact">
                     <h3 class="section-title">Evaluation Metrics</h3>
                     <ul class="about-list">
-                        <li>Cumulative return (rCR)</li>
-                        <li>Sharpe ratio (rSR)</li>
-                        <li>Final score = (rCR + rSR) / 2 (baselines omit W/L)</li>
+                        <li>Official rank by final portfolio value (Preseason Standings)</li>
+                        <li>Also reported: cumulative return, Sharpe, max drawdown</li>
+                        <li>Entry types: Model, Baseline Strategy, Market Index</li>
                     </ul>
                 </div>
             </div>
@@ -1396,9 +1358,9 @@
                 <div class="contest-identity">
                     <div class="contest-title-row">
                         <h2 class="contest-title">SecureFinAI Contest 2026</h2>
-                        <span class="status-badge live contest-live-badge">Live</span>
+                        <span class="status-badge upcoming contest-live-badge">Upcoming</span>
                     </div>
-                    <p class="contest-subtitle">Sep 1 – Oct 30, 2026 · 7 teams</p>
+                    <p class="contest-subtitle">Sep 1 – Oct 30, 2026</p>
                 </div>
                 <div class="contest-actions">
                     <button id="competitionRulesBtn" class="agent-action-btn agent-action-secondary contest-action-btn" type="button">Rules</button>
@@ -1410,8 +1372,8 @@
                 <!-- Left: Stats -->
                 <div class="header-stats compact">
                     <div class="stat-item compact">
-                        <span class="stat-label">Teams</span>
-                        <span class="stat-value" id="totalTeams">—</span>
+                        <span class="stat-label">Phase</span>
+                        <span class="stat-value" id="totalTeams">Preseason</span>
                     </div>
                     <div class="stat-item compact">
                         <span class="stat-label">Window</span>
@@ -1429,10 +1391,19 @@
 
                 <!-- Right: Controls -->
                 <div class="header-controls compact">
-                    <div class="filter-tabs compact">
-                        <button class="filter-tab compact active" data-filter="all">All</button>
-                        <button class="filter-tab compact" data-filter="teams">Teams</button>
-                        <button class="filter-tab compact" data-filter="baselines">Baselines</button>
+                    <div class="curve-picker" id="curvePicker">
+                        <button type="button" class="curve-picker-trigger" id="curvePickerTrigger" aria-expanded="false" aria-haspopup="true">
+                            <span class="curve-picker-trigger-label">Show on Chart</span>
+                            <span class="curve-picker-sep" aria-hidden="true">·</span>
+                            <span class="curve-picker-count" id="curvePickerCount">0 selected</span>
+                            <span class="curve-picker-caret" aria-hidden="true">▾</span>
+                        </button>
+                        <div class="curve-picker-menu" id="curvePickerMenu" hidden role="dialog" aria-label="Chart curves">
+                            <div class="curve-picker-menu-head">
+                                <button type="button" class="curve-picker-clear" id="curvePickerClear">Clear</button>
+                            </div>
+                            <div class="curve-picker-body" id="curvePickerBody"></div>
+                        </div>
                     </div>
 
                     <div class="view-toggle compact">
@@ -1459,26 +1430,18 @@
                 <!-- Left: Table -->
                 <section class="leaderboard-table-section compact">
                     <div class="table-header compact">
-                        <h3>Official Rankings</h3>
-                        <div class="sort-toggle compact">
-                            <span class="sort-label">Sort</span>
-                            <button class="sort-btn compact active" data-sort="return">Return</button>
-                            <button class="sort-btn compact" data-sort="sharpe">Sharpe</button>
-                        </div>
+                        <h3>Preseason Standings</h3>
                     </div>
                     <div class="table-wrapper compact">
                         <table class="leaderboard-table compact">
                             <thead>
                                 <tr>
-                                    <th class="rank-col">Rank</th>
-                                    <th class="name-col">Team Name</th>
-                                    <th class="model-col">Model</th>
-                                    <th class="portfolio-col">Value</th>
-                                    <th class="return-col">Return</th>
-                                    <th class="sharpe-col">Sharpe</th>
-                                    <th class="dd-col">Max DD</th>
-                                    <th class="ranks-col">Ranks</th>
-                                    <th class="score-col">Score</th>
+                                    <th class="rank-col sortable" data-sort="rank" aria-sort="ascending">Rank <span class="sort-arrow" aria-hidden="true"></span></th>
+                                    <th class="name-col">Entry</th>
+                                    <th class="portfolio-col sortable" data-sort="value">Value <span class="sort-arrow" aria-hidden="true"></span></th>
+                                    <th class="return-col sortable" data-sort="return">Return <span class="sort-arrow" aria-hidden="true"></span></th>
+                                    <th class="sharpe-col sortable" data-sort="sharpe">Sharpe <span class="sort-arrow" aria-hidden="true"></span></th>
+                                    <th class="dd-col sortable" data-sort="dd">Max DD <span class="sort-arrow" aria-hidden="true"></span></th>
                                 </tr>
                             </thead>
                             <tbody id="leaderboardTableBody">
@@ -1488,26 +1451,26 @@
                     </div>
                 </section>
 
-                <!-- Right: Rules + Team Detail -->
+                <!-- Right: Rules + Entry Detail -->
                 <aside class="leaderboard-table-sidebar compact">
                     <!-- Ranking Rules -->
                     <div class="sidebar-card compact">
                         <h3 class="sidebar-title compact">Rules</h3>
                         <div class="ranking-formula compact">
-                            <p class="formula-compact">Final Score = (rCR + rSR) / 2</p>
+                            <p class="formula-compact">Official rank = final portfolio value</p>
                             <ul class="formula-items compact">
-                                <li>rCR = Return rank</li>
-                                <li>rSR = Sharpe rank</li>
-                                <li>Baselines: no W/L</li>
+                                <li>Higher account value ranks first</li>
+                                <li>Ties break on cumulative return</li>
+                                <li>Click column headers to re-sort</li>
                             </ul>
                         </div>
                     </div>
 
-                    <!-- Team Detail -->
+                    <!-- Entry Detail -->
                     <div class="sidebar-card compact">
-                        <h3 class="sidebar-title compact">Team</h3>
+                        <h3 class="sidebar-title compact">Entry Details</h3>
                         <div id="selectedTeamDetail" class="team-detail compact">
-                            <div class="no-selection">Click team</div>
+                            <div class="no-selection">Click a row</div>
                         </div>
                     </div>
                 </aside>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1543,9 +1543,48 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Load ticker without blocking the rest of the page
     loadMarketTicker();
     setInterval(loadMarketTicker, 30000);
-    
+    updateMarketsOpenStatus();
+    setInterval(updateMarketsOpenStatus, 60000);
+
     console.log('🎯 Dashboard ready. Default runs:', window.DEFAULT_RUNS || 'None configured');
 });
+
+/**
+ * US equity regular session: Mon–Fri 09:30–16:00 America/New_York.
+ * Holidays are not modeled; closed on weekends and outside RTH.
+ */
+function isUsEquityMarketOpen(now = new Date()) {
+    const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/New_York',
+        weekday: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+    }).formatToParts(now);
+    const get = (type) => parts.find((p) => p.type === type)?.value;
+    const weekday = get('weekday');
+    if (weekday === 'Sat' || weekday === 'Sun') return false;
+    let hour = Number(get('hour'));
+    const minute = Number(get('minute'));
+    // Some engines emit "24" for midnight.
+    if (hour === 24) hour = 0;
+    const mins = hour * 60 + minute;
+    return mins >= 9 * 60 + 30 && mins < 16 * 60;
+}
+
+function updateMarketsOpenStatus() {
+    const el = document.getElementById('tickerMarketsStatus');
+    if (!el) return;
+    const label = el.querySelector('.ticker-markets-label');
+    const open = isUsEquityMarketOpen();
+    el.classList.toggle('is-closed', !open);
+    el.classList.toggle('ticker-markets-open', true);
+    if (label) label.textContent = open ? 'Markets open' : 'Markets closed';
+    el.setAttribute('aria-label', open ? 'US equity markets are open' : 'US equity markets are closed');
+}
+
+window.updateMarketsOpenStatus = updateMarketsOpenStatus;
+window.isUsEquityMarketOpen = isUsEquityMarketOpen;
 
 /**
  * Load performance metrics from latest backtest run

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -3,8 +3,8 @@
 // ============================================================================
 
 let leaderboardPayload = null;
-let currentLeaderboardFilter = 'all';
-let currentLeaderboardSort = 'return'; // 'return' | 'sharpe'
+let currentLeaderboardSort = 'rank'; // 'rank' | 'value' | 'return' | 'sharpe' | 'dd'
+let currentLeaderboardSortDir = 'asc'; // rank: asc (1 best); metrics usually start desc
 let selectedLeaderboardEntry = null;
 let equityCurvesData = null;
 let equityCurvesChartInstance = null;
@@ -17,6 +17,9 @@ let hiddenInitialized = false;
 let hoveredDatasetIndex = null;
 let canvasLeaveBound = false;
 const selectedBenchmarkLabel = 'SPY';
+/** Expanded groups in the Show-on-Chart picker: model | baseline | index */
+let curvePickerExpanded = new Set();
+let curvePickerOutsideBound = false;
 
 // Stable per-series style presets. `kind` drives width/opacity hierarchy:
 //   benchmark -> neutral gray, dotted / dash-dot, understated
@@ -49,6 +52,14 @@ const MODEL_COLOR_PALETTE = [
   '#FBBF24', '#FB923C', '#F472B6', '#A78BFA', '#34D399',
 ];
 const modelColorMap = {};
+
+function formatEntryBadge(badge) {
+  const raw = String(badge || '').trim();
+  if (!raw || raw === 'Baseline') return 'Baseline Strategy';
+  if (raw === 'Index') return 'Market Index';
+  if (raw === 'Strategy') return 'Baseline Strategy';
+  return raw;
+}
 
 function isModelEntry(entry) {
   return !!(entry && (entry.is_model || entry.team_badge === 'Model'));
@@ -100,6 +111,289 @@ function getEntryKind(entry) {
   const label = entry.model || entry.team_name;
   const preset = LEADERBOARD_STYLES[label];
   return preset ? preset.kind : 'strategy';
+}
+
+/** Map series kind → chart-picker group id. */
+function getFilterCategory(entry) {
+  const kind = getEntryKind(entry);
+  if (kind === 'model' || kind === 'team') return 'model';
+  if (kind === 'benchmark') return 'index';
+  return 'baseline'; // strategy baselines
+}
+
+const CURVE_PICKER_GROUPS = [
+  { id: 'model', title: 'Models' },
+  { id: 'baseline', title: 'Baseline Strategies' },
+  { id: 'index', title: 'Market Indices' },
+];
+
+function entrySeriesLabel(entry) {
+  return entry.model || entry.team_name || entry.entry_id || '';
+}
+
+function getCurvePickerGroups(entries) {
+  const buckets = { model: [], baseline: [], index: [] };
+  (entries || []).forEach((entry) => {
+    const cat = getFilterCategory(entry);
+    if (buckets[cat]) buckets[cat].push(entry);
+  });
+  // Models: sort by return desc for a familiar board order
+  buckets.model.sort(
+    (a, b) => (Number(b.cumulative_return) || 0) - (Number(a.cumulative_return) || 0)
+  );
+  return CURVE_PICKER_GROUPS.map((g) => ({
+    ...g,
+    entries: buckets[g.id] || [],
+  })).filter((g) => g.entries.length > 0);
+}
+
+function seriesVisible(label) {
+  return !hiddenSeries.has(label);
+}
+
+function countVisibleSeries(entries) {
+  return (entries || []).filter((e) => seriesVisible(entrySeriesLabel(e))).length;
+}
+
+function setGroupVisibility(groupEntries, visible) {
+  groupEntries.forEach((entry) => {
+    const label = entrySeriesLabel(entry);
+    if (!label) return;
+    if (visible) hiddenSeries.delete(label);
+    else hiddenSeries.add(label);
+  });
+}
+
+function groupCheckState(groupEntries) {
+  const total = groupEntries.length;
+  if (!total) return 'none';
+  const visible = groupEntries.filter((e) => seriesVisible(entrySeriesLabel(e))).length;
+  if (visible === 0) return 'none';
+  if (visible === total) return 'all';
+  return 'partial';
+}
+
+function updateCurvePickerCount() {
+  const el = document.getElementById('curvePickerCount');
+  if (!el) return;
+  const entries = leaderboardPayload?.entries || [];
+  const n = countVisibleSeries(entries);
+  const total = entries.length;
+  el.textContent = total ? `${n} selected` : '0 selected';
+}
+
+function renderCurvePicker() {
+  const body = document.getElementById('curvePickerBody');
+  if (!body) return;
+  const groups = getCurvePickerGroups(leaderboardPayload?.entries || []);
+
+  body.innerHTML = groups.map((group) => {
+    const state = groupCheckState(group.entries);
+    const visibleN = group.entries.filter((e) => seriesVisible(entrySeriesLabel(e))).length;
+    const expanded = curvePickerExpanded.has(group.id);
+    const checkClass =
+      state === 'all' ? 'is-checked' : state === 'partial' ? 'is-partial' : 'is-unchecked';
+    // Always show selected/total so collapsed groups aren't mistaken for "all".
+    const countLabel = `${visibleN}/${group.entries.length}`;
+
+    const children = group.entries.map((entry, idx) => {
+      const label = entrySeriesLabel(entry);
+      const on = seriesVisible(label);
+      const safeName = String(label)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/"/g, '&quot;');
+      return `
+        <label class="curve-picker-item">
+          <input type="checkbox" data-group-id="${group.id}" data-entry-idx="${idx}" ${on ? 'checked' : ''} />
+          <span class="curve-picker-item-name">${safeName}</span>
+        </label>`;
+    }).join('');
+
+    return `
+      <div class="curve-picker-group" data-group="${group.id}">
+        <div class="curve-picker-group-row">
+          <button type="button" class="curve-picker-group-check ${checkClass}"
+            data-group-toggle="${group.id}" aria-label="Toggle ${group.title}"
+            aria-checked="${state === 'all' ? 'true' : state === 'none' ? 'false' : 'mixed'}"></button>
+          <button type="button" class="curve-picker-group-expand" data-group-expand="${group.id}"
+            aria-expanded="${expanded ? 'true' : 'false'}">
+            <span class="curve-picker-group-title">${group.title} (${countLabel})</span>
+            <span class="curve-picker-group-chevron" aria-hidden="true">${expanded ? '▾' : '›'}</span>
+          </button>
+        </div>
+        <div class="curve-picker-children${expanded ? '' : ' is-collapsed'}">${children}</div>
+      </div>`;
+  }).join('');
+
+  updateCurvePickerCount();
+}
+
+function applyChartVisibilityChange() {
+  updateCurvePickerCount();
+  const open = document.getElementById('curvePickerTrigger')?.getAttribute('aria-expanded') === 'true';
+  if (open) renderCurvePicker();
+  else updateCurvePickerCount();
+  renderEquityCurvesChart();
+}
+
+function setCurvePickerOpen(open) {
+  const menu = document.getElementById('curvePickerMenu');
+  const trigger = document.getElementById('curvePickerTrigger');
+  const root = document.getElementById('curvePicker');
+  if (!menu || !trigger) return;
+  menu.hidden = !open;
+  trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+  root?.classList.toggle('is-open', open);
+  if (open) renderCurvePicker();
+}
+
+function updateLeaderboardHeader(payload) {
+  const entries = payload.entries || [];
+  // Best LLM / provided model by cumulative return (not overall board rank).
+  const models = entries
+    .filter((e) => isModelEntry(e))
+    .slice()
+    .sort((a, b) => (Number(b.cumulative_return) || 0) - (Number(a.cumulative_return) || 0));
+
+  const totalEl = document.getElementById('totalTeams');
+  const windowEl = document.getElementById('tradingWindow');
+  const updatedEl = document.getElementById('lastUpdate');
+  const leaderEl = document.getElementById('leaderTeam');
+
+  if (totalEl) totalEl.textContent = 'Preseason';
+  if (windowEl) windowEl.textContent = payload.window?.label || '—';
+  if (updatedEl) {
+    updatedEl.textContent = payload.updated_at
+      ? new Date(payload.updated_at).toLocaleString()
+      : '—';
+  }
+  if (leaderEl) {
+    const top = models[0];
+    leaderEl.textContent = top
+      ? (top.model || top.team_name)
+      : (payload.leader || '—');
+  }
+  updateCurvePickerCount();
+}
+
+function initLeaderboardListeners() {
+  const trigger = document.getElementById('curvePickerTrigger');
+  const menu = document.getElementById('curvePickerMenu');
+  const body = document.getElementById('curvePickerBody');
+  const clearBtn = document.getElementById('curvePickerClear');
+
+  // Keep the menu open while interacting: stop bubbles, and close only on
+  // outside pointerdown (avoids the classic "rerender detaches target →
+  // document click thinks it's outside" bug).
+  menu?.addEventListener('click', (e) => e.stopPropagation());
+  menu?.addEventListener('pointerdown', (e) => e.stopPropagation());
+
+  trigger?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const open = trigger.getAttribute('aria-expanded') === 'true';
+    setCurvePickerOpen(!open);
+  });
+
+  clearBtn?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const entries = leaderboardPayload?.entries || [];
+    entries.forEach((entry) => {
+      const label = entrySeriesLabel(entry);
+      if (label) hiddenSeries.add(label);
+    });
+    applyChartVisibilityChange();
+  });
+
+  body?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const expandBtn = e.target.closest('[data-group-expand]');
+    if (expandBtn) {
+      e.preventDefault();
+      const id = expandBtn.dataset.groupExpand;
+      if (curvePickerExpanded.has(id)) curvePickerExpanded.delete(id);
+      else curvePickerExpanded.add(id);
+      renderCurvePicker();
+      return;
+    }
+
+    const groupToggle = e.target.closest('[data-group-toggle]');
+    if (groupToggle) {
+      e.preventDefault();
+      const id = groupToggle.dataset.groupToggle;
+      const group = getCurvePickerGroups(leaderboardPayload?.entries || [])
+        .find((g) => g.id === id);
+      if (!group) return;
+      const state = groupCheckState(group.entries);
+      // All on → turn off; partial or none → turn all on.
+      setGroupVisibility(group.entries, state !== 'all');
+      applyChartVisibilityChange();
+    }
+  });
+
+  body?.addEventListener('change', (e) => {
+    e.stopPropagation();
+    const input = e.target;
+    if (!(input instanceof HTMLInputElement) || input.dataset.entryIdx == null) return;
+    const groupId = input.dataset.groupId;
+    const idx = Number(input.dataset.entryIdx);
+    const group = getCurvePickerGroups(leaderboardPayload?.entries || [])
+      .find((g) => g.id === groupId);
+    const entry = group?.entries?.[idx];
+    if (!entry) return;
+    const label = entrySeriesLabel(entry);
+    if (input.checked) hiddenSeries.delete(label);
+    else hiddenSeries.add(label);
+    applyChartVisibilityChange();
+  });
+
+  if (!curvePickerOutsideBound) {
+    document.addEventListener('pointerdown', (e) => {
+      const root = document.getElementById('curvePicker');
+      if (!root?.classList.contains('is-open')) return;
+      if (e.target instanceof Node && root.contains(e.target)) return;
+      setCurvePickerOpen(false);
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') setCurvePickerOpen(false);
+    });
+    curvePickerOutsideBound = true;
+  }
+
+  document.querySelectorAll('.leaderboard-table th.sortable').forEach((th) => {
+    th.addEventListener('click', () => {
+      const key = th.dataset.sort;
+      if (!key) return;
+      if (currentLeaderboardSort === key) {
+        currentLeaderboardSortDir = currentLeaderboardSortDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        currentLeaderboardSort = key;
+        // Rank: 1 first. Value/Return/Sharpe: high first. Max DD: low first.
+        currentLeaderboardSortDir = key === 'dd' || key === 'rank' ? 'asc' : 'desc';
+      }
+      updateLeaderboardSortHeaders();
+      populateLeaderboardTable();
+    });
+  });
+  updateLeaderboardSortHeaders();
+
+  document.querySelectorAll('.view-toggle-btn').forEach((btn) => {
+    btn.addEventListener('click', async (e) => {
+      document.querySelectorAll('.view-toggle-btn').forEach((b) => b.classList.remove('active'));
+      e.target.classList.add('active');
+      currentChartView = e.target.dataset.view === 'absolute' ? 'absolute' : 'cumulative';
+      await renderEquityCurvesChart();
+    });
+  });
+
+  document.querySelectorAll('.chart-view-btn').forEach((btn) => {
+    btn.addEventListener('click', async (e) => {
+      document.querySelectorAll('.chart-view-btn').forEach((b) => b.classList.remove('active'));
+      e.target.classList.add('active');
+      currentChartView = e.target.dataset.view === 'absolute' ? 'absolute' : 'cumulative';
+      await renderEquityCurvesChart();
+    });
+  });
 }
 
 function formatLeaderboardNumber(num) {
@@ -169,7 +463,7 @@ function buildEquityCurvesFromEntries(entries) {
     const values = times.map((t) => (t in byTime ? byTime[t] : null));
     const firstReal = values.find((v) => v != null);
     curves[seriesLabel] = values;
-    initials[seriesLabel] = Number(entry.initial_equity) || firstReal || 100000;
+    initials[seriesLabel] = Number(entry.initial_equity) || firstReal || 1000;
     trajectories[seriesLabel] = getSeriesStyle(seriesLabel, entry);
   });
 
@@ -195,66 +489,6 @@ function computeDefaultHidden(entries) {
   return hidden;
 }
 
-function updateLeaderboardHeader(payload) {
-  const entries = payload.entries || [];
-  // Entries arrive pre-ranked; the first team entry is the leading participant.
-  const teams = entries.filter((e) => getEntryKind(e) === 'team');
-
-  const totalEl = document.getElementById('totalTeams');
-  const windowEl = document.getElementById('tradingWindow');
-  const updatedEl = document.getElementById('lastUpdate');
-  const leaderEl = document.getElementById('leaderTeam');
-
-  if (totalEl) totalEl.textContent = String(teams.length);
-  if (windowEl) windowEl.textContent = payload.window?.label || '—';
-  if (updatedEl) {
-    updatedEl.textContent = payload.updated_at
-      ? new Date(payload.updated_at).toLocaleString()
-      : '—';
-  }
-  if (leaderEl) leaderEl.textContent = teams.length ? teams[0].team_name : 'No team results';
-}
-
-function initLeaderboardListeners() {
-  document.querySelectorAll('.filter-tab').forEach((btn) => {
-    btn.addEventListener('click', (e) => {
-      document.querySelectorAll('.filter-tab').forEach((b) => b.classList.remove('active'));
-      e.target.classList.add('active');
-      currentLeaderboardFilter = e.target.dataset.filter;
-      applyFilterVisibility();
-      populateLeaderboardTable();
-      renderEquityCurvesChart();
-    });
-  });
-
-  document.querySelectorAll('.sort-btn').forEach((btn) => {
-    btn.addEventListener('click', (e) => {
-      document.querySelectorAll('.sort-btn').forEach((b) => b.classList.remove('active'));
-      e.target.classList.add('active');
-      currentLeaderboardSort = e.target.dataset.sort === 'sharpe' ? 'sharpe' : 'return';
-      populateLeaderboardTable();
-    });
-  });
-
-  document.querySelectorAll('.view-toggle-btn').forEach((btn) => {
-    btn.addEventListener('click', async (e) => {
-      document.querySelectorAll('.view-toggle-btn').forEach((b) => b.classList.remove('active'));
-      e.target.classList.add('active');
-      currentChartView = e.target.dataset.view === 'absolute' ? 'absolute' : 'cumulative';
-      await renderEquityCurvesChart();
-    });
-  });
-
-  document.querySelectorAll('.chart-view-btn').forEach((btn) => {
-    btn.addEventListener('click', async (e) => {
-      document.querySelectorAll('.chart-view-btn').forEach((b) => b.classList.remove('active'));
-      e.target.classList.add('active');
-      currentChartView = e.target.dataset.view;
-      await renderEquityCurvesChart();
-    });
-  });
-}
-
 async function loadLeaderboardData() {
   console.log('Loading leaderboard from API...');
 
@@ -265,12 +499,14 @@ async function loadLeaderboardData() {
     equityCurvesData = buildEquityCurvesFromEntries(entries);
 
     if (!hiddenInitialized) {
-      hiddenSeries = computeDefaultHidden(entries);
+      // Chart picker defaults to all curves visible (user then trims via dropdown).
+      hiddenSeries = new Set();
       hiddenInitialized = true;
     }
 
     updateLeaderboardHeader(leaderboardPayload);
     populateLeaderboardTable();
+    renderCurvePicker();
 
     if (!leaderboardListenersInitialized) {
       initLeaderboardListeners();
@@ -284,33 +520,50 @@ async function loadLeaderboardData() {
   }
 }
 
-function getFilteredLeaderboardEntries() {
-  let entries = (leaderboardPayload?.entries || []).slice();
-  if (currentLeaderboardFilter === 'baselines') {
-    entries = entries.filter((e) => e.entry_type === 'baseline');
-  } else if (currentLeaderboardFilter === 'teams') {
-    entries = entries.filter((e) => getEntryKind(e) === 'team');
-  }
-
-  const key = currentLeaderboardSort === 'sharpe' ? 'sharpe_ratio' : 'cumulative_return';
-  entries.sort((a, b) => (Number(b[key]) || 0) - (Number(a[key]) || 0));
-  return entries;
+function updateLeaderboardSortHeaders() {
+  document.querySelectorAll('.leaderboard-table th.sortable').forEach((th) => {
+    const active = th.dataset.sort === currentLeaderboardSort;
+    th.classList.toggle('is-sorted', active);
+    th.setAttribute('aria-sort', active
+      ? (currentLeaderboardSortDir === 'asc' ? 'ascending' : 'descending')
+      : 'none');
+    const arrow = th.querySelector('.sort-arrow');
+    if (arrow) {
+      arrow.textContent = active ? (currentLeaderboardSortDir === 'asc' ? '↑' : '↓') : '';
+    }
+  });
 }
 
-// The filter tabs also drive which curves are visible on the chart.
-function applyFilterVisibility() {
-  const entries = leaderboardPayload?.entries || [];
-  if (currentLeaderboardFilter === 'teams') {
-    hiddenSeries = new Set(
-      entries.filter((e) => getEntryKind(e) !== 'team').map((e) => e.model || e.team_name)
-    );
-  } else if (currentLeaderboardFilter === 'baselines') {
-    hiddenSeries = new Set(
-      entries.filter((e) => e.entry_type !== 'baseline').map((e) => e.model || e.team_name)
-    );
-  } else {
-    hiddenSeries = computeDefaultHidden(entries);
-  }
+function getFilteredLeaderboardEntries() {
+  // Official rankings table always lists every entry; chart visibility is separate.
+  // Left Rank stays the official portfolio-value rank; this only reorders rows.
+  const entries = (leaderboardPayload?.entries || []).slice();
+  const dir = currentLeaderboardSortDir === 'asc' ? 1 : -1;
+  const num = (v) => Number(v) || 0;
+  entries.sort((a, b) => {
+    let cmp = 0;
+    switch (currentLeaderboardSort) {
+      case 'rank':
+        cmp = num(a.rank) - num(b.rank);
+        break;
+      case 'value':
+        cmp = num(a.portfolio_value) - num(b.portfolio_value);
+        break;
+      case 'return':
+        cmp = num(a.cumulative_return) - num(b.cumulative_return);
+        break;
+      case 'sharpe':
+        cmp = num(a.sharpe_ratio) - num(b.sharpe_ratio);
+        break;
+      case 'dd':
+        cmp = Math.abs(num(a.max_drawdown)) - Math.abs(num(b.max_drawdown));
+        break;
+      default:
+        cmp = num(a.rank) - num(b.rank);
+    }
+    return cmp * dir;
+  });
+  return entries;
 }
 
 function populateLeaderboardTable() {
@@ -319,15 +572,13 @@ function populateLeaderboardTable() {
 
   const filtered = getFilteredLeaderboardEntries();
   if (!filtered.length) {
-    tbody.innerHTML = '<tr><td colspan="9" style="text-align:center;padding:24px;color:var(--text-secondary);">No leaderboard entries yet. Baselines compute on first load (requires market data).</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;padding:24px;color:var(--text-secondary);">No leaderboard entries yet. Baselines compute on first load (requires market data).</td></tr>';
     return;
   }
 
   tbody.innerHTML = filtered.map((entry) => {
-    const rankBadges = `<span class="rank-badge ${entry.rank_cr <= 3 ? 'top3' : ''}">${entry.rank_cr}</span>
-         <span class="rank-badge ${entry.rank_sr <= 3 ? 'top3' : ''}">${entry.rank_sr}</span>`;
-
     const safeId = String(entry.entry_id || entry.team_name).replace(/'/g, "\\'");
+    const entryLabel = entry.model || entry.team_name || '—';
     const ret = Number(entry.cumulative_return || 0);
     const retClass = ret >= 0 ? 'return-positive' : 'return-negative';
     const ddRaw = Number(entry.max_drawdown || 0);
@@ -338,19 +589,16 @@ function populateLeaderboardTable() {
         <td class="rank-cell">${entry.rank}</td>
         <td>
           <div class="team-name-badge">
-            <span>${entry.team_name}</span>
-            <span class="team-badge">${entry.team_badge || 'Baseline'}</span>
+            <span>${entryLabel}</span>
+            <span class="team-badge">${formatEntryBadge(entry.team_badge)}</span>
           </div>
         </td>
-        <td>${entry.model || '—'}</td>
         <td style="text-align: right; font-family: var(--font-mono);">$${formatLeaderboardNumber(entry.portfolio_value)}</td>
         <td style="text-align: right;" class="${retClass}">
           <span class="metric-value-text">${(ret * 100).toFixed(2)}%</span>
         </td>
         <td style="text-align: right; font-family: var(--font-mono);">${Number(entry.sharpe_ratio || 0).toFixed(2)}</td>
         <td style="text-align: right; font-family: var(--font-mono);">${dd}%</td>
-        <td style="text-align: center;">${rankBadges}</td>
-        <td style="text-align: right; font-weight: 600;">${Number(entry.final_score || 0).toFixed(2)}</td>
       </tr>
     `;
   }).join('');
@@ -368,14 +616,19 @@ function selectLeaderboardTeam(entryId) {
   if (detailPanel) {
     const ret = Number(entry.cumulative_return || 0);
     const retColor = ret >= 0 ? 'var(--success-color)' : 'var(--danger-color)';
+    const entryLabel = entry.model || entry.team_name || '—';
     detailPanel.innerHTML = `
       <div class="team-detail-row">
-        <span class="team-detail-label">Name</span>
-        <span class="team-detail-value">${entry.team_name}</span>
+        <span class="team-detail-label">Entry</span>
+        <span class="team-detail-value">${entryLabel}</span>
       </div>
       <div class="team-detail-row">
-        <span class="team-detail-label">Model</span>
-        <span class="team-detail-value">${entry.model || '—'}</span>
+        <span class="team-detail-label">Type</span>
+        <span class="team-detail-value">${formatEntryBadge(entry.team_badge || (entry.entry_type === 'baseline' ? 'Baseline Strategy' : 'Agent'))}</span>
+      </div>
+      <div class="team-detail-row">
+        <span class="team-detail-label">Value</span>
+        <span class="team-detail-value">$${formatLeaderboardNumber(entry.portfolio_value)}</span>
       </div>
       <div class="team-detail-row">
         <span class="team-detail-label">Return</span>
@@ -392,10 +645,6 @@ function selectLeaderboardTeam(entryId) {
       <div class="team-detail-row">
         <span class="team-detail-label">Rank</span>
         <span class="team-detail-value">${entry.rank} / ${leaderboardPayload?.total_entries || '—'}</span>
-      </div>
-      <div class="team-detail-row">
-        <span class="team-detail-label">Type</span>
-        <span class="team-detail-value">${entry.entry_type === 'baseline' ? 'Baseline' : 'Agent'}</span>
       </div>
     `;
   }
@@ -566,6 +815,10 @@ function buildCustomLegend(chart) {
       const label = el.dataset.label;
       if (hiddenSeries.has(label)) hiddenSeries.delete(label);
       else hiddenSeries.add(label);
+      updateCurvePickerCount();
+      if (document.getElementById('curvePickerTrigger')?.getAttribute('aria-expanded') === 'true') {
+        renderCurvePicker();
+      }
       renderEquityCurvesChart();
     });
   });

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -738,12 +738,21 @@ a.header-brand:hover .title-section h1 {
     white-space: nowrap;
 }
 
+.ticker-markets-open.is-closed {
+    color: var(--text-muted);
+}
+
 .ticker-markets-dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
     background: var(--success-color);
     box-shadow: 0 0 6px rgba(0, 200, 81, 0.6);
+}
+
+.ticker-markets-open.is-closed .ticker-markets-dot {
+    background: var(--text-muted);
+    box-shadow: none;
 }
 
 .ticker-source-label {
@@ -2680,6 +2689,213 @@ a.header-brand:hover .title-section h1 {
     gap: 8px;
 }
 
+/* Show-on-Chart multi-select dropdown */
+.curve-picker {
+    position: relative;
+    flex: 0 0 auto;
+}
+
+.curve-picker-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: border-color 0.15s, background 0.15s;
+}
+
+.curve-picker-trigger:hover,
+.curve-picker.is-open .curve-picker-trigger {
+    border-color: rgba(56, 189, 248, 0.45);
+    background: rgba(56, 189, 248, 0.06);
+}
+
+.curve-picker-sep {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.curve-picker-count {
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+}
+
+.curve-picker-caret {
+    color: var(--text-muted);
+    font-size: 10px;
+    margin-left: 2px;
+}
+
+.curve-picker-menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 40;
+    width: min(320px, calc(100vw - 32px));
+    max-height: min(420px, 70vh);
+    overflow: auto;
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-card);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+
+.curve-picker-menu-head {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 12px;
+    padding: 2px 4px 10px;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 8px;
+}
+
+.curve-picker-clear {
+    border: none;
+    background: transparent;
+    color: var(--home-accent-cyan, #22d3ee);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 2px 4px;
+}
+
+.curve-picker-clear:hover {
+    text-decoration: underline;
+}
+
+.curve-picker-group + .curve-picker-group {
+    margin-top: 4px;
+}
+
+.curve-picker-group-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 2px;
+}
+
+.curve-picker-group-check {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
+    border-radius: 3px;
+    border: 1.5px solid rgba(148, 163, 184, 0.55);
+    background: transparent;
+    cursor: pointer;
+    position: relative;
+    padding: 0;
+}
+
+.curve-picker-group-check.is-checked {
+    border-color: #38bdf8;
+    background: #38bdf8;
+}
+
+.curve-picker-group-check.is-checked::after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 5px;
+    height: 9px;
+    border: solid #0b1220;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
+.curve-picker-group-check.is-partial {
+    border-color: #38bdf8;
+    background: rgba(56, 189, 248, 0.2);
+}
+
+.curve-picker-group-check.is-partial::after {
+    content: '';
+    position: absolute;
+    left: 3px;
+    right: 3px;
+    top: 6px;
+    height: 2px;
+    background: #38bdf8;
+    border-radius: 1px;
+}
+
+.curve-picker-group-expand {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 4px 2px;
+    text-align: left;
+}
+
+.curve-picker-group-expand:hover {
+    color: #67e8f9;
+}
+
+.curve-picker-group-chevron {
+    color: var(--text-muted);
+    font-size: 12px;
+    width: 12px;
+    text-align: center;
+}
+
+.curve-picker-children {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 2px 0 6px 24px;
+}
+
+.curve-picker-children.is-collapsed {
+    display: none;
+}
+
+.curve-picker-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 2px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.curve-picker-item:hover {
+    background: rgba(148, 163, 184, 0.08);
+    color: var(--text-primary);
+}
+
+.curve-picker-item input {
+    accent-color: #38bdf8;
+    width: 14px;
+    height: 14px;
+    margin: 0;
+}
+
+.curve-picker-item-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 /* Control & Filter Tabs */
 .leaderboard-controls {
     display: flex;
@@ -3039,16 +3255,30 @@ a.header-brand:hover .title-section h1 {
 }
 
 .leaderboard-table th.rank-col { width: 60px; text-align: center; }
-.leaderboard-table th.name-col { width: 230px; }
-.leaderboard-table th.model-col { width: 150px; }
+.leaderboard-table th.name-col { width: 220px; }
 .leaderboard-table th.portfolio-col { width: 130px; text-align: right; }
-.leaderboard-table th.return-col { width: 130px; text-align: right; }
+.leaderboard-table th.return-col { width: 110px; text-align: right; }
 .leaderboard-table th.sharpe-col { width: 100px; text-align: right; }
 .leaderboard-table th.dd-col { width: 100px; text-align: right; }
-.leaderboard-table th.ranks-col { width: 120px; text-align: center; }
-.leaderboard-table th.rank-badges-col { width: 120px; text-align: center; }
-.leaderboard-table th.final-score-col { width: 100px; text-align: right; }
-.leaderboard-table th.status-col { width: 80px; text-align: center; }
+
+.leaderboard-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+.leaderboard-table th.sortable:hover {
+    color: var(--text-primary);
+}
+.leaderboard-table th.sortable.is-sorted {
+    color: var(--accent-color, #60a5fa);
+}
+.leaderboard-table th.sortable .sort-arrow {
+    display: inline-block;
+    min-width: 0.75em;
+    margin-left: 2px;
+    font-size: 10px;
+    opacity: 0.9;
+}
 
 .leaderboard-table tbody tr {
     border-bottom: 1px solid var(--border-color);
@@ -3113,8 +3343,9 @@ a.header-brand:hover .title-section h1 {
     color: white;
     padding: 2px 6px;
     border-radius: 3px;
-    font-size: 10px;
+    font-size: 9px;
     font-weight: 700;
+    white-space: nowrap;
 }
 
 .return-positive {
@@ -3141,6 +3372,11 @@ a.header-brand:hover .title-section h1 {
 .status-badge.live {
     background-color: rgba(0, 200, 81, 0.15);
     color: var(--success-color);
+}
+
+.status-badge.upcoming {
+    background-color: rgba(56, 189, 248, 0.15);
+    color: #38bdf8;
 }
 
 .status-badge.baseline {
@@ -4712,6 +4948,40 @@ a.header-brand:hover .title-section h1 {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: 12px;
+}
+
+.participants-empty-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: calc(100vh - 200px);
+    padding: 24px 16px;
+    box-sizing: border-box;
+}
+
+.participants-empty {
+    padding: 28px 24px;
+    border: 1px dashed var(--border-color);
+    border-radius: 8px;
+    background: var(--bg-secondary, transparent);
+    text-align: center;
+    max-width: 480px;
+    width: 100%;
+}
+
+.participants-empty-title {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.participants-empty-text {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-secondary);
 }
 
 .agent-card,

--- a/render-discord-bot.yaml
+++ b/render-discord-bot.yaml
@@ -23,6 +23,9 @@ services:
         value: 3.13.5
       - key: ATL_API_BASE
         value: https://agentictrading.onrender.com
+      # Discord deep links must open the Vercel SPA, not the Render API host.
+      - key: PUBLIC_APP_URL
+        value: https://agentic-trading-lab.vercel.app
       - key: DISCORD_BOT_TOKEN
         sync: false
       - key: DISCORD_GUILD_ID


### PR DESCRIPTION
## Summary
- Reframe Competition leaderboard as Preseason Standings: rank by final portfolio value, Entry column with full badges, sortable metric headers, clearer About / Participating Teams empty state.
- Point Discord Dashboard deep links at the Vercel SPA (`PUBLIC_APP_URL`), with Render-API fallback detection so links no longer open the API host.
- Preserve attached-agent deep-link semantics from recent Discord review hardening.

## Test plan
- [ ] Competition → Leaderboard: Rank 1…N by portfolio value; Entry badges say Model / Baseline Strategy / Market Index; column-header sort arrows work
- [ ] Participating Teams shows centered “Season hasn't started yet”
- [ ] About explains backtest window 2026-04-15 → 2026-05-15
- [ ] Discord bot result includes Dashboard URL on `agentic-trading-lab.vercel.app` when `ATL_API_BASE` is Render
- [ ] `pytest dashboard/backend/tests/integrations/test_discord_wiring.py`


Made with [Cursor](https://cursor.com)