### PR TITLE
chore(news): simplify v2 cutover follow-ups

### DIFF
--- a/dashboard/backend/execution/backtest_backend.py
+++ b/dashboard/backend/execution/backtest_backend.py
@@ -32,15 +32,12 @@ def load_news_sentiment(universe: List[str], timestamp: Any) -> Tuple[Dict[str, 
     get_news_sentiment(universe, timestamp) -> {"news_sentiment": {...}, "news_overview": str|None}.
     A backtest must not die because news is unavailable, so both failure modes
     below degrade to an empty slot — but they LOG, because fail-closed and
-    fail-silent are different things. The adapter already handles its own
-    expected misses quietly (404, network, bad key) and returns empty rather
-    than raising; anything that actually escapes it is unexpected, which is why
-    these log at exception level rather than warning.
+    fail-silent are different things: without a log, a producer contract break
+    is indistinguishable from a quiet news day.
 
-    Without the log, a producer contract break (e.g. the 2026-07-14 FinSearch
-    score -> sentiment_score rename raising KeyError out of _project_entry) is
-    indistinguishable from a quiet news day: sentiment silently empties out of
-    every step with no exception, no log, and no failing test.
+    Exception level rather than warning is deliberate: the adapter already
+    handles its own expected misses quietly (404, network, bad key) and returns
+    empty rather than raising, so anything escaping it is genuinely unexpected.
     """
     try:
         from dashboard.backend.integrations.news_sentiment import get_news_sentiment  # type: ignore

--- a/dashboard/backend/integrations/news_sentiment.py
+++ b/dashboard/backend/integrations/news_sentiment.py
@@ -236,12 +236,11 @@ def _story_fields(sig: dict) -> dict:
 def _project_entry(sig: dict, reference_ts: float) -> dict:
     return {
         "sentiment": sig["sentiment"],
-        # Reads the wire's v2 key; emits the INTERNAL key `score`, which
-        # api/v2/models.py's NewsSentimentEntry validates. The two vocabularies
-        # are decoupled by design — this is not a half-finished rename.
-        # No v1 fallback: signals v2 is a hard rename and FinSearch normalizes
-        # at its boundary, so `score` cannot reach us. A KeyError here means the
-        # producer contract broke and should be seen, not smoothed over.
+        # Asymmetry is deliberate, not a half-finished rename: the wire's key is
+        # `sentiment_score`, the internal envelope's is `score` (validated by
+        # api/v2/models.py's NewsSentimentEntry). Do NOT "fix" the emitted key
+        # to match the wire. No v1 fallback — a KeyError here means the producer
+        # contract broke and must be seen, not smoothed over.
         "score": sig["sentiment_score"],
         **_story_fields(sig),
         "n_articles": sig["n_articles"],
@@ -312,7 +311,7 @@ def fetch_items(*, limit: int = _PANEL_FEED_LIMIT) -> Optional[list]:
 
 
 def _feed_from_items(items) -> list:
-    """Project news-story v1 items onto the panel feed keys — a near-
+    """Project news-story v2 items onto the panel feed keys — a near-
     passthrough now that AF's items endpoint speaks the shared vocabulary
     (headline/url on the wire; docs/integrations/finsearch-news-items.md):
     headline->headline, url->url, source->source, published->published,

--- a/dashboard/backend/tests/test_execution_backends.py
+++ b/dashboard/backend/tests/test_execution_backends.py
@@ -80,17 +80,23 @@ def test_backtest_backend_emits_typed_context(monkeypatch):
     assert ack["accepted"] is True
 
 
-def test_news_sentiment_fail_closed_when_loader_raises(monkeypatch):
-    # Plan 1 adapter exists but throws at call time → still fail-closed.
+def _install_fake_adapter(monkeypatch, raises: Exception):
+    """Install an importable news_sentiment adapter whose get_news_sentiment
+    raises, i.e. the call-time failure branch rather than the import-time one."""
     import types
 
     fake = types.ModuleType("dashboard.backend.integrations.news_sentiment")
 
     def _boom(universe, timestamp):
-        raise RuntimeError("news service down")
+        raise raises
 
     fake.get_news_sentiment = _boom
     monkeypatch.setitem(sys.modules, "dashboard.backend.integrations.news_sentiment", fake)
+
+
+def test_news_sentiment_fail_closed_when_loader_raises(monkeypatch):
+    # Plan 1 adapter exists but throws at call time → still fail-closed.
+    _install_fake_adapter(monkeypatch, RuntimeError("news service down"))
 
     sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
     assert sentiment == {} and overview is None
@@ -103,15 +109,7 @@ def test_news_sentiment_loader_failure_is_logged(monkeypatch, caplog):
     sentiment slot empties with no exception, no log and no red test. That is
     exactly how the 2026-07-14 score -> sentiment_score rename could have
     zeroed sentiment out of every backtest unnoticed."""
-    import types
-
-    fake = types.ModuleType("dashboard.backend.integrations.news_sentiment")
-
-    def _boom(universe, timestamp):
-        raise KeyError("sentiment_score")
-
-    fake.get_news_sentiment = _boom
-    monkeypatch.setitem(sys.modules, "dashboard.backend.integrations.news_sentiment", fake)
+    _install_fake_adapter(monkeypatch, KeyError("sentiment_score"))
 
     with caplog.at_level("ERROR"):
         sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")

--- a/dashboard/backend/tests/test_news_sentiment_fixture.py
+++ b/dashboard/backend/tests/test_news_sentiment_fixture.py
@@ -78,7 +78,11 @@ def test_items_wire_fixture_does_not_speak_the_retired_vocabulary():
     it `editorial_score`), but note it is retired for a stricter reason: the
     items endpoint has no boundary normalizer, so `editorial_score` sits in the
     producer's REQUIRED_FIELDS and a pre-rename batch trips the batch-level
-    poison pill and 404s rather than being served as v1."""
+    poison pill and 404s rather than being served as v1.
+
+    These are named guards kept for their failure message; the exact-set match
+    in test_items_wire_fixture_matches_contract_essentials already implies all
+    three, and is what generalizes to the next rename."""
     for item in load_items_wire_fixture()["items"]:
         assert "title" not in item
         assert "link" not in item
@@ -137,14 +141,19 @@ def test_signals_fixture_validates_against_the_vendored_producer_schema():
 
 
 def test_signals_fixtures_do_not_speak_the_retired_score_vocabulary():
-    """The `score` -> `sentiment_score` rename is hard, not a dual-write:
-    signals-v2.schema.json sets additionalProperties:false and requires
-    sentiment_score, and FinSearch normalizes at its API boundary so `score`
-    never reaches the wire (whether the artifact is read as latest or via
-    ?as_of). A fixture still carrying `score` would describe a shape the
-    producer cannot emit — which is precisely the failure this suite had:
-    v1-pinned fixtures stay green while prod serves v2, so they fail when you
-    fix them and pass when you are wrong."""
+    """Named guard on the retired `score` key, kept for its failure message
+    rather than its coverage: the schema test above already forbids a stray
+    `score` on the on-disk fixture (additionalProperties:false), and the wire
+    fixture inherits that transitively via
+    test_wire_fixture_is_base_minus_strip_plus_staleness's dict equality. Those
+    two are what actually generalize to the NEXT rename; this one just says so
+    out loud. The float assertion below is not redundant — see its comment.
+
+    A fixture carrying `score` describes a shape the producer cannot emit (see
+    the "two vocabularies" note in docs/integrations/finsearch-news-sentiment.md).
+    That was this suite's blind channel: v1-pinned fixtures stayed green while
+    prod served v2, so they failed when you fixed them and passed when you were
+    wrong."""
     for body in (load_signals_fixture(), load_signals_wire_fixture()):
         for sig in body["signals"].values():
             assert "score" not in sig

--- a/dashboard/backend/tests/test_sentiment_score_projection.py
+++ b/dashboard/backend/tests/test_sentiment_score_projection.py
@@ -1,20 +1,10 @@
-"""PR-2 of the FinSearch score-field disambiguation (see FinSearch spec
-2026-07-14-score-field-disambiguation-design.md): the transitional v1 `score`
-fallback is gone, and reading v1 is now an error rather than a kindness.
+"""PR-2 of the FinSearch score-field disambiguation: the transitional v1 `score`
+fallback is gone, so a v1-only payload is now a KeyError rather than a silent
+kindness. This module is only about which key `_project_entry` READS.
 
-Signals v2 is a HARD rename, not a dual-write: signals-v2.schema.json requires
-`sentiment_score` and sets additionalProperties:false, and FinSearch renames at
-its API boundary so `score` never reaches the wire — whether the artifact is
-read as latest or via `?as_of`, and whether the artifact on disk is native v2
-or a normalized v1. There is no grace period left to be tolerant of, so a
-payload still carrying `score` is not an old-but-valid producer worth
-accommodating; it is a broken one. Tolerating it would only paint a plausible
-number onto the panel while hiding the breakage.
-
-Note `_project_entry` still EMITS the internal key `score`. That is deliberate,
-not a missed rename: api/v2/models.py's NewsSentimentEntry validates the
-internal envelope, whose vocabulary is decoupled from the wire's by design.
-This module is only about which key we READ.
+Why there is no fallback to be tolerant of, and why `_project_entry` still
+deliberately EMITS the internal key `score`: see the "two vocabularies" note in
+docs/integrations/finsearch-news-sentiment.md.
 """
 import pytest
 


### PR DESCRIPTION
Cleanup pass over the merged #116 / #117. Comments, docstrings and one test helper — no behavior change. Suite 977 passed / 4 skipped, same as main.

**Extracted `_install_fake_adapter`** — the `types.ModuleType` fake was copy-pasted across three tests in `test_execution_backends.py`. Deliberately *not* parametrized: the import-time and call-time branches need structurally different fakes, so merging them would put an if/else in the test body.

**Deduped the "hard rename, not a dual-write" argument**, which was re-derived in full at four sites (~35 lines that drift independently on the next rename). `finsearch-news-sentiment.md` is canonical now; the code sites cross-reference it. Kept the one fact that prevents a plausible wrong edit at `_project_entry` — don't "fix" the emitted internal `score` to match the wire, `NewsSentimentEntry` validates it.

**Fixed two docstrings that claimed to be the regression guard.** They aren't. The schema check (`additionalProperties:false`) and `test_wire_fixture_is_base_minus_strip_plus_staleness`'s dict equality already imply `"score" not in sig` for both fixtures; `set(item) == ITEMS_STORY_KEYS` implies the items ones. Those are what generalize to the next rename. The named assertions stay for their failure message, now framed as belt-and-suspenders. The float assertion is genuinely not redundant — schema `number` admits ints — and is unchanged.

**`_feed_from_items` docstring** said `news-story v1`, the last code-level leftover of the v1→v2 sweep. (The two spec-doc hits are dated design records — accurate history, left alone.)

**Considered and skipped:** throttling the per-step `logger.exception`. Sound on its own (~140µs/~500B per call during a sustained break) but it adds module-level state and time-windowed behavior to straight-line logic, and changes intended behavior in a PR whose point was making failures loud. Worth a separate discussion.

**Follow-up, not addressed here:** `backtest_backend.py`'s `except` reasons about `_project_entry`'s internals from another module. `get_news_sentiment` has one caller today, so a second would silently reproduce the fail-silent bug #116 fixed. Related: its dict comprehension has no per-entry isolation, so one malformed signal blanks every ticker for that step — unlike `_representative_feed`'s log-and-drop. Both pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbs5wnQZhTi9CQ3pb14vDo