### PR TITLE
fix(news): isolate the backtest signals projection

### DIFF
--- a/dashboard/backend/execution/backtest_backend.py
+++ b/dashboard/backend/execution/backtest_backend.py
@@ -35,9 +35,12 @@ def load_news_sentiment(universe: List[str], timestamp: Any) -> Tuple[Dict[str, 
     fail-silent are different things: without a log, a producer contract break
     is indistinguishable from a quiet news day.
 
-    Exception level rather than warning is deliberate: the adapter already
-    handles its own expected misses quietly (404, network, bad key) and returns
-    empty rather than raising, so anything escaping it is genuinely unexpected.
+    Exception level rather than warning is deliberate: the adapter handles its
+    own expected misses quietly (404, network, bad key) AND reports its own
+    wire-shape drift (dropping the unreadable entry, ERROR-ing if that empties
+    the step), so anything still escaping it is genuinely unexpected. Don't
+    reach back across the boundary to interpret what escaped — an except here
+    that explains the adapter's internals goes stale the moment they move.
     """
     try:
         from dashboard.backend.integrations.news_sentiment import get_news_sentiment  # type: ignore
@@ -52,8 +55,7 @@ def load_news_sentiment(universe: List[str], timestamp: Any) -> Tuple[Dict[str, 
     except Exception as exc:
         logger.exception(
             "load_news_sentiment: adapter raised %r; sentiment slot left empty "
-            "for this step (a KeyError here usually means the producer's "
-            "payload shape changed)", exc)
+            "for this step", exc)
         return {}, None
 
 

--- a/dashboard/backend/execution/backtest_backend.py
+++ b/dashboard/backend/execution/backtest_backend.py
@@ -37,10 +37,10 @@ def load_news_sentiment(universe: List[str], timestamp: Any) -> Tuple[Dict[str, 
 
     Exception level rather than warning is deliberate: the adapter handles its
     own expected misses quietly (404, network, bad key) AND reports its own
-    wire-shape drift (dropping the unreadable entry, ERROR-ing if that empties
-    the step), so anything still escaping it is genuinely unexpected. Don't
-    reach back across the boundary to interpret what escaped — an except here
-    that explains the adapter's internals goes stale the moment they move.
+    wire-shape drift (see get_news_sentiment), so anything still escaping it is
+    genuinely unexpected. Don't reach back across the boundary to interpret what
+    escaped — an except here that explains the adapter's internals goes stale the
+    moment they move.
     """
     try:
         from dashboard.backend.integrations.news_sentiment import get_news_sentiment  # type: ignore

--- a/dashboard/backend/integrations/news_sentiment.py
+++ b/dashboard/backend/integrations/news_sentiment.py
@@ -256,7 +256,7 @@ def _project_step_signals(considered: dict, reference_ts: float) -> dict:
     The isolation is the whole point. This was a dict comprehension, so one
     off-spec ticker raised out of the entire projection and the caller blanked
     the sentiment slot for EVERY ticker that step — a producer typo on MSFT
-    silently deleting AAPL's news. The panel has always dropped and carried on
+    silently deleting NVDA's news. The panel has always dropped and carried on
     (_representative_feed); the backtest is the projection that never learned it.
 
     A dropped ticker is indistinguishable from a ticker with no news — which is
@@ -390,11 +390,16 @@ def _alarm_if_all_dropped(raw, projected: Union[list, dict], *, source: str,
 
     Failing closed is not the same as failing visibly, and every projection here
     only buys the first: a malformed entry is dropped with a per-entry warning
-    and the panel carries on, so a producer renaming a field looks exactly like
+    and the caller carries on, so a producer renaming a field looks exactly like
     routine noise. On 2026-07-14 AF renamed title/link -> headline/url and this
-    adapter served the Phase-A feed for hours on warnings alone. The caller
-    escalates a True to `degraded` so the break reaches the panel too — a log
-    line only ever reaches whoever happens to be reading logs, and nobody was."""
+    adapter served the Phase-A feed for hours on warnings alone.
+
+    What a True is worth is the caller's to decide, and the callers differ. The
+    panel's escalate it to `degraded` so the break reaches the badge — a log line
+    only ever reaches whoever happens to be reading logs, and nobody was. The
+    backtest path has no equivalent channel and is log-only pending #123. So do
+    not read this helper as a promise that drift always reaches a human; it
+    reports, and reporting is only as loud as the channel the caller gives it."""
     if not (raw and not projected):
         return False
     logger.error("news_sentiment: %s produced 0 usable entries from %d raw "

--- a/dashboard/backend/integrations/news_sentiment.py
+++ b/dashboard/backend/integrations/news_sentiment.py
@@ -249,8 +249,45 @@ def _project_entry(sig: dict, reference_ts: float) -> dict:
     }
 
 
+def _project_step_signals(considered: dict, reference_ts: float) -> dict:
+    """Per-step backtest signals projected to the internal entry shape, dropping
+    the entries `_project_entry` cannot read.
+
+    The isolation is the whole point. This was a dict comprehension, so one
+    off-spec ticker raised out of the entire projection and the caller blanked
+    the sentiment slot for EVERY ticker that step — a producer typo on MSFT
+    silently deleting AAPL's news. The panel has always dropped and carried on
+    (_representative_feed); the backtest is the projection that never learned it.
+
+    A dropped ticker is indistinguishable from a ticker with no news — which is
+    the shape this dict already has (only tickers WITH signals appear), so the
+    blast radius shrinks from "every ticker" to "the broken one". Wholesale
+    drift is the case that still needs saying out loud: see the caller's
+    _alarm_if_all_dropped.
+
+    `_project_entry` stays the single source of which fields are required, and a
+    KeyError names the missing one — so an all-tickers-at-once "missing
+    'sentiment_score'" reads as a rename rather than as routine noise.
+    """
+    projected = {}
+    for sym, sig in considered.items():
+        try:
+            projected[sym] = _project_entry(sig, reference_ts)
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning("news_sentiment: dropping step signal %r — %s: %s",
+                           sym, type(exc).__name__, exc)
+    return projected
+
+
 def get_news_sentiment(universe, timestamp) -> dict:
-    """Contract interface for execution/backtest_backend.load_news_sentiment."""
+    """Contract interface for execution/backtest_backend.load_news_sentiment.
+
+    Reports its own contract breaks (drop + warn per entry, ERROR on wholesale
+    drift) rather than raising them at the caller. The caller's fail-closed
+    try/except is a backstop for the genuinely unexpected, not the thing that
+    makes a producer rename visible — leaving that to the caller made the
+    reporting only as good as each new caller's memory to re-implement it.
+    """
     empty = {"news_sentiment": {}, "news_overview": None}
     ts = _coerce_timestamp(timestamp)
     if ts is None:
@@ -262,11 +299,15 @@ def get_news_sentiment(universe, timestamp) -> dict:
     if not body:
         return empty
     wanted = set(tickers)
-    out = {
-        sym: _project_entry(sig, reference_ts)
-        for sym, sig in (body.get("signals") or {}).items()
-        if not wanted or sym in wanted
-    }
+    considered = {sym: sig for sym, sig in (body.get("signals") or {}).items()
+                  if not wanted or sym in wanted}
+    out = _project_step_signals(considered, reference_ts)
+    # `considered`, never the raw signals block: a signal for a ticker outside
+    # the universe is filtered by design, not dropped by drift, so alarming on
+    # it would cry wolf on every narrow-universe run and train the reader to
+    # ignore the one alarm that matters.
+    _alarm_if_all_dropped(considered, out, source="backtest step signals",
+                          consequence="this step's sentiment slot is empty")
     return {"news_sentiment": out, "news_overview": body.get("news_overview")}
 
 
@@ -341,7 +382,8 @@ def _feed_from_items(items) -> list:
     return feed
 
 
-def _alarm_if_all_dropped(raw, projected: list, *, source: str, consequence: str) -> bool:
+def _alarm_if_all_dropped(raw, projected: Union[list, dict], *, source: str,
+                          consequence: str) -> bool:
     """Whether `raw` projected to NOTHING — i.e. the wire contract moved rather
     than one story being off-spec — logging an ERROR if so. An empty batch is
     "no news", not drift.

--- a/dashboard/backend/tests/test_execution_backends.py
+++ b/dashboard/backend/tests/test_execution_backends.py
@@ -103,12 +103,15 @@ def test_news_sentiment_fail_closed_when_loader_raises(monkeypatch):
 
 
 def test_news_sentiment_loader_failure_is_logged(monkeypatch, caplog):
-    """Fail-closed must not mean fail-silent. A producer field rename reaches
-    here as a KeyError escaping the adapter; swallowed without a log it is
-    indistinguishable from a quiet news day or a producer outage, so the
-    sentiment slot empties with no exception, no log and no red test. That is
-    exactly how the 2026-07-14 score -> sentiment_score rename could have
-    zeroed sentiment out of every backtest unnoticed."""
+    """Fail-closed must not mean fail-silent: swallowed without a log, an adapter
+    fault empties the sentiment slot with no exception and no red test — from
+    out here, indistinguishable from a quiet news day.
+
+    A producer rename no longer arrives this way. The adapter drops and alarms on
+    its own wire-shape drift, so this is the backstop for what is left: a fault
+    unexpected enough to escape it entirely, reported with whatever it carried
+    (hence the assertion on the exception's own text, not on a hint this end
+    guesses about the other end's internals)."""
     _install_fake_adapter(monkeypatch, KeyError("sentiment_score"))
 
     with caplog.at_level("ERROR"):

--- a/dashboard/backend/tests/test_news_sentiment_adapter.py
+++ b/dashboard/backend/tests/test_news_sentiment_adapter.py
@@ -319,13 +319,12 @@ def _body_without(field, *, symbols):
 
 
 def test_one_malformed_step_signal_does_not_blank_the_other_tickers(monkeypatch, caplog):
-    """Per-entry isolation on the backtest path.
+    """Per-entry isolation on the backtest path: one off-spec ticker must not
+    take the readable ones down with it.
 
-    This projection was a dict comprehension, so one off-spec ticker raised out
-    of the whole thing and the caller's fail-closed except emptied the sentiment
-    slot for EVERY ticker that step — one producer typo on MSFT silently
-    deleting NVDA's news. The panel has dropped-and-carried-on since
-    _representative_feed; this is the projection that never learned it."""
+    Delete this and nothing stops the projection going back to a dict
+    comprehension, where a single producer typo on MSFT empties the sentiment
+    slot for EVERY ticker that step. _project_step_signals carries the why."""
     body = _body_without("sentiment_score", symbols={"MSFT"})
     monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
     ts = datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc)

--- a/dashboard/backend/tests/test_news_sentiment_adapter.py
+++ b/dashboard/backend/tests/test_news_sentiment_adapter.py
@@ -307,6 +307,74 @@ def test_degraded_artifact_still_projects_in_backtest_path(monkeypatch):
     assert out["news_overview"] == body["news_overview"]
 
 
+def _body_without(field, *, symbols):
+    """The wire fixture with `field` stripped from `symbols` — i.e. the shape a
+    producer rename actually leaves behind."""
+    body = dict(load_signals_wire_fixture())
+    body["signals"] = {
+        sym: {k: v for k, v in sig.items() if not (sym in symbols and k == field)}
+        for sym, sig in body["signals"].items()
+    }
+    return body
+
+
+def test_one_malformed_step_signal_does_not_blank_the_other_tickers(monkeypatch, caplog):
+    """Per-entry isolation on the backtest path.
+
+    This projection was a dict comprehension, so one off-spec ticker raised out
+    of the whole thing and the caller's fail-closed except emptied the sentiment
+    slot for EVERY ticker that step — one producer typo on MSFT silently
+    deleting NVDA's news. The panel has dropped-and-carried-on since
+    _representative_feed; this is the projection that never learned it."""
+    body = _body_without("sentiment_score", symbols={"MSFT"})
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    ts = datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc)
+
+    with caplog.at_level("WARNING"):
+        out = ns.get_news_sentiment(["MSFT", "NVDA"], ts)
+
+    assert "MSFT" not in out["news_sentiment"]   # dropped...
+    assert "NVDA" in out["news_sentiment"]       # ...without taking this one with it
+    # Names the missing key, not a bare "malformed": "missing 'sentiment_score'"
+    # on every ticker at once is what reads as a rename rather than as noise.
+    assert any("sentiment_score" in r.getMessage() for r in caplog.records)
+
+
+def test_every_step_signal_dropped_alarms_instead_of_reading_as_a_quiet_news_day(
+        monkeypatch, caplog):
+    """The case per-entry isolation would otherwise hide. A rename makes every
+    entry unreadable, so log-and-drop alone yields an empty slot plus a few
+    warnings — indistinguishable from "no news this step", which is exactly how
+    the 2026-07-14 outage ran for hours on warnings nobody read."""
+    body = _body_without("sentiment_score", symbols={"MSFT", "NVDA"})
+    monkeypatch.setattr(ns, "_http_get", lambda **kw: _fake_response(body=body))
+    ts = datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc)
+
+    with caplog.at_level("ERROR"):
+        out = ns.get_news_sentiment(["MSFT", "NVDA"], ts)
+
+    assert out["news_sentiment"] == {}
+    assert any("drift" in r.getMessage()
+               for r in caplog.records if r.levelname == "ERROR")
+
+
+def test_universe_filter_alone_is_not_drift(monkeypatch, caplog):
+    """The alarm's `raw` is the post-filter set, never the wire's signals block.
+    A signal for a ticker outside the universe is filtered by design, not dropped
+    by drift — alarming on it would fire on every narrow-universe run and train
+    the reader to ignore the one alarm that matters."""
+    monkeypatch.setattr(ns, "_http_get",
+                        lambda **kw: _fake_response(body=load_signals_wire_fixture()))
+    ts = datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc)
+
+    with caplog.at_level("ERROR"):
+        out = ns.get_news_sentiment(["JPM"], ts)     # fixture has MSFT/NVDA only
+
+    assert out["news_sentiment"] == {}               # correctly empty...
+    assert not [r for r in caplog.records
+                if r.levelname == "ERROR"]           # ...but not a contract break
+
+
 def test_304_revalidation_serves_cached_body(monkeypatch):
     """A conditional GET that returns 304 serves the previously cached body
     (the latest-read path always sends If-None-Match). The on-disk fixture


### PR DESCRIPTION
`get_news_sentiment` projected via a dict comprehension, so one off-spec ticker raised out of the whole projection and `load_news_sentiment`'s fail-closed except emptied the sentiment slot for **every** ticker that step — a producer typo on MSFT silently deleting NVDA's news. The panel has dropped-and-carried-on since `_representative_feed`; this is the projection that never learned it.

Per-entry drop + the existing `_alarm_if_all_dropped`. Three symptoms, one cause — the adapter left contract-break reporting to its caller:

- **Isolation.** Blast radius drops from "every ticker" to "the broken one". Safe because the dict is already partial by nature (only tickers *with* signals appear), so a dropped ticker is the shape callers already handle.
- **Layering.** `backtest_backend`'s except no longer has to explain `_project_entry`'s KeyError from another module. That hint is now removed — it would go stale the moment the adapter's internals move, which is what this PR does.
- **The second caller.** `get_news_sentiment` has one production caller today. The fail-loud property #116 added lives in *the caller's* try/except, so caller #2 (live paper-trading — anticipated in `finsearch-news-signals-panel-design.md:115`) silently regresses unless it remembers to re-implement it. Now there is no exception to forget to catch.

**Isolation without the alarm would be a regression, not a fix.** A rename makes *every* entry unreadable, so log-and-drop alone yields an empty slot plus a few warnings — indistinguishable from a quiet news day. That is how the 2026-07-14 outage ran for hours. Per `_alarm_if_all_dropped`'s docstring, the alarm is what separates "one story is off-spec" from "the contract moved".

**The alarm's `raw` arg is the post-filter set, never the wire's `signals` block.** A signal for a ticker outside the universe is filtered by design, not dropped by drift; feeding the raw block would fire on every narrow-universe run and train the reader to ignore the one alarm that matters. `test_universe_filter_alone_is_not_drift` pins it.

`_project_entry` stays the single source of which fields are required — no duplicated key list, and `KeyError`'s own text names the missing key, so the log reads `missing 'sentiment_score'` rather than a bare "malformed".

**Escalation is log-only, deliberately.** The panel escalates drift to a `degraded` badge; the backtest has no equivalent channel. `RunManifest.news_sentiment_source` is the candidate but is a *provenance* field that is unwired today (always `None`) — filing a follow-up rather than half-wiring it into a status flag here.

Mutation-tested (all three new guards fail when reverted; the alarm-deletion mutation was re-run after the first attempt produced a vacuous syntax error rather than a real failure). Suite green, delta is exactly +3 and nothing else moves (main 990 -> 993 passed, 2 skipped). Absolute counts vary with optional deps — `discord` installed or not swings the total, which is where an earlier 980/4 reading came from.

**Review fix (`ca36d12`, docs only).** `_alarm_if_all_dropped`'s docstring claimed "the caller escalates a True to `degraded`" — true for the panel's call sites, false for the one this PR adds, which discards the return by design. Same hazard this PR removes from `backtest_backend.py`, one function over; #123 already quotes the line as if it were universal. Also NVDA-for-AAPL (AAPL is the one watchlist ticker the fixture gives no signals to) and the test docstring no longer re-narrates the history verbatim.

**Re #120:** independent (`get_news_sentiment` vs `get_latest_panel_payload`), and test-merged clean. Both widen `_alarm_if_all_dropped` to `Union[list, dict]`; this makes that change byte-identical to #120's so it merges either order. #120's "applied to ALL THREE projections" is left alone — it enumerates the *panel's* projections and stays accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbs5wnQZhTi9CQ3pb14vDo
