### PR TITLE
feat(news): panel feed prefers raw items endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ FINGPT_API_KEY=your_fingpt_api_key_here
 # Optional override of the FinSearch producer base URL (defaults to the live
 # endpoint). Point at a local fixture/staging server for dev.
 # FINSEARCH_SIGNALS_URL=http://localhost:9000
+# Optional override of the FinSearch raw news-items endpoint (defaults to the
+# live endpoint). Point at a local fixture/staging server for dev.
+# FINSEARCH_ITEMS_URL=https://agenticfinsearch.org/api/news/items/
 
 # OpenRouter multi-provider gateway (Anthropic Messages skin).
 # Leaderboard entries with "integration": "openrouter" route through this

--- a/dashboard/backend/integrations/news_sentiment.py
+++ b/dashboard/backend/integrations/news_sentiment.py
@@ -20,6 +20,8 @@ import requests
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "https://agenticfinsearch.org/api/signals/news/"
+DEFAULT_ITEMS_URL = "https://agenticfinsearch.org/api/news/items/"
+_PANEL_FEED_LIMIT = 50   # how many raw items to request for the panel's left column
 _TIMEOUT_SECONDS = 10
 _MAX_CACHE_ENTRIES = 64  # bounded — a long-lived server must not grow monotonically
 # Short throttle window for today/latest *failures* (outage/config errors), so a
@@ -57,6 +59,10 @@ def _base_url() -> str:
     return os.environ.get("FINSEARCH_SIGNALS_URL", DEFAULT_BASE_URL)
 
 
+def _items_url() -> str:
+    return os.environ.get("FINSEARCH_ITEMS_URL", DEFAULT_ITEMS_URL)
+
+
 def _headers() -> Dict[str, str]:
     key = os.environ.get("FINGPT_API_KEY", "")
     return {"Authorization": f"Bearer {key}"} if key else {}
@@ -64,6 +70,11 @@ def _headers() -> Dict[str, str]:
 
 def _http_get(*, params: Dict[str, str], headers: Dict[str, str]):
     return requests.get(_base_url(), params=params, headers=headers,
+                        timeout=_TIMEOUT_SECONDS)
+
+
+def _http_get_items(*, params: Dict[str, str], headers: Dict[str, str]):
+    return requests.get(_items_url(), params=params, headers=headers,
                         timeout=_TIMEOUT_SECONDS)
 
 
@@ -259,20 +270,66 @@ def _feed_sort_key(item: dict) -> float:
         return 0.0
 
 
-def get_latest_panel_payload(tickers) -> dict:
-    """Latest-artifact read for the Home panel (no as_of).
+def fetch_items(*, limit: int = _PANEL_FEED_LIMIT) -> Optional[list]:
+    """Newest raw news-items batch for the panel feed. Returns list[dict], or
+    None on ANY failure (fail closed — the caller falls back to the
+    signals-derived representative feed). Latest-only, no as_of; the
+    /api/news/signals router already caches the panel payload, so no extra
+    memo here."""
+    try:
+        resp = _http_get_items(params={"limit": str(limit)}, headers=_headers())
+    except Exception as exc:  # network/timeout: fail closed
+        logger.warning("news_sentiment: items fetch failed: %s", exc)
+        return None
+    if resp.status_code == 200:
+        try:
+            body = resp.json()
+        except ValueError:
+            logger.error("news_sentiment: unparseable items body")
+            return None
+        items = body.get("items")
+        if not isinstance(items, list):
+            logger.error("news_sentiment: items body missing 'items' list")
+            return None
+        return items
+    if resp.status_code == 401:
+        logger.error("news_sentiment: 401 from producer — missing/wrong FINGPT_API_KEY (items)")
+    elif resp.status_code == 404:
+        pass  # no items batch yet: normal
+    else:
+        logger.warning("news_sentiment: unexpected items status %s", resp.status_code)
+    return None
 
-    `feed` is served backend-side even though Phase A derives it from
-    `signals`, so the wire format (and the frontend) do not change when
-    Phase B swaps the feed source to the raw-items endpoint.
 
-    One malformed signal is dropped (logged) rather than collapsing the whole
-    panel: the producer is the trust boundary, but a single off-spec entry must
-    still degrade to partial rendering, not an outage."""
-    body = fetch_signals(as_of=None, tickers=tuple(sorted(tickers or ())))
-    if not body:
-        return dict(UNAVAILABLE_PAYLOAD)
-    signals = body.get("signals") or {}
+def _feed_from_items(items) -> list:
+    """Map raw news-items onto the EXISTING panel feed item keys (wire shape
+    unchanged): title->headline, link->url, source->source,
+    published->published, tickers[0]|None->ticker. Drops a malformed item
+    (KeyError/TypeError) with a warning instead of collapsing the feed. Sorted
+    newest-first via _feed_sort_key."""
+    feed = []
+    for item in items:
+        try:
+            tickers = item["tickers"]
+            entry = {
+                "headline": item["title"],
+                "source": item["source"],
+                "url": item["link"],
+                "published": item["published"],
+                "ticker": tickers[0] if tickers else None,
+            }
+        except (KeyError, TypeError):
+            logger.warning("news_sentiment: dropping malformed panel item %r",
+                           item.get("guid") if isinstance(item, dict) else item)
+            continue
+        feed.append(entry)
+    feed.sort(key=_feed_sort_key, reverse=True)
+    return feed
+
+
+def _representative_feed(signals: dict) -> list:
+    """Phase-A feed: one representative story per signal. Used as the panel
+    feed's fallback when the raw-items feed is unavailable."""
     feed = []
     for sym, s in signals.items():
         try:
@@ -282,6 +339,33 @@ def get_latest_panel_payload(tickers) -> dict:
             continue
         feed.append({**story, "published": s.get("published"), "ticker": sym})
     feed.sort(key=_feed_sort_key, reverse=True)
+    return feed
+
+
+def get_latest_panel_payload(tickers) -> dict:
+    """Latest-artifact read for the Home panel (no as_of).
+
+    `feed` prefers the richer raw-items endpoint (Phase B: multiple stories
+    per signal) and falls back to the Phase-A representative feed (one story
+    per signal, derived from `signals`) on ANY items failure — so the panel
+    can never regress below Phase A. `signals`/status/overview/staleness
+    always come from `fetch_signals`: it is the gate, so when it fails the
+    panel is unavailable regardless of items, and `fetch_items` is not even
+    called.
+
+    One malformed signal/item is dropped (logged) rather than collapsing the
+    whole panel: the producer is the trust boundary, but a single off-spec
+    entry must still degrade to partial rendering, not an outage."""
+    body = fetch_signals(as_of=None, tickers=tuple(sorted(tickers or ())))
+    if not body:
+        return dict(UNAVAILABLE_PAYLOAD)
+    signals = body.get("signals") or {}
+    feed = None
+    items = fetch_items()
+    if items:
+        feed = _feed_from_items(items)
+    if not feed:  # None, [], or all-malformed -> fall back to Phase A
+        feed = _representative_feed(signals)
     return {
         "status": body.get("status", "ok"),
         "status_reason": body.get("status_reason"),

--- a/dashboard/backend/integrations/news_sentiment.py
+++ b/dashboard/backend/integrations/news_sentiment.py
@@ -287,7 +287,7 @@ def fetch_items(*, limit: int = _PANEL_FEED_LIMIT) -> Optional[list]:
         except ValueError:
             logger.error("news_sentiment: unparseable items body")
             return None
-        items = body.get("items")
+        items = body.get("items") if isinstance(body, dict) else None
         if not isinstance(items, list):
             logger.error("news_sentiment: items body missing 'items' list")
             return None

--- a/dashboard/backend/tests/test_news_sentiment_adapter.py
+++ b/dashboard/backend/tests/test_news_sentiment_adapter.py
@@ -380,6 +380,18 @@ def test_items_missing_items_list_falls_back(monkeypatch):
     assert payload["feed"] == ns._representative_feed(signals_body["signals"])
 
 
+def test_items_non_dict_body_falls_back(monkeypatch):
+    """A valid-JSON but non-dict items body (e.g. a bare list) must fail closed
+    to None — body.get() on a list would AttributeError — so the panel falls
+    back to the representative feed rather than raising."""
+    signals_body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=signals_body))
+    monkeypatch.setattr(ns, "_http_get_items",
+                         lambda **kw: _fake_response(body=[{"guid": "g1"}]))  # bare list, not a dict
+    payload = ns.get_latest_panel_payload(["MSFT", "AAPL"])
+    assert payload["feed"] == ns._representative_feed(signals_body["signals"])
+
+
 def test_items_unparseable_body_falls_back(monkeypatch):
     signals_body = load_signals_fixture()
     monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=signals_body))

--- a/dashboard/backend/tests/test_news_sentiment_adapter.py
+++ b/dashboard/backend/tests/test_news_sentiment_adapter.py
@@ -12,8 +12,15 @@ from dashboard.backend.tests.test_news_sentiment_fixture import (
 
 
 @pytest.fixture(autouse=True)
-def _clean():
+def _clean(monkeypatch):
     ns.clear_cache()
+    # Default the items endpoint to a fast 404 ("no items yet") so pre-Phase-B
+    # tests that only mock ns._http_get keep exercising Phase-A behavior
+    # (representative feed) instead of silently hitting the real network via
+    # get_latest_panel_payload's new fetch_items() call. Phase-B tests below
+    # override this per-test.
+    monkeypatch.setattr(ns, "_http_get_items",
+                         lambda **kw: _fake_response(status=404, body={"error": "no_items"}))
     yield
     ns.clear_cache()
 
@@ -310,3 +317,109 @@ def test_304_revalidation_serves_cached_body(monkeypatch):
     second = ns.get_latest_panel_payload(["MSFT"])   # 304 -> cached body reused, not refetched
     assert second["staleness_hours"] == body["staleness_hours"]
     assert not responses                             # both queued responses consumed
+
+
+# --- Phase B: panel feed prefers the raw items endpoint --------------------
+# The FinSearch producer now exposes GET /api/news/items/ (raw multi-story
+# batch). The panel feed prefers it and falls back to the Phase-A
+# representative feed (derived from `signals`) on ANY items failure, so the
+# panel can never regress below Phase A. `signals`/status/overview/staleness
+# always come from `fetch_signals` regardless of which feed source wins.
+
+
+def _items_body(items, batch="items-test.jsonl"):
+    return {"items": items, "count": len(items), "batch": batch}
+
+
+def test_items_feed_preferred_and_mapped_correctly(monkeypatch):
+    signals_body = load_signals_fixture()
+    items = [
+        {"guid": "g1", "title": "Fed cuts rates", "link": "https://x/1", "source": "Reuters",
+         "published": 1700000200.0, "description": "d1", "tickers": ["AAPL"], "score": 0.5},
+        {"guid": "g2", "title": "Tech rally continues", "link": "https://x/2", "source": "Bloomberg",
+         "published": 1700000100.0, "description": "d2", "tickers": [], "score": 0.3},
+    ]
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=signals_body))
+    monkeypatch.setattr(ns, "_http_get_items", lambda **kw: _fake_response(body=_items_body(items)))
+    payload = ns.get_latest_panel_payload(["MSFT", "AAPL"])
+    assert payload["news_overview"] == signals_body["news_overview"]  # signals side unchanged
+    assert payload["signals"]
+    feed = payload["feed"]
+    assert [entry["headline"] for entry in feed] == ["Fed cuts rates", "Tech rally continues"]  # newest-first
+    assert feed[0] == {
+        "headline": "Fed cuts rates", "source": "Reuters", "url": "https://x/1",
+        "published": 1700000200.0, "ticker": "AAPL",
+    }
+    assert feed[1]["ticker"] is None  # empty tickers list -> None
+
+
+def test_items_404_falls_back_to_representative_feed(monkeypatch):
+    signals_body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=signals_body))
+    monkeypatch.setattr(ns, "_http_get_items",
+                         lambda **kw: _fake_response(status=404, body={"error": "no_items"}))
+    payload = ns.get_latest_panel_payload(["MSFT", "AAPL"])
+    assert payload["feed"] == ns._representative_feed(signals_body["signals"])
+
+
+def test_items_transport_error_falls_back_to_representative_feed(monkeypatch):
+    signals_body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=signals_body))
+    def _boom(**kw):
+        raise OSError("connection refused")
+    monkeypatch.setattr(ns, "_http_get_items", _boom)
+    payload = ns.get_latest_panel_payload(["MSFT", "AAPL"])
+    assert payload["feed"] == ns._representative_feed(signals_body["signals"])
+
+
+def test_items_missing_items_list_falls_back(monkeypatch):
+    signals_body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=signals_body))
+    monkeypatch.setattr(ns, "_http_get_items", lambda **kw: _fake_response(body={"count": 0}))
+    payload = ns.get_latest_panel_payload(["MSFT", "AAPL"])
+    assert payload["feed"] == ns._representative_feed(signals_body["signals"])
+
+
+def test_items_unparseable_body_falls_back(monkeypatch):
+    signals_body = load_signals_fixture()
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=signals_body))
+    def _raise_value_error():
+        raise ValueError("bad json")
+    monkeypatch.setattr(ns, "_http_get_items",
+                         lambda **kw: SimpleNamespace(status_code=200, headers={}, json=_raise_value_error))
+    payload = ns.get_latest_panel_payload(["MSFT", "AAPL"])
+    assert payload["feed"] == ns._representative_feed(signals_body["signals"])
+
+
+def test_items_all_malformed_falls_back(monkeypatch):
+    signals_body = load_signals_fixture()
+    malformed_items = [{"guid": "g1", "link": "https://x/1", "source": "Reuters",
+                         "published": 1700000200.0, "tickers": ["AAPL"]}]  # missing "title"
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=signals_body))
+    monkeypatch.setattr(ns, "_http_get_items", lambda **kw: _fake_response(body=_items_body(malformed_items)))
+    payload = ns.get_latest_panel_payload(["MSFT", "AAPL"])
+    assert payload["feed"] == ns._representative_feed(signals_body["signals"])
+
+
+def test_signals_down_returns_unavailable_and_skips_items_fetch(monkeypatch):
+    def _boom(**kw):
+        raise OSError("down")
+    monkeypatch.setattr(ns, "_http_get", _boom)
+    def _fetch_items_must_not_be_called(**kw):
+        raise AssertionError("fetch_items must not be called when signals is down")
+    monkeypatch.setattr(ns, "fetch_items", _fetch_items_must_not_be_called)
+    payload = ns.get_latest_panel_payload(["MSFT"])
+    assert payload == ns.UNAVAILABLE_PAYLOAD
+
+
+def test_feed_from_items_maps_exact_five_keys():
+    items = [
+        {"guid": "g1", "title": "Fed cuts rates", "link": "https://x/1", "source": "Reuters",
+         "published": 1700000200.0, "description": "d1", "tickers": ["AAPL", "MSFT"], "score": 0.5},
+    ]
+    feed = ns._feed_from_items(items)
+    assert feed == [{
+        "headline": "Fed cuts rates", "source": "Reuters", "url": "https://x/1",
+        "published": 1700000200.0, "ticker": "AAPL",
+    }]
+    assert set(feed[0].keys()) == {"headline", "source", "url", "published", "ticker"}


### PR DESCRIPTION
Phase B of the FinSearch news-signals integration (Phase A = #102). Upgrades the Home panel's **feed** (left column) to prefer FinSearch's new `GET /api/news/items/` raw-items endpoint, falling back to the existing Phase-A representative-story feed on **any** failure — so the panel can never regress below Phase A.

**What it does**
- `get_latest_panel_payload` now fetches `/api/news/items/` first for the feed; on any failure (transport error, non-200, unparseable/non-dict body, empty, all-malformed) it falls back to the signals-derived representative feed. `signals`/`status`/`overview`/`staleness` still come from the signals artifact (unchanged).
- Panel feed output shape is **unchanged** (`{headline, source, url, published, ticker}`); the AF wire now speaks news-story v1 (`headline`/`url` + `schema_version`). Frontend: heading → "Latest news", null-ticker meta-line fix.
- New `FINSEARCH_ITEMS_URL` env (`.env.example` updated); `fetch_items` is fully fail-closed (never raises).

**Tests**: +9 offline cases in `test_news_sentiment_adapter.py` (mapping correctness, each fallback trigger, signals-down-skips-items-fetch, non-dict body). Adapter file 30/30.

**Depends on**: the FinSearch `/api/news/items/` endpoint being deployed (separate PR in Agentic-FinSearch). Until then the feed transparently uses the Phase-A source.

**Note on CI**: the one failing test (`test_agent_runs_metadata.py::test_engine_llm_run_metadata_snapshot`) is **pre-existing on `main`**, unrelated to this PR — introduced by #104 (`_llm_run_metadata` reads `self.prompt_adaptations`, which the `__new__`-based test never sets). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rCr1NSRDG8kpsYtHPndmM