### PR TITLE
Polish home dashboard modules and CTAs

### DIFF
--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -8,8 +8,8 @@
     <link rel="apple-touch-icon" href="/images/atltransparent.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=17">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css?v=52">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -91,6 +91,7 @@
       <symbol id="icon-graduation" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"/><path d="M22 10v6"/><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"/></symbol>
       <symbol id="icon-arrow-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></symbol>
       <symbol id="icon-chevron-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></symbol>
+      <symbol id="icon-chevron-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></symbol>
       <symbol id="icon-brain" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M9 13h6"/></symbol>
       <symbol id="icon-network" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="9" y="2" width="6" height="6" rx="1"/><path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3"/><path d="M12 12V8"/></symbol>
       <symbol id="icon-timer" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><line x1="10" x2="14" y1="2" y2="2"/><line x1="12" x2="15" y1="14" y2="11"/><circle cx="12" cy="14" r="8"/></symbol>
@@ -103,7 +104,11 @@
       <symbol id="icon-minus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></symbol>
       <symbol id="icon-trophy" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/><path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18"/><path d="M4 22h16"/><path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22"/><path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22"/><path d="M18 2H6v7a6 6 0 0 0 12 0V2Z"/></symbol>
       <symbol id="icon-external-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></symbol>
-    </svg>
+          <symbol id="icon-terminal" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/></symbol>
+      <symbol id="icon-user" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></symbol>
+      <symbol id="icon-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></symbol>
+      <symbol id="icon-check-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></symbol>
+</svg>
     <!-- Header -->
     <header class="header">
         <div class="header-left">
@@ -136,7 +141,7 @@
             <div id="authControls" class="header-account">
                 <span id="authUserLabel" class="auth-user-label" hidden></span>
                 <button id="authSignInBtn" class="auth-btn auth-btn-text" type="button">Sign in</button>
-                <button id="authSignUpBtn" class="auth-btn" type="button">Sign up</button>
+                <button id="authSignUpBtn" class="auth-btn auth-btn-primary" type="button">Sign up</button>
                 <button id="authLogoutBtn" class="auth-btn auth-btn-secondary" type="button" hidden>Log out</button>
             </div>
         </div>
@@ -185,296 +190,261 @@
 
     <!-- Home -->
     <div id="homeView" class="page-view home-view">
-        <div class="home-page">
-            <div class="home-page__inner">
-                <section class="home-hero">
-                    <div class="home-hero-bg" aria-hidden="true"></div>
-                    <div class="home-hero-grid">
-                        <div class="home-hero-left">
-                            <h2 class="home-headline">
+        <div class="home-page home-page--pager">
+            <div class="home-pager-track" id="homePagerTrack" data-page="0">
+                <section class="home-pager-screen" id="homeScreenLanding" aria-label="Welcome">
+                    <div class="home-landing-hero">
+                    <div class="home-landing-hero-grid-bg" aria-hidden="true"></div>
+                    <div class="home-landing-hero-inner">
+                        <div class="home-landing-hero-copy">
+                            <h1 class="home-landing-headline">
                                 Talk to Agents<br>
                                 <span class="home-headline-accent">Test Trading Ideas</span>
-                            </h2>
-                            <div class="hero-agent-network" aria-hidden="true">
-                                <svg viewBox="0 0 720 300" preserveAspectRatio="xMidYMid meet" class="hero-agent-network-svg">
-                                    <defs>
-                                        <radialGradient id="networkGlow" cx="50%" cy="50%" r="50%">
-                                            <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.35"/>
-                                            <stop offset="60%" stop-color="#0284c7" stop-opacity="0.10"/>
-                                            <stop offset="100%" stop-color="#020617" stop-opacity="0"/>
-                                        </radialGradient>
-                                        <linearGradient id="networkLine" x1="0" y1="0" x2="1" y2="1">
-                                            <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.15"/>
-                                            <stop offset="50%" stop-color="#38bdf8" stop-opacity="0.75"/>
-                                            <stop offset="100%" stop-color="#6366f1" stop-opacity="0.18"/>
-                                        </linearGradient>
-                                        <filter id="softGlow" x="-50%" y="-50%" width="200%" height="200%">
-                                            <feGaussianBlur stdDeviation="4" result="blur"/>
-                                            <feMerge>
-                                                <feMergeNode in="blur"/>
-                                                <feMergeNode in="SourceGraphic"/>
-                                            </feMerge>
-                                        </filter>
-                                    </defs>
-                                    <!-- particle field -->
-                                    <g opacity="0.35">
-                                        <circle cx="48" cy="42" r="1.2" fill="#38bdf8"/>
-                                        <circle cx="120" cy="28" r="1" fill="#22d3ee"/>
-                                        <circle cx="210" cy="56" r="1.1" fill="#6366f1"/>
-                                        <circle cx="330" cy="24" r="1" fill="#38bdf8"/>
-                                        <circle cx="520" cy="38" r="1.2" fill="#22d3ee"/>
-                                        <circle cx="640" cy="52" r="1" fill="#6366f1"/>
-                                        <circle cx="680" cy="120" r="1.1" fill="#38bdf8"/>
-                                        <circle cx="60" cy="220" r="1" fill="#22c55e"/>
-                                        <circle cx="180" cy="260" r="1.2" fill="#38bdf8"/>
-                                        <circle cx="590" cy="240" r="1" fill="#6366f1"/>
-                                    </g>
-                                    <!-- arena rings -->
-                                    <ellipse cx="360" cy="155" rx="290" ry="118" fill="none" stroke="rgba(34,211,238,0.07)" stroke-width="1" class="network-ring network-ring--outer"/>
-                                    <ellipse cx="360" cy="155" rx="220" ry="90" fill="none" stroke="rgba(34,211,238,0.11)" stroke-width="1" class="network-ring network-ring--mid"/>
-                                    <ellipse cx="360" cy="155" rx="150" ry="62" fill="none" stroke="rgba(56,189,248,0.14)" stroke-width="1" stroke-dasharray="4 8" class="network-ring network-ring--inner"/>
-                                    <!-- connecting paths -->
-                                    <path d="M360 155 Q280 90 130 72" fill="none" stroke="url(#networkLine)" stroke-width="1.2" opacity="0.7" class="network-path"/>
-                                    <path d="M360 155 Q470 70 590 88" fill="none" stroke="url(#networkLine)" stroke-width="1.2" opacity="0.7" class="network-path"/>
-                                    <path d="M360 155 Q300 220 110 228" fill="none" stroke="url(#networkLine)" stroke-width="1.1" opacity="0.55" class="network-path"/>
-                                    <path d="M360 155 Q430 230 610 218" fill="none" stroke="url(#networkLine)" stroke-width="1.1" opacity="0.55" class="network-path"/>
-                                    <path d="M360 155 Q360 40 360 28" fill="none" stroke="url(#networkLine)" stroke-width="1" opacity="0.45" class="network-path"/>
-                                    <path d="M360 155 Q250 155 190 155" fill="none" stroke="url(#networkLine)" stroke-width="1" opacity="0.4" class="network-path"/>
-                                    <path d="M360 155 Q470 155 530 155" fill="none" stroke="url(#networkLine)" stroke-width="1" opacity="0.4" class="network-path"/>
-                                    <!-- central platform -->
-                                    <ellipse cx="360" cy="158" rx="72" ry="28" fill="url(#networkGlow)" opacity="0.85"/>
-                                    <ellipse cx="360" cy="158" rx="72" ry="28" fill="none" stroke="rgba(34,211,238,0.35)" stroke-width="1.2" filter="url(#softGlow)"/>
-                                    <!-- central ATL node -->
-                                    <circle cx="360" cy="148" r="34" fill="rgba(8,18,40,0.92)" stroke="#22d3ee" stroke-width="2" filter="url(#softGlow)"/>
-                                    <circle cx="360" cy="148" r="44" fill="none" stroke="rgba(34,211,238,0.18)" stroke-width="1" class="network-pulse-ring"/>
-                                    <text x="360" y="154" text-anchor="middle" fill="#22d3ee" font-size="15" font-weight="700" font-family="Inter, sans-serif">ATL</text>
-                                    <!-- surrounding agent nodes -->
-                                    <g class="network-agent-node">
-                                        <circle cx="130" cy="72" r="18" fill="rgba(8,18,40,0.9)" stroke="#22d3ee" stroke-width="1.5"/>
-                                        <circle cx="130" cy="58" r="3" fill="#22c55e" class="network-live-dot"/>
-                                        <circle cx="130" cy="72" r="7" fill="none" stroke="rgba(34,211,238,0.5)" stroke-width="1"/>
-                                    </g>
-                                    <g class="network-agent-node network-agent-node--green">
-                                        <polygon points="590,88 604,98 604,118 576,118 576,98" fill="rgba(8,18,40,0.9)" stroke="#22c55e" stroke-width="1.5"/>
-                                        <circle cx="590" cy="74" r="3" fill="#22c55e" class="network-live-dot"/>
-                                    </g>
-                                    <g class="network-agent-node network-agent-node--purple">
-                                        <circle cx="360" cy="28" r="16" fill="rgba(8,18,40,0.9)" stroke="#6366f1" stroke-width="1.5"/>
-                                        <circle cx="360" cy="14" r="3" fill="#22c55e" class="network-live-dot"/>
-                                    </g>
-                                    <g class="network-agent-node">
-                                        <circle cx="610" cy="218" r="15" fill="rgba(8,18,40,0.9)" stroke="#38bdf8" stroke-width="1.5"/>
-                                    </g>
-                                    <g class="network-agent-node network-agent-node--green">
-                                        <circle cx="110" cy="228" r="14" fill="rgba(8,18,40,0.9)" stroke="#22c55e" stroke-width="1.5"/>
-                                        <circle cx="110" cy="214" r="3" fill="#22c55e" class="network-live-dot"/>
-                                    </g>
-                                    <g class="network-agent-node">
-                                        <circle cx="190" cy="155" r="12" fill="rgba(8,18,40,0.88)" stroke="rgba(56,189,248,0.45)" stroke-width="1.2"/>
-                                    </g>
-                                    <g class="network-agent-node">
-                                        <circle cx="530" cy="155" r="12" fill="rgba(8,18,40,0.88)" stroke="rgba(56,189,248,0.45)" stroke-width="1.2"/>
-                                        <circle cx="530" cy="141" r="2.5" fill="#22c55e" class="network-live-dot"/>
-                                    </g>
-                                    <g class="network-agent-node network-agent-node--purple">
-                                        <circle cx="680" cy="120" r="11" fill="rgba(8,18,40,0.88)" stroke="#5865f2" stroke-width="1.2"/>
-                                    </g>
-                                </svg>
+                            </h1>
+                            <div class="home-landing-ctas">
+                                <button id="homeGetStartedBtn" class="home-btn home-btn-primary home-landing-cta" type="button">Get Started</button>
+                                <a class="home-btn home-btn-secondary home-landing-cta" href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">Join Discord Community</a>
                             </div>
-                            <div class="home-platform-metrics">
-                                <div class="home-platform-metric">
-                                    <span class="home-platform-metric-icon"><svg class="ui-icon"><use href="#icon-users"/></svg></span>
-                                    <div class="home-platform-metric-copy">
-                                        <span id="homeMetricAgents" class="home-platform-metric-value tabular-nums">28</span>
-                                        <span class="home-platform-metric-label">Agents Online <span class="home-live-dot" aria-hidden="true"></span></span>
-                                    </div>
+                        </div>
+                        <div class="home-landing-playground" aria-label="Agent playground preview">
+                            <div class="home-playground-window">
+                                <div class="home-playground-titlebar">
+                                    <span class="home-playground-dot home-playground-dot--red" aria-hidden="true"></span>
+                                    <span class="home-playground-dot home-playground-dot--yellow" aria-hidden="true"></span>
+                                    <span class="home-playground-dot home-playground-dot--green" aria-hidden="true"></span>
+                                    <span class="home-playground-title">
+                                        <svg class="ui-icon ui-icon--inline" aria-hidden="true"><use href="#icon-terminal"/></svg>
+                                        agent-playground.exe
+                                    </span>
                                 </div>
-                                <div class="home-platform-metric">
-                                    <span class="home-platform-metric-icon"><svg class="ui-icon"><use href="#icon-brain"/></svg></span>
-                                    <div class="home-platform-metric-copy">
-                                        <span id="homeMetricDecisions" class="home-platform-metric-value tabular-nums">147</span>
-                                        <span class="home-platform-metric-label">Decisions Today</span>
+                                <div id="homePlaygroundChat" class="home-playground-chat" data-step="0">
+                                    <div class="home-chat-row home-chat-row--user home-chat-step" data-step="0">
+                                        <div class="home-chat-avatar home-chat-avatar--user" aria-hidden="true">
+                                            <svg class="ui-icon ui-icon--inline"><use href="#icon-user"/></svg>
+                                        </div>
+                                        <div class="home-chat-bubble home-chat-bubble--user">
+                                            I want to follow Warren Buffett. If Berkshire makes a move, copy the move and tell me how it goes.
+                                        </div>
                                     </div>
-                                </div>
-                                <div class="home-platform-metric">
-                                    <span class="home-platform-metric-icon"><svg class="ui-icon"><use href="#icon-chart"/></svg></span>
-                                    <div class="home-platform-metric-copy">
-                                        <span id="homeMetricTrades" class="home-platform-metric-value tabular-nums">36</span>
-                                        <span class="home-platform-metric-label">Trades Today</span>
+                                    <div class="home-chat-row home-chat-row--agent home-chat-step" data-step="1" hidden>
+                                        <div class="home-chat-avatar" aria-hidden="true">
+                                            <svg class="ui-icon ui-icon--inline"><use href="#icon-bot"/></svg>
+                                        </div>
+                                        <div class="home-chat-bubble home-chat-bubble--agent">
+                                            <div class="home-chat-agent-line">
+                                                <svg class="ui-icon ui-icon--inline home-chat-icon-accent"><use href="#icon-search"/></svg>
+                                                <span>Fetching Berkshire Hathaway 13F filings...</span>
+                                            </div>
+                                            <ul class="home-chat-checklist">
+                                                <li><svg class="ui-icon ui-icon--inline home-chat-check"><use href="#icon-check-circle"/></svg><span>Q1 2025 → +$OXY +$SIRI −$PARA</span></li>
+                                                <li><svg class="ui-icon ui-icon--inline home-chat-check"><use href="#icon-check-circle"/></svg><span>Q4 2024 → +$OXY +$VZ −$HP</span></li>
+                                                <li><svg class="ui-icon ui-icon--inline home-chat-check"><use href="#icon-check-circle"/></svg><span>Copy-trade rules set · 6 tickers tracked</span></li>
+                                            </ul>
+                                        </div>
                                     </div>
-                                </div>
-                                <div class="home-platform-metric">
-                                    <span class="home-platform-metric-icon"><svg class="ui-icon"><use href="#icon-flask"/></svg></span>
-                                    <div class="home-platform-metric-copy">
-                                        <span id="homeMetricBacktests" class="home-platform-metric-value tabular-nums">12</span>
-                                        <span class="home-platform-metric-label">Backtests Running</span>
+                                    <div class="home-chat-row home-chat-row--agent home-chat-step" data-step="2" hidden>
+                                        <div class="home-chat-avatar" aria-hidden="true">
+                                            <svg class="ui-icon ui-icon--inline"><use href="#icon-bot"/></svg>
+                                        </div>
+                                        <div class="home-chat-bubble home-chat-bubble--agent">
+                                            <div class="home-chat-agent-line">
+                                                <svg class="ui-icon ui-icon--inline home-chat-icon-accent"><use href="#icon-chart"/></svg>
+                                                <span>Running backtest · 24 months, $10k start...</span>
+                                            </div>
+                                            <div class="home-chat-agent-line home-chat-agent-line--muted">
+                                                <svg class="ui-icon ui-icon--inline"><use href="#icon-check-circle"/></svg>
+                                                <span>22 trades · avg hold 63 days</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="home-chat-row home-chat-row--agent home-chat-step" data-step="3" hidden>
+                                        <div class="home-chat-avatar" aria-hidden="true">
+                                            <svg class="ui-icon ui-icon--inline"><use href="#icon-bot"/></svg>
+                                        </div>
+                                        <div class="home-chat-bubble home-chat-bubble--agent">
+                                            <div class="home-chat-agent-line home-chat-agent-line--positive">
+                                                <svg class="ui-icon ui-icon--inline"><use href="#icon-chart"/></svg>
+                                                <strong>Backtest Complete</strong>
+                                            </div>
+                                            <svg class="home-chat-equity" viewBox="0 0 240 50" preserveAspectRatio="none" aria-hidden="true">
+                                                <defs>
+                                                    <linearGradient id="homeHeroEquityFill" x1="0" y1="0" x2="0" y2="1">
+                                                        <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.35"/>
+                                                        <stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/>
+                                                    </linearGradient>
+                                                </defs>
+                                                <polygon points="0,50 0,42 20,40 40,38 60,34 80,36 100,30 120,28 140,22 160,24 180,16 200,12 220,14 240,8 240,50" fill="url(#homeHeroEquityFill)"/>
+                                                <polyline points="0,42 20,40 40,38 60,34 80,36 100,30 120,28 140,22 160,24 180,16 200,12 220,14 240,8" fill="none" stroke="#22d3ee" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+                                            </svg>
+                                            <div class="home-chat-metrics">
+                                                <div>Return <span class="positive">+41.2%</span></div>
+                                                <div>Sharpe <span>1.31</span></div>
+                                                <div>Win Rate <span>68%</span></div>
+                                                <div>Max DD <span class="negative">-9.4%</span></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="home-chat-row home-chat-row--agent home-chat-step" data-step="4" hidden>
+                                        <div class="home-chat-avatar" aria-hidden="true">
+                                            <svg class="ui-icon ui-icon--inline"><use href="#icon-bot"/></svg>
+                                        </div>
+                                        <div class="home-chat-bubble home-chat-bubble--agent">
+                                            <p class="home-chat-prompt-text">
+                                                Looks solid. Want me to run this in
+                                                <span class="home-headline-accent">paper trading</span>
+                                                and alert you when Berkshire's next 13F drops?
+                                            </p>
+                                            <div class="home-chat-actions">
+                                                <span class="home-chat-action home-chat-action--primary">Yes, start now</span>
+                                                <span class="home-chat-action">Not yet</span>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <aside id="homeSpotlight" class="home-spotlight">
-                            <div class="home-spotlight-header">
-                                <span class="home-live-dot home-live-dot--lg" aria-hidden="true"></span>
-                                <h3 class="home-spotlight-title">Live Agent Spotlight</h3>
-                                <span class="status-badge live">Live</span>
-                            </div>
-                            <div class="home-spotlight-agent">
-                                <span class="icon-shell" aria-hidden="true"><svg class="ui-icon"><use href="#icon-bot"/></svg></span>
-                                <div class="home-spotlight-agent-meta">
-                                    <div class="home-spotlight-agent-row">
-                                        <span class="home-spotlight-agent-name">FinAgent Alpha</span>
-                                        <span class="home-verified" title="Verified agent"><svg class="ui-icon ui-icon--inline"><use href="#icon-badge-check"/></svg></span>
-                                    </div>
-                                    <p class="home-spotlight-strategy">Advanced momentum and risk-aware strategy</p>
-                                    <span class="agent-discord connected">Discord connected</span>
-                                </div>
-                            </div>
-                            <div class="home-spotlight-stats">
-                                <div class="home-spotlight-stat">
-                                    <span class="home-spotlight-stat-label">Portfolio Value</span>
-                                    <span class="home-spotlight-stat-value tabular-nums">$103,240</span>
-                                </div>
-                                <div class="home-spotlight-stat">
-                                    <span class="home-spotlight-stat-label">Return</span>
-                                    <span class="home-spotlight-stat-value positive tabular-nums">+3.24%</span>
-                                    <svg id="homeSpotlightSparkline" class="home-sparkline home-sparkline--inline" viewBox="0 0 40 16" aria-hidden="true"><polyline points="0,14 8,10 16,12 24,6 32,8 40,2" fill="none" stroke="#22c55e" stroke-width="1.5"/></svg>
-                                </div>
-                                <div class="home-spotlight-stat">
-                                    <span class="home-spotlight-stat-label">Season Rank</span>
-                                    <span class="home-spotlight-stat-value tabular-nums">#6</span>
-                                    <span class="home-spotlight-rank-context">Top 2%</span>
-                                </div>
-                            </div>
-                            <div class="home-spotlight-action-block">
-                                <div class="home-spotlight-action-head">
-                                    <span class="home-spotlight-action-label">Latest Action</span>
-                                    <span id="homeSpotlightActionTime" class="home-spotlight-action-time">10:21 AM UTC</span>
-                                </div>
-                                <p id="homeSpotlightActionMain" class="home-spotlight-action-main tabular-nums">
-                                    <span class="home-highlight-positive home-spotlight-action-verb">BUY</span> NVDA at <span id="homeSpotlightPrice">$921.43</span>
-                                </p>
-                                <p id="homeSpotlightRationale" class="home-spotlight-rationale">Momentum strengthened with above-average volume.</p>
-                                <div class="home-spotlight-footer">
-                                    <span class="home-spotlight-footer-label">Last Active</span>
-                                    <span id="homeSpotlightLastActive" class="home-spotlight-footer-value">2 min ago</span>
-                                    <span id="homeSpotlightAction" hidden>BUY NVDA</span>
-                                </div>
-                            </div>
-                        </aside>
+                    </div>
+
+                    <button id="homeScrollHint" class="home-scroll-hint" type="button" aria-label="Scroll to dashboard">
+                        <span class="home-scroll-hint-label">Scroll</span>
+                        <svg class="home-scroll-hint-icon" aria-hidden="true"><use href="#icon-chevron-down"/></svg>
+                    </button>
                     </div>
                 </section>
 
-                <section class="home-dashboard-grid">
-                    <div class="home-dash-card home-dash-card--activity">
-                        <div class="home-dash-card-head">
-                            <h3 class="home-section-title">Live Agent Activity</h3>
-                            <a id="homeActivityViewAll" class="home-link-btn" href="#">View all</a>
-                        </div>
-                        <div id="homeActivityFeed" class="home-timeline"></div>
-                    </div>
-
-                    <div class="home-dash-card home-dash-card--agents">
-                        <div class="home-dash-card-head">
-                            <h3 class="home-section-title">Top Agents</h3>
-                        </div>
-                        <div class="home-leaderboard-wrap">
-                            <table class="home-leaderboard">
-                                <thead>
-                                    <tr>
-                                        <th>Rank</th>
-                                        <th>Agent</th>
-                                        <th>Portfolio</th>
-                                        <th>Return</th>
-                                        <th>Win Rate</th>
-                                        <th>Move</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-                                        <td><span class="home-rank-badge home-rank-badge--1">1</span></td>
-                                        <td><span class="home-agent-cell"><span class="icon-shell icon-shell--xs"><svg class="ui-icon"><use href="#icon-bot"/></svg></span>QuantNova</span></td>
-                                        <td class="tabular-nums">$128,760</td>
-                                        <td class="tabular-nums positive">+7.84%</td>
-                                        <td class="tabular-nums">71.3%</td>
-                                        <td><span class="home-rank-move up"><svg class="ui-icon ui-icon--inline"><use href="#icon-trending-up"/></svg>1</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td><span class="home-rank-badge home-rank-badge--2">2</span></td>
-                                        <td><span class="home-agent-cell"><span class="icon-shell icon-shell--xs"><svg class="ui-icon"><use href="#icon-bot"/></svg></span>MacroMind</span></td>
-                                        <td class="tabular-nums">$112,430</td>
-                                        <td class="tabular-nums positive">+5.91%</td>
-                                        <td class="tabular-nums">68.2%</td>
-                                        <td><span class="home-rank-move up"><svg class="ui-icon ui-icon--inline"><use href="#icon-trending-up"/></svg>2</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td><span class="home-rank-badge home-rank-badge--3">3</span></td>
-                                        <td><span class="home-agent-cell"><span class="icon-shell icon-shell--xs"><svg class="ui-icon"><use href="#icon-bot"/></svg></span>FinAgent Alpha</span></td>
-                                        <td class="tabular-nums">$103,240</td>
-                                        <td class="tabular-nums positive">+3.24%</td>
-                                        <td class="tabular-nums">65.7%</td>
-                                        <td><span class="home-rank-move up"><svg class="ui-icon ui-icon--inline"><use href="#icon-trending-up"/></svg>1</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td>4</td>
-                                        <td><span class="home-agent-cell"><span class="icon-shell icon-shell--xs"><svg class="ui-icon"><use href="#icon-bot"/></svg></span>AlphaWave</span></td>
-                                        <td class="tabular-nums">$98,120</td>
-                                        <td class="tabular-nums positive">+2.71%</td>
-                                        <td class="tabular-nums">63.1%</td>
-                                        <td><span class="home-rank-move down"><svg class="ui-icon ui-icon--inline"><use href="#icon-trending-down"/></svg>1</span></td>
-                                    </tr>
-                                    <tr>
-                                        <td>5</td>
-                                        <td><span class="home-agent-cell"><span class="icon-shell icon-shell--xs"><svg class="ui-icon"><use href="#icon-bot"/></svg></span>ValueSeeker</span></td>
-                                        <td class="tabular-nums">$91,880</td>
-                                        <td class="tabular-nums positive">+1.98%</td>
-                                        <td class="tabular-nums">61.4%</td>
-                                        <td><span class="home-rank-move flat"><svg class="ui-icon ui-icon--inline"><use href="#icon-minus"/></svg></span></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                        <button id="homeViewLeaderboardBtn" class="home-btn home-btn-outline" type="button">View Full Leaderboard</button>
-                    </div>
-
-                    <div class="home-dash-card home-dash-card--season">
-                        <h3 class="home-section-title">Current Season</h3>
-                        <div class="home-season-head">
-                            <div class="home-season-name">SecureFinAI Contest 2026</div>
-                            <span class="status-badge upcoming">Upcoming</span>
-                        </div>
-                        <p class="home-season-window">Sep 1 – Oct 30, 2026</p>
-                        <p class="home-season-days tabular-nums">Registration not open</p>
-                        <div class="home-season-counts">
-                            <div class="home-season-count"><span class="metric-label">Phase</span><span class="metric-value">Preseason</span></div>
-                            <div class="home-season-count"><span class="metric-label">Status</span><span class="metric-value">Upcoming</span></div>
-                        </div>
-                        <div class="home-progress">
-                            <div class="home-progress-labels">
-                                <span class="metric-label">Progress</span>
-                                <span class="home-progress-value tabular-nums">46%</span>
+                <section class="home-pager-screen" id="homeScreenDashboard" aria-label="Dashboard">
+                <div class="home-dashboard-screen-inner">
+                    <div class="home-modules" id="homeModules">
+                        <div class="dashboard-top-grid">
+                        <article class="home-module home-module--portfolio" id="homeModulePortfolio">
+                            <header class="home-module-head">
+                                <h3 class="home-module-title">My Portfolio</h3>
+                                <span class="hm-demo-badge" id="homePortfolioDemoBadge">Demo data</span>
+                            </header>
+                            <div class="hm-port-user">
+                                <div class="home-module-avatar" id="homePortfolioAvatar" aria-hidden="true">G</div>
+                                <div class="hm-port-user-meta">
+                                    <p class="home-module-name" id="homePortfolioName">Guest Account</p>
+                                    <button class="hm-mini-btn hm-mini-btn--ghost" id="homeModulePortfolioBtn" type="button">Sign in</button>
+                                </div>
                             </div>
-                            <div class="home-progress-track"><div class="home-progress-fill" style="width: 46%"></div></div>
-                        </div>
-                        <button id="homeViewCompetitionBtn" class="home-btn home-btn-outline" type="button">View Competition</button>
-                    </div>
-
-                    <div class="home-dash-card home-dash-card--pulse">
-                        <div class="home-dash-card-head">
-                            <div>
-                                <h3 class="home-section-title">Market / Agent Pulse</h3>
-                                <p class="home-dash-subtitle">What agents are discussing</p>
+                            <div class="hm-port-metrics" id="homePortfolioMetrics">
+                                <div class="hm-port-metric hm-port-metric--equity">
+                                    <span class="hm-port-metric-label" id="homePortfolioEquityLabel">Demo Portfolio · Total Equity</span>
+                                    <strong class="hm-port-metric-value tabular-nums" id="homePortfolioEquity">$10,000.00</strong>
+                                </div>
+                                <div class="hm-port-metric hm-port-metric--side">
+                                    <span class="hm-port-metric-label">Today’s P&amp;L</span>
+                                    <strong class="hm-port-metric-value tabular-nums" id="homeMetricPnl">$0.00 <em id="homeMetricPnlPct">(0.00%)</em></strong>
+                                </div>
                             </div>
+                            <div class="hm-port-range" role="tablist" aria-label="Equity range">
+                                <button type="button" class="hm-range-btn is-active" data-port-range="1D">1D</button>
+                                <button type="button" class="hm-range-btn" data-port-range="7D">7D</button>
+                                <button type="button" class="hm-range-btn" data-port-range="1M">1M</button>
+                                <button type="button" class="hm-range-btn" data-port-range="3M">3M</button>
+                                <button type="button" class="hm-range-btn" data-port-range="1Y">1Y</button>
+                                <button type="button" class="hm-range-btn" data-port-range="All">All</button>
+                            </div>
+                            <figure class="hm-port-figure" id="homePortfolioFigure">
+                                <svg id="homePortfolioChart" class="hm-port-chart" viewBox="0 0 360 148" role="img" aria-label="Portfolio equity over time"></svg>
+                                <div class="hm-port-tooltip" id="homePortfolioTooltip" hidden></div>
+                            </figure>
+                            <button class="hm-footer-btn" id="homeModuleViewPortfolioBtn" type="button">View my portfolio</button>
+                        </article>
+
+                        <article class="home-module home-module--agent" id="homeModuleAgent">
+                            <header class="home-module-head">
+                                <h3 class="home-module-title">My Agents</h3>
+                            </header>
+                            <div class="home-module-body" id="homeAgentBody">
+                                <div class="hm-agent-empty" id="homeAgentEmpty">
+                                    <button class="hm-agent-empty-cta" id="homeModuleCreateAgentEmpty" type="button">Create your agent</button>
+                                </div>
+                                <div class="hm-agent-filled" id="homeAgentFilled" hidden></div>
+                            </div>
+                            <button class="hm-footer-btn" id="homeModuleViewAgentsBtn" type="button" hidden>Manage agents</button>
+                        </article>
+
+                        <article class="home-module home-module--ranking" id="homeModuleRanking">
+                            <header class="home-module-head">
+                                <h3 class="home-module-title">Leaderboard</h3>
+                            </header>
+                            <div class="hm-rank-meta">
+                                <span>Backtest window · 2026-04-15 → 2026-05-15</span>
+                                <span>Ranked by cumulative return</span>
+                            </div>
+                            <div class="hm-rank-table-head" aria-hidden="true">
+                                <span>#</span><span>Entry</span><span>Value</span><span>Return</span><span>Sharpe</span>
+                            </div>
+                            <ol class="home-module-rank-list" id="homeModuleRankList">
+                                <li class="home-module-rank-empty">Loading rankings…</li>
+                            </ol>
+                            <button class="hm-footer-btn" id="homeModuleRankingBtn" type="button">Explore leaderboard</button>
+                        </article>
                         </div>
-                        <div class="home-pulse-tabs" role="tablist">
-                            <button class="home-pulse-tab active" type="button" data-pulse-tab="traded" role="tab">Most Traded</button>
-                            <button class="home-pulse-tab" type="button" data-pulse-tab="discussed" role="tab">Most Discussed</button>
-                            <button class="home-pulse-tab" type="button" data-pulse-tab="trending" role="tab">Trending Up</button>
+
+                        <div class="dashboard-bottom-grid">
+                        <article class="home-module home-module--market" id="homeModuleMarket">
+                            <header class="home-module-head hm-market-head">
+                                <div class="hm-market-title-row">
+                                    <h3 class="home-module-title" id="homeModuleMarketTitle">Market News</h3>
+                                    <span class="hm-demo-badge" id="homeMarketDemoBadge" hidden>Demo data</span>
+                                </div>
+                                <div class="hm-tabs" role="tablist" aria-label="Market panels">
+                                    <button type="button" class="hm-tab is-active" data-market-tab="news" role="tab" aria-selected="true">News</button>
+                                    <button type="button" class="hm-tab" data-market-tab="signals" role="tab" aria-selected="false">Signals</button>
+                                </div>
+                                <span class="hm-source-label" id="homeModuleMarketBtn" role="link" tabindex="0">Powered by FinSearch</span>
+                            </header>
+                            <div class="hm-market-grid">
+                                <div class="hm-market-feed" id="homeMarketNewsPane">
+                                    <p class="home-module-market-status" id="homeMarketStatus" hidden></p>
+                                    <ul class="hm-news-list" id="homeModuleNewsList"></ul>
+                                </div>
+                                <div class="hm-market-feed" id="homeMarketSignalsPane" hidden>
+                                    <p class="home-module-market-status" id="homeMarketSignalsStatus" hidden></p>
+                                    <ul class="hm-news-list" id="homeModuleSignalsList"></ul>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="home-module home-module--community" id="homeModuleCommunity">
+                            <header class="home-module-head">
+                                <h3 class="home-module-title">Community Overview</h3>
+                                <div class="hm-community-head-meta">
+                                    <span class="hm-demo-badge" id="homeCommunityDemoBadge">Demo data</span>
+                                    <span class="hm-live-badge"><span class="home-live-dot" aria-hidden="true"></span>Live</span>
+                                </div>
+                            </header>
+                            <div class="hm-community-stats">
+                                <div class="hm-community-stat">
+                                    <span id="homeMetricAgents" class="hm-community-value tabular-nums">28</span>
+                                    <span class="hm-community-label">Active agents</span>
+                                </div>
+                                <div class="hm-community-stat">
+                                    <span id="homeMetricUsers" class="hm-community-value tabular-nums">126</span>
+                                    <span class="hm-community-label">Backtests today</span>
+                                </div>
+                                <div class="hm-community-stat">
+                                    <span id="homeMetricTrades" class="hm-community-value tabular-nums">37</span>
+                                    <span class="hm-community-label">Paper trades today</span>
+                                </div>
+                            </div>
+                            <p class="hm-activity-label">Recent Activity</p>
+                            <ul class="hm-activity-list" id="homeCommunityActivity">
+                                <li><span class="hm-act-dot"></span><span>AlphaWolf published a strategy</span><time class="tabular-nums">5m ago</time></li>
+                                <li><span class="hm-act-dot"></span><span>QuantNova completed a backtest</span><time class="tabular-nums">18m ago</time></li>
+                                <li><span class="hm-act-dot"></span><span>Momentum Scout moved to #3</span><time class="tabular-nums">31m ago</time></li>
+                            </ul>
+                            <button class="hm-footer-btn" id="homeModuleCommunityBtn" type="button">Join the Discord community</button>
+                        </article>
                         </div>
-                        <div id="homeMarketPulseList" class="home-pulse-list"></div>
-                        <button id="homeViewMarketPulseBtn" class="home-btn home-btn-outline" type="button">View Market Pulse</button>
                     </div>
+                </div>
                 </section>
 
+                <div class="home-pager-hidden" hidden>
                 <section class="home-news-signals" id="homeNewsSignals" aria-label="News and signals">
                     <div class="home-section-title-row">
                         <h2 class="home-section-title">News &amp; Signals <span class="nns-source-tag">via Agentic FinSearch</span></h2>
@@ -554,24 +524,7 @@
                         </a>
                     </div>
                 </section>
-            </div>
-        </div>
-    </div>
-
-    <div id="homeLiveToast" class="home-live-toast" hidden role="status" aria-live="polite">
-        <button id="homeLiveToastClose" class="home-live-toast-close" type="button" aria-label="Dismiss">
-            <svg class="ui-icon"><use href="#icon-x"/></svg>
-        </button>
-        <div class="home-live-toast-head">
-            <span class="home-live-dot" aria-hidden="true"></span>
-            <span class="home-live-toast-label">NEW DECISION · 2m ago</span>
-        </div>
-        <div class="home-live-toast-body">
-            <span class="home-live-toast-icon" aria-hidden="true"><svg class="ui-icon"><use href="#icon-bot"/></svg></span>
-            <div class="home-live-toast-content">
-                <p class="home-live-toast-agent">FinAgent Alpha</p>
-                <p class="home-live-toast-action tabular-nums">BUY NVDA at $921.43</p>
-                <p class="home-live-toast-rationale">"Momentum strengthened with above-average volume."</p>
+                </div>
             </div>
         </div>
     </div>
@@ -778,6 +731,7 @@
                                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
                             </button>
                         </div>
+                        <button id="addAgentBtnToolbar" class="home-btn home-btn-primary agent-toolbar-add" type="button">Add Agent +</button>
                     </div>
                 </div>
                 <div id="agentsGrid" class="agents-grid"></div>
@@ -1495,9 +1449,9 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=2"></script>
     <script src="js/agent-editor.js?v=7"></script>
-    <script src="app.js?v=12"></script>
+    <script src="app.js?v=19"></script>
     <script src="js/leaderboard.js?v=11"></script>
-    <script src="home-page.js"></script>
+    <script src="home-page.js?v=30"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),
          both loaded above — not beside the market-events/* block, which loads

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -173,26 +173,46 @@ function decorateAgent(agent) {
 
 const MOCK_AGENTS = [
   {
+    agent_id: 'mock-momentum-scout', name: 'Momentum Scout', agent_type: 'builtin',
+    model_name: 'GPT-5.5', is_live: true, cash_allocation: 10000,
+    paper_equity: 12480.32, paper_day_pnl: 184.2, paper_day_pnl_pct: 1.5,
+    paper_buying_power: 4820, paper_open_positions: 6,
+    paper_last_activity: 'Bought 4 NVDA · 18 min ago',
+    paper_updated_at: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+    run_count: 2, latest_run: { total_return: 0.084, start_date: '2026-06-01', end_date: '2026-06-30', initial_equity: 10000, final_equity: 10842.5 },
+    total_input_tokens: 41000, total_output_tokens: 21500, total_est_cost_usd: 0.085, runs: [],
+  },
+  {
     agent_id: 'mock-test-agent-2', name: 'test agent 2', agent_type: 'builtin',
-    model_name: 'anthropic/claude-haiku-4-5', run_count: 1,
-    latest_run: { total_return: 0.065, sharpe_ratio: 2.67 },
+    model_name: 'anthropic/claude-haiku-4-5', run_count: 1, cash_allocation: 10000,
+    latest_run: {
+      total_return: 0.08425, sharpe_ratio: 2.67,
+      start_date: '2026-06-01', end_date: '2026-06-30',
+      initial_equity: 10000, final_equity: 10842.5,
+      created_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    },
     total_input_tokens: 41000, total_output_tokens: 21500, total_est_cost_usd: 0.085, runs: [],
   },
   {
     agent_id: 'mock-test-agent', name: 'test agent', agent_type: 'builtin', is_active: true,
     model_name: 'anthropic/claude-haiku-4-5', run_count: 1,
-    latest_run: { total_return: -0.004, sharpe_ratio: -16.84 },
+    latest_run: { total_return: -0.004, sharpe_ratio: -16.84, start_date: '2026-05-01', end_date: '2026-05-31', initial_equity: 10000, final_equity: 9960 },
     total_input_tokens: 30000, total_output_tokens: 17500, total_est_cost_usd: 0.064, runs: [],
   },
   {
+    agent_id: 'mock-draft-alpha', name: 'Alpha Draft', agent_type: 'builtin',
+    model_name: 'anthropic/claude-haiku-4-5', run_count: 0, cash_allocation: 1000,
+    latest_run: {}, total_input_tokens: 0, total_output_tokens: 0, runs: [],
+  },
+  {
     agent_id: 'mock-test', name: 'test', agent_type: 'external',
-    model_name: 'local-model', run_count: 0,
+    model_name: 'local-model', run_count: 0, cash_allocation: 1000,
     latest_run: {}, total_input_tokens: 0, total_output_tokens: 0, runs: [],
   },
   {
     agent_id: 'mock-sdk-1', name: 'sdk-selftest-agent', agent_type: 'external',
     model_name: 'rule-based', run_count: 1,
-    latest_run: { total_return: 0.02, sharpe_ratio: 4.25 },
+    latest_run: { total_return: 0.02, sharpe_ratio: 4.25, start_date: '2026-06-01', end_date: '2026-06-30', initial_equity: 10000, final_equity: 10200 },
     total_input_tokens: 44800, total_output_tokens: 20000, total_est_cost_usd: 0.0, runs: [],
   },
   {
@@ -230,15 +250,359 @@ const MOCK_AGENTS = [
 // Holds the most recently loaded agents so the toolbar can re-filter without refetching.
 let allAgents = [];
 let agentViewMode = 'grid';
+
+/** @returns {{ key: 'paper'|'backtested'|'draft', label: string, className: string }} */
 function resolveAgentStatusBadge(agent) {
-  if (agent.is_live === true || agent.deployment_status === 'live') {
-    return { label: 'Live', className: 'live' };
+  const deployment = String(agent.deployment_status || '').toLowerCase();
+  if (
+    agent.is_live === true ||
+    deployment === 'live' ||
+    deployment === 'paper'
+  ) {
+    return { key: 'paper', label: 'PAPER TRADING', className: 'paper' };
   }
   const runCount = Number(agent.run_count) || (Array.isArray(agent.runs) ? agent.runs.length : 0);
-  if (runCount > 0) {
-    return { label: 'Backtested', className: 'backtested' };
+  if (runCount > 0 || agent.latest_run?.run_id || agent.latest_run?.total_return != null) {
+    return { key: 'backtested', label: 'IDLE', className: 'idle' };
   }
-  return { label: 'Draft', className: 'draft' };
+  return { key: 'draft', label: 'DRAFT', className: 'draft' };
+}
+
+function formatAgentMoney(value, { cents = true } = {}) {
+  if (value == null || value === '' || !Number.isFinite(Number(value))) return '—';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: cents ? 2 : 0,
+    maximumFractionDigits: cents ? 2 : 0,
+  }).format(Number(value));
+}
+
+function formatSignedMoney(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return '—';
+  const body = formatAgentMoney(Math.abs(n));
+  if (n > 0) return `+${body}`;
+  if (n < 0) return `−${body}`;
+  return body;
+}
+
+function formatRelativeTime(iso) {
+  if (!iso) return '';
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return '';
+  const mins = Math.round((Date.now() - t) / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function formatShortDateRange(start, end) {
+  const fmt = (raw, withYear = false) => {
+    if (!raw) return '';
+    const dt = new Date(raw);
+    if (Number.isNaN(dt.getTime())) {
+      const s = String(raw);
+      return s.length >= 10 ? s.slice(5, 10) : s;
+    }
+    return dt.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      ...(withYear ? { year: 'numeric' } : {}),
+    });
+  };
+  const a = fmt(start);
+  const b = fmt(end, true);
+  if (a && b) return `${a} — ${b}`;
+  return a || b || '—';
+}
+
+function agentRunCount(agent) {
+  return Number(agent.run_count) || (Array.isArray(agent.runs) ? agent.runs.length : 0);
+}
+
+function renderAgentRunsLink(agent) {
+  const count = agentRunCount(agent);
+  const label = `${count} backtest${count === 1 ? '' : 's'}`;
+  return `
+    <button class="agent-card-runs-link agent-view-runs-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">
+      <span class="agent-card-runs-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 19V5"/><path d="M4 19h16"/><path d="M7 15l3-3 3 2 5-6"/></svg>
+      </span>
+      <span>${escapeHtml(label)}</span>
+      <span class="agent-card-runs-chevron" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>
+      </span>
+    </button>`;
+}
+
+function hashStringSeed(str) {
+  let h = 0;
+  const s = String(str || '');
+  for (let i = 0; i < s.length; i += 1) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return Math.abs(h) || 1;
+}
+
+function renderAgentSparkline(seed, positive = true) {
+  const color = positive ? '#4ade80' : '#ff6b6b';
+  const fillId = `agSpark-${hashStringSeed(seed)}`;
+  const n = 8;
+  const pts = [];
+  let v = 0.35 + (hashStringSeed(seed) % 30) / 100;
+  for (let i = 0; i < n; i += 1) {
+    const wobble = ((hashStringSeed(`${seed}:${i}`) % 17) - 8) / 40;
+    v = Math.max(0.08, Math.min(0.92, v + wobble + (positive ? 0.04 : -0.03)));
+    pts.push([ (i / (n - 1)) * 80, 36 - v * 32 ]);
+  }
+  const line = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' ');
+  const area = `${line} L80,36 L0,36 Z`;
+  return `
+    <svg class="agent-card-sparkline" viewBox="0 0 80 36" width="80" height="36" aria-hidden="true">
+      <defs>
+        <linearGradient id="${fillId}" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="${color}" stop-opacity="0.35"/>
+          <stop offset="100%" stop-color="${color}" stop-opacity="0"/>
+        </linearGradient>
+      </defs>
+      <path d="${area}" fill="url(#${fillId})"/>
+      <path d="${line}" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>`;
+}
+
+function agentTypeLabel(agent) {
+  return agent.agent_type === 'builtin' ? 'Built-in' : 'External';
+}
+
+/** Human-readable model label from provider paths like anthropic/claude-haiku-4-5. */
+function formatAgentModelLabel(modelName) {
+  const raw = String(modelName || '').trim();
+  if (!raw) return 'Local model';
+  const known = {
+    'anthropic/claude-haiku-4-5': 'Claude Haiku 4.5',
+    'anthropic/claude-sonnet-4-6': 'Claude Sonnet 4.6',
+    'claude-haiku-4.5': 'Claude Haiku 4.5',
+    'claude-sonnet-4.6': 'Claude Sonnet 4.6',
+    'gpt-5.5': 'GPT-5.5',
+    'openai/gpt-5.5': 'GPT-5.5',
+    'local-model': 'Local model',
+    'rule-based': 'Rule-based',
+    'rule-based-demo': 'Rule-based',
+  };
+  if (known[raw]) return known[raw];
+  try {
+    const escaped = (typeof CSS !== 'undefined' && CSS.escape) ? CSS.escape(raw) : raw.replace(/"/g, '\\"');
+    const option = document.querySelector(`option[value="${escaped}"]`);
+    if (option?.textContent?.trim() && option.textContent.trim() !== raw) {
+      return option.textContent.trim();
+    }
+  } catch (_) { /* ignore selector errors */ }
+  let label = raw.includes('/') ? raw.split('/').pop() : raw;
+  label = label.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  label = label.replace(/\b(\d)\s+(\d)\b/g, '$1.$2');
+  return label;
+}
+
+function agentRobotIcon() {
+  return `<span class="agent-card-icon" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="5" y="9" width="14" height="10" rx="3"/>
+      <path d="M12 5v4"/><circle cx="12" cy="4" r="1"/>
+      <circle cx="9" cy="14" r="1.1" fill="currentColor" stroke="none"/>
+      <circle cx="15" cy="14" r="1.1" fill="currentColor" stroke="none"/>
+    </svg>
+  </span>`;
+}
+
+function resolvePaperCardMetrics(agent) {
+  const cash = Number(agent.cash_allocation);
+  const fallback = Number.isFinite(cash) ? cash : 10000;
+  const equity = Number(agent.paper_equity ?? agent.paper_portfolio_value);
+  const hasLive = Number.isFinite(equity);
+  const dayPnl = Number(agent.paper_day_pnl);
+  const dayPnlPct = Number(agent.paper_day_pnl_pct);
+  const buyingPower = Number(agent.paper_buying_power);
+  const openPositions = Number(agent.paper_open_positions);
+  return {
+    equity: hasLive ? equity : fallback,
+    dayPnl: Number.isFinite(dayPnl) ? dayPnl : null,
+    dayPnlPct: Number.isFinite(dayPnlPct) ? dayPnlPct : null,
+    buyingPower: Number.isFinite(buyingPower) ? buyingPower : fallback,
+    openPositions: Number.isFinite(openPositions) ? openPositions : 0,
+    lastActivity: agent.paper_last_activity || null,
+    updatedAt: agent.paper_updated_at || null,
+    hasLive,
+  };
+}
+
+function resolveBacktestCardMetrics(agent) {
+  const run = agent.latest_run || (Array.isArray(agent.runs) && agent.runs[0]) || null;
+  const cash = Number(agent.cash_allocation);
+  const initial = Number(run?.initial_equity);
+  const startEquity = Number.isFinite(initial)
+    ? initial
+    : Number.isFinite(cash)
+      ? cash
+      : 10000;
+  const final = Number(run?.final_equity);
+  let ending = Number.isFinite(final) ? final : null;
+  const retRaw = Number(run?.total_return);
+  const retFrac = Number.isFinite(retRaw)
+    ? Math.abs(retRaw) <= 1
+      ? retRaw
+      : retRaw / 100
+    : null;
+  if (ending == null && retFrac != null) ending = startEquity * (1 + retFrac);
+  if (ending == null) ending = startEquity;
+  const pnl = ending - startEquity;
+  return {
+    ending,
+    pnl,
+    positive: pnl >= 0,
+    period: formatShortDateRange(run?.start_date, run?.end_date),
+    universe: run?.universe || run?.index || 'DJIA',
+    createdAt: run?.created_at || null,
+    runId: run?.run_id || null,
+  };
+}
+
+function renderAgentCardBody(agent, statusKey) {
+  if (statusKey === 'paper') {
+    const m = resolvePaperCardMetrics(agent);
+    const positive = m.dayPnl == null ? true : m.dayPnl >= 0;
+    let changeHtml = '';
+    if (m.dayPnl != null) {
+      const pct =
+        m.dayPnlPct != null
+          ? ` (${m.dayPnlPct >= 0 ? '+' : ''}${m.dayPnlPct.toFixed(2)}%)`
+          : '';
+      changeHtml = `<p class="agent-card-change ${positive ? 'is-pos' : 'is-neg'}">${escapeHtml(formatSignedMoney(m.dayPnl))}${escapeHtml(pct)} today</p>`;
+    } else if (!m.hasLive) {
+      changeHtml = `<p class="agent-card-change is-muted">Allocated capital · paper session not live yet</p>`;
+    }
+    const activity = m.lastActivity
+      ? escapeHtml(m.lastActivity)
+      : m.hasLive
+        ? 'Paper trading active'
+        : 'Ready for paper trading';
+    const updated = m.updatedAt
+      ? `Updated ${formatRelativeTime(m.updatedAt)}`
+      : '';
+    return `
+      <div class="agent-card-hero">
+        <div class="agent-card-hero-text">
+          <div class="agent-card-metric-head">
+            <span class="agent-card-mode-chip">PAPER</span>
+            <span class="agent-card-metric-label">Portfolio Value</span>
+          </div>
+          <p class="agent-card-metric-value">${escapeHtml(formatAgentMoney(m.equity))}</p>
+          ${changeHtml}
+        </div>
+        ${renderAgentSparkline(agent.agent_id || agent.name, positive)}
+      </div>
+      <div class="agent-card-divider"></div>
+      <div class="agent-card-stats">
+        <div class="agent-card-stat">
+          <span class="agent-card-stat-label">Buying Power</span>
+          <span class="agent-card-stat-value">${escapeHtml(formatAgentMoney(m.buyingPower, { cents: false }))}</span>
+        </div>
+        <div class="agent-card-stat">
+          <span class="agent-card-stat-label">Open Positions</span>
+          <span class="agent-card-stat-value">${escapeHtml(String(m.openPositions))}</span>
+        </div>
+      </div>
+      ${renderAgentRunsLink(agent)}
+      <div class="agent-card-divider"></div>
+      <div class="agent-card-activity">
+        <span class="agent-card-activity-icon agent-card-activity-icon--buy" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="9" cy="20" r="1"/><circle cx="17" cy="20" r="1"/><path d="M3 4h2l2.4 11.2a2 2 0 0 0 2 1.6h7.4a2 2 0 0 0 2-1.5L21 8H7"/></svg>
+        </span>
+        <div class="agent-card-activity-text">
+          <span>${activity}</span>
+          ${updated ? `<span class="agent-card-activity-sub">${escapeHtml(updated)}</span>` : ''}
+        </div>
+      </div>`;
+  }
+
+  if (statusKey === 'backtested') {
+    const m = resolveBacktestCardMetrics(agent);
+    const runCount = agentRunCount(agent);
+    const runLabel = runCount > 0 ? `Completed backtest #${runCount}` : 'Completed a backtest';
+    return `
+      <div class="agent-card-hero">
+        <div class="agent-card-hero-text">
+          <div class="agent-card-metric-head">
+            <span class="agent-card-mode-chip agent-card-mode-chip--backtest">BACKTEST</span>
+            <span class="agent-card-metric-label">Ending Value</span>
+          </div>
+          <p class="agent-card-metric-value">${escapeHtml(formatAgentMoney(m.ending))}</p>
+          <p class="agent-card-change ${m.positive ? 'is-pos' : 'is-neg'}">${escapeHtml(formatSignedMoney(m.pnl))} during latest run</p>
+        </div>
+        ${renderAgentSparkline(agent.agent_id || agent.name, m.positive)}
+      </div>
+      <p class="agent-card-period">${escapeHtml(m.period)}</p>
+      <div class="agent-card-divider"></div>
+      ${renderAgentRunsLink(agent)}
+      <div class="agent-card-divider"></div>
+      <div class="agent-card-activity">
+        <span class="agent-card-activity-icon agent-card-activity-icon--done" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="m8.5 12.5 2.5 2.5 4.5-5"/></svg>
+        </span>
+        <div class="agent-card-activity-text">
+          <span>${escapeHtml(runLabel)}</span>
+        </div>
+      </div>`;
+  }
+
+  const capital =
+    agent.cash_allocation != null
+      ? formatAgentCashAllocation(agent.cash_allocation)
+      : '$1,000';
+  return `
+    <div class="agent-card-hero agent-card-hero--draft">
+      <div class="agent-card-hero-text">
+        <span class="agent-card-metric-label">Allocated Capital</span>
+        <p class="agent-card-metric-value">${escapeHtml(capital)}</p>
+      </div>
+    </div>
+    <div class="agent-card-empty">
+      <span class="agent-card-empty-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 16l4-4 3 3 5-6 4 4"/><path d="M4 20h16"/></svg>
+      </span>
+      <strong>No backtest runs yet</strong>
+      <span>Run a backtest to evaluate this agent.</span>
+    </div>`;
+}
+
+function renderAgentCardActions(agent, statusKey) {
+  const id = escapeHtml(agent.agent_id);
+  let primary = '';
+  if (statusKey === 'paper') {
+    primary = `<button class="agent-card-cta agent-open-btn" type="button" data-agent-id="${id}">Open Agent</button>`;
+  } else if (statusKey === 'backtested') {
+    primary = `<button class="agent-card-cta agent-card-cta--outline agent-view-runs-btn" type="button" data-agent-id="${id}">View All Runs</button>`;
+  } else {
+    primary = `<button class="agent-card-cta agent-run-backtest-btn" type="button" data-agent-id="${id}">Run Backtest</button>`;
+  }
+  const rotate =
+    agent.agent_type === 'builtin'
+      ? ''
+      : `<button class="agent-menu-item agent-rotate-key-btn" type="button" data-agent-id="${id}">New API key</button>`;
+  return `
+    <div class="agent-card-actions agent-card-actions--status">
+      ${primary}
+      <div class="agent-card-menu">
+        <button class="agent-menu-toggle" type="button" aria-label="More actions" aria-expanded="false" data-agent-id="${id}">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="6" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="18" cy="12" r="1.6"/></svg>
+        </button>
+        <div class="agent-menu-dropdown" hidden>
+          <button class="agent-menu-item agent-edit-btn" type="button" data-agent-id="${id}">Edit</button>
+          ${rotate}
+          <button class="agent-menu-item agent-menu-item--danger agent-delete-btn" type="button" data-agent-id="${id}">Delete</button>
+        </div>
+      </div>
+    </div>`;
 }
 
 // Demo/mock agents (MOCK_AGENTS) have no database row, so renames made in the editor
@@ -344,6 +708,43 @@ function renderAgentsError() {
   if (errorEl) errorEl.hidden = false;
 }
 
+async function openAgentInBacktest(agent, runId = null) {
+  if (!agent) return;
+  await activateAgent(agent);
+  if (runId) localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, runId);
+  navigateToPage('playground', { playgroundTab: 'backtest' });
+  currentMode = 'backtest';
+  await loadData();
+}
+
+async function openAgentInPaper(agent) {
+  if (!agent) return;
+  await activateAgent(agent);
+  navigateToPage('playground', { playgroundTab: 'paper' });
+  currentMode = 'paper';
+  await loadData();
+}
+
+function bindAgentCardMenus(grid) {
+  grid.querySelectorAll('.agent-menu-toggle').forEach((btn) => {
+    btn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const menu = btn.closest('.agent-card-menu');
+      const dropdown = menu?.querySelector('.agent-menu-dropdown');
+      if (!dropdown) return;
+      const willOpen = dropdown.hidden;
+      grid.querySelectorAll('.agent-menu-dropdown').forEach((el) => {
+        el.hidden = true;
+      });
+      grid.querySelectorAll('.agent-menu-toggle').forEach((el) => {
+        el.setAttribute('aria-expanded', 'false');
+      });
+      dropdown.hidden = !willOpen;
+      btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+    });
+  });
+}
+
 function renderAgentsGrid(agents) {
   const grid = document.getElementById('agentsGrid');
   const empty = document.getElementById('agentsEmptyState');
@@ -362,45 +763,28 @@ function renderAgentsGrid(agents) {
     const isBuiltin = agent.agent_type === 'builtin';
     const statusBadge = resolveAgentStatusBadge(agent);
     const card = document.createElement('div');
-    card.className = `section-card agent-card agent-card--compact${isBuiltin ? ' agent-card-builtin' : ''}`;
-
-    const typeBadge = isBuiltin
-      ? '<span class="status-badge builtin">Built-in</span>'
-      : '<span class="agent-discord connected">External agent</span>';
-
-    const apiKeyButton = isBuiltin
-      ? ''
-      : `<button class="agent-action-btn agent-action-secondary agent-rotate-key-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">New API key</button>`;
-
-    const cashBadge = agent.cash_allocation != null
-      ? `<span class="agent-cash-allocation" title="Starting capital budget for this agent">Initial cash: ${formatAgentCashAllocation(agent.cash_allocation)}</span>`
-      : '';
+    card.className = `section-card agent-card agent-card--status agent-card--${statusBadge.key}${isBuiltin ? ' agent-card-builtin' : ''}`;
+    const model = escapeHtml(agent.model_name || 'local-model');
+    const type = escapeHtml(agentTypeLabel(agent));
 
     card.innerHTML = `
-      <div class="agent-card-head">
-        <h3 class="agent-name">${escapeHtml(agent.name)}</h3>
-        <span class="status-badge ${statusBadge.className}">${statusBadge.label}</span>
+      <div class="agent-card-top">
+        <div class="agent-card-identity">
+          ${agentRobotIcon()}
+          <div class="agent-card-identity-text">
+            <h3 class="agent-name">${escapeHtml(agent.name)}</h3>
+            <p class="agent-card-submeta">${model} · ${type}</p>
+          </div>
+        </div>
+        <span class="status-badge ${statusBadge.className}"><span class="status-badge-dot" aria-hidden="true"></span>${statusBadge.label}</span>
       </div>
-      <div class="agent-meta">
-        <span>${escapeHtml(agent.model_name || 'local-model')}</span>
-        ${typeBadge}
-        ${cashBadge}
-      </div>
-      ${isBuiltin && agent.description ? `<p class="agent-description">${escapeHtml(agent.description)}</p>` : ''}
-      <div class="agent-meta">
-        <span>${agent.run_count || 0} backtest run(s)</span>
-        ${renderAgentTokenCost(agent)}
-      </div>
-      ${renderAgentRunList(agent)}
-      <div class="agent-card-actions">
-        <button class="agent-action-btn agent-edit-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">Edit</button>
-        <button class="agent-action-btn agent-select-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">View in Playground</button>
-        ${apiKeyButton}
-        <button class="agent-action-btn agent-delete-btn" type="button" data-agent-id="${escapeHtml(agent.agent_id)}">Delete</button>
-      </div>
+      ${renderAgentCardBody(agent, statusBadge.key)}
+      ${renderAgentCardActions(agent, statusBadge.key)}
     `;
     grid.appendChild(card);
   });
+
+  bindAgentCardMenus(grid);
 
   grid.querySelectorAll('.agent-edit-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
@@ -412,27 +796,26 @@ function renderAgentsGrid(agents) {
     });
   });
 
-  grid.querySelectorAll('.agent-select-btn').forEach((btn) => {
+  grid.querySelectorAll('.agent-open-btn').forEach((btn) => {
     btn.addEventListener('click', async () => {
       const agent = agents.find((a) => a.agent_id === btn.dataset.agentId);
-      if (!agent) return;
-      await activateAgent(agent);
-      navigateToPage('playground', { playgroundTab: 'backtest' });
-      currentMode = 'backtest';
-      await loadData();
+      await openAgentInPaper(agent);
     });
   });
 
-  grid.querySelectorAll('.agent-run-link').forEach((btn) => {
+  grid.querySelectorAll('.agent-view-runs-btn').forEach((btn) => {
     btn.addEventListener('click', async () => {
       const agent = agents.find((a) => a.agent_id === btn.dataset.agentId);
-      const runId = btn.dataset.runId;
-      if (!agent || !runId) return;
-      await activateAgent(agent);
-      localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, runId);
-      navigateToPage('playground', { playgroundTab: 'backtest' });
-      currentMode = 'backtest';
-      await loadData();
+      if (!agent) return;
+      const runId = resolveBacktestCardMetrics(agent).runId;
+      await openAgentInBacktest(agent, runId);
+    });
+  });
+
+  grid.querySelectorAll('.agent-run-backtest-btn').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const agent = agents.find((a) => a.agent_id === btn.dataset.agentId);
+      await openAgentInBacktest(agent);
     });
   });
 
@@ -480,6 +863,16 @@ function renderAgentsGrid(agents) {
     });
   });
 }
+
+document.addEventListener('click', (event) => {
+  if (event.target.closest?.('.agent-card-menu')) return;
+  document.querySelectorAll('#agentsGrid .agent-menu-dropdown').forEach((el) => {
+    el.hidden = true;
+  });
+  document.querySelectorAll('#agentsGrid .agent-menu-toggle').forEach((el) => {
+    el.setAttribute('aria-expanded', 'false');
+  });
+});
 
 function escapeHtml(value) {
   return String(value ?? '')
@@ -629,6 +1022,9 @@ async function loadAgents() {
     if (typeof window.updateAgentAllocationFromAgents === 'function') {
       window.updateAgentAllocationFromAgents(allAgents.map(decorateAgent));
     }
+    if (typeof window.refreshHomeModules === 'function') {
+      window.refreshHomeModules();
+    }
   } catch (error) {
     console.warn('Failed to load agents:', error.message);
     if (isDemoMode()) {
@@ -640,6 +1036,9 @@ async function loadAgents() {
       allAgents = [];
       renderAgentsError();
       populateBacktestAgentSelect();
+    }
+    if (typeof window.refreshHomeModules === 'function') {
+      window.refreshHomeModules();
     }
   }
 }
@@ -1107,6 +1506,9 @@ function updateAuthUI() {
     logoutBtn.hidden = true;
   }
 
+  if (typeof window.refreshHomeModules === 'function') {
+    window.refreshHomeModules();
+  }
 }
 
 function setAuthMode(mode) {
@@ -1392,6 +1794,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Initialize session FIRST (before any API calls)
     initSession();
     initAuthUI();
+    await restoreActiveAgentSession();
+    // Load agents before home modules render so the dashboard My Agents card
+    // is not empty on first paint (previously only loaded on My Agents tab).
+    try {
+        await loadAgents();
+    } catch (error) {
+        console.warn('Initial loadAgents failed:', error.message);
+    }
     applyInitialNavigation();
     window.addEventListener('agent-editor-saved', async (event) => {
         const agent = event.detail?.agent;
@@ -1419,7 +1829,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         currentMode = 'backtest';
         await loadData();
     });
-    await restoreActiveAgentSession();
     await applyAgentRunDeepLink();
     const config = loadConfigFromURL();
     window.CURRENT_CONFIG = config;
@@ -2919,9 +3328,8 @@ function persistNavigation() {
 function clearNavBootState() {
     const html = document.documentElement;
     html.removeAttribute('data-nav-boot');
-    html.removeAttribute('data-nav-page');
-    html.removeAttribute('data-nav-playground-tab');
-    html.removeAttribute('data-nav-competition-tab');
+    // Keep data-nav-page / tab attrs as the live navigation signal (home snap
+    // scroll and other page-scoped CSS depend on them after boot).
 }
 
 function applyInitialNavigation() {
@@ -3120,6 +3528,11 @@ function navigateToPage(page, options = {}) {
     if (options.playgroundTab) playgroundTab = options.playgroundTab;
     if (options.competitionTab) competitionTab = options.competitionTab;
 
+    const html = document.documentElement;
+    html.setAttribute('data-nav-page', page);
+    html.setAttribute('data-nav-playground-tab', playgroundTab);
+    html.setAttribute('data-nav-competition-tab', competitionTab);
+
     document.querySelectorAll('.primary-nav .mode-btn').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.mode === page);
     });
@@ -3257,6 +3670,7 @@ function initNavigation() {
     document.getElementById('agentViewList')?.addEventListener('click', () => setAgentViewMode('list'));
 
     document.getElementById('addAgentBtn')?.addEventListener('click', openAddAgentModal);
+    document.getElementById('addAgentBtnToolbar')?.addEventListener('click', openAddAgentModal);
     document.getElementById('addAgentModalClose')?.addEventListener('click', closeAddAgentModal);
     document.getElementById('addAgentModalBackdrop')?.addEventListener('click', closeAddAgentModal);
     document.getElementById('connectExternalAgentBtn')?.addEventListener('click', openCreateExternalAgentModal);

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -151,7 +151,7 @@ let homeMockIndex = 0;
 let homeToastTimer = null;
 let homeActivePulseTab = 'traded';
 let homeFeedHovered = false;
-let homeMetricValues = { agents: 28, decisions: 147, trades: 36, backtests: 12 };
+let homeMetricValues = { agents: 28, decisions: 147, trades: 37, backtests: 126 };
 let homeEvents = [];
 let homeLatestEvent = null;
 
@@ -493,40 +493,11 @@ function renderMarketPulseTab(tab) {
 }
 
 function hideLiveToast() {
-    const toast = document.getElementById('homeLiveToast');
-    if (!toast) return;
-    toast.classList.remove('home-live-toast--visible');
-    window.clearTimeout(homeToastTimer);
-    homeToastTimer = window.setTimeout(() => {
-        toast.hidden = true;
-    }, 280);
+    // Live toast removed from Home.
 }
 
-function showLiveToast(toastData) {
-    const toast = document.getElementById('homeLiveToast');
-    if (!toast) return;
-
-    toast.className = `home-live-toast home-live-toast--${toastData.tone || 'cyan'}`;
-
-    const label = toast.querySelector('.home-live-toast-label');
-    const agent = toast.querySelector('.home-live-toast-agent');
-    const action = toast.querySelector('.home-live-toast-action');
-    const rationale = toast.querySelector('.home-live-toast-rationale');
-    const iconUse = toast.querySelector('.home-live-toast-icon use');
-
-    if (label) label.textContent = `${toastData.label} · ${toastData.time}`;
-    if (agent) agent.textContent = toastData.agent;
-    if (action) action.textContent = toastData.action;
-    if (rationale) {
-        rationale.textContent = toastData.rationale ? `"${toastData.rationale}"` : '';
-        rationale.hidden = !toastData.rationale;
-    }
-    if (iconUse && toastData.icon) iconUse.setAttribute('href', `#${toastData.icon}`);
-
-    toast.hidden = false;
-    requestAnimationFrame(() => toast.classList.add('home-live-toast--visible'));
-    window.clearTimeout(homeToastTimer);
-    homeToastTimer = window.setTimeout(hideLiveToast, 6000);
+function showLiveToast(_toastData) {
+    // Live toast removed from Home.
 }
 
 function pushMockEvent(event) {
@@ -621,15 +592,1023 @@ function navigateToLeaderboard() {
     }
 }
 
+function initLandingPlaygroundChat() {
+    const root = document.getElementById('homePlaygroundChat');
+    if (!root || root.dataset.simStarted === '1') return;
+    root.dataset.simStarted = '1';
+
+    const steps = Array.from(root.querySelectorAll('.home-chat-step'));
+    let step = 0;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function revealThrough(n) {
+        steps.forEach((el) => {
+            const s = Number(el.dataset.step || 0);
+            if (s <= n) el.hidden = false;
+        });
+        root.dataset.step = String(n);
+        // Keep latest agent bubble in view as steps advance.
+        const latest = steps.find((el) => Number(el.dataset.step || 0) === n);
+        if (latest && typeof latest.scrollIntoView === 'function') {
+            latest.scrollIntoView({ block: 'nearest', behavior: reduceMotion ? 'auto' : 'smooth' });
+        }
+    }
+
+    if (reduceMotion) {
+        revealThrough(4);
+        return;
+    }
+
+    revealThrough(0);
+    const timer = setInterval(() => {
+        step += 1;
+        revealThrough(step);
+        if (step >= 4) clearInterval(timer);
+    }, 2200);
+}
+
+function initHomeGetStarted() {
+    document.getElementById('homeGetStartedBtn')?.addEventListener('click', () => {
+        if (typeof navigateToPage === 'function') {
+            navigateToPage('playground', { playgroundTab: 'agents' });
+            return;
+        }
+        document.getElementById('homeLiveSection')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+}
+
+function measureAppChromeHeight() {
+    const header = document.querySelector('.header');
+    const ticker = document.querySelector('.ticker-bar');
+    const tickerInfo = document.querySelector('.ticker-info');
+    let h = 0;
+    if (header) h += header.getBoundingClientRect().height;
+    if (ticker) h += ticker.getBoundingClientRect().height;
+    if (tickerInfo) h += tickerInfo.getBoundingClientRect().height;
+    // homeView starts after these siblings; include a small safety gap
+    const measured = Math.max(120, Math.round(h));
+    document.documentElement.style.setProperty('--app-chrome-height', `${measured}px`);
+    return measured;
+}
+
+function setHomePagerPage(page) {
+    const track = document.getElementById('homePagerTrack');
+    const hint = document.getElementById('homeScrollHint');
+    if (!track) return;
+    const next = page === 1 ? 1 : 0;
+    track.dataset.page = String(next);
+    if (hint) hint.classList.toggle('is-hidden', next === 1);
+    if (next === 1) {
+        const hasAgents = typeof allAgents !== 'undefined' && Array.isArray(allAgents) && allAgents.length > 0;
+        if (!hasAgents && typeof loadAgents === 'function') {
+            Promise.resolve(loadAgents()).catch(() => {
+                refreshHomeModules();
+            });
+        } else {
+            refreshHomeModules();
+        }
+    }
+}
+
+function homeEscape(value) {
+    if (typeof escapeHtml === 'function') return escapeHtml(value);
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function homeSafeUrl(raw) {
+    const s = String(raw == null ? '' : raw).trim();
+    return /^https?:\/\//i.test(s) ? s : '#';
+}
+
+function homeInitials(name) {
+    const parts = String(name || '').trim().split(/\s+/).filter(Boolean);
+    if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return '?';
+}
+
+function homeFormatMoney(value, digits = 0) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return digits ? '$10,000.00' : '$10,000';
+    return `$${n.toLocaleString('en-US', {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+    })}`;
+}
+
+function homeFormatReturnPct(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return '—';
+    const pct = n * 100;
+    const sign = pct > 0 ? '+' : '';
+    return `${sign}${pct.toFixed(2)}%`;
+}
+
+function homeSparkPolyline(values, width = 52, height = 18) {
+    const nums = (values || []).map(Number).filter(Number.isFinite);
+    if (nums.length < 2) {
+        return `0,${height / 2} ${width},${height / 2}`;
+    }
+    const min = Math.min(...nums);
+    const max = Math.max(...nums);
+    const span = max - min || 1;
+    return nums.map((v, i) => {
+        const x = (i / (nums.length - 1)) * width;
+        const y = height - ((v - min) / span) * (height - 2) - 1;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+}
+
+function getHomeAuthUser() {
+    if (typeof getStoredAuthUser === 'function') return getStoredAuthUser();
+    return window.AUTH_USER || null;
+}
+
+function isHomeSignedIn() {
+    const token = localStorage.getItem(typeof AUTH_TOKEN_KEY === 'string' ? AUTH_TOKEN_KEY : 'auth-token');
+    return !!(token && getHomeAuthUser());
+}
+
+function openHomeCreateAgent() {
+    if (!isHomeSignedIn()) {
+        if (typeof openAuthModal === 'function') openAuthModal('signup');
+        return;
+    }
+    if (typeof navigateToPage === 'function') {
+        navigateToPage('playground', { playgroundTab: 'agents' });
+    }
+    if (typeof openAddAgentModal === 'function') openAddAgentModal();
+}
+
+/** Demo / placeholder portfolio used by the home module until live broker data is wired. */
+const HOME_PORTFOLIO = {
+    equity: 10000,
+    dayPnl: 0,
+    alloc: { cash: 6200, stocks: 2800, crypto: 1000 },
+};
+
+let homePortRange = '1D';
+let homePortChartState = null;
+
+function homePortRangeMeta(range) {
+    switch (range) {
+        case '7D': return { points: 8, xLabels: ['6d', '4d', '2d', 'Now'] };
+        case '1M': return { points: 13, xLabels: ['4w', '3w', '2w', '1w', 'Now'] };
+        case '3M': return { points: 14, xLabels: ['3m', '2m', '1m', 'Now'] };
+        case '1Y': return { points: 13, xLabels: ['12m', '9m', '6m', '3m', 'Now'] };
+        case 'All': return { points: 13, xLabels: ['Start', 'Mid', 'Now'] };
+        case '1D':
+        default: return { points: 13, xLabels: ['9:30', '12:00', '15:00', 'Now'] };
+    }
+}
+
+function homePortTimestamps(range, count) {
+    const now = Date.now();
+    const labels = [];
+    if (range === '1D') {
+        // Regular session 09:30 → 16:00
+        const start = new Date();
+        start.setHours(9, 30, 0, 0);
+        const end = new Date();
+        end.setHours(16, 0, 0, 0);
+        for (let i = 0; i < count; i += 1) {
+            const t = start.getTime() + ((end.getTime() - start.getTime()) * i) / (count - 1);
+            labels.push(new Date(t));
+        }
+        return labels;
+    }
+    const spans = {
+        '7D': 7 * 86400000,
+        '1M': 30 * 86400000,
+        '3M': 90 * 86400000,
+        '1Y': 365 * 86400000,
+        All: 365 * 86400000,
+    };
+    const span = spans[range] || spans['7D'];
+    for (let i = 0; i < count; i += 1) {
+        labels.push(new Date(now - span + (span * i) / (count - 1)));
+    }
+    return labels;
+}
+
+function homePortSeries(equity, dayPnl, range) {
+    const { points, xLabels } = homePortRangeMeta(range);
+    const end = Number(equity) || 10000;
+    const pnl = Number(dayPnl) || 0;
+    const values = [];
+    const times = homePortTimestamps(range, points);
+
+    // When there is no real change, keep an intentional flat series — do not invent drift.
+    if (Math.abs(pnl) < 1e-9) {
+        for (let i = 0; i < points; i += 1) values.push(end);
+    } else if (range === '1D') {
+        const start = end - pnl;
+        for (let i = 0; i < points; i += 1) {
+            const t = i / (points - 1);
+            values.push(start + (end - start) * t);
+        }
+    } else {
+        const start = end - pnl;
+        for (let i = 0; i < points; i += 1) {
+            const t = i / (points - 1);
+            values.push(start + (end - start) * t);
+        }
+        values[values.length - 1] = end;
+    }
+
+    const isFlat = values.every((v) => Math.abs(v - values[0]) < 1e-6);
+    return { values, xLabels, times, startValue: values[0], endValue: values[values.length - 1], isFlat };
+}
+
+function homeNiceStep(rough) {
+    const abs = Math.max(Math.abs(rough), 1e-9);
+    const exp = Math.floor(Math.log10(abs));
+    const mag = 10 ** exp;
+    const norm = abs / mag;
+    let nice;
+    if (norm <= 1) nice = 1;
+    else if (norm <= 2) nice = 2;
+    else if (norm <= 5) nice = 5;
+    else nice = 10;
+    return nice * mag;
+}
+
+/** Three adaptive Y ticks; domain is not forced through zero. Not used for flat charts. */
+function homeAdaptiveYScale(values) {
+    const dataMin = Math.min(...values);
+    const dataMax = Math.max(...values);
+    const mid = (dataMin + dataMax) / 2;
+    const rawSpan = Math.max(dataMax - dataMin, 1e-9);
+    let half = Math.max(rawSpan * 0.7, rawSpan / 2 + 25);
+    let lo = mid - half;
+    let hi = mid + half;
+    lo = Math.min(lo, dataMin);
+    hi = Math.max(hi, dataMax);
+
+    const step = homeNiceStep((hi - lo) / 2);
+    let midTick = Math.round(mid / step) * step;
+    let top = midTick + step;
+    let bot = midTick - step;
+    while (dataMax > top) top += step;
+    while (dataMin < bot) bot -= step;
+    if (top === bot) {
+        top = midTick + step;
+        bot = midTick - step;
+    }
+    return { min: bot, max: top, ticks: [top, midTick, bot] };
+}
+
+function homeFormatAxisMoney(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return '—';
+    const rounded = Math.round(n);
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+    }).format(rounded);
+}
+
+function homeFormatExactMoney(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return '—';
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    }).format(n);
+}
+
+function homeFormatSignedMoney(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return '—';
+    const body = homeFormatExactMoney(Math.abs(n));
+    if (n > 0) return `+${body}`;
+    if (n < 0) return `−${body}`;
+    return body;
+}
+
+function homeFormatHoverTime(date, range) {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '—';
+    if (range === '1D') {
+        return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    }
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function bindHomePortfolioChartHover() {
+    const figure = document.getElementById('homePortfolioFigure');
+    const svg = document.getElementById('homePortfolioChart');
+    const tip = document.getElementById('homePortfolioTooltip');
+    if (!figure || !svg || !tip || figure.dataset.hoverBound === '1') return;
+    figure.dataset.hoverBound = '1';
+
+    const hide = () => {
+        tip.hidden = true;
+        const cross = svg.querySelector('.hm-port-crosshair');
+        const focus = svg.querySelector('.hm-port-focus');
+        if (cross) cross.setAttribute('opacity', '0');
+        if (focus) focus.setAttribute('opacity', '0');
+    };
+
+    figure.addEventListener('mouseleave', hide);
+    figure.addEventListener('mousemove', (event) => {
+        const state = homePortChartState;
+        if (!state?.pts?.length) return;
+        const rect = svg.getBoundingClientRect();
+        const xSvg = ((event.clientX - rect.left) / rect.width) * state.W;
+        let best = 0;
+        let bestDist = Infinity;
+        state.pts.forEach((p, i) => {
+            const d = Math.abs(p[0] - xSvg);
+            if (d < bestDist) {
+                bestDist = d;
+                best = i;
+            }
+        });
+        const pt = state.pts[best];
+        const value = state.values[best];
+        const start = state.startValue;
+        const chg = value - start;
+        const chgClass = chg > 0.005 ? 'is-pos' : chg < -0.005 ? 'is-neg' : 'is-flat';
+        tip.innerHTML = `
+          <span>${homeEscape(homeFormatHoverTime(state.times[best], state.range))}</span>
+          <strong>${homeEscape(homeFormatExactMoney(value))}</strong>
+          <span class="hm-port-tip-chg ${chgClass}">${homeEscape(homeFormatSignedMoney(chg))} vs period start</span>
+        `;
+        tip.hidden = false;
+        const tipX = (pt[0] / state.W) * rect.width;
+        const tipY = (pt[1] / state.H) * rect.height;
+        tip.style.left = `${tipX}px`;
+        tip.style.top = `${tipY}px`;
+
+        const cross = svg.querySelector('.hm-port-crosshair');
+        const focus = svg.querySelector('.hm-port-focus');
+        if (cross) {
+            cross.setAttribute('x1', pt[0].toFixed(1));
+            cross.setAttribute('x2', pt[0].toFixed(1));
+            cross.setAttribute('opacity', '1');
+        }
+        if (focus) {
+            focus.setAttribute('cx', pt[0].toFixed(1));
+            focus.setAttribute('cy', pt[1].toFixed(1));
+            focus.setAttribute('opacity', '1');
+        }
+    });
+}
+
+function renderHomePortfolioChart(equity = HOME_PORTFOLIO.equity, dayPnl = HOME_PORTFOLIO.dayPnl, range = homePortRange) {
+    const svg = document.getElementById('homePortfolioChart');
+    const tip = document.getElementById('homePortfolioTooltip');
+    if (!svg) return;
+    if (tip) tip.hidden = true;
+
+    const series = homePortSeries(equity, dayPnl, range);
+    const { values, xLabels, times, startValue, isFlat } = series;
+    const W = 360;
+    const H = 148;
+
+    // Flat charts reclaim Y-axis width; varied charts keep a compact left gutter.
+    const pad = isFlat
+        ? { top: 14, right: 12, bottom: 24, left: 12 }
+        : { top: 12, right: 12, bottom: 24, left: 46 };
+    const plotW = W - pad.left - pad.right;
+    const plotH = H - pad.top - pad.bottom;
+
+    let minV;
+    let maxV;
+    let yTicks = [];
+    if (isFlat) {
+        // Keep a tiny visual band so the flat line sits mid-plot without fake ticks.
+        minV = values[0] - 1;
+        maxV = values[0] + 1;
+    } else {
+        const scale = homeAdaptiveYScale(values);
+        minV = scale.min;
+        maxV = scale.max;
+        yTicks = scale.ticks;
+    }
+
+    const xAt = (i) => pad.left + (i / Math.max(values.length - 1, 1)) * plotW;
+    const yAt = (v) => pad.top + ((maxV - v) / (maxV - minV || 1)) * plotH;
+    const pts = values.map((v, i) => [xAt(i), yAt(v)]);
+    const line = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' ');
+
+    const xTickIdx = xLabels.map((_, i) => {
+        if (xLabels.length === 1) return 0;
+        return Math.round((i / (xLabels.length - 1)) * (values.length - 1));
+    });
+    const xAxis = xLabels.map((label, i) => {
+        const x = xAt(xTickIdx[i]);
+        return `<text x="${x.toFixed(1)}" y="${H - 6}" text-anchor="middle" fill="rgba(148,163,184,0.65)" font-size="9" font-family="ui-sans-serif, system-ui, sans-serif">${label}</text>`;
+    }).join('');
+
+    let plotBody = '';
+    const area = `${line} L${pts[pts.length - 1][0].toFixed(1)},${(pad.top + plotH).toFixed(1)} L${pts[0][0].toFixed(1)},${(pad.top + plotH).toFixed(1)} Z`;
+    const endPt = pts[pts.length - 1];
+    if (isFlat) {
+        // Flat: cyan line + restrained area fill, no Y-axis labels, no endpoint label.
+        plotBody = `
+          <defs>
+            <linearGradient id="hmPortFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="rgba(34,211,238,0.28)"/>
+              <stop offset="100%" stop-color="rgba(34,211,238,0)"/>
+            </linearGradient>
+          </defs>
+          <path d="${area}" fill="url(#hmPortFill)"/>
+          <path d="${line}" fill="none" stroke="#22d3ee" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <line class="hm-port-crosshair" x1="${pts[0][0]}" y1="${pad.top}" x2="${pts[0][0]}" y2="${pad.top + plotH}" stroke="rgba(34,211,238,0.35)" stroke-width="1" stroke-dasharray="3 3" opacity="0"/>
+          <circle class="hm-port-focus" cx="${pts[0][0]}" cy="${pts[0][1]}" r="3.2" fill="#22d3ee" opacity="0"/>
+        `;
+    } else {
+        const yGrid = yTicks.map((v) => {
+            const y = yAt(v);
+            return `
+              <line x1="${pad.left}" y1="${y.toFixed(1)}" x2="${W - pad.right}" y2="${y.toFixed(1)}" stroke="rgba(148,163,184,0.12)" stroke-width="1"/>
+              <text x="${pad.left - 7}" y="${(y + 3).toFixed(1)}" text-anchor="end" fill="rgba(148,163,184,0.7)" font-size="9" font-family="ui-sans-serif, system-ui, sans-serif">${homeFormatAxisMoney(v)}</text>`;
+        }).join('');
+        plotBody = `
+          <defs>
+            <linearGradient id="hmPortFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="rgba(34,211,238,0.28)"/>
+              <stop offset="100%" stop-color="rgba(34,211,238,0)"/>
+            </linearGradient>
+          </defs>
+          ${yGrid}
+          <path d="${area}" fill="url(#hmPortFill)"/>
+          <path d="${line}" fill="none" stroke="#22d3ee" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <line class="hm-port-crosshair" x1="${endPt[0]}" y1="${pad.top}" x2="${endPt[0]}" y2="${pad.top + plotH}" stroke="rgba(34,211,238,0.35)" stroke-width="1" stroke-dasharray="3 3" opacity="0"/>
+          <circle class="hm-port-focus" cx="${endPt[0]}" cy="${endPt[1]}" r="3.4" fill="#22d3ee" opacity="0"/>
+          <circle cx="${endPt[0].toFixed(1)}" cy="${endPt[1].toFixed(1)}" r="2.6" fill="#22d3ee"/>
+        `;
+    }
+
+    svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+    svg.innerHTML = `
+      <line x1="${pad.left}" y1="${pad.top + plotH}" x2="${W - pad.right}" y2="${pad.top + plotH}" stroke="rgba(148,163,184,0.22)" stroke-width="1"/>
+      ${plotBody}
+      ${xAxis}
+    `;
+
+    homePortChartState = {
+        W, H, pad, pts, values, times, startValue, range, plotH, isFlat,
+    };
+    bindHomePortfolioChartHover();
+}
+
+function syncHomePortfolioAlloc(equity = HOME_PORTFOLIO.equity) {
+    const total = Number(equity) || HOME_PORTFOLIO.equity;
+    const cash = Math.round(total * 0.62);
+    const stocks = Math.round(total * 0.28);
+    const crypto = Math.max(0, Math.round(total - cash - stocks));
+    return { cash, stocks, crypto, invested: stocks + crypto };
+}
+
+function updateHomePortfolioModule() {
+    const user = getHomeAuthUser();
+    const signedIn = isHomeSignedIn();
+    const avatar = document.getElementById('homePortfolioAvatar');
+    const nameEl = document.getElementById('homePortfolioName');
+    const equityEl = document.getElementById('homePortfolioEquity');
+    const labelEl = document.getElementById('homePortfolioEquityLabel');
+    const btn = document.getElementById('homeModulePortfolioBtn');
+    const pnl = document.getElementById('homeMetricPnl');
+    const demoBadge = document.getElementById('homePortfolioDemoBadge');
+
+    const equity = HOME_PORTFOLIO.equity;
+    const dayPnl = HOME_PORTFOLIO.dayPnl;
+    const dayPct = equity ? (dayPnl / equity) * 100 : 0;
+    syncHomePortfolioAlloc(equity);
+
+    if (!signedIn || !user) {
+        if (avatar) avatar.textContent = 'G';
+        if (nameEl) nameEl.textContent = 'Guest Account';
+        if (labelEl) labelEl.textContent = 'Demo Portfolio · Total Equity';
+        if (btn) {
+            btn.hidden = false;
+            btn.textContent = 'Sign in';
+        }
+        if (demoBadge) demoBadge.hidden = false;
+    } else {
+        const label = user.display_name || user.email || 'Trader';
+        if (avatar) avatar.textContent = homeInitials(label);
+        if (nameEl) nameEl.textContent = label;
+        if (labelEl) labelEl.textContent = 'Total Equity';
+        if (btn) btn.hidden = true;
+        if (demoBadge) demoBadge.hidden = true;
+    }
+
+    if (equityEl) equityEl.textContent = homeFormatMoney(equity, 2);
+    if (pnl) {
+        const pctText = `(${dayPct === 0 ? '0.00' : `${dayPct > 0 ? '+' : ''}${dayPct.toFixed(2)}`}%)`;
+        pnl.innerHTML = `${homeEscape(homeFormatMoney(dayPnl, 2))} <em id="homeMetricPnlPct">${homeEscape(pctText)}</em>`;
+    }
+    renderHomePortfolioChart(equity, dayPnl, homePortRange);
+}
+
+function renderHomeAgentStatusCard(agent) {
+    const status = (typeof resolveAgentStatusBadge === 'function')
+        ? resolveAgentStatusBadge(agent)
+        : { key: 'draft', label: 'DRAFT', className: 'draft' };
+    const esc = (typeof escapeHtml === 'function') ? escapeHtml : (v) => String(v ?? '');
+    const modelLabel = (typeof formatAgentModelLabel === 'function')
+        ? formatAgentModelLabel(agent.model_name)
+        : (agent.model_name || 'local-model');
+    const type = (typeof agentTypeLabel === 'function')
+        ? agentTypeLabel(agent)
+        : (agent.agent_type === 'builtin' ? 'Built-in' : 'External');
+    const icon = (typeof agentRobotIcon === 'function')
+        ? agentRobotIcon()
+        : '';
+    const body = (typeof renderAgentCardBody === 'function')
+        ? renderAgentCardBody(agent, status.key)
+        : '';
+
+    return `
+      <div class="agent-card agent-card--status agent-card--home agent-card--${status.key}">
+        <div class="agent-card-top">
+          <div class="agent-card-identity">
+            ${icon}
+            <div class="agent-card-identity-text">
+              <h3 class="agent-name">${esc(agent.name || 'Untitled agent')}</h3>
+              <p class="agent-card-submeta">${esc(modelLabel)} · ${esc(type)}</p>
+            </div>
+          </div>
+          <span class="status-badge ${status.className}"><span class="status-badge-dot" aria-hidden="true"></span>${status.label}</span>
+        </div>
+        ${body}
+      </div>`;
+}
+
+function updateHomeAgentModule() {
+    const empty = document.getElementById('homeAgentEmpty');
+    const filled = document.getElementById('homeAgentFilled');
+    const viewBtn = document.getElementById('homeModuleViewAgentsBtn');
+
+    const agents = (typeof allAgents !== 'undefined' && Array.isArray(allAgents))
+        ? allAgents.filter((a) => a?.agent_id && !(typeof isDemoAgent === 'function' && isDemoAgent(a.agent_id)))
+        : [];
+    const activeId = localStorage.getItem('active-agent-id');
+    const agent = agents.find((a) => a.agent_id === activeId) || agents[0] || null;
+
+    if (!agent) {
+        if (empty) empty.hidden = false;
+        if (filled) {
+            filled.hidden = true;
+            filled.innerHTML = '';
+        }
+        if (viewBtn) viewBtn.hidden = true;
+        return;
+    }
+
+    if (empty) empty.hidden = true;
+    if (viewBtn) viewBtn.hidden = false;
+    if (!filled) return;
+    filled.hidden = false;
+    filled.innerHTML = renderHomeAgentStatusCard(agent);
+
+    filled.querySelectorAll('.agent-view-runs-btn').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+            if (typeof openAgentInBacktest === 'function') {
+                const runId = typeof resolveBacktestCardMetrics === 'function'
+                    ? resolveBacktestCardMetrics(agent).runId
+                    : null;
+                await openAgentInBacktest(agent, runId);
+                return;
+            }
+            if (typeof navigateToPage === 'function') {
+                navigateToPage('playground', { playgroundTab: 'backtest' });
+            }
+        });
+    });
+}
+
+async function loadHomeLeaderboardModule() {
+    const list = document.getElementById('homeModuleRankList');
+    if (!list) return;
+
+    const HOME_MOCK_LEADERBOARD = [
+        { rank: 1, model: 'DeepSeek V4 Pro', cumulative_return: 0.0749, sharpe_ratio: 5.01, portfolio_value: 107490 },
+        { rank: 2, model: 'SPY', cumulative_return: 0.0595, sharpe_ratio: 1.27, portfolio_value: 105950 },
+        { rank: 3, model: 'Equal-Weight', cumulative_return: 0.0504, sharpe_ratio: 1.11, portfolio_value: 105040 },
+        { rank: 4, model: 'Buy & Hold', cumulative_return: 0.0487, sharpe_ratio: 0.98, portfolio_value: 104870 },
+        { rank: 5, model: 'Qwen3.7 Plus', cumulative_return: 0.0249, sharpe_ratio: 0.72, portfolio_value: 102490 },
+    ];
+
+    function homeEntryType(entry) {
+        const badge = String(entry.team_badge || entry.entry_type || entry.kind || '').toLowerCase();
+        const label = String(entry.model || entry.team_name || '').toLowerCase();
+        if (badge.includes('index') || ['spy', 'qqq', 'dia', 'vix', 'djia'].includes(label)) return 'index';
+        if (badge.includes('baseline') || label.includes('equal') || label.includes('buy') || label.includes('hold') || label.includes('mean')) {
+            return 'baseline';
+        }
+        if (entry.is_baseline === true) return 'baseline';
+        return 'model';
+    }
+
+    function homeFormatPortfolioValue(value) {
+        const n = Number(value);
+        if (!Number.isFinite(n)) return '—';
+        if (n >= 1000) {
+            return `$${Math.round(n).toLocaleString('en-US')}`;
+        }
+        return homeFormatMoney(n, 0);
+    }
+
+    function renderEntries(entries) {
+        list.innerHTML = entries.map((entry) => {
+            const rank = Number(entry.rank) || 0;
+            const rankClass = rank >= 1 && rank <= 3 ? ` home-module-rank--${rank}` : '';
+            const label = entry.model || entry.team_name || '—';
+            const ret = Number(entry.cumulative_return || 0);
+            const retClass = ret >= 0 ? 'positive' : 'negative';
+            const sharpe = Number(entry.sharpe_ratio || 0);
+            const type = homeEntryType(entry);
+            const typeLabel = type === 'index' ? 'INDEX' : type === 'baseline' ? 'BASELINE' : 'MODEL';
+            const value = homeFormatPortfolioValue(entry.portfolio_value);
+            return `<li>
+                <span class="home-module-rank${rankClass}">${homeEscape(rank || '—')}</span>
+                <span class="hm-rank-entry">
+                    <span class="home-module-rank-name">${homeEscape(label)}</span>
+                    <span class="hm-type-badge hm-type-badge--${type}">${typeLabel}</span>
+                </span>
+                <span class="hm-rank-value tabular-nums">${homeEscape(value)}</span>
+                <span class="hm-rank-ret ${retClass} tabular-nums">${homeEscape(homeFormatReturnPct(ret))}</span>
+                <span class="hm-rank-sharpe tabular-nums">${homeEscape(sharpe.toFixed(2))}</span>
+            </li>`;
+        }).join('');
+    }
+
+    try {
+        if (typeof API === 'undefined' || typeof API_BASE === 'undefined') {
+            renderEntries(HOME_MOCK_LEADERBOARD);
+            return;
+        }
+        const payload = await API.get(`${API_BASE}/api/v1/leaderboard?t=${Date.now()}`);
+        const entries = (payload.entries || [])
+            .slice()
+            .sort((a, b) => (Number(a.rank) || 999) - (Number(b.rank) || 999));
+
+        if (!entries.length) {
+            renderEntries(HOME_MOCK_LEADERBOARD);
+            return;
+        }
+        renderEntries(entries);
+    } catch (error) {
+        console.warn('Home leaderboard module failed:', error.message);
+        renderEntries(HOME_MOCK_LEADERBOARD);
+    }
+}
+
+function homeSentimentClass(raw) {
+    const s = String(raw || '').toLowerCase();
+    if (s.includes('bull')) return 'bullish';
+    if (s.includes('bear')) return 'bearish';
+    return 'neutral';
+}
+
+function homeRelTime(publishedEpochSeconds) {
+    if (window.formatMarketEventRelativeTime) {
+        return window.formatMarketEventRelativeTime(publishedEpochSeconds * 1000, new Date());
+    }
+    return '';
+}
+
+const HOME_MOCK_NEWS = {
+    status: 'ok',
+    _mock: true,
+    feed: [
+        {
+            ticker: 'AAPL', category: 'Earnings', sentiment: 'bullish', source: 'FinSearch',
+            headline: 'Apple beats expectations as services revenue climbs again',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 12 * 60,
+        },
+        {
+            ticker: 'NVDA', category: 'Markets', sentiment: 'bullish', source: 'FinSearch',
+            headline: 'Nvidia demand remains firm as AI capex cycle extends',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 28 * 60,
+        },
+        {
+            ticker: 'SPY', category: 'Economy', sentiment: 'neutral', source: 'FinSearch',
+            headline: 'Fed speakers lean cautious ahead of next policy decision',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 46 * 60,
+        },
+        {
+            ticker: 'TSLA', category: 'Markets', sentiment: 'bearish', source: 'FinSearch',
+            headline: 'Tesla wobbles as delivery outlook stays uncertain',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 71 * 60,
+        },
+        {
+            ticker: 'MSFT', category: 'Markets', sentiment: 'bullish', source: 'FinSearch',
+            headline: 'Microsoft cloud growth steadies enterprise spending outlook',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 95 * 60,
+        },
+        {
+            ticker: 'AMZN', category: 'Earnings', sentiment: 'bullish', source: 'FinSearch',
+            headline: 'Amazon ads and AWS margins keep profit momentum intact',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 110 * 60,
+        },
+        {
+            ticker: 'JPM', category: 'Economy', sentiment: 'neutral', source: 'FinSearch',
+            headline: 'Banks brace for mixed credit trends into the next quarter',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 140 * 60,
+        },
+        {
+            ticker: 'META', category: 'Markets', sentiment: 'bullish', source: 'FinSearch',
+            headline: 'Meta ad pricing firms as engagement stays elevated',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 165 * 60,
+        },
+        {
+            ticker: 'BA', category: 'Markets', sentiment: 'bearish', source: 'FinSearch',
+            headline: 'Boeing delivery cadence remains under pressure',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 190 * 60,
+        },
+        {
+            ticker: 'XOM', category: 'Economy', sentiment: 'neutral', source: 'FinSearch',
+            headline: 'Energy majors track oil range as inventories stabilize',
+            url: 'https://agenticfinsearch.org/', published: Math.floor(Date.now() / 1000) - 220 * 60,
+        },
+    ],
+    signals: {
+        AAPL: { sentiment: 'bullish', score: 0.72, rationale: 'Positive earnings impulse', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        NVDA: { sentiment: 'bullish', score: 0.68, rationale: 'AI demand remains elevated', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        TSLA: { sentiment: 'bearish', score: -0.41, rationale: 'Delivery outlook softness', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        SPY: { sentiment: 'neutral', score: 0.08, rationale: 'Macro tone mixed', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        MSFT: { sentiment: 'bullish', score: 0.55, rationale: 'Cloud demand resilient', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        AMZN: { sentiment: 'bullish', score: 0.49, rationale: 'Ads + AWS margin support', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        META: { sentiment: 'bullish', score: 0.61, rationale: 'Ad pricing firms', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        BA: { sentiment: 'bearish', score: -0.33, rationale: 'Delivery cadence pressure', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        JPM: { sentiment: 'neutral', score: 0.05, rationale: 'Credit trends mixed', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+        XOM: { sentiment: 'neutral', score: -0.02, rationale: 'Oil range-bound', source: 'FinSearch', url: 'https://agenticfinsearch.org/' },
+    },
+};
+
+let homeMarketPayload = null;
+
+function setHomeMarketDemoBadge(isMock) {
+    const badge = document.getElementById('homeMarketDemoBadge');
+    if (badge) badge.hidden = !isMock;
+}
+
+function renderHomeMarketNews(payload) {
+    const list = document.getElementById('homeModuleNewsList');
+    const status = document.getElementById('homeMarketStatus');
+    if (!list) return;
+
+    const live = payload
+        && payload.status !== 'unavailable'
+        && Array.isArray(payload.feed)
+        && payload.feed.length > 0
+        && !payload._mock;
+    const data = live ? payload : HOME_MOCK_NEWS;
+    setHomeMarketDemoBadge(!live);
+
+    if (status) {
+        if (live && Number.isFinite(Number(data.staleness_hours))) {
+            status.hidden = false;
+            status.textContent = `Updated ${Number(data.staleness_hours).toFixed(1)}h ago`;
+        } else {
+            status.hidden = true;
+            status.textContent = '';
+        }
+    }
+
+    const items = (data.feed || []).slice(0, 40);
+    list.innerHTML = items.map((item) => {
+        const sent = homeSentimentClass(item.sentiment || item.category);
+        const logo = (item.ticker || item.source || '?').toString().slice(0, 2).toUpperCase();
+        const meta = [item.ticker, item.category || item.source || 'FinSearch', homeRelTime(item.published)]
+            .filter(Boolean).join(' · ');
+        const label = sent === 'bullish' ? 'Bullish' : sent === 'bearish' ? 'Bearish' : 'Neutral';
+        return `<li>
+            <span class="hm-news-logo hm-news-logo--${sent === 'bullish' ? 'bull' : sent === 'bearish' ? 'bear' : 'neut'}">${homeEscape(logo)}</span>
+            <div class="hm-news-main">
+                <a href="${homeEscape(homeSafeUrl(item.url || 'https://agenticfinsearch.org/'))}" target="_blank" rel="noopener noreferrer">${homeEscape(item.headline || 'Untitled')}</a>
+                <span class="hm-news-meta">${homeEscape(meta)}</span>
+            </div>
+            <span class="hm-sent hm-sent--${sent}">${label}</span>
+        </li>`;
+    }).join('');
+}
+
+function renderHomeMarketSignals(payload) {
+    const list = document.getElementById('homeModuleSignalsList');
+    const status = document.getElementById('homeMarketSignalsStatus');
+    if (!list) return;
+
+    const live = payload
+        && payload.status !== 'unavailable'
+        && payload.signals
+        && Object.keys(payload.signals).length > 0
+        && !payload._mock;
+    const data = live ? payload : HOME_MOCK_NEWS;
+    const signals = Object.entries(data.signals || {});
+    setHomeMarketDemoBadge(!live);
+
+    if (status) {
+        if (live) {
+            status.hidden = false;
+            status.textContent = `${signals.length} signal${signals.length === 1 ? '' : 's'}`;
+        } else {
+            status.hidden = true;
+            status.textContent = '';
+        }
+    }
+
+    list.innerHTML = signals.slice(0, 40).map(([sym, s]) => {
+        const sent = homeSentimentClass(s.sentiment);
+        const label = sent === 'bullish' ? 'Bullish' : sent === 'bearish' ? 'Bearish' : 'Neutral';
+        return `<li>
+            <span class="hm-news-logo hm-news-logo--${sent === 'bullish' ? 'bull' : sent === 'bearish' ? 'bear' : 'neut'}">${homeEscape(String(sym).slice(0, 2))}</span>
+            <div class="hm-news-main">
+                <a href="${homeEscape(homeSafeUrl(s.url || 'https://agenticfinsearch.org/'))}" target="_blank" rel="noopener noreferrer">${homeEscape(sym)} · score ${Number(s.score || 0).toFixed(2)}</a>
+                <span class="hm-news-meta">${homeEscape(s.rationale || s.source || 'FinSearch')}</span>
+            </div>
+            <span class="hm-sent hm-sent--${sent}">${label}</span>
+        </li>`;
+    }).join('');
+}
+
+async function loadHomeMarketNewsModule() {
+    try {
+        if (typeof API === 'undefined' || typeof API_BASE === 'undefined') {
+            homeMarketPayload = HOME_MOCK_NEWS;
+            renderHomeMarketNews(homeMarketPayload);
+            renderHomeMarketSignals(homeMarketPayload);
+            return;
+        }
+        homeMarketPayload = await API.get(`${API_BASE}/api/news/signals`);
+        renderHomeMarketNews(homeMarketPayload);
+        renderHomeMarketSignals(homeMarketPayload);
+    } catch (error) {
+        console.warn('FinSearch news/signals unavailable:', error?.message || error);
+        homeMarketPayload = HOME_MOCK_NEWS;
+        renderHomeMarketNews(homeMarketPayload);
+        renderHomeMarketSignals(homeMarketPayload);
+    }
+}
+
+function setHomeMarketTab(tab) {
+    document.querySelectorAll('[data-market-tab]').forEach((btn) => {
+        const on = btn.dataset.marketTab === tab;
+        btn.classList.toggle('is-active', on);
+        btn.setAttribute('aria-selected', on ? 'true' : 'false');
+    });
+    const news = document.getElementById('homeMarketNewsPane');
+    const signals = document.getElementById('homeMarketSignalsPane');
+    if (news) news.hidden = tab !== 'news';
+    if (signals) signals.hidden = tab !== 'signals';
+    const title = document.getElementById('homeModuleMarketTitle');
+    if (title) title.textContent = tab === 'signals' ? 'Market Signals' : 'Market News';
+}
+
+function refreshHomeModules() {
+    updateHomePortfolioModule();
+    updateHomeAgentModule();
+    loadHomeLeaderboardModule();
+    loadHomeMarketNewsModule();
+}
+
+function initHomeSnapScroll() {
+    const view = document.getElementById('homeView');
+    const track = document.getElementById('homePagerTrack');
+    const hint = document.getElementById('homeScrollHint');
+    if (!view || !track || view.dataset.snapBound === '1') return;
+    view.dataset.snapBound = '1';
+
+    measureAppChromeHeight();
+    window.addEventListener('resize', measureAppChromeHeight);
+
+    let locked = false;
+    const lockMs = 550;
+
+    function currentPage() {
+        return track.dataset.page === '1' ? 1 : 0;
+    }
+
+    function go(page) {
+        locked = true;
+        setHomePagerPage(page);
+        window.setTimeout(() => { locked = false; }, lockMs);
+    }
+
+    hint?.addEventListener('click', () => go(1));
+
+    // Capture wheel on home view: only two pages, hard stop at dashboard.
+    view.addEventListener('wheel', (event) => {
+        // Let nested scrollers (e.g. leaderboard list) handle their own wheel.
+        const scrollable = event.target.closest?.('.home-module-rank-list, .hm-news-list, .home-playground-chat');
+        if (scrollable) {
+            const canScroll = scrollable.scrollHeight > scrollable.clientHeight + 1;
+            if (canScroll) {
+                const atTop = scrollable.scrollTop <= 0;
+                const atBottom = scrollable.scrollTop + scrollable.clientHeight >= scrollable.scrollHeight - 1;
+                if ((event.deltaY < 0 && !atTop) || (event.deltaY > 0 && !atBottom)) {
+                    return;
+                }
+            }
+        }
+        if (Math.abs(event.deltaY) < 6) return;
+        event.preventDefault();
+        if (locked) return;
+        const page = currentPage();
+        if (page === 0 && event.deltaY > 0) {
+            go(1);
+            return;
+        }
+        if (page === 1 && event.deltaY < 0) {
+            go(0);
+        }
+        // page === 1 && deltaY > 0 → bottom; swallow the event
+    }, { passive: false });
+
+    // Also block touchpad/page scroll chaining on the document while home is shown.
+    view.addEventListener('touchmove', (event) => {
+        // Allow nothing to bubble-scroll the page behind the pager.
+        if (event.target.closest('.home-playground-chat')) return;
+        event.preventDefault();
+    }, { passive: false });
+
+    setHomePagerPage(0);
+}
+
+function initHomeModules() {
+    document.getElementById('homeModulePortfolioBtn')?.addEventListener('click', () => {
+        if (!isHomeSignedIn()) {
+            if (typeof openAuthModal === 'function') openAuthModal('login');
+        }
+    });
+    document.getElementById('homeModuleViewPortfolioBtn')?.addEventListener('click', () => {
+        if (typeof navigateToPage === 'function') {
+            navigateToPage('playground', { playgroundTab: 'agents' });
+        }
+        window.requestAnimationFrame(() => {
+            document.querySelector('#playgroundAgentsPanel .page-header')?.scrollIntoView({
+                block: 'start',
+                behavior: 'smooth',
+            });
+        });
+    });
+    document.getElementById('homeModuleCreateAgentEmpty')?.addEventListener('click', openHomeCreateAgent);
+    document.getElementById('homeModuleViewAgentsBtn')?.addEventListener('click', () => {
+        if (typeof navigateToPage === 'function') {
+            navigateToPage('playground', { playgroundTab: 'agents' });
+        }
+    });
+    document.getElementById('homeModuleRankingBtn')?.addEventListener('click', navigateToLeaderboard);
+    document.getElementById('homeViewLeaderboardBtn')?.addEventListener('click', navigateToLeaderboard);
+    const openFinSearch = () => window.open('https://agenticfinsearch.org/', '_blank', 'noopener,noreferrer');
+    document.getElementById('homeModuleMarketBtn')?.addEventListener('click', openFinSearch);
+    document.getElementById('homeModuleMarketBtn')?.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            openFinSearch();
+        }
+    });
+    document.getElementById('homeModuleCommunityBtn')?.addEventListener('click', (event) => {
+        if (typeof openDiscordWithAccount === 'function') {
+            openDiscordWithAccount(event);
+            return;
+        }
+        window.open('https://discord.gg/9HnQ6XDG98', '_blank', 'noopener,noreferrer');
+    });
+
+    document.querySelectorAll('[data-market-tab]').forEach((btn) => {
+        btn.addEventListener('click', () => setHomeMarketTab(btn.dataset.marketTab));
+    });
+    document.querySelectorAll('[data-port-range]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            homePortRange = btn.dataset.portRange || '1D';
+            document.querySelectorAll('[data-port-range]').forEach((b) => {
+                b.classList.toggle('is-active', b === btn);
+            });
+            renderHomePortfolioChart(HOME_PORTFOLIO.equity, HOME_PORTFOLIO.dayPnl, homePortRange);
+        });
+    });
+
+    refreshHomeModules();
+}
+
 function initHomePage() {
     homeEvents = INITIAL_EVENTS.map((event) => ({ ...event }));
-    renderActivityFeed(homeEvents.map((event) => eventToActivity(event)));
-    initMarketPulseTabs();
+    if (document.getElementById('homeActivityFeed')) {
+        renderActivityFeed(homeEvents.map((event) => eventToActivity(event)));
+    }
+    if (document.getElementById('homeMarketPulseList')) {
+        initMarketPulseTabs();
+    }
     initActivityFeedHover();
+    initLandingPlaygroundChat();
+    initHomeGetStarted();
+    initHomeSnapScroll();
+    initHomeModules();
 
-    document.getElementById('homeLiveToastClose')?.addEventListener('click', dismissLatestEvent);
-
-    document.getElementById('homeViewLeaderboardBtn')?.addEventListener('click', navigateToLeaderboard);
     document.getElementById('homeResourceLeaderboardBtn')?.addEventListener('click', navigateToLeaderboard);
 
     document.getElementById('homeActivityViewAll')?.addEventListener('click', (e) => {
@@ -649,6 +1628,17 @@ function onHomePageShow() {
     if (!homeMockLive) homeMockLive = useMockLiveEvents();
     homeMockLive.start();
     window.newsSignalsPanel && window.newsSignalsPanel.onShow();
+    measureAppChromeHeight();
+    initHomeSnapScroll();
+    setHomePagerPage(0);
+    const hasAgents = typeof allAgents !== 'undefined' && Array.isArray(allAgents) && allAgents.length > 0;
+    if (!hasAgents && typeof loadAgents === 'function') {
+        Promise.resolve(loadAgents()).catch(() => {
+            refreshHomeModules();
+        });
+    } else {
+        refreshHomeModules();
+    }
 }
 
 function onHomePageHide() {
@@ -661,3 +1651,4 @@ window.initHomePage = initHomePage;
 window.onHomePageShow = onHomePageShow;
 window.onHomePageHide = onHomePageHide;
 window.useMockLiveEvents = useMockLiveEvents;
+window.refreshHomeModules = refreshHomeModules;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -68,9 +68,9 @@ body {
     grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
     align-items: center;
     background-color: var(--bg-surface);
-    padding: 16px 24px;
+    padding: 10px 24px;
     border-bottom: 1px solid var(--border-color);
-    gap: 16px;
+    gap: 12px;
 }
 
 .header-brand {
@@ -333,6 +333,18 @@ a.header-brand:hover .title-section h1 {
     cursor: pointer;
     font-size: 11px;
     font-weight: 600;
+}
+
+.auth-btn-primary {
+    border-color: rgba(34, 211, 238, 0.55);
+    background: linear-gradient(135deg, #22d3ee, #38bdf8);
+    color: #041018;
+    box-shadow: 0 4px 14px rgba(34, 211, 238, 0.2);
+}
+
+.auth-btn-primary:hover {
+    filter: brightness(1.05);
+    border-color: rgba(34, 211, 238, 0.75);
 }
 
 .auth-btn:hover {
@@ -633,37 +645,40 @@ a.header-brand:hover .title-section h1 {
 .ticker-item {
     display: flex;
     align-items: center;
-    gap: 5px;
-    padding: 7px 10px;
-    border-right: 1px solid var(--border-color);
+    gap: 8px;
+    padding: 8px 14px;
+    border-right: 1px solid rgba(148, 163, 184, 0.16);
     white-space: nowrap;
     flex: 0 0 auto;
     flex-shrink: 0;
 }
 
 .ticker-item:last-child {
-    border-right: none;
+    border-right: 1px solid rgba(148, 163, 184, 0.16);
 }
 
 .ticker-item .symbol {
-    font-size: 10px;
+    font-size: 12px;
     font-weight: 700;
-    color: var(--text-secondary);
-    min-width: 36px;
+    color: var(--text-primary);
+    min-width: 42px;
+    letter-spacing: 0.02em;
 }
 
 .ticker-item .price {
-    font-size: 10px;
+    font-size: 12px;
     font-weight: 600;
     color: var(--text-secondary);
     font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
 }
 
 .ticker-item .change {
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 700;
     font-family: var(--font-mono);
-    min-width: 40px;
+    font-variant-numeric: tabular-nums;
+    min-width: 52px;
 }
 
 .ticker-item .change.positive {
@@ -3369,9 +3384,34 @@ a.header-brand:hover .title-section h1 {
     text-transform: none;
 }
 
-.status-badge.live {
+.status-badge.live,
+.status-badge.paper {
     background-color: rgba(0, 200, 81, 0.15);
     color: var(--success-color);
+}
+
+.status-badge-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    margin-right: 6px;
+    background: currentColor;
+    vertical-align: 1px;
+}
+
+.status-badge.paper,
+.status-badge.backtested,
+.status-badge.idle,
+.status-badge.draft {
+    display: inline-flex;
+    align-items: center;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 10px;
+    font-weight: 700;
+    padding: 4px 9px;
+    border-radius: 999px;
 }
 
 .status-badge.upcoming {
@@ -3389,9 +3429,10 @@ a.header-brand:hover .title-section h1 {
     color: var(--text-muted);
 }
 
-.status-badge.backtested {
-    background-color: rgba(34, 211, 238, 0.12);
-    color: #67e8f9;
+.status-badge.backtested,
+.status-badge.idle {
+    background-color: rgba(107, 114, 128, 0.18);
+    color: var(--text-muted);
 }
 
 .leaderboard-footer {
@@ -4393,6 +4434,1111 @@ a.header-brand:hover .title-section h1 {
     position: relative;
 }
 
+/* Strict 2-page home pager: Landing ↔ Dashboard only */
+html[data-nav-page="home"] {
+    --app-chrome-height: 148px;
+}
+html[data-nav-page="home"] body {
+    overflow: hidden;
+    height: 100%;
+}
+html[data-nav-page="home"] #homeView.home-view {
+    height: calc(100dvh - var(--app-chrome-height));
+    max-height: calc(100dvh - var(--app-chrome-height));
+    overflow: hidden;
+    padding: 0;
+}
+html[data-nav-page="home"] #homeView .home-page--pager {
+    height: 100%;
+    overflow: hidden;
+    padding: 0;
+}
+html[data-nav-page="home"] #homeView .home-pager-track {
+    height: 200%;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+    will-change: transform;
+}
+html[data-nav-page="home"] #homeView .home-pager-track[data-page="1"] {
+    transform: translateY(-50%);
+}
+html[data-nav-page="home"] #homeView .home-pager-screen {
+    flex: 0 0 50%;
+    height: 50%;
+    max-height: 50%;
+    overflow: hidden;
+    box-sizing: border-box;
+}
+html[data-nav-page="home"] #homeView #homeScreenLanding {
+    position: relative;
+}
+html[data-nav-page="home"] #homeView .home-landing-hero {
+    height: 100%;
+    min-height: 0;
+    padding: clamp(20px, 3vh, 40px) 1.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    box-sizing: border-box;
+}
+html[data-nav-page="home"] #homeView .home-landing-hero-inner {
+    /* Wider page-1 rail so a larger center gap does not crush the two columns.
+       Page-2 padding (home-dashboard-screen-inner) stays untouched. */
+    width: 100%;
+    max-width: 1440px;
+    margin-inline: auto;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 6.8rem;
+}
+html[data-nav-page="home"] #homeView .home-landing-hero-copy {
+    flex: 1 1 0;
+    min-width: 0;
+}
+html[data-nav-page="home"] #homeView .home-landing-playground {
+    flex: 1 1 0;
+    width: 100%;
+    max-width: 42rem;
+    min-width: 0;
+    flex-shrink: 0;
+}
+html[data-nav-page="home"] #homeView .home-playground-window {
+    height: min(480px, calc(100dvh - var(--app-chrome-height) - 200px));
+    min-height: min(380px, calc(100dvh - var(--app-chrome-height) - 200px));
+    max-height: min(480px, calc(100dvh - var(--app-chrome-height) - 160px));
+}
+html[data-nav-page="home"] #homeView .home-dashboard-screen-inner {
+    height: 100%;
+    box-sizing: border-box;
+    padding: 16px 28px 20px;
+    display: flex;
+    flex-direction: column;
+    max-width: 1500px;
+    width: 100%;
+    margin-inline: auto;
+    overflow: hidden;
+}
+html[data-nav-page="home"] #homeView .home-modules {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+html[data-nav-page="home"] #homeView .dashboard-top-grid {
+    flex: 1.12 1 0;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: 1.2fr 0.85fr 1.05fr;
+    gap: 16px;
+}
+html[data-nav-page="home"] #homeView .dashboard-bottom-grid {
+    flex: 0.98 1 0;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: 1.8fr 1fr;
+    gap: 16px;
+}
+
+/* display:* rules on cards must not override the HTML hidden attribute */
+#homeModules [hidden] { display: none !important; }
+
+/* --- Dashboard polish additions --- */
+.hm-demo-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    color: rgba(148, 163, 184, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    background: rgba(148, 163, 184, 0.08);
+    white-space: nowrap;
+}
+.hm-demo-badge[hidden] { display: none !important; }
+.hm-demo-badge--quiet {
+    font-weight: 600;
+    color: var(--text-muted);
+}
+.hm-demo-note {
+    margin: -4px 0 10px;
+    font-size: 11px;
+    color: var(--text-muted);
+}
+.hm-metric-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    margin: 10px 0 8px;
+    flex-shrink: 0;
+}
+.hm-metric {
+    padding: 8px 9px;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.1);
+    background: rgba(8, 14, 28, 0.45);
+}
+.hm-metric-label {
+    display: block;
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-bottom: 3px;
+}
+.hm-metric-value {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+.hm-workflow {
+    list-style: none;
+    margin: auto 0 0;
+    padding: 10px 0 0;
+    display: flex;
+    align-items: center;
+    gap: 0;
+    border-top: 1px solid rgba(148, 163, 184, 0.12);
+    font-size: 11px;
+    font-weight: 650;
+    color: var(--text-muted);
+}
+.hm-workflow li {
+    display: inline-flex;
+    align-items: center;
+}
+.hm-workflow li:not(:last-child)::after {
+    content: "→";
+    margin: 0 8px;
+    color: rgba(148, 163, 184, 0.55);
+    font-weight: 500;
+}
+.hm-rank-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 12px;
+    align-items: center;
+    margin: -4px 0 10px;
+    font-size: 11.5px;
+    color: var(--text-muted);
+}
+.hm-method-link {
+    color: rgba(34, 211, 238, 0.85);
+    text-decoration: none;
+    font-weight: 600;
+}
+.hm-method-link:hover { text-decoration: underline; }
+.hm-type-badge {
+    display: inline-flex;
+    margin-left: 6px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    vertical-align: middle;
+    color: var(--text-muted);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(148, 163, 184, 0.06);
+}
+.hm-type-badge--model { color: rgba(125, 211, 252, 0.95); border-color: rgba(56, 189, 248, 0.25); }
+.hm-type-badge--baseline { color: rgba(196, 181, 253, 0.95); border-color: rgba(167, 139, 250, 0.25); }
+.hm-type-badge--index { color: rgba(148, 163, 184, 0.95); }
+.hm-rank-entry {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    gap: 4px;
+    overflow: hidden;
+}
+.hm-rank-entry .home-module-rank-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.hm-type-badge { flex-shrink: 0; }
+.hm-source-label {
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--text-muted);
+    cursor: pointer;
+}
+.hm-source-label:hover { color: rgba(34, 211, 238, 0.9); }
+.hm-side-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+.hm-side-label {
+    margin: 0;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+.hm-quote-list li:hover {
+    border-color: rgba(34, 211, 238, 0.25);
+    background: rgba(34, 211, 238, 0.05);
+}
+.hm-port-footer {
+    border-top: 1px solid rgba(148, 163, 184, 0.12);
+    padding-top: 8px;
+}
+.home-module-cta { width: auto; }
+
+
+.home-module {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+    padding: 14px 16px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    background: linear-gradient(165deg, #141c2e 0%, #0d1322 100%);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255,255,255,0.03);
+    overflow: hidden;
+}
+.home-module-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 12px;
+    flex-shrink: 0;
+}
+.home-module-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    text-transform: none;
+    color: rgba(226, 232, 240, 0.92);
+}
+.home-module-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--home-accent-cyan);
+    border: 1px solid rgba(34, 211, 238, 0.28);
+    background: rgba(34, 211, 238, 0.08);
+}
+.home-module-body { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+.home-module-name {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+.home-module-desc {
+    margin: 8px 0 0;
+    font-size: 12.5px;
+    color: var(--text-secondary);
+    line-height: 1.45;
+    max-width: 28ch;
+}
+.home-module-link {
+    flex-shrink: 0;
+    margin-top: auto;
+    padding-top: 10px;
+    align-self: flex-start;
+    border: none;
+    background: none;
+    color: var(--home-accent-cyan);
+    font-size: 12.5px;
+    font-weight: 600;
+    cursor: pointer;
+}
+.home-module-link:hover { text-decoration: underline; }
+.hm-head-link { margin: 0; padding: 0; }
+.hm-mini-btn {
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    background: rgba(15, 23, 42, 0.7);
+    color: var(--text-primary);
+    border-radius: 999px;
+    padding: 5px 12px;
+    font-size: 11px;
+    font-weight: 650;
+    cursor: pointer;
+}
+.hm-mini-btn--ghost {
+    border-color: rgba(34, 211, 238, 0.45);
+    color: var(--home-accent-cyan);
+    background: rgba(34, 211, 238, 0.08);
+}
+.hm-mini-btn--accent {
+    border-color: transparent;
+    color: #041018;
+    background: linear-gradient(135deg, #22d3ee, #38bdf8);
+    box-shadow: 0 2px 10px rgba(34, 211, 238, 0.18);
+}
+.hm-footer-btn {
+    margin-top: auto;
+    flex-shrink: 0;
+    width: 100%;
+    border: 1px solid rgba(34, 211, 238, 0.32);
+    background: rgba(34, 211, 238, 0.05);
+    color: var(--home-accent-cyan);
+    border-radius: 999px;
+    padding: 9px 12px;
+    font-size: 13px;
+    font-weight: 650;
+    cursor: pointer;
+}
+.hm-footer-btn:hover { background: rgba(34, 211, 238, 0.12); }
+.hm-footer-btn[hidden] { display: none !important; }
+.home-module--portfolio {
+    overflow: hidden;
+}
+.home-module--portfolio .home-module-head {
+    margin-bottom: 6px;
+}
+.home-module--portfolio .hm-footer-btn {
+    padding: 8px 12px;
+}
+
+/* Portfolio */
+.hm-port-user {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    flex-shrink: 0;
+}
+.hm-port-user-meta {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.home-module--portfolio .home-module-name {
+    font-size: 13.5px;
+}
+.home-module-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 12px;
+    font-weight: 800;
+    color: #041018;
+    background: linear-gradient(135deg, #22d3ee, #38bdf8);
+    flex-shrink: 0;
+}
+.hm-port-metrics {
+    display: grid;
+    grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.65fr);
+    gap: 0;
+    align-items: end;
+    margin-bottom: 6px;
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+}
+.hm-port-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 0 12px 0 0;
+    min-width: 0;
+}
+.hm-port-metric--side {
+    padding: 0 0 1px 12px;
+    border-left: 1px solid rgba(148, 163, 184, 0.16);
+}
+.hm-port-metric-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.hm-port-metric-value {
+    font-size: 14px;
+    font-weight: 700;
+    color: #e5e7eb;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+.hm-port-metric--equity .hm-port-metric-value {
+    font-size: 24px;
+    font-weight: 800;
+    color: #fff;
+    letter-spacing: -0.03em;
+}
+.hm-port-metric-value em {
+    font-style: normal;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-left: 2px;
+}
+.hm-port-range {
+    display: flex;
+    gap: 2px;
+    margin-bottom: 2px;
+    flex-shrink: 0;
+}
+.hm-range-btn {
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 10.5px;
+    font-weight: 650;
+    padding: 3px 7px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+.hm-range-btn.is-active {
+    color: var(--home-accent-cyan);
+    background: rgba(34, 211, 238, 0.12);
+}
+.hm-port-figure {
+    position: relative;
+    margin: 0 0 8px;
+    flex: 1 1 auto;
+    min-height: 132px;
+    max-height: none;
+    display: flex;
+    align-items: stretch;
+}
+.hm-port-chart {
+    width: 100%;
+    height: 100%;
+    min-height: 132px;
+    display: block;
+}
+.hm-port-tooltip {
+    position: absolute;
+    z-index: 5;
+    min-width: 132px;
+    padding: 7px 9px;
+    border-radius: 8px;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    background: rgba(10, 14, 28, 0.94);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.35;
+    pointer-events: none;
+    transform: translate(-50%, calc(-100% - 10px));
+}
+.hm-port-tooltip[hidden] { display: none !important; }
+.hm-port-tooltip strong {
+    display: block;
+    color: #fff;
+    font-size: 12.5px;
+    font-weight: 700;
+    margin: 2px 0;
+}
+.hm-port-tooltip .hm-port-tip-chg.is-pos { color: #4ade80; }
+.hm-port-tooltip .hm-port-tip-chg.is-neg { color: #f87171; }
+.hm-port-tooltip .hm-port-tip-chg.is-flat { color: var(--text-muted); }
+.hm-port-footer {
+    margin-top: auto;
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+}
+.hm-port-alloc-block { min-width: 0; }
+.hm-port-alloc-title {
+    margin: 0 0 6px;
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+.hm-port-alloc {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 12px;
+    align-items: center;
+    min-width: 0;
+}
+.hm-donut {
+    width: 52px;
+    height: 52px;
+    flex-shrink: 0;
+}
+.hm-alloc-legend {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    font-size: 11.5px;
+    color: var(--text-secondary);
+    min-width: 0;
+}
+.hm-alloc-legend li {
+    display: grid;
+    grid-template-columns: 8px minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 0;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+.hm-alloc-legend li:last-child { border-bottom: none; padding-bottom: 0; }
+.hm-alloc-legend li:first-child { padding-top: 0; }
+.hm-alloc-legend strong {
+    color: var(--text-primary);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+.hm-alloc-legend em {
+    font-style: normal;
+    color: var(--text-muted);
+    width: 36px;
+    text-align: right;
+    white-space: nowrap;
+}
+.hm-alloc-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.hm-dot {
+    width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+}
+.hm-dot--cash { background: #22d3ee; }
+.hm-dot--stocks { background: #22c55e; }
+.hm-dot--crypto { background: #a78bfa; }
+.hm-buying-power {
+    margin: 0;
+    padding-top: 10px;
+    border-top: 1px solid rgba(148, 163, 184, 0.14);
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.3;
+}
+.hm-buying-power strong { color: var(--home-accent-cyan); }
+
+/* Agent */
+.hm-agent-empty {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    min-height: 0;
+    padding: 24px 12px;
+}
+.hm-agent-empty-cta {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--home-accent-cyan, #22d3ee);
+    font-size: 15px;
+    font-weight: 650;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    padding: 8px 12px;
+    border-radius: 8px;
+    transition: background 0.15s, color 0.15s;
+}
+.hm-agent-empty-cta:hover {
+    background: rgba(34, 211, 238, 0.1);
+    color: #67e8f9;
+}
+.hm-agent-filled {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-height: 0;
+    flex: 1;
+}
+.hm-agent-filled[hidden],
+.hm-agent-empty[hidden] {
+    display: none !important;
+}
+.home-module--agent .home-module-head {
+    margin-bottom: 12px;
+}
+.home-module--agent .agent-card--home {
+    flex: 1;
+    gap: 14px;
+    padding: 0;
+    min-height: 0;
+    border: none;
+    background: transparent;
+    border-radius: 0;
+    justify-content: flex-start;
+}
+.home-module--agent .agent-card-identity {
+    gap: 12px;
+}
+.home-module--agent .agent-card-metric-value {
+    font-size: 26px;
+    line-height: 1.15;
+}
+.home-module--agent .agent-card-metric-head {
+    margin-bottom: 4px;
+}
+.home-module--agent .agent-card-icon {
+    width: 40px;
+    height: 40px;
+}
+.home-module--agent .agent-card-icon svg {
+    width: 20px;
+    height: 20px;
+}
+.home-module--agent .agent-name {
+    font-size: 16px;
+    line-height: 1.25;
+}
+.home-module--agent .agent-card-submeta {
+    font-size: 12.5px;
+    color: var(--text-muted);
+    line-height: 1.3;
+}
+.home-module--agent .agent-card-sparkline {
+    width: 96px;
+    height: 42px;
+}
+.home-module--agent .agent-card-hero {
+    align-items: flex-start;
+    gap: 12px;
+}
+.home-module--agent .agent-card-change {
+    margin-top: 6px;
+}
+.home-module--agent .agent-card-period {
+    margin: -4px 0 0;
+}
+.home-module--agent .agent-card-period,
+.home-module--agent .agent-card-activity-text,
+.home-module--agent .agent-card-change {
+    font-size: 12px;
+}
+.home-module--agent .agent-card-actions {
+    display: none !important;
+}
+.home-module--agent .agent-card-runs-link {
+    display: flex !important;
+    margin: 0;
+    padding: 8px 0;
+    font-size: 12.5px;
+}
+.home-module--agent .agent-card-activity {
+    padding: 0;
+}
+.home-module--agent .agent-card-empty {
+    padding: 16px 12px;
+}
+.home-module--agent .hm-footer-btn {
+    margin-top: auto;
+}
+
+/* Leaderboard */
+.hm-rank-table-head {
+    display: grid;
+    grid-template-columns: 22px minmax(0, 1.2fr) 72px 64px 48px;
+    gap: 6px;
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+    padding: 0 2px;
+}
+.hm-rank-table-head span:nth-child(n+3) { text-align: right; }
+.home-module-rank-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.35) transparent;
+}
+.home-module-rank-list::-webkit-scrollbar {
+    width: 6px;
+}
+.home-module-rank-list::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.35);
+    border-radius: 999px;
+}
+.home-module-rank-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+.home-module-rank-list li {
+    display: grid;
+    grid-template-columns: 22px minmax(0, 1.2fr) 72px 64px 48px;
+    align-items: center;
+    gap: 6px;
+    font-size: 12.5px;
+}
+.home-module-rank {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--text-secondary);
+    background: rgba(148, 163, 184, 0.12);
+}
+.home-module-rank--1 { color: #041018; background: #fbbf24; }
+.home-module-rank--2 { color: #041018; background: #94a3b8; }
+.home-module-rank--3 { color: #041018; background: #d97706; }
+.home-module-rank-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+    font-weight: 600;
+}
+.hm-rank-ret, .hm-rank-sharpe, .hm-rank-value { text-align: right; font-variant-numeric: tabular-nums; }
+.hm-rank-sharpe { color: var(--text-secondary); }
+.hm-rank-value { color: var(--text-secondary); font-size: 11px; }
+.home-module-rank-empty {
+    display: block;
+    font-size: 12px;
+    color: var(--text-muted);
+    padding: 8px 0;
+    grid-column: 1 / -1;
+}
+
+/* Market */
+.hm-market-head {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+.hm-market-title-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    justify-self: start;
+}
+.hm-market-head .hm-tabs {
+    justify-self: center;
+}
+.hm-market-head .hm-source-label {
+    justify-self: end;
+    text-align: right;
+}
+.hm-tabs, .hm-side-tabs { display: flex; gap: 2px; }
+.hm-tab, .hm-side-tab {
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 13.5px;
+    font-weight: 650;
+    padding: 4px 10px;
+    border-radius: 0;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+}
+.hm-tab.is-active, .hm-side-tab.is-active {
+    color: var(--home-accent-cyan);
+    border-bottom-color: var(--home-accent-cyan);
+}
+.hm-side-tab { font-size: 12px; padding: 3px 8px; }
+.hm-market-grid {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+.hm-market-feed {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding-right: 0;
+    margin-right: 0;
+    border-right: none;
+}
+.hm-market-feed[hidden] {
+    display: none !important;
+}
+.home-module-market-status {
+    margin: 0 0 8px;
+    font-size: 11.5px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+.home-module-market-status[hidden] { display: none !important; }
+.hm-news-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 4px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.35) transparent;
+}
+.hm-news-list::-webkit-scrollbar {
+    width: 6px;
+}
+.hm-news-list::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.35);
+    border-radius: 999px;
+}
+.hm-news-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+.hm-news-list li {
+    display: grid;
+    grid-template-columns: 30px 1fr auto;
+    gap: 10px;
+    align-items: start;
+    min-width: 0;
+}
+.hm-news-logo {
+    width: 30px; height: 30px; border-radius: 8px;
+    display: grid; place-items: center;
+    font-size: 10px; font-weight: 800;
+    color: #041018;
+    background: linear-gradient(135deg, #94a3b8, #64748b);
+}
+.hm-news-logo--bull { background: linear-gradient(135deg, #86efac, #22c55e); }
+.hm-news-logo--bear { background: linear-gradient(135deg, #fca5a5, #ef4444); }
+.hm-news-logo--neut { background: linear-gradient(135deg, #cbd5e1, #94a3b8); }
+.hm-news-main { min-width: 0; }
+.hm-news-main a {
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 650;
+    line-height: 1.35;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.hm-news-main a:hover { color: var(--home-accent-cyan); }
+.hm-news-meta {
+    display: block;
+    margin-top: 3px;
+    font-size: 11.5px;
+    color: var(--text-muted);
+}
+.hm-sent {
+    font-size: 10px;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+.hm-sent--bullish { color: #86efac; background: rgba(34,197,94,0.12); }
+.hm-sent--bearish { color: #fca5a5; background: rgba(239,68,68,0.12); }
+.hm-sent--neutral { color: #cbd5e1; background: rgba(148,163,184,0.12); }
+.home-module-news-empty {
+    font-size: 12px;
+    color: var(--text-muted);
+    padding: 8px 0;
+}
+.hm-quote-list {
+    list-style: none;
+    margin: 10px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1;
+    min-height: 0;
+}
+.hm-quote-list li {
+    display: grid;
+    grid-template-columns: 44px 1fr auto 52px;
+    align-items: center;
+    gap: 8px;
+    font-size: 12.5px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    background: rgba(8, 14, 28, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.1);
+}
+.hm-quote-sym { font-weight: 700; color: var(--text-primary); }
+.hm-quote-price { color: var(--text-secondary); text-align: right; font-variant-numeric: tabular-nums; }
+.hm-quote-chg { text-align: right; font-weight: 650; font-variant-numeric: tabular-nums; }
+.hm-quote-spark { width: 52px; height: 18px; }
+
+/* Community */
+.hm-community-head-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+.hm-live-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    font-size: 12.5px;
+    font-weight: 650;
+    color: #86efac;
+}
+.hm-community-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 12px;
+    flex-shrink: 0;
+}
+.hm-community-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px;
+    border-radius: 10px;
+    background: rgba(8, 14, 28, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.1);
+}
+.hm-community-value {
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    color: #fff;
+    line-height: 1;
+}
+.hm-community-label { font-size: 11.5px; color: var(--text-muted); }
+.hm-community-delta { font-size: 11px; font-weight: 650; }
+.hm-activity-label {
+    margin: 0 0 8px;
+    font-size: 12.5px;
+    font-weight: 650;
+    letter-spacing: 0.01em;
+    text-transform: none;
+    color: var(--text-muted);
+}
+.hm-activity-list {
+    list-style: none;
+    margin: 0 0 4px;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: visible;
+}
+.hm-activity-list li {
+    display: grid;
+    grid-template-columns: 8px 1fr auto;
+    gap: 8px;
+    align-items: start;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+.hm-act-dot {
+    width: 7px; height: 7px; border-radius: 50%;
+    margin-top: 5px;
+    background: var(--home-accent-cyan);
+    box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.12);
+}
+.hm-activity-list time {
+    color: var(--text-muted);
+    white-space: nowrap;
+    font-size: 11.5px;
+    font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 1100px) {
+    html[data-nav-page="home"] #homeView .dashboard-top-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+    html[data-nav-page="home"] #homeView .dashboard-top-grid .home-module--ranking {
+        grid-column: 1 / -1;
+    }
+    html[data-nav-page="home"] #homeView .dashboard-bottom-grid {
+        grid-template-columns: 1fr;
+    }
+}
+@media (max-width: 820px) {
+    html[data-nav-page="home"] #homeView .home-dashboard-screen-inner {
+        padding: 16px;
+        overflow: auto;
+    }
+    html[data-nav-page="home"] #homeView .home-modules,
+    html[data-nav-page="home"] #homeView .dashboard-top-grid,
+    html[data-nav-page="home"] #homeView .dashboard-bottom-grid {
+        display: flex;
+        flex-direction: column;
+        height: auto;
+        flex: none;
+    }
+    .home-module { min-height: 320px; height: auto; }
+}
+
+.home-scroll-hint {
+    position: absolute;
+    left: 50%;
+    bottom: 18px;
+    transform: translateX(-50%);
+    z-index: 3;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 8px 12px;
+    border: none;
+    background: transparent;
+    color: rgba(148, 163, 184, 0.9);
+    cursor: pointer;
+    transition: color 0.2s, opacity 0.25s;
+}
+.home-scroll-hint:hover { color: var(--home-accent-cyan); }
+.home-scroll-hint-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+.home-scroll-hint-icon {
+    width: 22px;
+    height: 22px;
+    animation: home-scroll-bounce 1.6s ease-in-out infinite;
+}
+.home-scroll-hint.is-hidden { opacity: 0; pointer-events: none; }
+@keyframes home-scroll-bounce {
+    0%, 100% { transform: translateY(0); opacity: 0.7; }
+    50% { transform: translateY(6px); opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+    html[data-nav-page="home"] #homeView .home-pager-track { transition: none; }
+    .home-scroll-hint-icon { animation: none; }
+}
+
+
 .home-page {
     width: 100%;
     box-sizing: border-box;
@@ -4466,7 +5612,240 @@ a.header-brand:hover .title-section h1 {
 .home-btn-outline { width: 100%; margin-top: 14px; background: transparent; color: var(--home-accent-cyan); border-color: rgba(34,211,238,0.3); }
 .home-btn-outline:hover { background: rgba(34,211,238,0.08); }
 
-/* Hero */
+/* Landing-style first viewport (ported from dashboard/landing Hero) */
+.home-landing-hero {
+    position: relative;
+    display: flex;
+    align-items: center;
+    min-height: calc(100vh - 148px);
+    padding: clamp(28px, 4vh, 56px) 0 clamp(36px, 5vh, 72px);
+    overflow: hidden;
+    box-sizing: border-box;
+}
+.home-landing-hero-grid-bg {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0.3;
+    background-image:
+        linear-gradient(to right, rgba(30, 42, 74, 0.5) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(30, 42, 74, 0.5) 1px, transparent 1px);
+    background-size: 40px 40px;
+    -webkit-mask-image: radial-gradient(ellipse at center, black, transparent 80%);
+    mask-image: radial-gradient(ellipse at center, black, transparent 80%);
+}
+.home-landing-hero-inner {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 4rem;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+.home-landing-hero-copy {
+    flex: 1 1 0;
+    min-width: 0;
+}
+.home-landing-headline {
+    margin: 0 0 32px;
+    max-width: 36rem;
+    font-size: clamp(2.5rem, 3.2vw, 3.625rem);
+    font-weight: 800;
+    line-height: 1.05;
+    letter-spacing: -0.04em;
+    color: #e5e7eb;
+}
+.home-landing-ctas {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+}
+.home-landing-cta {
+    min-height: 48px;
+    padding: 12px 32px;
+    font-size: 16px;
+    border-radius: 9px;
+    text-decoration: none;
+}
+.home-landing-playground {
+    flex: 1 1 0;
+    width: 100%;
+    max-width: 42rem;
+    min-width: 0;
+    flex-shrink: 0;
+}
+.home-playground-window {
+    display: flex;
+    flex-direction: column;
+    height: 480px;
+    max-height: 480px;
+    min-height: 480px;
+    overflow: hidden;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    background: rgba(15, 27, 55, 0.92);
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+}
+.home-playground-titlebar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 40px;
+    flex-shrink: 0;
+    padding: 0 16px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+    background: rgba(8, 18, 40, 0.55);
+}
+.home-playground-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+}
+.home-playground-dot--red { background: rgba(239, 68, 68, 0.85); }
+.home-playground-dot--yellow { background: rgba(148, 163, 184, 0.45); }
+.home-playground-dot--green { background: rgba(34, 197, 94, 0.85); }
+.home-playground-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: 12px;
+    font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    color: rgba(148, 163, 184, 0.85);
+}
+.home-playground-chat {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 16px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    line-height: 1.45;
+}
+.home-chat-row {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    animation: home-chat-fade-in 0.55s ease-out both;
+}
+.home-chat-row--user { flex-direction: row-reverse; }
+.home-chat-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    background: rgba(148, 163, 184, 0.12);
+    color: rgba(148, 163, 184, 0.9);
+}
+.home-chat-avatar--user {
+    background: rgba(34, 211, 238, 0.2);
+    color: var(--home-accent-cyan);
+}
+.home-chat-bubble {
+    max-width: 88%;
+    padding: 12px;
+    border-radius: 8px;
+}
+.home-chat-bubble--user {
+    border: 1px solid rgba(34, 211, 238, 0.25);
+    background: rgba(34, 211, 238, 0.15);
+    border-radius: 8px 8px 8px 2px;
+    color: var(--text-primary);
+}
+.home-chat-bubble--agent {
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    background: rgba(8, 18, 40, 0.55);
+    border-radius: 8px 8px 2px 8px;
+    color: rgba(148, 163, 184, 0.95);
+}
+.home-chat-agent-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+}
+.home-chat-agent-line--muted {
+    margin-bottom: 0;
+    color: rgba(148, 163, 184, 0.85);
+    font-size: 12px;
+}
+.home-chat-agent-line--positive {
+    color: var(--home-positive-green);
+    margin-bottom: 4px;
+}
+.home-chat-icon-accent { color: var(--home-accent-cyan); }
+.home-chat-checklist {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 12px;
+}
+.home-chat-checklist li {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+}
+.home-chat-check { color: var(--home-positive-green); margin-top: 1px; }
+.home-chat-equity {
+    display: block;
+    width: 100%;
+    height: 56px;
+    margin: 8px 0 4px;
+}
+.home-chat-metrics {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+    font-size: 12px;
+    margin-top: 4px;
+}
+.home-chat-metrics span { font-weight: 600; color: var(--text-primary); }
+.home-chat-metrics .positive { color: var(--home-positive-green); }
+.home-chat-metrics .negative { color: var(--home-negative-red); }
+.home-chat-prompt-text {
+    margin: 0 0 12px;
+    color: var(--text-primary);
+}
+.home-chat-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.home-chat-action {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: rgba(148, 163, 184, 0.9);
+}
+.home-chat-action--primary {
+    border-color: rgba(34, 211, 238, 0.5);
+    background: rgba(34, 211, 238, 0.1);
+    color: var(--home-accent-cyan);
+}
+@keyframes home-chat-fade-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* Live hero (former first screen: network + spotlight) */
 .home-hero {
     position: relative; overflow: hidden;
     border: 1px solid rgba(34,211,238,0.3); border-radius: 14px;
@@ -4474,6 +5853,22 @@ a.header-brand:hover .title-section h1 {
     box-shadow: 0 0 64px rgba(34,211,238,0.1), 0 20px 40px rgba(0,0,0,0.32);
     padding: clamp(24px, 2.5vw, 32px);
 }
+.home-live-section-title {
+    margin: 0 0 8px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: none;
+    color: rgba(148, 163, 184, 0.85);
+    position: relative;
+    z-index: 2;
+}
+.home-live-hero .home-hero-left { min-height: 300px; }
+.home-live-hero .hero-agent-network { bottom: 72px; }
+.home-live-hero .home-hero-grid {
+    grid-template-columns: 1fr;
+}
+
 .home-hero-bg {
     position: absolute; inset: 0; pointer-events: none;
     background: radial-gradient(circle at 70% 60%, rgba(34,211,238,0.12) 0%, transparent 48%);
@@ -4913,6 +6308,11 @@ a.header-brand:hover .title-section h1 {
 @media (max-width: 1200px) {
     .home-dashboard-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .home-hero-grid { grid-template-columns: 1fr; }
+    .home-landing-hero-inner { flex-direction: column; align-items: stretch; }
+    .home-landing-hero-copy { text-align: center; }
+    .home-landing-headline { margin-left: auto; margin-right: auto; }
+    .home-landing-ctas { justify-content: center; }
+    .home-landing-playground { max-width: 100%; }
     .nns-split { grid-template-columns: 1fr; }
 }
 
@@ -4925,6 +6325,9 @@ a.header-brand:hover .title-section h1 {
     .home-spotlight-stats { grid-template-columns: 1fr; }
     .home-spotlight-stat { border-right: none !important; padding: 8px 0; border-bottom: 1px solid var(--home-border-subtle); }
     .home-spotlight-stat:last-child { border-bottom: none; }
+    .home-landing-hero { min-height: auto; padding-top: 20px; }
+    .home-playground-window { height: 420px; min-height: 420px; max-height: 420px; }
+    .home-chat-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 720px) {
@@ -4934,11 +6337,14 @@ a.header-brand:hover .title-section h1 {
     .home-platform-metrics { grid-template-columns: 1fr; }
     .home-platform-metric { border-right: none !important; }
     .home-live-toast { left: 16px; right: 16px; bottom: 16px; width: auto; }
+    .home-landing-ctas { flex-direction: column; width: 100%; }
+    .home-landing-cta { width: 100%; }
 }
 
 @media (prefers-reduced-motion: reduce) {
     .home-live-dot, .home-timeline-item, .home-live-toast, .home-spotlight,
-    .network-ring, .network-pulse-ring, .network-agent-node, .network-live-dot {
+    .network-ring, .network-pulse-ring, .network-agent-node, .network-live-dot,
+    .home-chat-row {
         animation: none !important; transition: none !important;
     }
 }
@@ -5389,6 +6795,13 @@ a.header-brand:hover .title-section h1 {
     flex-wrap: wrap;
 }
 
+.agent-toolbar-add {
+    white-space: nowrap;
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-size: 13px;
+}
+
 .agent-toolbar-select {
     padding: 8px 12px;
     border-radius: 8px;
@@ -5468,31 +6881,406 @@ a.header-brand:hover .title-section h1 {
     color: var(--home-accent-cyan);
 }
 
-/* Compact agent cards + denser grid (4–5 per row on desktop) */
+/* Status-aware agent cards (PAPER / BACKTESTED / DRAFT) */
 .agents-grid {
-    grid-template-columns: repeat(auto-fill, minmax(232px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 16px;
 }
 
-.agent-card--compact {
+.agent-card--status {
+    gap: 14px;
+    padding: 18px;
+    min-height: 100%;
+    border-radius: 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+}
+
+.agent-card-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.agent-card-identity {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+}
+
+.agent-card-icon {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: rgba(34, 211, 238, 0.1);
+    color: var(--home-accent-cyan, #22d3ee);
+    border: 1px solid rgba(34, 211, 238, 0.22);
+}
+
+.agent-card-icon svg {
+    width: 22px;
+    height: 22px;
+}
+
+.agent-card-identity-text {
+    min-width: 0;
+}
+
+.agent-card--status .agent-name {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.agent-card-submeta {
+    margin: 3px 0 0;
+    font-size: 12px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.agent-card-hero {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.agent-card-hero-text {
+    min-width: 0;
+    flex: 1;
+}
+
+.agent-card-metric-head {
+    display: flex;
+    align-items: center;
     gap: 8px;
-    padding: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 4px;
 }
 
-.agent-card--compact .agent-name {
-    font-size: 14px;
+.agent-card-mode-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 7px;
+    border-radius: 999px;
+    font-size: 9px;
+    font-weight: 750;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #86efac;
+    background: rgba(34, 197, 94, 0.12);
+    border: 1px solid rgba(34, 197, 94, 0.28);
 }
 
-.agent-card--compact .agent-metric {
-    padding: 6px 8px;
+.agent-card-mode-chip--backtest {
+    color: #67e8f9;
+    background: rgba(34, 211, 238, 0.1);
+    border-color: rgba(34, 211, 238, 0.28);
 }
 
-.agent-card--compact .agent-card-actions {
-    gap: 5px;
+.agent-card-metric-label {
+    display: inline;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-bottom: 0;
 }
 
-.agent-card--compact .agent-action-btn {
-    padding: 5px 8px;
-    font-size: 10px;
+.agent-card-metric-value {
+    margin: 0;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+    color: var(--text-primary);
+}
+
+.agent-card-change {
+    margin: 6px 0 0;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.agent-card-change.is-pos { color: #4ade80; }
+.agent-card-change.is-neg { color: var(--danger-color); }
+.agent-card-change.is-muted {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.agent-card-period {
+    margin: -4px 0 0;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.agent-card-divider {
+    height: 1px;
+    background: rgba(148, 163, 184, 0.12);
+    margin: 0;
+}
+
+.agent-card-runs-link {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 0;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 12.5px;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: left;
+}
+
+.agent-card-runs-link:hover {
+    color: var(--home-accent-cyan, #22d3ee);
+}
+
+.agent-card-runs-icon,
+.agent-card-runs-chevron {
+    display: inline-flex;
+    flex: 0 0 auto;
+}
+
+.agent-card-runs-icon svg,
+.agent-card-runs-chevron svg {
+    width: 16px;
+    height: 16px;
+}
+
+.agent-card-runs-link > span:nth-child(2) {
+    flex: 1;
+    min-width: 0;
+}
+
+.agent-card-sparkline {
+    flex: 0 0 auto;
+    margin-top: 4px;
+    opacity: 0.95;
+}
+
+.agent-card-stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 16px;
+}
+
+.agent-card-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.agent-card-stat-label {
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.agent-card-stat-value {
+    font-size: 13px;
+    font-weight: 650;
+    color: var(--text-primary);
+}
+
+.agent-card-activity {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.agent-card-activity-icon {
+    flex: 0 0 auto;
+    display: inline-flex;
+    width: 18px;
+    height: 18px;
+    margin-top: 1px;
+}
+
+.agent-card-activity-icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.agent-card-activity-icon--buy { color: #4ade80; }
+.agent-card-activity-icon--done { color: #67e8f9; }
+
+.agent-card-activity-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.agent-card-activity-sub {
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.agent-card-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 22px 14px;
+    border: 1px dashed rgba(107, 114, 128, 0.45);
+    border-radius: 10px;
+    text-align: center;
+    color: var(--text-muted);
+    background: rgba(15, 19, 40, 0.35);
+}
+
+.agent-card-empty-icon {
+    display: inline-flex;
+    color: var(--text-muted);
+    opacity: 0.7;
+    margin-bottom: 2px;
+}
+
+.agent-card-empty-icon svg {
+    width: 28px;
+    height: 28px;
+}
+
+.agent-card-empty strong {
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 650;
+}
+
+.agent-card-empty span {
+    font-size: 12px;
+    line-height: 1.4;
+    max-width: 220px;
+}
+
+.agent-card-actions--status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: auto;
+}
+
+.agent-card-cta {
+    flex: 1;
+    min-width: 0;
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    background: var(--home-accent-cyan, #22d3ee);
+    color: #04101a;
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: filter 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.agent-card-cta:hover {
+    filter: brightness(1.06);
+}
+
+.agent-card-cta--outline {
+    background: transparent;
+    border-color: var(--home-accent-cyan, #22d3ee);
+    color: var(--home-accent-cyan, #22d3ee);
+}
+
+.agent-card-cta--outline:hover {
+    filter: none;
+    background: rgba(34, 211, 238, 0.1);
+}
+
+.agent-card-menu {
+    position: relative;
+    flex: 0 0 auto;
+}
+
+.agent-menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.agent-menu-toggle svg {
+    width: 18px;
+    height: 18px;
+}
+
+.agent-menu-toggle:hover,
+.agent-menu-toggle[aria-expanded="true"] {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+    border-color: rgba(148, 163, 184, 0.35);
+}
+
+.agent-menu-dropdown {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 6px);
+    z-index: 20;
+    min-width: 148px;
+    padding: 6px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-surface);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.agent-menu-dropdown[hidden] {
+    display: none !important;
+}
+
+.agent-menu-item {
+    display: block;
+    width: 100%;
+    padding: 8px 10px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+}
+
+.agent-menu-item:hover {
+    background: var(--bg-hover);
+}
+
+.agent-menu-item--danger {
+    color: #f87171;
 }
 
 /* List view — one full-width card per row */
@@ -5500,12 +7288,8 @@ a.header-brand:hover .title-section h1 {
     grid-template-columns: 1fr;
 }
 
-.agents-grid--list .agent-card--compact .agent-metrics {
-    max-width: 320px;
-}
-
-.agents-grid--list .agent-card--compact .agent-card-actions {
-    justify-content: flex-start;
+.agents-grid--list .agent-card--status {
+    max-width: 720px;
 }
 
 /* Responsive */
@@ -5680,8 +7464,8 @@ a.header-brand:hover .title-section h1 {
 }
 
 .status-badge.draft {
-    background-color: rgba(92, 124, 250, 0.15);
-    color: var(--neutral-color);
+    background-color: rgba(107, 114, 128, 0.18);
+    color: var(--text-muted);
 }
 
 .status-badge.offline {


### PR DESCRIPTION
## Summary
- Refine Home dashboard cards (My Portfolio, My Agents, Leaderboard, Market News/Signals, Community Overview) with Title Case titles, cleaner demo-data labeling, and consistent outlined footer CTAs.
- Improve My Agents: human-readable model labels, backtest history row, Manage agents CTA, spacing aligned to the agents page card.
- Reorganize Community Overview (Live in header, metrics then Recent Activity) and keep FinSearch wiring for Market News/Signals without changing backend APIs.

## Test plan
- [ ] Hard-refresh `/app` and confirm titles: My Portfolio / My Agents / Leaderboard / Market News / Community Overview
- [ ] Confirm first-row CTAs: View my portfolio / Manage agents / Explore leaderboard (outlined, bottom-aligned)
- [ ] My Agents shows `Claude Haiku 4.5 · Built-in` (not raw provider path) and `1 backtest →` separate from Completed backtest activity
- [ ] Market tab switches title to Market Signals; Demo data badge only when feed is mocked
- [ ] Community: Live badge in header, no Sample live activity text
- [ ] No backend/API changes; based on latest `upstream/main` with no upstream overrides


Made with [Cursor](https://cursor.com)