### PR TITLE
fix: serve home-news-signals.js + sentiment_score dual-read

### DIFF
--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -294,6 +294,11 @@ async def serve_home_page_js():
     """Serve home-page.js for the Home tab mock live UI."""
     return FileResponse(frontend_path / "home-page.js", media_type="text/javascript")
 
+@app.get("/home-news-signals.js", include_in_schema=False)
+async def serve_home_news_signals_js():
+    """Serve home-news-signals.js for the Home tab news & signals panel."""
+    return FileResponse(frontend_path / "home-news-signals.js", media_type="text/javascript")
+
 @app.get("/js/{file_name}", include_in_schema=False)
 async def serve_js_module(file_name: str):
     """Serve js/*.js modules (e.g. leaderboard.js)."""

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -133,6 +133,7 @@ EXPECTED_FULL_CONTRACT = {
     ("GET", "/health"),
     ("GET", "/favicon.ico"),
     ("GET", "/favicon.svg"),
+    ("GET", "/home-news-signals.js"),
     ("GET", "/home-page.js"),
     ("GET", "/images/{file_name}"),
     ("GET", "/js/{file_name}"),

--- a/dashboard/backend/tests/test_static_routes.py
+++ b/dashboard/backend/tests/test_static_routes.py
@@ -55,3 +55,15 @@ def test_favicon_ico_still_serves_png():
     resp = client.get("/favicon.ico")
     assert resp.status_code == 200
     assert "image/png" in resp.headers.get("content-type", "")
+
+
+def test_home_news_signals_js_is_served():
+    """The Home news & signals panel script must be routed. app.html loads
+    ``home-news-signals.js``, but app.py never registered a route for it
+    (every sibling asset has one), so the request 404ed and the panel's five
+    containers rendered permanently empty since the panel shipped."""
+    client = TestClient(app)
+    resp = client.get("/home-news-signals.js")
+    assert resp.status_code == 200
+    assert "text/javascript" in resp.headers.get("content-type", "")
+    assert b"newsSignalsPanel" in resp.content

--- a/dashboard/frontend/home-news-signals.js
+++ b/dashboard/frontend/home-news-signals.js
@@ -68,7 +68,7 @@
     sigList.innerHTML = Object.entries(payload.signals || {}).map(([sym, s]) => `
       <li class="nns-item nns-signal nns-${escapeHtml(s.sentiment)}">
         <span class="nns-chip">${escapeHtml(s.sentiment)}</span>
-        <strong>${escapeHtml(sym)}</strong> <span class="nns-score">${Number(s.score).toFixed(2)}</span>
+        <strong>${escapeHtml(sym)}</strong> <span class="nns-score">${Number(s.sentiment_score ?? s.score).toFixed(2)}</span>
         <span class="nns-rationale">${escapeHtml(s.rationale || '')}</span>
         <a class="nns-src" href="${escapeHtml(safeUrl(s.url))}" target="_blank" rel="noopener noreferrer">${escapeHtml(s.source)}</a>
       </li>`).join('') || '<li class="nns-empty">No directional reads.</li>';


### PR DESCRIPTION
## What

1. **`app.py`: add the missing `/home-news-signals.js` route** (mirrors `/home-page.js`). `app.html` loads this script but no route served it, so the Home news & signals panel's five containers have rendered empty since the panel shipped — the script 404ed on every load. Contract test updated; new functional test verified RED (404) before the fix.
2. **`home-news-signals.js`: `Number(s.sentiment_score ?? s.score)`** — transitional dual-read for the FinSearch signals wire rename `score` → `sentiment_score` (schema v2, Agentic-FinSearch#361). The panel payload proxies raw wire signals to the browser, so #112's Python fallback (backtest envelope path) doesn't cover it. The `?? s.score` fallback and #112's stay until v2 is live; both get deleted in PR-2b.

## Why now

This route fix doubles as a deploy tracer: `/home-news-signals.js` flipping 404 → 200 on prod is the first externally observable proof the Render pipeline ships what's on main, which transitively confirms fdc9cef (#112) is live — unverifiable until now because #112's fallback is behaviorally invisible while FinSearch serves v1.

Backend suite: 974 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbs5wnQZhTi9CQ3pb14vDo