### PR TITLE
Add Daily Leaderboard to Competition

### DIFF
--- a/dashboard/backend/api/routers/leaderboard.py
+++ b/dashboard/backend/api/routers/leaderboard.py
@@ -15,15 +15,22 @@ router = APIRouter(prefix="/v1/leaderboard", tags=["leaderboard"])
 
 
 @router.get("")
-async def api_get_leaderboard(refresh: bool = Query(default=False)):
+async def api_get_leaderboard(
+    refresh: bool = Query(default=False),
+    period: str = Query(
+        default="contest",
+        description="Leaderboard period: 'contest' (fixed preseason window) or 'daily' (last completed weekday).",
+    ),
+):
     """
-    Official competition leaderboard for the configured contest window.
+    Official competition / daily leaderboard for the requested period.
 
     Baselines are computed from Alpaca hourly backtest data and cached in SQLite.
     Pass ?refresh=true to recompute (e.g. after config change).
+    Pass ?period=daily for the rolling one-day board.
     """
     try:
-        return get_leaderboard(force_refresh=refresh)
+        return get_leaderboard(force_refresh=refresh, period=period)
     except RuntimeError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except Exception as exc:

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -26,10 +26,11 @@ from dashboard.backend.domain.leaderboard.baselines import (
 )
 from dashboard.backend.domain.leaderboard.strategies._common import reference_start_date
 from dashboard.backend.domain.leaderboard.strategies import get_strategy
-from dashboard.backend.paths import CONFIG_DIR
+from dashboard.backend.paths import CONFIG_DIR, DATA_DIR
 
 LEADERBOARD_MODE = "leaderboard"
 VALID_PERIODS = ("contest", "daily")
+_SKIP_CACHE_PATH = DATA_DIR / "leaderboard_skip_cache.json"
 
 # H6 integrity threshold: an LLM entry must have decided at least this fraction
 # of its steps with the model itself. Below it, the curve is mostly a rule-based
@@ -116,6 +117,56 @@ def _run_id(strategy_id: str, start_date: str, end_date: str) -> str:
     return f"lb_{strategy_id}_{start_date.replace('-', '')}_{end_date.replace('-', '')}"
 
 
+def _skip_cache_key(session_id: str, start_date: str, end_date: str, strategy_id: str) -> str:
+    return f"{session_id}|{start_date}|{end_date}|{strategy_id}"
+
+
+def _load_skip_cache() -> Dict[str, str]:
+    if not _SKIP_CACHE_PATH.exists():
+        return {}
+    try:
+        with open(_SKIP_CACHE_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_skip_cache(cache: Dict[str, str]) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(_SKIP_CACHE_PATH, "w", encoding="utf-8") as f:
+        json.dump(cache, f, indent=2, sort_keys=True)
+
+
+def _is_skipped(
+    session_id: str, start_date: str, end_date: str, strategy_id: str, cache: Dict[str, str]
+) -> bool:
+    return _skip_cache_key(session_id, start_date, end_date, strategy_id) in cache
+
+
+def _record_skip(
+    session_id: str,
+    start_date: str,
+    end_date: str,
+    strategy_id: str,
+    reason: str,
+    cache: Dict[str, str],
+) -> None:
+    """Remember an uncomputable baseline for this window so we don't refetch daily."""
+    cache[_skip_cache_key(session_id, start_date, end_date, strategy_id)] = reason
+    _save_skip_cache(cache)
+
+
+def _clear_skips_for_window(
+    session_id: str, start_date: str, end_date: str, cache: Dict[str, str]
+) -> Dict[str, str]:
+    prefix = f"{session_id}|{start_date}|{end_date}|"
+    kept = {k: v for k, v in cache.items() if not k.startswith(prefix)}
+    if len(kept) != len(cache):
+        _save_skip_cache(kept)
+    return kept
+
+
 def _find_cached_run(strategy_id: str, start_date: str, end_date: str, session_id: str) -> Optional[Dict[str, Any]]:
     for run in db.get_runs_by_session(session_id) or []:
         if (
@@ -167,23 +218,47 @@ def ensure_leaderboard_runs(
     period: Optional[str] = "contest",
     config: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Compute and persist leaderboard baselines if missing."""
+    """Compute and persist leaderboard baselines if missing.
+
+    Successful runs are cached in SQLite. Strategies that fail for a given
+    window (empty curve / no bars) are recorded in a small skip cache so a
+    broken baseline like mean-variance cannot force an Alpaca refetch on every
+    page load — especially important for the daily board ("once per day").
+    """
     config = config or resolve_leaderboard_config(period)
     session_id = config["session_id"]
     start_date = config["start_date"]
     end_date = config["end_date"]
     initial_capital = float(config.get("initial_capital", INITIAL_CAPITAL))
+    skip_cache = _load_skip_cache()
+    if force_refresh:
+        skip_cache = _clear_skips_for_window(session_id, start_date, end_date, skip_cache)
 
-    needs_fetch = force_refresh
+    missing: List[Dict[str, Any]] = []
     for strategy in config.get("strategies", []):
         if not _auto_compute(strategy):
             continue  # LLM models are deployed manually, never block a request
-        if force_refresh:
+        strategy_id = strategy["id"]
+        if not force_refresh and _find_cached_run(strategy_id, start_date, end_date, session_id):
             continue
-        if not _find_cached_run(strategy["id"], start_date, end_date, session_id):
-            needs_fetch = True
-            break
+        if not force_refresh and _is_skipped(session_id, start_date, end_date, strategy_id, skip_cache):
+            continue
+        missing.append(strategy)
 
+    # Nothing left to compute — serve cached board without touching Alpaca.
+    if not missing and not force_refresh:
+        return {
+            "session_id": session_id,
+            "start_date": start_date,
+            "end_date": end_date,
+            "period": config.get("period", "contest"),
+            "created": 0,
+            "skipped": 0,
+            "refreshed_at": _utcnow_iso(),
+            "cache_hit": True,
+        }
+
+    needs_fetch = bool(missing) or force_refresh
     bars_by_symbol: Optional[Dict[str, Any]] = None
     if needs_fetch:
         if _config_needs_alpaca(config):
@@ -202,7 +277,9 @@ def ensure_leaderboard_runs(
 
     created = 0
     skipped = 0
-    for strategy in config.get("strategies", []):
+    # Only iterate strategies that still need work (or everything on force refresh).
+    to_run = config.get("strategies", []) if force_refresh else missing
+    for strategy in to_run:
         strategy_id = strategy["id"]
         if not _auto_compute(strategy):
             continue  # deployed via deploy_model_run(), not on-demand
@@ -221,12 +298,18 @@ def ensure_leaderboard_runs(
 
         if required and not bars:
             print(f"⚠️ Skipping {strategy_id}: no Alpaca bars for contest window")
+            _record_skip(
+                session_id, start_date, end_date, strategy_id, "no_bars", skip_cache
+            )
             skipped += 1
             continue
 
         curve = strategy_impl.run(bars, start_date, end_date, initial_capital)
         if not curve:
             print(f"⚠️ Skipping {strategy_id}: empty equity curve")
+            _record_skip(
+                session_id, start_date, end_date, strategy_id, "empty_curve", skip_cache
+            )
             skipped += 1
             continue
 
@@ -273,6 +356,7 @@ def ensure_leaderboard_runs(
         "created": created,
         "skipped": skipped,
         "refreshed_at": _utcnow_iso(),
+        "cache_hit": False,
     }
 
 

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -11,8 +11,8 @@ moved.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
 
 import dashboard.backend.infrastructure.llm.token_cost as token_cost
 from dashboard.backend.database import db
@@ -29,6 +29,7 @@ from dashboard.backend.domain.leaderboard.strategies import get_strategy
 from dashboard.backend.paths import CONFIG_DIR
 
 LEADERBOARD_MODE = "leaderboard"
+VALID_PERIODS = ("contest", "daily")
 
 # H6 integrity threshold: an LLM entry must have decided at least this fraction
 # of its steps with the model itself. Below it, the curve is mostly a rule-based
@@ -57,6 +58,58 @@ def load_leaderboard_config() -> Dict[str, Any]:
     path = CONFIG_DIR / "leaderboard.json"
     with open(path, encoding="utf-8") as f:
         return json.load(f)
+
+
+def _normalize_period(period: Optional[str]) -> str:
+    value = (period or "contest").strip().lower()
+    return value if value in VALID_PERIODS else "contest"
+
+
+def daily_window_dates(as_of: Optional[date] = None) -> Tuple[str, str]:
+    """Most recently completed weekday (Mon–Fri), used as the daily board window."""
+    d = as_of or datetime.now(timezone.utc).date()
+    d = d - timedelta(days=1)
+    while d.weekday() >= 5:  # Sat/Sun → roll back to Friday
+        d -= timedelta(days=1)
+    iso = d.isoformat()
+    return iso, iso
+
+
+def resolve_leaderboard_config(period: Optional[str] = "contest") -> Dict[str, Any]:
+    """Return the effective leaderboard config for ``contest`` or ``daily``.
+
+    Daily reuses the same strategy roster as the contest board, but caches under
+    a separate session and a rolling 1-day (last completed weekday) window.
+    """
+    base = load_leaderboard_config()
+    period_key = _normalize_period(period)
+    if period_key == "daily":
+        start_date, end_date = daily_window_dates()
+        # Drop fixed contest reference so mean-variance gets a fresh prior month.
+        daily_base = {k: v for k, v in base.items() if k != "reference_start_date"}
+        return {
+            **daily_base,
+            "session_id": base.get("daily_session_id", "leaderboard-daily"),
+            "start_date": start_date,
+            "end_date": end_date,
+            "reference_start_date": reference_start_date(start_date, None),
+            "description": (
+                f"Daily leaderboard for {start_date} (last completed US weekday). "
+                "Baselines recompute on load; LLM models are refreshed by the daily deploy job."
+            ),
+            "period": "daily",
+            "board_title": "Daily Leaderboard",
+            "phase_label": "Daily",
+            "standings_label": "Daily Standings",
+        }
+    return {
+        **base,
+        "period": "contest",
+        "board_title": "Competition Leaderboard",
+        "phase_label": "Preseason",
+        "standings_label": "Preseason Standings",
+    }
+
 
 
 def _run_id(strategy_id: str, start_date: str, end_date: str) -> str:
@@ -109,9 +162,13 @@ def _config_needs_mean_variance(config: Dict[str, Any]) -> bool:
     return False
 
 
-def ensure_leaderboard_runs(force_refresh: bool = False) -> Dict[str, Any]:
+def ensure_leaderboard_runs(
+    force_refresh: bool = False,
+    period: Optional[str] = "contest",
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Compute and persist leaderboard baselines if missing."""
-    config = load_leaderboard_config()
+    config = config or resolve_leaderboard_config(period)
     session_id = config["session_id"]
     start_date = config["start_date"]
     end_date = config["end_date"]
@@ -212,6 +269,7 @@ def ensure_leaderboard_runs(force_refresh: bool = False) -> Dict[str, Any]:
         "session_id": session_id,
         "start_date": start_date,
         "end_date": end_date,
+        "period": config.get("period", "contest"),
         "created": created,
         "skipped": skipped,
         "refreshed_at": _utcnow_iso(),
@@ -303,6 +361,7 @@ def deploy_model_run(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     allow_fallback: bool = False,
+    period: Optional[str] = "contest",
 ) -> Dict[str, Any]:
     """Compute and persist one (expensive) leaderboard model entry.
 
@@ -310,9 +369,10 @@ def deploy_model_run(
     leaderboard: it runs the model's hourly backtest over the contest window,
     stores the equity curve + metrics + token cost, and caches it so the web
     leaderboard can display it without recomputing. Pass start/end to test on a
-    shorter window (writes a separate cached run for that window).
+    shorter window (writes a separate cached run for that window). Pass
+    ``period="daily"`` to target the rolling daily board window.
     """
-    config = load_leaderboard_config()
+    config = resolve_leaderboard_config(period)
     session_id = config["session_id"]
     start_date = start_date or config["start_date"]
     end_date = end_date or config["end_date"]
@@ -435,10 +495,13 @@ def _rank_entries(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return entries
 
 
-def get_leaderboard(force_refresh: bool = False) -> Dict[str, Any]:
+def get_leaderboard(
+    force_refresh: bool = False,
+    period: Optional[str] = "contest",
+) -> Dict[str, Any]:
     """Return ranked leaderboard entries with chart-ready equity curves."""
-    meta = ensure_leaderboard_runs(force_refresh=force_refresh)
-    config = load_leaderboard_config()
+    config = resolve_leaderboard_config(period)
+    meta = ensure_leaderboard_runs(force_refresh=force_refresh, config=config)
     session_id = config["session_id"]
     start_date = config["start_date"]
     end_date = config["end_date"]
@@ -519,10 +582,14 @@ def get_leaderboard(force_refresh: bool = False) -> Dict[str, Any]:
         leader = entries[0]["team_name"] if entries else "—"
 
     return {
+        "period": config.get("period", "contest"),
+        "board_title": config.get("board_title", "Competition Leaderboard"),
+        "phase_label": config.get("phase_label", "Preseason"),
+        "standings_label": config.get("standings_label", "Preseason Standings"),
         "window": {
             "start_date": start_date,
             "end_date": end_date,
-            "label": f"{start_date} → {end_date}",
+            "label": f"{start_date} → {end_date}" if start_date != end_date else start_date,
             "description": config.get("description", ""),
         },
         "updated_at": meta.get("refreshed_at"),

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -489,9 +489,17 @@ def deploy_model_run(
         }
 
     strategy_impl = get_strategy(entry)
-    bars = fetch_hourly_bars(strategy_impl.required_symbols(), start_date, end_date)
+    # LLM prompts need indicator lookback; for a 1-day daily window that means
+    # fetching prior bars while only trading inside [start_date, end_date].
+    bars_start = reference_start_date(start_date, config)
+    if bars_start > start_date:
+        bars_start = start_date
+    bars = fetch_hourly_bars(strategy_impl.required_symbols(), bars_start, end_date)
     if not bars:
-        raise RuntimeError("No market data returned for the contest window")
+        raise RuntimeError(
+            f"No market data returned for bars window {bars_start} → {end_date}"
+        )
+    print(f"  bars fetch: {bars_start} → {end_date} (trade window {start_date} → {end_date})")
 
     curve = strategy_impl.run(bars, start_date, end_date, initial_capital)
     if not curve:

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -11,6 +11,8 @@ moved.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -68,6 +70,10 @@ def _normalize_period(period: Optional[str]) -> str:
 
 def daily_window_dates(as_of: Optional[date] = None) -> Tuple[str, str]:
     """Most recently completed weekday (Mon–Fri), used as the daily board window."""
+    # UTC "yesterday" is intentionally conservative: for the ~4h between a
+    # weekday's 16:00 ET close and 00:00 UTC the board still shows the prior
+    # completed session rather than a partial/in-progress one. Same-day
+    # freshness is driven by the nightly deploy job, not this boundary.
     d = as_of or datetime.now(timezone.utc).date()
     d = d - timedelta(days=1)
     while d.weekday() >= 5:  # Sat/Sun → roll back to Friday
@@ -96,7 +102,7 @@ def resolve_leaderboard_config(period: Optional[str] = "contest") -> Dict[str, A
             "reference_start_date": reference_start_date(start_date, None),
             "description": (
                 f"Daily leaderboard for {start_date} (last completed US weekday). "
-                "Baselines recompute on load; LLM models are refreshed by the daily deploy job."
+                "Baselines recompute on load; LLM entries appear once the daily deploy job runs."
             ),
             "period": "daily",
             "board_title": "Daily Leaderboard",
@@ -110,7 +116,6 @@ def resolve_leaderboard_config(period: Optional[str] = "contest") -> Dict[str, A
         "phase_label": "Preseason",
         "standings_label": "Preseason Standings",
     }
-
 
 
 def _run_id(strategy_id: str, start_date: str, end_date: str) -> str:
@@ -133,9 +138,30 @@ def _load_skip_cache() -> Dict[str, str]:
 
 
 def _save_skip_cache(cache: Dict[str, str]) -> None:
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    with open(_SKIP_CACHE_PATH, "w", encoding="utf-8") as f:
-        json.dump(cache, f, indent=2, sort_keys=True)
+    """Persist the skip cache.
+
+    Best-effort optimization only: this sidecar just avoids re-fetching a
+    baseline already known to be uncomputable for a window. Concurrent writers
+    race last-write-wins, and a lost write merely costs one extra recompute
+    (``_load_skip_cache`` already tolerates a missing/corrupt file). We still
+    write to a unique temp file and ``os.replace`` so a crash mid-write can
+    never leave a truncated, unparseable JSON file behind for readers.
+    """
+    # The temp file must sit in the destination's own directory so os.replace
+    # is an atomic same-filesystem rename (a cross-device rename raises OSError).
+    dest_dir = _SKIP_CACHE_PATH.parent
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(dest_dir), prefix=".skip_cache_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(cache, f, indent=2, sort_keys=True)
+        os.replace(tmp, _SKIP_CACHE_PATH)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _is_skipped(
@@ -162,6 +188,31 @@ def _clear_skips_for_window(
 ) -> Dict[str, str]:
     prefix = f"{session_id}|{start_date}|{end_date}|"
     kept = {k: v for k, v in cache.items() if not k.startswith(prefix)}
+    if len(kept) != len(cache):
+        _save_skip_cache(kept)
+    return kept
+
+
+def _prune_stale_window_skips(
+    session_id: str, start_date: str, end_date: str, cache: Dict[str, str]
+) -> Dict[str, str]:
+    """Drop skip entries for *earlier* windows of this same session.
+
+    The daily board's window rolls every trading day, so yesterday's
+    ``leaderboard-daily|<old-window>|...`` keys are dead the moment the window
+    advances. Without pruning, the sidecar would gain one entry per failing
+    baseline per day forever (a slow leak on a persistent disk). For a
+    fixed-window board like the contest there are no other-window keys under
+    its ``session_id``, so this is a no-op there. Entries from *other* sessions
+    are always preserved.
+    """
+    session_prefix = f"{session_id}|"
+    current_prefix = f"{session_id}|{start_date}|{end_date}|"
+    kept = {
+        k: v
+        for k, v in cache.items()
+        if not k.startswith(session_prefix) or k.startswith(current_prefix)
+    }
     if len(kept) != len(cache):
         _save_skip_cache(kept)
     return kept
@@ -231,6 +282,9 @@ def ensure_leaderboard_runs(
     end_date = config["end_date"]
     initial_capital = float(config.get("initial_capital", INITIAL_CAPITAL))
     skip_cache = _load_skip_cache()
+    # Bound the sidecar: forget skip entries for now-stale windows of this
+    # rolling board before doing anything else (no-op for fixed-window boards).
+    skip_cache = _prune_stale_window_skips(session_id, start_date, end_date, skip_cache)
     if force_refresh:
         skip_cache = _clear_skips_for_window(session_id, start_date, end_date, skip_cache)
 

--- a/dashboard/backend/domain/leaderboard/strategies/llm_agent.py
+++ b/dashboard/backend/domain/leaderboard/strategies/llm_agent.py
@@ -28,7 +28,7 @@ from dashboard.backend.infrastructure.llm.backtest_harness import (
 from dashboard.backend.infrastructure.llm.providers import KNOWN_INTEGRATIONS
 
 from .base import BaselineStrategy
-from ._common import build_price_cache, market_timestamps, subset_bars
+from ._common import build_price_cache, market_timestamps, subset_bars, timestamps_in_contest
 
 
 class LLMAgentStrategy(BaselineStrategy):
@@ -82,12 +82,16 @@ class LLMAgentStrategy(BaselineStrategy):
             return []
 
         # Technical indicators are required for the LLM prompt context.
+        # Bars may include a lookback period before start_date (needed for a
+        # 1-day daily board); decision steps are clipped to the contest window.
         data = {
             sym: TechnicalIndicators.calculate_indicators(df)
             for sym, df in bars_subset.items()
         }
 
-        timestamps = market_timestamps(data)
+        timestamps = timestamps_in_contest(
+            market_timestamps(data), start_date, end_date
+        )
         if not timestamps:
             return []
         price_cache = build_price_cache(data, timestamps)

--- a/dashboard/backend/tests/domain/leaderboard/test_service_move.py
+++ b/dashboard/backend/tests/domain/leaderboard/test_service_move.py
@@ -150,7 +150,7 @@ def isolated_service(tmp_path, monkeypatch):
     monkeypatch.setattr(
         canon_service,
         "ensure_leaderboard_runs",
-        lambda force_refresh=False: {
+        lambda force_refresh=False, period="contest", config=None: {
             "session_id": _CONFIG["session_id"],
             "start_date": _CONFIG["start_date"],
             "end_date": _CONFIG["end_date"],
@@ -194,7 +194,10 @@ def test_get_leaderboard_schema_and_ranking(isolated_service):
     result = canon_service.get_leaderboard()
     assert set(result.keys()) == {
         "window", "updated_at", "total_entries", "leader", "entries", "display_capital",
+        # period + board labelling fields (contest vs daily)
+        "period", "board_title", "phase_label", "standings_label",
     }
+    assert result["period"] == "contest"
     assert result["total_entries"] == 2
     assert result["window"]["label"] == "2026-04-15 → 2026-05-15"
     assert result["display_capital"] == 100000

--- a/dashboard/backend/tests/test_leaderboard_api.py
+++ b/dashboard/backend/tests/test_leaderboard_api.py
@@ -77,10 +77,11 @@ def test_leaderboard_api_returns_baselines(client, monkeypatch):
     monkeypatch.setattr(
         lb_service,
         "ensure_leaderboard_runs",
-        lambda force_refresh=False: {
+        lambda force_refresh=False, period="contest", config=None: {
             "session_id": "leaderboard-contest",
             "start_date": "2026-04-15",
             "end_date": "2026-05-15",
+            "period": "contest",
             "created": 0,
             "refreshed_at": "2026-06-18T00:00:00+00:00",
         },
@@ -90,6 +91,8 @@ def test_leaderboard_api_returns_baselines(client, monkeypatch):
     assert resp.status_code == 200
     body = resp.json()
     assert body["total_entries"] == 2
+    assert body["period"] == "contest"
+    assert body["phase_label"] == "Preseason"
     assert len(body["entries"]) == 2
     names = {e["team_name"] for e in body["entries"]}
     assert names == {"Agentic Trading Lab"}
@@ -98,4 +101,73 @@ def test_leaderboard_api_returns_baselines(client, monkeypatch):
     assert "SPY" in models
     assert body["entries"][0]["rank"] == 1
     assert body["entries"][0]["entry_type"] == "baseline"
-    assert "win_loss_ratio" not in body["entries"][0]
+
+
+def test_daily_leaderboard_api_uses_daily_window(client, monkeypatch):
+    day = "2026-07-14"  # Tuesday
+    monkeypatch.setattr(lb_service, "daily_window_dates", lambda as_of=None: (day, day))
+
+    start = day
+    end = day
+    for strategy_id, final, ret, sharpe in (
+        ("djia_index", 101000, 0.01, 0.5),
+        ("spy_index", 100500, 0.005, 0.4),
+    ):
+        run_id = f"lb_{strategy_id}_{start.replace('-', '')}_{end.replace('-', '')}"
+        lb_service.db.insert_run(
+            run_id=run_id,
+            session_id="leaderboard-daily",
+            agent_name="Agentic Trading Lab",
+            mode="leaderboard",
+            start_date=start,
+            end_date=end,
+            initial_equity=100000,
+            final_equity=final,
+            total_return=ret,
+            sharpe_ratio=sharpe,
+            max_drawdown=-0.01,
+            num_trades=1,
+            llm_model=strategy_id,
+        )
+        lb_service.db.insert_equity_points(
+            run_id,
+            [
+                {"timestamp": f"{start}T14:00:00", "equity": 100000, "cash": 0, "positions_value": 100000},
+                {"timestamp": f"{end}T20:00:00", "equity": final, "cash": 0, "positions_value": final},
+            ],
+        )
+
+    monkeypatch.setattr(
+        lb_service,
+        "ensure_leaderboard_runs",
+        lambda force_refresh=False, period="contest", config=None: {
+            "session_id": "leaderboard-daily",
+            "start_date": day,
+            "end_date": day,
+            "period": "daily",
+            "created": 0,
+            "refreshed_at": "2026-07-15T00:00:00+00:00",
+        },
+    )
+
+    resp = client.get("/api/v1/leaderboard?period=daily")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["period"] == "daily"
+    assert body["phase_label"] == "Daily"
+    assert body["standings_label"] == "Daily Standings"
+    assert body["window"]["start_date"] == day
+    assert body["window"]["end_date"] == day
+    assert body["total_entries"] == 2
+    assert body["entries"][0]["rank"] == 1
+
+
+def test_daily_window_dates_skips_weekend():
+    # Monday → previous Friday
+    from datetime import date
+
+    start, end = lb_service.daily_window_dates(as_of=date(2026, 7, 13))  # Monday
+    assert start == end == "2026-07-10"
+    # Tuesday → Monday
+    start, end = lb_service.daily_window_dates(as_of=date(2026, 7, 14))
+    assert start == end == "2026-07-13"

--- a/dashboard/backend/tests/test_leaderboard_api.py
+++ b/dashboard/backend/tests/test_leaderboard_api.py
@@ -269,3 +269,50 @@ def test_ensure_leaderboard_runs_skips_refetch_after_empty_curve(tmp_path, monke
     assert second.get("cache_hit") is True
     assert second["created"] == 0
     assert fetch_calls["n"] == 1  # no second Alpaca pull
+
+
+def test_prune_stale_window_skips_bounds_daily_sidecar(tmp_path, monkeypatch):
+    """Rolling daily windows must not accumulate skip entries forever."""
+    import json as _json
+
+    monkeypatch.setattr(lb_service, "_SKIP_CACHE_PATH", tmp_path / "skips.json")
+
+    cache = {
+        # stale daily windows — should be dropped
+        "leaderboard-daily|2026-07-10|2026-07-10|mean_variance_djia": "empty_curve",
+        "leaderboard-daily|2026-07-13|2026-07-13|mean_variance_djia": "no_bars",
+        # current daily window — must be kept
+        "leaderboard-daily|2026-07-14|2026-07-14|mean_variance_djia": "empty_curve",
+        # a different session (contest) — must always be kept
+        "leaderboard|2025-01-01|2025-03-31|mean_variance_djia": "no_bars",
+    }
+
+    kept = lb_service._prune_stale_window_skips(
+        "leaderboard-daily", "2026-07-14", "2026-07-14", cache
+    )
+
+    assert set(kept) == {
+        "leaderboard-daily|2026-07-14|2026-07-14|mean_variance_djia",
+        "leaderboard|2025-01-01|2025-03-31|mean_variance_djia",
+    }
+    # the reduced set was persisted to disk
+    on_disk = _json.loads((tmp_path / "skips.json").read_text(encoding="utf-8"))
+    assert set(on_disk) == set(kept)
+
+
+def test_prune_stale_window_skips_noop_for_fixed_window(tmp_path, monkeypatch):
+    """A fixed-window (contest) board has no other-window keys under its session,
+    so nothing is pruned and no needless disk write happens."""
+    monkeypatch.setattr(lb_service, "_SKIP_CACHE_PATH", tmp_path / "skips.json")
+
+    cache = {
+        "leaderboard|2025-01-01|2025-03-31|mean_variance_djia": "no_bars",
+        # a daily entry is a *different* session (the trailing '|' guards against
+        # the "leaderboard" prefix matching "leaderboard-daily") → preserved.
+        "leaderboard-daily|2026-07-13|2026-07-13|mean_variance_djia": "empty_curve",
+    }
+    kept = lb_service._prune_stale_window_skips(
+        "leaderboard", "2025-01-01", "2025-03-31", dict(cache)
+    )
+    assert kept == cache  # unchanged
+    assert not (tmp_path / "skips.json").exists()  # no write when nothing pruned

--- a/dashboard/backend/tests/test_leaderboard_api.py
+++ b/dashboard/backend/tests/test_leaderboard_api.py
@@ -171,3 +171,101 @@ def test_daily_window_dates_skips_weekend():
     # Tuesday → Monday
     start, end = lb_service.daily_window_dates(as_of=date(2026, 7, 14))
     assert start == end == "2026-07-13"
+
+
+def test_ensure_leaderboard_runs_skips_refetch_after_empty_curve(tmp_path, monkeypatch):
+    """A failed baseline must not force Alpaca refetch on every page load."""
+    db_path = tmp_path / "lb.db"
+    test_db = db_module.BacktestDatabase(db_path=db_path)
+    monkeypatch.setattr(db_module, "db", test_db)
+    monkeypatch.setattr(lb_service, "db", test_db)
+    monkeypatch.setattr(lb_service, "_SKIP_CACHE_PATH", tmp_path / "skips.json")
+
+    config = {
+        "session_id": "leaderboard-daily",
+        "start_date": "2026-07-14",
+        "end_date": "2026-07-14",
+        "initial_capital": 1000,
+        "period": "daily",
+        "strategies": [
+            {
+                "id": "equal_weight_djia",
+                "name": "Agentic Trading Lab",
+                "label": "Baseline Strategy",
+                "model": "Equal-Weight",
+                "strategy": "equal_weight_index",
+                "symbols": [],
+            },
+            {
+                "id": "mean_variance_djia",
+                "name": "Agentic Trading Lab",
+                "label": "Baseline Strategy",
+                "model": "Mean-Variance",
+                "strategy": "mean_variance",
+                "symbols": [],
+            },
+        ],
+    }
+
+    class _Ok:
+        used_llm = None
+
+        def required_symbols(self):
+            return ["AAPL"]
+
+        def run(self, bars, start, end, capital):
+            return [
+                {"timestamp": f"{start}T14:00:00", "equity": capital, "cash": 0, "positions_value": capital},
+                {"timestamp": f"{end}T20:00:00", "equity": capital * 1.01, "cash": 0, "positions_value": capital * 1.01},
+            ]
+
+        def num_trades(self):
+            return 1
+
+    class _Empty:
+        used_llm = None
+
+        def required_symbols(self):
+            return ["AAPL"]
+
+        def run(self, bars, start, end, capital):
+            return []
+
+        def num_trades(self):
+            return 0
+
+    def fake_get_strategy(strategy):
+        return _Ok() if strategy["id"] == "equal_weight_djia" else _Empty()
+
+    fetch_calls = {"n": 0}
+
+    def fake_fetch(symbols, start, end):
+        fetch_calls["n"] += 1
+        return {"AAPL": object()}
+
+    monkeypatch.setattr(lb_service, "get_strategy", fake_get_strategy)
+    monkeypatch.setattr(lb_service, "fetch_hourly_bars", fake_fetch)
+    monkeypatch.setattr(lb_service, "_config_needs_alpaca", lambda cfg: True)
+    monkeypatch.setattr(lb_service, "_alpaca_bars_start", lambda cfg: cfg["start_date"])
+    monkeypatch.setattr(lb_service, "_symbols_for_config", lambda cfg: ["AAPL"])
+    monkeypatch.setattr(
+        lb_service,
+        "calc_metrics",
+        lambda curve, capital: {
+            "initial_equity": capital,
+            "final_equity": capital * 1.01,
+            "total_return": 0.01,
+            "sharpe_ratio": 1.0,
+            "max_drawdown": -0.01,
+        },
+    )
+
+    first = lb_service.ensure_leaderboard_runs(config=config)
+    assert first["created"] == 1
+    assert first["skipped"] == 1
+    assert fetch_calls["n"] == 1
+
+    second = lb_service.ensure_leaderboard_runs(config=config)
+    assert second.get("cache_hit") is True
+    assert second["created"] == 0
+    assert fetch_calls["n"] == 1  # no second Alpaca pull

--- a/dashboard/config/leaderboard.json
+++ b/dashboard/config/leaderboard.json
@@ -1,5 +1,6 @@
 {
   "session_id": "leaderboard-contest",
+  "daily_session_id": "leaderboard-daily",
   "initial_capital": 1000,
   "start_date": "2026-04-15",
   "end_date": "2026-05-15",

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -70,6 +70,7 @@
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="leaderboard"] .competition-subtabs [data-competition-tab="leaderboard"],
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="participants"] .competition-subtabs [data-competition-tab="participants"],
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="about"] .competition-subtabs [data-competition-tab="about"] { background: var(--info-color); color: white; }
+    html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="daily"] #leaderboardView,
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="leaderboard"] #leaderboardView { display: flex !important; }
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="participants"] #competitionParticipantsPanel { display: block !important; }
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="about"] #competitionAboutPanel { display: block !important; }
@@ -1265,7 +1266,7 @@
                 </div>
                 <div class="section-card">
                     <h3 class="section-title">Daily Leaderboard</h3>
-                    <p class="about-text">The Daily Leaderboard is the same chart + standings UI as Competition, but each entry is an hourly backtest over the <strong>last completed US weekday</strong>. Baselines refresh automatically; LLM models are redeployed by the daily job so the board updates every trading day.</p>
+                    <p class="about-text">The Daily Leaderboard is the same chart + standings UI as Competition, but each entry is an hourly backtest over the <strong>last completed US weekday</strong>. Baseline and index lines refresh automatically on load. LLM entries are added when the daily deploy job runs.</p>
                 </div>
                 <div class="section-card">
                     <h3 class="section-title">Competition Leaderboard</h3>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -24,7 +24,7 @@
                 community: { page: 'community' },
                 backtest: { page: 'playground', playgroundTab: 'backtest' },
                 paper: { page: 'playground', playgroundTab: 'paper' },
-                contest: { page: 'competition', competitionTab: 'leaderboard' },
+                contest: { page: 'competition', competitionTab: 'daily' },
                 'my-algo': { page: 'playground', playgroundTab: 'agents' },
             };
             // Discord / share deep links: open Playground backtest immediately.
@@ -44,7 +44,7 @@
         html.setAttribute('data-nav-boot', '');
         html.setAttribute('data-nav-page', nav.page);
         html.setAttribute('data-nav-playground-tab', nav.playgroundTab || 'agents');
-        html.setAttribute('data-nav-competition-tab', nav.competitionTab || 'leaderboard');
+        html.setAttribute('data-nav-competition-tab', nav.competitionTab || 'daily');
     })();
     </script>
     <style id="nav-boot-style">
@@ -66,6 +66,7 @@
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="backtest"] .main-container.playground-backtest-panel { display: grid !important; }
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="paper"] #paperTradingView { display: block !important; }
     html[data-nav-boot][data-nav-page="competition"] .competition-subtabs .subtab-btn.active { background: transparent; color: var(--text-secondary); }
+    html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="daily"] .competition-subtabs [data-competition-tab="daily"],
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="leaderboard"] .competition-subtabs [data-competition-tab="leaderboard"],
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="participants"] .competition-subtabs [data-competition-tab="participants"],
     html[data-nav-boot][data-nav-page="competition"][data-nav-competition-tab="about"] .competition-subtabs [data-competition-tab="about"] { background: var(--info-color); color: white; }
@@ -1242,7 +1243,8 @@
     <!-- Competition -->
     <div id="competitionView" class="page-view competition-view" style="display: none;">
         <div class="subtab-bar competition-subtabs">
-            <button class="subtab-btn active" data-competition-tab="leaderboard">Leaderboard</button>
+            <button class="subtab-btn active" data-competition-tab="daily">Daily Leaderboard</button>
+            <button class="subtab-btn" data-competition-tab="leaderboard">Competition Leaderboard</button>
             <button class="subtab-btn" data-competition-tab="participants">Participating Teams</button>
             <button class="subtab-btn" data-competition-tab="about">About</button>
         </div>
@@ -1262,7 +1264,11 @@
                     <p class="about-text">SecureFinAI Contest 2026 is a paper-trading competition for LLM-powered agents. The contest is currently in <strong>Preseason</strong>. Participating teams join when the season starts (registration Aug 2026).</p>
                 </div>
                 <div class="section-card">
-                    <h3 class="section-title">Current Leaderboard</h3>
+                    <h3 class="section-title">Daily Leaderboard</h3>
+                    <p class="about-text">The Daily Leaderboard is the same chart + standings UI as Competition, but each entry is an hourly backtest over the <strong>last completed US weekday</strong>. Baselines refresh automatically; LLM models are redeployed by the daily job so the board updates every trading day.</p>
+                </div>
+                <div class="section-card">
+                    <h3 class="section-title">Competition Leaderboard</h3>
                     <p class="about-text">Preseason Standings are a <strong>backtest leaderboard</strong>, not live trading. Each entry is an hourly backtest over <strong>2026-04-15 → 2026-05-15</strong> (one-month window), comparing provided LLM models, baseline strategies, and market indices. Official rank is by final portfolio value.</p>
                 </div>
                 <div class="section-card compact">
@@ -1385,7 +1391,7 @@
                 <!-- Left: Table -->
                 <section class="leaderboard-table-section compact">
                     <div class="table-header compact">
-                        <h3>Preseason Standings</h3>
+                        <h3 id="leaderboardStandingsTitle">Preseason Standings</h3>
                     </div>
                     <div class="table-wrapper compact">
                         <table class="leaderboard-table compact">

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1783,7 +1783,7 @@ let tradingLogFilter = 'all';
 let currentMode = "home";
 let currentPage = "home";
 let playgroundTab = "agents";
-let competitionTab = "leaderboard";
+let competitionTab = "daily";
 let allRuns = [];
 let comparisonData = null;
 let backtestChartData = null;
@@ -3336,7 +3336,7 @@ function applyInitialNavigation() {
     const initial = resolveInitialNavigation();
     navigateToPage(initial.page, {
         playgroundTab: initial.playgroundTab || 'agents',
-        competitionTab: initial.competitionTab || 'leaderboard',
+        competitionTab: initial.competitionTab || 'daily',
     });
     if (typeof initHomePage === 'function') {
         initHomePage();
@@ -3354,7 +3354,7 @@ function resolveInitialNavigation() {
         community: { page: 'community' },
         backtest: { page: 'playground', playgroundTab: 'backtest' },
         paper: { page: 'playground', playgroundTab: 'paper' },
-        contest: { page: 'competition', competitionTab: 'leaderboard' },
+        contest: { page: 'competition', competitionTab: 'daily' },
         'my-algo': { page: 'playground', playgroundTab: 'agents' },
     };
 
@@ -3499,14 +3499,15 @@ function showCompetitionPanel(tab) {
     const leaderboard = document.getElementById('leaderboardView');
     const participants = document.getElementById('competitionParticipantsPanel');
     const about = document.getElementById('competitionAboutPanel');
+    const showBoard = tab === 'leaderboard' || tab === 'daily';
 
-    if (leaderboard) leaderboard.style.display = tab === 'leaderboard' ? 'flex' : 'none';
+    if (leaderboard) leaderboard.style.display = showBoard ? 'flex' : 'none';
     if (participants) participants.style.display = tab === 'participants' ? 'block' : 'none';
     if (about) about.style.display = tab === 'about' ? 'block' : 'none';
 
-    if (tab === 'leaderboard') {
+    if (showBoard) {
         currentMode = 'contest';
-        loadLeaderboardData();
+        loadLeaderboardData(tab === 'daily' ? 'daily' : 'contest');
     } else {
         currentMode = tab;
     }
@@ -3638,7 +3639,7 @@ function initNavigation() {
     });
 
     document.getElementById('homeViewCompetitionBtn')?.addEventListener('click', () => {
-        navigateToPage('competition', { competitionTab: 'leaderboard' });
+        navigateToPage('competition', { competitionTab: 'daily' });
     });
 
     document.getElementById('homeViewMarketPulseBtn')?.addEventListener('click', () => {
@@ -3711,12 +3712,12 @@ function switchMode(mode) {
     const legacyMap = {
         backtest: { page: 'playground', playgroundTab: 'backtest' },
         paper: { page: 'playground', playgroundTab: 'paper' },
-        contest: { page: 'competition', competitionTab: 'leaderboard' },
+        contest: { page: 'competition', competitionTab: 'daily' },
         'my-algo': { page: 'playground', playgroundTab: 'agents' },
         home: { page: 'home' },
         agents: { page: 'playground', playgroundTab: 'agents' },
         playground: { page: 'playground', playgroundTab: 'agents' },
-        competition: { page: 'competition', competitionTab: 'leaderboard' },
+        competition: { page: 'competition', competitionTab: 'daily' },
     };
 
     const target = legacyMap[mode] || { page: mode };

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -260,8 +260,10 @@ function updateLeaderboardHeader(payload) {
   const windowEl = document.getElementById('tradingWindow');
   const updatedEl = document.getElementById('lastUpdate');
   const leaderEl = document.getElementById('leaderTeam');
+  const standingsEl = document.getElementById('leaderboardStandingsTitle');
+  const subtitleEl = document.querySelector('#leaderboardView .contest-subtitle');
 
-  if (totalEl) totalEl.textContent = 'Preseason';
+  if (totalEl) totalEl.textContent = payload.phase_label || (payload.period === 'daily' ? 'Daily' : 'Preseason');
   if (windowEl) windowEl.textContent = payload.window?.label || '—';
   if (updatedEl) {
     updatedEl.textContent = payload.updated_at
@@ -274,7 +276,46 @@ function updateLeaderboardHeader(payload) {
       ? (top.model || top.team_name)
       : (payload.leader || '—');
   }
+  if (standingsEl) {
+    standingsEl.textContent = payload.standings_label
+      || (payload.period === 'daily' ? 'Daily Standings' : 'Preseason Standings');
+  }
+  if (subtitleEl) {
+    subtitleEl.textContent = payload.period === 'daily'
+      ? (payload.window?.label ? `Daily window · ${payload.window.label}` : 'Daily window · last completed weekday')
+      : 'Sep 1 – Oct 30, 2026';
+  }
   updateCurvePickerCount();
+}
+
+async function loadLeaderboardData(period = 'contest') {
+  console.log('Loading leaderboard from API...', period);
+  const boardPeriod = period === 'daily' ? 'daily' : 'contest';
+
+  try {
+    const url = `${API_BASE}/api/v1/leaderboard?period=${encodeURIComponent(boardPeriod)}&t=${Date.now()}`;
+    leaderboardPayload = await API.get(url);
+    const entries = leaderboardPayload.entries || [];
+    equityCurvesData = buildEquityCurvesFromEntries(entries);
+
+    // Reset chart visibility when switching boards so daily/contest don't share hide state.
+    hiddenSeries = new Set();
+    hiddenInitialized = true;
+
+    updateLeaderboardHeader(leaderboardPayload);
+    populateLeaderboardTable();
+    renderCurvePicker();
+
+    if (!leaderboardListenersInitialized) {
+      initLeaderboardListeners();
+      leaderboardListenersInitialized = true;
+    }
+
+    await renderEquityCurvesChart();
+  } catch (error) {
+    console.error('Error loading leaderboard:', error);
+    displayLeaderboardError(error.message);
+  }
 }
 
 function initLeaderboardListeners() {
@@ -487,37 +528,6 @@ function computeDefaultHidden(entries) {
     if (kind === 'strategy' && hasTeams) hidden.add(label);
   });
   return hidden;
-}
-
-async function loadLeaderboardData() {
-  console.log('Loading leaderboard from API...');
-
-  try {
-    const url = `${API_BASE}/api/v1/leaderboard?t=${Date.now()}`;
-    leaderboardPayload = await API.get(url);
-    const entries = leaderboardPayload.entries || [];
-    equityCurvesData = buildEquityCurvesFromEntries(entries);
-
-    if (!hiddenInitialized) {
-      // Chart picker defaults to all curves visible (user then trims via dropdown).
-      hiddenSeries = new Set();
-      hiddenInitialized = true;
-    }
-
-    updateLeaderboardHeader(leaderboardPayload);
-    populateLeaderboardTable();
-    renderCurvePicker();
-
-    if (!leaderboardListenersInitialized) {
-      initLeaderboardListeners();
-      leaderboardListenersInitialized = true;
-    }
-
-    await renderEquityCurvesChart();
-  } catch (error) {
-    console.error('Error loading leaderboard:', error);
-    displayLeaderboardError(error.message);
-  }
 }
 
 function updateLeaderboardSortHeaders() {

--- a/dashboard/scripts/deploy_leaderboard_model.py
+++ b/dashboard/scripts/deploy_leaderboard_model.py
@@ -57,6 +57,12 @@ def main() -> int:
     parser.add_argument("--end", default=None, help="Override window end (YYYY-MM-DD) for testing")
     parser.add_argument("--force", action="store_true", help="Recompute even if a cached run exists")
     parser.add_argument(
+        "--period",
+        choices=("contest", "daily"),
+        default="contest",
+        help="Target board: contest (fixed preseason window) or daily (last completed weekday)",
+    )
+    parser.add_argument(
         "--allow-fallback",
         action="store_true",
         help="Publish even if the LLM entry fell back to rule-based trading "
@@ -78,7 +84,7 @@ def main() -> int:
             )
         return 0
 
-    print(f"Deploying '{args.entry}' to the leaderboard...")
+    print(f"Deploying '{args.entry}' to the {args.period} leaderboard...")
     if args.start or args.end:
         print(f"  (test window override: {args.start or 'config'} → {args.end or 'config'})")
 
@@ -89,6 +95,7 @@ def main() -> int:
             start_date=args.start,
             end_date=args.end,
             allow_fallback=args.allow_fallback,
+            period=args.period,
         )
     except LeaderboardFallbackError as exc:
         print("\n❌ Refused to publish a rule-based fallback under an LLM name:")

--- a/dashboard/scripts/refresh_daily_leaderboard.py
+++ b/dashboard/scripts/refresh_daily_leaderboard.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Refresh the Daily Leaderboard for the last completed US weekday.
+
+1. Recomputes cheap baselines (indices + rule-based strategies) for the daily window.
+2. Optionally redeploys every ``llm_agent`` entry (real API calls — pass ``--models``).
+
+Schedule nightly after US market close, e.g.:
+
+    # Baselines only (cheap):
+    python dashboard/scripts/refresh_daily_leaderboard.py
+
+    # Baselines + all LLM models:
+    python dashboard/scripts/refresh_daily_leaderboard.py --models
+
+Or hit ``GET /api/v1/leaderboard?period=daily&refresh=true`` for baselines only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+DASHBOARD_DIR = Path(__file__).resolve().parent.parent
+
+from _bootstrap import ensure_repo_root
+
+ensure_repo_root()
+
+load_dotenv(DASHBOARD_DIR / ".env")
+load_dotenv(DASHBOARD_DIR.parent / ".env")
+
+from dashboard.backend.domain.leaderboard.service import (  # noqa: E402
+    LeaderboardFallbackError,
+    deploy_model_run,
+    ensure_leaderboard_runs,
+    resolve_leaderboard_config,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Refresh the Daily Leaderboard window")
+    parser.add_argument(
+        "--models",
+        action="store_true",
+        help="Also redeploy every llm_agent entry for the daily window (expensive)",
+    )
+    parser.add_argument(
+        "--allow-fallback",
+        action="store_true",
+        help="Allow publishing LLM entries that fell back to rule-based trading",
+    )
+    args = parser.parse_args()
+
+    config = resolve_leaderboard_config("daily")
+    start = config["start_date"]
+    end = config["end_date"]
+    print(f"Daily leaderboard window: {start} → {end}")
+    print(f"Session: {config['session_id']}")
+
+    print("Recomputing baselines…")
+    try:
+        meta = ensure_leaderboard_runs(force_refresh=True, period="daily", config=config)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"Baselines created: {meta.get('created', 0)} (skipped {meta.get('skipped', 0)})")
+
+    if not args.models:
+        print("Done (baselines only). Pass --models to redeploy LLM entries.")
+        print("View: GET /api/v1/leaderboard?period=daily")
+        return 0
+
+    llm_entries = [
+        s for s in config.get("strategies", [])
+        if s.get("strategy") == "llm_agent" or s.get("auto_compute") is False
+    ]
+    print(f"Deploying {len(llm_entries)} model entr(y/ies)…")
+    failures = 0
+    for entry in llm_entries:
+        entry_id = entry["id"]
+        print(f"\n--- {entry_id} ({entry.get('model')}) ---")
+        try:
+            result = deploy_model_run(
+                entry_id,
+                force_refresh=True,
+                period="daily",
+                allow_fallback=args.allow_fallback,
+            )
+            ret = result.get("total_return")
+            ret_s = f"{ret * 100:+.2f}%" if ret is not None else "—"
+            print(f"  ok  run={result.get('run_id')}  return={ret_s}")
+        except (LeaderboardFallbackError, ValueError, RuntimeError) as exc:
+            failures += 1
+            print(f"  FAIL: {exc}", file=sys.stderr)
+
+    print(f"\nDone. Failures: {failures}")
+    print("View: GET /api/v1/leaderboard?period=daily")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/scripts/refresh_daily_leaderboard.py
+++ b/dashboard/scripts/refresh_daily_leaderboard.py
@@ -4,6 +4,13 @@
 1. Recomputes cheap baselines (indices + rule-based strategies) for the daily window.
 2. Optionally redeploys every ``llm_agent`` entry (real API calls — pass ``--models``).
 
+NOTE: nothing in this repo runs this script automatically yet — there is no cron
+or CI schedule wired up. Until one exists, the daily board shows baselines and
+index lines only (those recompute on load); LLM entries will not appear. It must
+also run somewhere that writes the *live* leaderboard DB: on the current
+free-tier Render deploy that DB is ephemeral (no persistent disk), so a schedule
+that runs off-instance won't reach prod without a persistent/shared DB.
+
 Schedule nightly after US market close, e.g.:
 
     # Baselines only (cheap):


### PR DESCRIPTION
## Summary
- Competition subtabs: **Daily Leaderboard** (first) · **Competition Leaderboard** · Participating Teams · About
- Daily board reuses the existing leaderboard chart/table via `GET /api/v1/leaderboard?period=daily` over the last completed US weekday; caches under `leaderboard-daily`
- Baselines auto-compute on load; LLM models refresh via `dashboard/scripts/refresh_daily_leaderboard.py --models` (nightly after market close)

## Test plan
- [ ] Competition → Daily Leaderboard shows same layout as Competition Leaderboard with Phase=Daily and a 1-day window
- [ ] Competition Leaderboard still shows the Apr–May preseason window
- [ ] `GET /api/v1/leaderboard?period=daily` returns `period: daily` and ranked entries
- [ ] `pytest dashboard/backend/tests/test_leaderboard_api.py -v` passes
- [ ] Optional: `python dashboard/scripts/refresh_daily_leaderboard.py` refreshes baselines


Made with [Cursor](https://cursor.com)