### PR TITLE
fix: close login modal on auth success

### DIFF
--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1821,8 +1821,10 @@ function initAuthUI() {
         })
         .catch((error) => {
           // Sign-in itself succeeded, so this must not reach the form's error
-          // slot; agents reload on the next refresh.
-          console.warn('Post-sign-in agent claim skipped:', error.message);
+          // slot; agents reload on the next refresh. Not named for the claim:
+          // claimAgentsForUser swallows the claim POST's own failure, so what
+          // lands here came from the reload leg after it.
+          console.warn('Post-sign-in agent reload failed:', error.message);
         });
     } catch (error) {
       if (errorEl) {

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1804,14 +1804,26 @@ function initAuthUI() {
         ? await AuthAPI.signup(email, displayName, password)
         : await AuthAPI.login(email, password);
       setAuthState(data.user, data.token);
-      await claimAgentsForUser();
+      // Authentication is complete here, so dismiss now. Everything below is
+      // post-sign-in housekeeping and must not hold the modal open — a slow or
+      // hung backend used to leave the popup up over an already-signed-in UI.
       closeAuthModal();
-      // If we arrived here from a Discord deep link that needed this account
-      // (params were kept), retry it now that the owner is signed in.
-      const deepLinkParams = new URLSearchParams(window.location.search);
-      if (deepLinkParams.get('agent_id') || deepLinkParams.get('run_id')) {
-        applyAgentRunDeepLink();
-      }
+      claimAgentsForUser()
+        .then(() => {
+          // If we arrived here from a Discord deep link that needed this account
+          // (params were kept), retry it now that the owner is signed in. This
+          // waits on the claim: until it lands the account does not own the
+          // agent yet and the deep link's fetch 403s.
+          const deepLinkParams = new URLSearchParams(window.location.search);
+          if (deepLinkParams.get('agent_id') || deepLinkParams.get('run_id')) {
+            applyAgentRunDeepLink();
+          }
+        })
+        .catch((error) => {
+          // Sign-in itself succeeded, so this must not reach the form's error
+          // slot; agents reload on the next refresh.
+          console.warn('Post-sign-in agent claim skipped:', error.message);
+        });
     } catch (error) {
       if (errorEl) {
         errorEl.textContent = error.message;


### PR DESCRIPTION
The login popup stayed open after a successful sign-in — the header already showed you as logged in, and you had to click the backdrop to dismiss it.

`closeAuthModal()` was sequenced behind `await claimAgentsForUser()` (`app.js:1807`), so dismissal waited on a `claim-account` POST + `loadAgents()`. `setAuthState()` had already signed the user in one line earlier. A slow backend left the modal up; a rejected claim meant it never auto-closed and rendered the claim's error inside the login form.

Now: dismiss on auth success, housekeeping runs in the background. The deep-link retry stays chained behind the claim (it needs ownership or it 403s), and a housekeeping failure `console.warn`s instead of reaching the form's error slot — the `catch` there now means "authentication failed" and nothing else.

Verified with a Playwright harness (slow / rejecting / hung claim all dismiss; genuine auth failure still errors; deep-link order unchanged). Against a real backend the sequence inverts from `AUTHENTICATED → claim → DISMISSED` to `AUTHENTICATED → DISMISSED → claim`.

Not covered by CI: there's no JS test framework for `dashboard/frontend`.

### Known limitations (not fixed here)

Dismissing the modal early uncovers UI that the overlay used to mask. None of these are fixable inside this hunk:

- **#152** — a claim that never *settles* (as opposed to rejecting) dismisses the modal but silently skips the deep-link retry; pre-PR the stuck modal was an accidental signal. Root cause is shared: `API.request`/`AuthAPI.request` have no timeout at all (the file's only `AbortController` is `loadMarketTicker`'s, `app.js:2477`). Gated on **#151**, because a local `Promise.race` fires the deep link before the claim lands and the resulting 403 tells the genuine owner the agent "belongs to a different account".
- **#151** — that false-ownership alert is already reachable without any timeout: `initAuthUI()` is not `async`, so the claim it kicks off races `DOMContentLoaded`'s `applyAgentRunDeepLink()`. Pre-existing; this PR neither causes nor fixes it.
- **#153** — Home briefly shows "Create your agent" to a returning user: `setAuthState()` → `updateAuthUI()` → `refreshHomeModules()` renders off the pre-claim `allAgents` (`home-page.js:1179`). Needs a loading state in `home-page.js`.
- **#154** — logout during an in-flight claim races two unguarded `loadAgents()` writes to the `allAgents` global (`app.js:1534` vs `app.js:1770`); last write wins. Needs a request-generation guard in `loadAgents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
