### PR TITLE
docs: correct the news drift-escalation claims

### DIFF
--- a/docs/integrations/finsearch-news-items.md
+++ b/docs/integrations/finsearch-news-items.md
@@ -1,7 +1,7 @@
 # FinSearch Raw News Items — the `news-story v2` Contract (Phase B)
 
 **Audience:** both teams — AF producer (`Main/backend/api/signals_views.py`, Agentic-FinSearch) and ATL consumer (`dashboard/backend/integrations/news_sentiment.py`).
-**Status (2026-07-14):** **live.** AF PR #359 shipped the producer and is deployed (wire shape verified against prod). The ATL consumer lands in PR #110 — ATL PR #107 merged at a commit that predated the `headline`/`url` rename, so between the two merges the adapter read the retired keys and the panel silently served the Phase-A fallback; #110 is the fix.
+**Status (2026-07-16):** **live on both sides.** AF PR #359 shipped the producer and is deployed (wire shape verified against prod); ATL PR #110 shipped the consumer, closing the window in which ATL PR #107 — merged at a commit predating the `headline`/`url` rename — read the retired keys while the panel silently served the Phase-A fallback. The drift guard has since been extended to the two projections that lacked one: the panel `signals` block (#119 → #120) and the per-step backtest projection (#122).
 **Design rationale:** `docs/superpowers/specs/2026-07-14-finsearch-news-story-contract-design.md`.
 **Companion:** [`finsearch-news-sentiment.md`](finsearch-news-sentiment.md) — Phase A, the signals endpoint this contract's vocabulary is anchored to.
 
@@ -45,9 +45,15 @@ fields are added additively; a breaking change bumps the version.
 > **What each layer actually catches — updated after the v2 rename shipped:**
 > - A rename of a field ATL *projects* (`headline`/`url`/`source`/`published`/
 >   `tickers`) makes every story fail to project; the panel falls back to Phase
->   A. The drift check in `get_latest_panel_payload` (0 usable entries from a
->   non-empty batch) logs an `ERROR` and escalates the payload to `degraded`.
->   This is what happened on 2026-07-14 with `title`/`link` → `headline`/`url`.
+>   A. `_alarm_if_all_dropped` (0 usable entries from a non-empty batch) logs an
+>   `ERROR`, and on the panel escalates the payload to `degraded`. This is what
+>   happened on 2026-07-14 with `title`/`link` → `headline`/`url`.
+>   **There is no longer a single drift check to point at:** the same helper now
+>   guards four projections across two entry points (panel feed, panel `signals`,
+>   Phase-A fallback, backtest step). The story triple `headline`/`source`/`url`
+>   is read through the shared `_story_fields`, so one rename trips the panel
+>   *and* the backtest — with different visibility on each. See "Drift escalates
+>   `status`…" under Consumer rules.
 > - A rename of a field ATL *doesn't* read — such as `score` →
 >   `editorial_score` itself — is invisible here: `_feed_from_items` never
 >   touches it, so no drift check can fire. What protects this case is entirely
@@ -93,12 +99,15 @@ powers ATL's Home-panel "Latest news" column.
 - Fail closed: a malformed **item** is dropped (logged), a malformed **body** falls back to the Phase-A representative feed — the panel never regresses below Phase A and never errors out.
 - `tickers[]` stays a list on the wire; ATL's panel currently collapses it to `tickers[0] | null` for its single chip (multi-chip display deferred). A `[]` general-market story therefore renders with **no ticker chip** — the meta line is joined from non-empty segments, so the separator collapses with it.
 - **Alarm on wholesale drift, in the logs *and* in the UI.** Because the fallback is silent by design, a consumer must distinguish *one* bad story from *the contract moved*. ATL logs `ERROR` when a non-empty batch projects to zero usable entries; an empty batch is "no news", not drift. This is the safety net the 2026-07-14 rename slipped past. The check (`_alarm_if_all_dropped`) is a property of *projection*, not of the items endpoint, so it guards the Phase-A fallback too — that path needs it at least as much, since when the signals vocabulary drifts there is nothing left to fall back to and the feed goes blank rather than merely stale.
-- **Drift escalates `status` to `degraded`.** A log line only reaches whoever is reading logs, and in 2026-07-14 nobody was — the panel looked healthy, because the fallback made it look healthy. So drift also sets `status: "degraded"` and appends a reader-facing `status_reason` (`news feed incomplete — upstream story format changed`), which the Home panel already renders as a badge. Two rules keep the badge worth reading: it stays dark on a quiet news day (an empty artifact drops nothing, so it isn't drift), and a drift reason is *appended to* the producer's own `status_reason` rather than replacing it — "a source timed out" and "the wire shape moved" are independent failures and the badge should not let the later one erase the earlier.
+- **Drift escalates `status` to `degraded` — on the panel path.** A log line only reaches whoever is reading logs, and on 2026-07-14 nobody was — the panel looked healthy, because the fallback made it look healthy. So panel drift also sets `status: "degraded"` and appends a reader-facing `status_reason` (`news feed incomplete — upstream story format changed`), which the Home panel already renders as a badge. Two rules keep the badge worth reading: it stays dark on a quiet news day (an empty artifact drops nothing, so it isn't drift), and a drift reason is *appended to* the producer's own `status_reason` rather than replacing it — "a source timed out" and "the wire shape moved" are independent failures and the badge should not let the later one erase the earlier.
+- **The backtest path alarms but cannot escalate — it is log-only, and that is a gap, not a design.** `_alarm_if_all_dropped` returns a bool and leaves the consequence to each caller; the three panel callers OR it into `degraded`, while `get_news_sentiment` (#122) **discards** it. Not an oversight: a backtest step has no badge and no reader, and the only status field in reach is `RunManifest.news_sentiment_source`, a provenance field that would have to cosplay as a status flag to carry this. So the step's `news_sentiment` slot just goes empty — which is exactly what a genuinely quiet step looks like. Wiring a real channel is **issue #123**; until it lands, drift on a backtest run is visible *only* in the logs, and by this repo's own doctrine a log nobody reads is not an alarm. **Don't read the helper's presence as a promise that drift reaches a human** — it reports, and reporting is only as loud as the channel the caller gives it.
 - **Pin the wire shape in a fixture, not in inline test dicts.** ATL records it once in `dashboard/backend/tests/fixtures/items-wire-fixture.json` (key set verified against prod) and drives the adapter's happy path from it, so a rename must visibly edit that file. Fixtures written inline beside the code they test drift *with* the code and stay green.
 
-## Known gap
+## Known gaps
 
-Nothing in ATL's test suite can *catch* a producer rename — the producer is mocked, so AF and ATL can only drift apart between deploys. The fixture makes the assumed shape reviewable and the drift `ERROR` makes a break visible within one poll, but neither is a cross-repo contract test. If this seam breaks a third time, the fix is a canary that exercises the real endpoint (or an AF-published fixture ATL diffs in CI), not more mocked coverage.
+**No cross-repo contract test.** Nothing in ATL's test suite can *catch* a producer rename — the producer is mocked, so AF and ATL can only drift apart between deploys. The fixture makes the assumed shape reviewable and the drift `ERROR` makes a break visible within one poll of the panel, but neither is a cross-repo contract test. If this seam breaks a third time, the fix is a canary that exercises the real endpoint (or an AF-published fixture ATL diffs in CI), not more mocked coverage.
+
+**Backtest drift has no channel** (issue #123). The alarm fires there, but nothing carries it to a reader — see the log-only bullet under Consumer rules. A backtest run whose news went silent mid-way is, today, indistinguishable from a run over a quiet news week unless someone reads the logs.
 
 ## Traceability
 
@@ -110,5 +119,10 @@ Nothing in ATL's test suite can *catch* a producer rename — the producer is mo
 | Fallback/fail-closed consumer behavior | ATL `news_sentiment.py` `get_latest_panel_payload` docstring |
 | Drift `ERROR` vs. per-item warning | ATL `test_items_all_dropped_logs_drift_error` / `test_partial_malformed_items_does_not_log_drift_error` |
 | Drift alarm covers the fallback, not just items | ATL `_alarm_if_all_dropped`; `test_representative_fallback_all_dropped_logs_drift_error` |
+| Panel `signals` is projected, not passed through raw (a `sentiment_score` rename would have painted "NaN" into every chip — no drop, no log) | ATL issue #119 → PR #120; `_project_panel_signals`, `_PANEL_SIGNAL_KEYS`; `test_panel_signal_missing_sentiment_score_is_dropped_not_rendered_nan` |
+| Panel feed and panel `signals` keep independent required-key sets | ATL `_PANEL_SIGNAL_KEYS` comment; `test_panel_signals_drift_survives_a_healthy_items_feed` |
+| Backtest step projection isolates the bad ticker instead of blanking every ticker | ATL PR #122; `_project_step_signals`; `test_one_malformed_step_signal_does_not_blank_the_other_tickers` |
+| Escalation asymmetry: panel drift → badge, backtest drift → log only | ATL `_alarm_if_all_dropped` docstring; `test_every_step_signal_dropped_alarms_instead_of_reading_as_a_quiet_news_day`; open issue #123 |
+| Universe filtering is not drift (a narrow `?tickers=` run must not cry wolf) | ATL `test_universe_filter_alone_is_not_drift` |
 | "Non-empty raw" half of the predicate (no crying wolf on a quiet news day) | ATL `test_items_empty_list_does_not_log_drift_error` / `test_empty_signals_artifact_does_not_log_drift_error` |
 | Recorded wire shape + its coherence with the signals fixtures | ATL `items-wire-fixture.json`; `test_news_sentiment_fixture.py` |

--- a/docs/integrations/finsearch-news-sentiment.md
+++ b/docs/integrations/finsearch-news-sentiment.md
@@ -1,7 +1,7 @@
 # Consuming FinSearch News-Sentiment Signals (Plan 1)
 
-**Audience:** whoever builds `dashboard/backend/integrations/news_sentiment.py`.
-**Status (2026-07-13):** the FinSearch producer half is **shipped and LIVE**; the ATL consumer seam is **already in this repo and fail-closed**. The only missing piece is the adapter this document specifies.
+**Audience:** whoever maintains `dashboard/backend/integrations/news_sentiment.py`.
+**Status (2026-07-16):** **shipped on both sides and live.** The FinSearch producer is live; the adapter this document specifies is built and consumed by the fail-closed loader. Read what follows as *the contract as shipped*, not as a work order — where this doc and the module disagree, the module wins and this doc is the bug.
 **See also:** [`finsearch-news-items.md`](finsearch-news-items.md) — the shared `news-story v2` story vocabulary and the raw-items endpoint behind the Home panel's "Latest news" column (Phase B).
 
 ---
@@ -140,7 +140,7 @@ And `news_overview` ← the top-level `news_overview` string (passthrough).
 
 ## Error & degraded handling (fail closed, log loud)
 
-The consumer slot already defaults to empty, so every failure mode collapses safely to "no news this step." Map them explicitly:
+The consumer slot already defaults to empty, so every failure mode collapses safely to "no news this step." That safety is exactly the hazard: **a collapsed slot and a quiet news day are the same object**, so the log level is the only thing separating "nothing happened" from "the contract moved." Map them explicitly:
 
 | Condition | Adapter behavior |
 |-----------|------------------|
@@ -150,6 +150,10 @@ The consumer slot already defaults to empty, so every failure mode collapses saf
 | `404` | No artifact at/before `as_of`. Return `{}` (normal for early steps). |
 | body `status: degraded` | Data is **still usable** — project it as normal, but surface `status_reason` (log / overview) so the run is auditable. |
 | network/timeout | Return `{}`; log. Do not retry hard inside a per-step call. |
+| **one signal is off-spec** (missing/renamed key, wrong type) | Drop **that ticker only**, `WARNING` naming the missing key, project the rest. A dropped ticker is indistinguishable from a quiet ticker — which is already this dict's shape (only tickers *with* news appear), so the blast radius is the broken ticker, not the step. Until #122 this was a dict comprehension: one off-spec ticker raised out of the whole projection and blanked the sentiment slot for **every** ticker that step. |
+| **every** signal is off-spec (non-empty artifact → 0 usable entries) | Wire-shape drift, not "no news": `ERROR` via `_alarm_if_all_dropped`. An **empty** artifact is not drift — nothing was dropped. A signal filtered out by the `?tickers=` universe is not drift either; the alarm compares against the *considered* subset, not the raw block. |
+
+**Why `ERROR` and not `WARNING`.** Per-entry warnings are what a producer rename looked like on 2026-07-14 — routine noise, for hours, under a green suite and an HTTP 200. A wholesale drop is the only signal that distinguishes *absent* from *broken*, and it has to be loud enough to be found. See [`finsearch-news-items.md`](finsearch-news-items.md) §"Drift escalates `status`…" for what each caller does with it — and note that on **this** (backtest) path the alarm is **log-only**: there is no per-step status field to raise, and giving drift a real channel is open issue #123. `_project_entry` deliberately keeps **no v1 `score` fallback**: a `KeyError` there means the contract broke and must be seen, not smoothed over.
 
 ---
 
@@ -161,60 +165,34 @@ The producer emits a one-line **`rationale`** per ticker (why the read is bullis
 
 ---
 
-## Reference sketch
+## Where the shipped adapter puts each of these
 
-Not prescriptive — the projection above is the contract; degraded-handling is yours to decide (the `rationale` question is settled — see the design note above).
+This section used to carry a reference sketch. It is **deleted, deliberately**:
+the adapter is built, so a sketch of it was a second and worse copy of the truth,
+and it drifted exactly as you'd predict — its projection loop had no per-ticker
+isolation, which is the defect #122 had to fix in the real module while the
+"reference" for that module went on demonstrating it. The projection table above
+is the contract; `dashboard/backend/integrations/news_sentiment.py` is the
+reference. Read the module.
 
-```python
-# dashboard/backend/integrations/news_sentiment.py
-import os, requests
-from datetime import datetime, timezone
+| Concern | Where it lives |
+|---------|----------------|
+| Transport, auth header, memo/negative cache, `?as_of` / `?tickers` | `fetch_signals` (+ `_http_get`, `_headers`) |
+| `signals[TICKER]` → `NewsSentimentEntry` | `_project_entry` (story triple via the shared `_story_fields`) |
+| Per-ticker drop isolation | `_project_step_signals` |
+| Wholesale-drift `ERROR` | `_alarm_if_all_dropped` (log-only on this path — issue #123) |
+| Entry point the loader calls | `get_news_sentiment` |
 
-_BASE = "https://agenticfinsearch.org/api/signals/news/"
+Two facts the sketch carried that are worth keeping in prose:
 
-def _headers():
-    key = os.environ.get("FINGPT_API_KEY", "")
-    return {"Authorization": f"Bearer {key}"} if key else {}
-
-def _coerce_timestamp(timestamp):
-    # The real call site (external_run_service.py:429-431) serializes the step
-    # timestamp to an ISO STRING, not a datetime — coerce, don't assume.
-    if isinstance(timestamp, str):
-        timestamp = datetime.fromisoformat(timestamp)
-    if timestamp.tzinfo is None:
-        timestamp = timestamp.replace(tzinfo=timezone.utc)
-    return timestamp
-
-def get_news_sentiment(universe, timestamp):
-    timestamp = _coerce_timestamp(timestamp)
-    as_of = timestamp.date().isoformat()
-    reference_ts = timestamp.timestamp()
-    resp = requests.get(
-        _BASE,
-        params={"as_of": as_of, "tickers": ",".join(universe)},
-        headers=_headers(), timeout=10,
-    )
-    if resp.status_code != 200:
-        return {"news_sentiment": {}, "news_overview": None}  # fail closed; log on 401/503/400
-    body = resp.json()
-    out = {}
-    for ticker, s in body.get("signals", {}).items():
-        out[ticker] = {
-            "sentiment": s["sentiment"],
-            "score": s["sentiment_score"],
-            "headline": s["headline"],
-            "source": s["source"],
-            "url": s["url"],
-            "n_articles": s["n_articles"],
-            "age_hours": max(0.0, (reference_ts - s["published"]) / 3600.0),
-            "rationale": s.get("rationale"),
-        }
-    return {"news_sentiment": out, "news_overview": body.get("news_overview")}
-
-# compute_sentiment(stories): the *producer* already computes sentiment over the
-# feed (Heartbeat/news_signals.py). ATL consumes the result; it does not recompute.
-# Keep this function only if you want a local offline path over the fixture.
-```
+- **`timestamp` arrives as an ISO string, not a `datetime`.** The real call site
+  (`external_run_service.py`) serializes it before the loader ever sees it, so
+  `_coerce_timestamp` coerces rather than assumes — and returns `None` for junk,
+  which `get_news_sentiment` fails closed on.
+- **ATL does not compute sentiment.** The producer already computes it over the
+  feed (`Heartbeat/news_signals.py`); this adapter consumes the result. There is
+  no local scoring path, and adding one would fork the frozen seam this document
+  opens with.
 
 ---
 
@@ -227,5 +205,7 @@ def get_news_sentiment(universe, timestamp):
 | Consumer seam, `NewsSentimentEntry`, fail-closed loader | ATL `api/v2/models.py`, `execution/backtest_backend.py`; `docs/superpowers/specs/2026-06-23-agent-api-foundation-design.md` |
 | Auth requirement | FinSearch `Docs/superpowers/plans/2026-07-12-endpoint-auth.md` (PRs #354/#355/#356); endpoint verified live 2026-07-13 |
 | `as_of`, Dow-30 reconcile | FinSearch PR #340 / #341; ATL #91 / #94 |
+| Per-entry drop isolation + wholesale-drift `ERROR` on the step path | ATL PR #122; `_project_step_signals`, `_alarm_if_all_dropped`; `test_one_malformed_step_signal_does_not_blank_the_other_tickers` / `test_every_step_signal_dropped_alarms_instead_of_reading_as_a_quiet_news_day` / `test_universe_filter_alone_is_not_drift` |
+| Backtest drift is log-only (no per-step status channel) | ATL open issue #123 |
 
 **Deliberate deviation from the plan:** the plan's frozen sketch listed `rationale`/`published` on the injected entry; the shipped `NewsSentimentEntry` carries `age_hours`/`n_articles` instead of `published`, plus (as of 2026-07-13) an optional `rationale`. This doc documents the shipped contract rather than assuming the older sketch.


### PR DESCRIPTION
Docs-only. The two FinSearch integration docs described a world with **one** drift check; after #120 and #122 there are four, across two entry points, and they disagree on what a drift is worth.

**Fixed**
- `status: degraded` was stated as a property of drift. It's a property of the *panel's* three call sites. `get_news_sentiment` (#122) discards the bool — a backtest step has no badge and no status field, so drift there is log-only pending #123. Now documented as a gap, not a design.
- "The drift check in `get_latest_panel_payload`" — singular, now false. `_story_fields` is shared, so a `headline` rename trips the panel *and* the backtest with different visibility.
- Both Traceability tables had no row for either new guard. Added, with test anchors.
- The `finsearch-news-sentiment.md` failure-mode table covered only transport failures (401/503/404/…) — nothing for the drop/alarm behavior that is now most of the fail-visible story.
- Both status headers were stale (#110 described as pending; the adapter described as unbuilt).

**Deleted: the reference sketch.** The adapter is built, so the sketch was a second copy of the truth — and it had drifted into demonstrating the exact defect #122 fixed: a projection loop with no per-ticker isolation, where one off-spec ticker raises out and the loader's fail-closed catch blanks *every* ticker. A reader following it reproduced #119/#122. Replaced with a where-it-lives table plus the two facts worth keeping (ISO-string coercion; ATL doesn't compute sentiment).

**Not stale, deliberately left:** "a rename of a field ATL *doesn't* read is invisible here". Its example is `editorial_score`, which `_feed_from_items` still never touches — the claim holds as written.

Verified against the merged code rather than review notes: all 4 call sites read, `_coerce_timestamp` confirmed to return `None` (not raise), `external_run_service.py:430-431` confirmed to still serialize ISO. No heading cited by code/tests was renamed. News suite 63/63.