### PR TITLE
test: guard @pg_only fixtures against wiping a remote DB

### DIFF
--- a/dashboard/backend/tests/_postgres_testing.py
+++ b/dashboard/backend/tests/_postgres_testing.py
@@ -1,0 +1,39 @@
+"""Shared safety guard for the live-Postgres (``@pg_only``) test tier.
+
+The ``@pg_only`` fixtures run unconditional ``DELETE FROM`` against whatever
+``TEST_POSTGRES_URL`` names. That variable is deliberately *not* stripped by
+``conftest.py`` (it is how a developer opts into the live tier), so a plausible
+``export TEST_POSTGRES_URL=$CONTENT_DATABASE_URL`` would point those deletes at
+the production Neon database -- wiping every account, agent, and API key.
+
+``require_local_postgres_url`` is the counterweight: the destructive fixtures
+call it before touching the database, so a non-local URL fails loud rather than
+silently wiping prod (or silently skipping).
+"""
+
+from urllib.parse import urlsplit
+
+# CI uses localhost:5432; the documented local recipe uses localhost:5433.
+# Every legitimate target is local, so an allowlist costs nothing.
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def require_local_postgres_url(url):
+    """Return ``url`` if it is safe for the destructive @pg_only fixtures.
+
+    Unset (``None``/``""``) passes through untouched -- that drives the skipif
+    that skips the whole tier. A URL whose host is not in ``_LOCAL_HOSTS``
+    raises ``RuntimeError``, refusing to let the fixtures ``DELETE`` from a
+    remote (i.e. potentially production) database.
+    """
+    if not url:
+        return url
+    host = (urlsplit(url).hostname or "").lower()
+    if host not in _LOCAL_HOSTS:
+        raise RuntimeError(
+            f"TEST_POSTGRES_URL points at non-local host {host!r}. The @pg_only "
+            "fixtures run unconditional DELETEs and would wipe that database. "
+            "Refusing to run them anywhere but localhost/127.0.0.1 -- use a "
+            "throwaway Postgres (see the module docstring)."
+        )
+    return url

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -17,6 +17,8 @@ import os
 
 import pytest
 
+from dashboard.backend.tests._postgres_testing import require_local_postgres_url
+
 TEST_POSTGRES_URL = os.getenv("TEST_POSTGRES_URL")
 
 pg_only = pytest.mark.skipif(
@@ -132,6 +134,7 @@ def test_malformed_url_is_rejected_before_psycopg_can_echo_it():
 
 @pytest.fixture
 def pg_agent_store():
+    require_local_postgres_url(TEST_POSTGRES_URL)
     from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore
 
     store = PostgresAgentStore(TEST_POSTGRES_URL)
@@ -335,6 +338,7 @@ def test_malformed_url_is_rejected_before_psycopg_can_echo_it_version_store():
 
 @pytest.fixture
 def pg_version_store():
+    require_local_postgres_url(TEST_POSTGRES_URL)
     from dashboard.backend.domain.agents.version_repository_postgres import (
         PostgresAgentVersionStore,
     )

--- a/dashboard/backend/tests/test_postgres_url_guard.py
+++ b/dashboard/backend/tests/test_postgres_url_guard.py
@@ -1,0 +1,79 @@
+"""The @pg_only destructive-fixture guard must refuse non-local databases.
+
+These are pure-function tests -- no live Postgres -- so they run in ordinary
+CI, unlike the @pg_only tier they protect. See issue #136.
+"""
+
+import importlib
+
+import pytest
+
+from dashboard.backend.tests._postgres_testing import require_local_postgres_url
+
+# Re-import the destructive fixtures so we can prove each one refuses a remote
+# URL. Requesting them here (rather than in their own @pg_only tests) exercises
+# the guard in ordinary CI: it must raise *before* any connection is attempted.
+from dashboard.backend.tests.test_agent_store_postgres import (  # noqa: F401
+    pg_agent_store,
+    pg_version_store,
+)
+from dashboard.backend.tests.test_strategy_store_postgres import (  # noqa: F401
+    pg_strategy_store,
+)
+from dashboard.backend.tests.test_users_postgres import (  # noqa: F401
+    temp_postgres_store,
+)
+
+
+def test_rejects_remote_neon_host():
+    remote = "postgresql://user:pw@ep-cool-wave-ai917qe3-pooler.neon.tech/neondb"
+    with pytest.raises(RuntimeError, match="non-local"):
+        require_local_postgres_url(remote)
+
+
+def test_rejects_remote_host_even_with_localhost_in_credentials():
+    # Naive substring matching on "localhost" would wrongly allow this; the
+    # real host is neon.tech. urlsplit() extracts the host, ignoring userinfo.
+    sneaky = "postgresql://localhost:localhost@ep-cool.neon.tech/db"
+    with pytest.raises(RuntimeError):
+        require_local_postgres_url(sneaky)
+
+
+def test_allows_localhost():
+    url = "postgresql://postgres:test@localhost:5433/atl_test"
+    assert require_local_postgres_url(url) == url
+
+
+def test_allows_127_0_0_1():
+    url = "postgresql://postgres:test@127.0.0.1:5432/atl_test"
+    assert require_local_postgres_url(url) == url
+
+
+def test_unset_url_passes_through():
+    # Unset TEST_POSTGRES_URL drives the skipif that skips the whole tier; the
+    # guard only cares about set-but-remote, so None/"" must not raise.
+    assert require_local_postgres_url(None) is None
+    assert require_local_postgres_url("") == ""
+
+
+# .invalid never resolves, so RED (an unguarded fixture) fails fast on connect
+# rather than hanging; GREEN raises before the fixture ever touches the network.
+_REMOTE_URL = "postgresql://user:pw@remote.invalid:5432/db"
+
+
+@pytest.mark.parametrize(
+    "fixture_name, origin_module",
+    [
+        ("pg_agent_store", "dashboard.backend.tests.test_agent_store_postgres"),
+        ("pg_version_store", "dashboard.backend.tests.test_agent_store_postgres"),
+        ("pg_strategy_store", "dashboard.backend.tests.test_strategy_store_postgres"),
+        ("temp_postgres_store", "dashboard.backend.tests.test_users_postgres"),
+    ],
+)
+def test_destructive_fixture_refuses_remote_url(
+    fixture_name, origin_module, monkeypatch, request
+):
+    mod = importlib.import_module(origin_module)
+    monkeypatch.setattr(mod, "TEST_POSTGRES_URL", _REMOTE_URL)
+    with pytest.raises(RuntimeError, match="non-local"):
+        request.getfixturevalue(fixture_name)

--- a/dashboard/backend/tests/test_strategy_store_postgres.py
+++ b/dashboard/backend/tests/test_strategy_store_postgres.py
@@ -12,6 +12,8 @@ import os
 
 import pytest
 
+from dashboard.backend.tests._postgres_testing import require_local_postgres_url
+
 TEST_POSTGRES_URL = os.getenv("TEST_POSTGRES_URL")
 
 pg_only = pytest.mark.skipif(
@@ -96,6 +98,7 @@ def test_malformed_url_is_rejected_before_psycopg_can_echo_it():
 
 @pytest.fixture
 def pg_strategy_store():
+    require_local_postgres_url(TEST_POSTGRES_URL)
     from dashboard.backend.domain.strategies.repository_postgres import (
         PostgresStrategyStore,
     )

--- a/dashboard/backend/tests/test_users_postgres.py
+++ b/dashboard/backend/tests/test_users_postgres.py
@@ -17,6 +17,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from dashboard.backend.app import app
+from dashboard.backend.tests._postgres_testing import require_local_postgres_url
 
 TEST_POSTGRES_URL = os.getenv("TEST_POSTGRES_URL")
 
@@ -55,6 +56,7 @@ def test_build_user_store_picks_postgres_when_url_set(monkeypatch):
 
 @pytest.fixture
 def temp_postgres_store():
+    require_local_postgres_url(TEST_POSTGRES_URL)
     from dashboard.backend.users_postgres import PostgresUserStore
 
     store = PostgresUserStore(TEST_POSTGRES_URL)


### PR DESCRIPTION
Closes #136.

The `@pg_only` fixtures `DELETE FROM external_agents / agent_versions / strategies / users` against whatever `TEST_POSTGRES_URL` names, and `conftest.py` deliberately does not strip that var (it is the opt-in for the live tier). `CONTENT_DATABASE_URL`/`USERS_DATABASE_URL` are the *same prod Neon DB*, so `export TEST_POSTGRES_URL=$CONTENT_DATABASE_URL && pytest` would wipe prod accounts + agents + API keys.

`require_local_postgres_url()` (new `_postgres_testing.py`, following the `_v2_fakes.py` shared-helper convention) allowlists `localhost`/`127.0.0.1`/`::1` via `urlsplit`. The four destructive fixtures call it first, so a remote URL now fails loud (red errors) instead of silently wiping prod — or silently skipping.

Tests: 5 unit + 4 fixture-guard integration cases (the latter prove each fixture refuses before touching the network). Suite: 1095 passed, 18 skipped; `@pg_only` tier still skips cleanly with no `TEST_POSTGRES_URL`.

Note: protection is per destructive fixture (the four that exist). A future 5th destructive fixture must call the guard too — left as a convention rather than an import-time raise, which this repo's CLAUDE.md warns can abort the whole collection session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)