### PR TITLE
fix(backtest): log news-sentiment failures

### DIFF
--- a/dashboard/backend/execution/backtest_backend.py
+++ b/dashboard/backend/execution/backtest_backend.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import threading
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -21,22 +22,41 @@ from dashboard.backend.domain.backtesting import external_run_service as ext
 # run_store singleton cover this module too.
 from dashboard.backend.domain.runs import repository as run_repo
 
+logger = logging.getLogger(__name__)
+
 
 def load_news_sentiment(universe: List[str], timestamp: Any) -> Tuple[Dict[str, Any], Optional[str]]:
-    """Populate the news_sentiment slot from Plan 1's adapter, fail-closed.
+    """Populate the news_sentiment slot from the news_sentiment adapter, fail-closed.
 
-    Plan 1 (dashboard/backend/integrations/news_sentiment.py) is expected to expose
+    dashboard/backend/integrations/news_sentiment.py exposes
     get_news_sentiment(universe, timestamp) -> {"news_sentiment": {...}, "news_overview": str|None}.
-    Until it lands, the slot is guaranteed present and empty.
+    A backtest must not die because news is unavailable, so both failure modes
+    below degrade to an empty slot — but they LOG, because fail-closed and
+    fail-silent are different things. The adapter already handles its own
+    expected misses quietly (404, network, bad key) and returns empty rather
+    than raising; anything that actually escapes it is unexpected, which is why
+    these log at exception level rather than warning.
+
+    Without the log, a producer contract break (e.g. the 2026-07-14 FinSearch
+    score -> sentiment_score rename raising KeyError out of _project_entry) is
+    indistinguishable from a quiet news day: sentiment silently empties out of
+    every step with no exception, no log, and no failing test.
     """
     try:
         from dashboard.backend.integrations.news_sentiment import get_news_sentiment  # type: ignore
     except Exception:
+        logger.exception(
+            "load_news_sentiment: news_sentiment adapter is unimportable; "
+            "sentiment slot left empty for this step")
         return {}, None
     try:
         data = get_news_sentiment(universe, timestamp) or {}
         return data.get("news_sentiment", {}) or {}, data.get("news_overview")
-    except Exception:
+    except Exception as exc:
+        logger.exception(
+            "load_news_sentiment: adapter raised %r; sentiment slot left empty "
+            "for this step (a KeyError here usually means the producer's "
+            "payload shape changed)", exc)
         return {}, None
 
 

--- a/dashboard/backend/tests/test_execution_backends.py
+++ b/dashboard/backend/tests/test_execution_backends.py
@@ -96,6 +96,44 @@ def test_news_sentiment_fail_closed_when_loader_raises(monkeypatch):
     assert sentiment == {} and overview is None
 
 
+def test_news_sentiment_loader_failure_is_logged(monkeypatch, caplog):
+    """Fail-closed must not mean fail-silent. A producer field rename reaches
+    here as a KeyError escaping the adapter; swallowed without a log it is
+    indistinguishable from a quiet news day or a producer outage, so the
+    sentiment slot empties with no exception, no log and no red test. That is
+    exactly how the 2026-07-14 score -> sentiment_score rename could have
+    zeroed sentiment out of every backtest unnoticed."""
+    import types
+
+    fake = types.ModuleType("dashboard.backend.integrations.news_sentiment")
+
+    def _boom(universe, timestamp):
+        raise KeyError("sentiment_score")
+
+    fake.get_news_sentiment = _boom
+    monkeypatch.setitem(sys.modules, "dashboard.backend.integrations.news_sentiment", fake)
+
+    with caplog.at_level("ERROR"):
+        sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
+
+    assert sentiment == {} and overview is None
+    assert any("sentiment_score" in r.getMessage() for r in caplog.records)
+
+
+def test_news_sentiment_import_failure_is_logged(monkeypatch, caplog):
+    """The adapter shipped long ago, so an ImportError here is a real packaging
+    or deployment fault — not the pre-Plan-1 'not landed yet' state this
+    fallback was originally written for. Say so rather than degrading mutely."""
+    monkeypatch.setitem(sys.modules,
+                        "dashboard.backend.integrations.news_sentiment", None)
+
+    with caplog.at_level("ERROR"):
+        sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
+
+    assert sentiment == {} and overview is None
+    assert any("news_sentiment" in r.getMessage() for r in caplog.records)
+
+
 def test_apply_decisions_executes_pre_validated_actions():
     # Per-action validation now happens at the v2 boundary (validate_actions);
     # the backend receives only valid actions and reports execution results.


### PR DESCRIPTION
`load_news_sentiment` swallowed both its import failure and its call failure with a bare `except Exception: return {}, None` and no log.

Fail-closed is correct — a backtest shouldn't die because news is down. Fail-**silent** isn't: a producer contract break empties the sentiment slot for every step, indistinguishable from a quiet news day. No exception, no log, no red test.

This is one of the three blind channels around the FinSearch `score` → `sentiment_score` rename, and the one that would swallow the `KeyError` that ATL PR-2b (deleting the v1 fallback) is about to start raising. Landing it first so that fail-loud actually fails loud.

`logger.exception` rather than `warning`: the adapter already handles its expected misses (404 / network / bad key) quietly and returns empty rather than raising, so anything escaping it is genuinely unexpected.

TDD: both tests failed on the log assertion first, with the `sentiment == {}` fail-closed assertions already passing — isolating this as an observability gap, not a behavior change. Suite 976 passed / 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbs5wnQZhTi9CQ3pb14vDo