### PR TITLE
fix(test): restore green main after #104 (_llm_run_metadata attrs)

### DIFF
--- a/dashboard/backend/tests/test_agent_runs_metadata.py
+++ b/dashboard/backend/tests/test_agent_runs_metadata.py
@@ -105,6 +105,12 @@ def test_engine_llm_run_metadata_snapshot(monkeypatch):
     from dashboard.backend.domain.backtesting.engine import HourlyBacktester
 
     backtester = HourlyBacktester.__new__(HourlyBacktester)  # skip creds init
+    # _llm_run_metadata() also reads the post-trade/pipeline attrs (added in the
+    # post-trade-analysis work); __init__ sets them, but __new__ skips it, so set
+    # the no-pipeline defaults here to keep this a pure llm_max_output_tokens test.
+    backtester.prompt_adaptations = []
+    backtester.initial_pipeline = None
+    backtester.pipeline = None
     monkeypatch.setattr(engine_mod.llm_harness, "DEFAULT_MAX_OUTPUT_TOKENS", 777)
 
     backtester.use_llm = True


### PR DESCRIPTION
Restores green backend CI on `main` (red since #104).

`test_agent_runs_metadata.py::test_engine_llm_run_metadata_snapshot` builds `HourlyBacktester` via `__new__` (skipping `__init__`), but #104 extended `_llm_run_metadata()` to read `self.prompt_adaptations` / `initial_pipeline` / `pipeline`. `__init__` sets those (`engine.py:75-79`), but the `__new__`'d test object didn't — so the test `AttributeError`ed on clean `main`.

**Test-only** — production always runs `__init__`, so this never affected real backtests. But since the deploy hook gates on backend tests passing on `main`, it has been keeping CI red and prod auto-deploy stalled since #104 merged.

Fix: set the no-pipeline defaults (`[]`/`None`/`None`) on the test object, keeping it a pure `llm_max_output_tokens` snapshot test. Full suite: **961 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rCr1NSRDG8kpsYtHPndmM
