### PR TITLE
fix: harden the Postgres persistence tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
     # does not boot. Cheap insurance: the container starts in a couple of seconds.
     services:
       postgres:
-        image: postgres:16-alpine
+        # Pinned to prod's major version: the live Neon database runs
+        # PostgreSQL 18.x (checked via version() during the #134 pre-merge
+        # review). This tier exists to catch dialect problems before prod, so it
+        # must ship to the same major version prod runs -- see issue #138.
+        image: postgres:18-alpine
         env:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: atl_test

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -47,10 +47,14 @@ class PostgresAgentStore:
         # would raise UndefinedColumn -- 500ing this whole surface while /health
         # stays green. Nothing catches it first: the SQLite tier is the default
         # in tests, and CI's Postgres service container is empty on every run,
-        # so the @pg_only tier only ever exercises the CREATE path, never the
-        # migrate path. The columns below fold in the SQLite store's five lazy
-        # ALTERs because this table starts empty; that is why there is no
-        # migration here yet. users_postgres.py has the pattern to copy.
+        # so the @pg_only tier only ever exercises the CREATE path -- except
+        # test_agent_schema_lazily_migrates_an_old_table_postgres, which recreates
+        # the pre-migration table to force the migrate path. The five ALTER ...
+        # ADD COLUMN IF NOT EXISTS statements below re-add the columns the SQLite
+        # store accreted as lazy migrations, so a deployment whose table predates
+        # them is brought up to shape on the next boot; on a fresh or current
+        # table they no-op. Add the next column the same way (Postgres supports
+        # ADD COLUMN IF NOT EXISTS natively; users_postgres.py has the pattern).
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 # owner_user_id is deliberately a plain INTEGER with no FK to
@@ -79,6 +83,29 @@ class PostgresAgentStore:
                         cash_allocation DOUBLE PRECISION
                     )
                     """
+                )
+                # Lazy migrations for a table created before these columns
+                # existed (mirrors the SQLite store's five post-ship ALTERs).
+                # Each no-ops on a fresh or already-current table. Must run
+                # before idx_external_agents_type, which indexes agent_type.
+                cur.execute(
+                    "ALTER TABLE external_agents "
+                    "ADD COLUMN IF NOT EXISTS agent_type TEXT NOT NULL DEFAULT 'external'"
+                )
+                cur.execute(
+                    "ALTER TABLE external_agents ADD COLUMN IF NOT EXISTS description TEXT"
+                )
+                cur.execute(
+                    "ALTER TABLE external_agents "
+                    "ADD COLUMN IF NOT EXISTS pipeline_config TEXT"
+                )
+                cur.execute(
+                    "ALTER TABLE external_agents "
+                    "ADD COLUMN IF NOT EXISTS cash_allocation DOUBLE PRECISION"
+                )
+                cur.execute(
+                    "ALTER TABLE external_agents "
+                    f"ADD COLUMN IF NOT EXISTS scopes TEXT NOT NULL DEFAULT '{DEFAULT_SCOPES}'"
                 )
                 cur.execute(
                     """

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -272,11 +272,20 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
     appear and the first real create_agent (which names them) raises
     UndefinedColumn: exactly the silent prod-500 this issue describes.
 
-    The pre-existing row -- not the empty table -- is the real prod scenario and
-    the real risk surface. `scopes` is an authorization input, so a legacy row
-    must emerge from the migration carrying the column DEFAULT; a NULL scopes
-    would be an authz hole. That backfill is precisely what ADD COLUMN ... NOT
-    NULL DEFAULT does for existing rows, and it is what this asserts.
+    The pre-existing row -- not the empty table -- is the risk surface worth
+    asserting on. `scopes` is an authorization input, so a legacy row must emerge
+    from the migration carrying the column DEFAULT; a NULL scopes would be an
+    authz hole. That backfill is precisely what ADD COLUMN ... NOT NULL DEFAULT
+    does for existing rows, and it is what this asserts.
+
+    The legacy shape below is SYNTHETIC, not historical: the Postgres twin shipped
+    in #134 with all five columns already folded into its CREATE TABLE, so no Neon
+    deployment has ever had this table. What this pins is the ALTER statements
+    themselves -- drop any one of them, or its NOT NULL DEFAULT, and this goes red.
+    The forward risk #135 actually names -- a *sixth* column added to CREATE TABLE
+    only, never reaching an existing deployment -- cannot be covered by a test
+    written today; the ADDING A COLUMN LATER? comment in repository_postgres.py is
+    what guards that, and it is the thing to keep alive.
     """
     from dashboard.backend.domain.agents.repository import DEFAULT_SCOPES
     from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -6,7 +6,7 @@ Two tiers, mirroring test_users_postgres.py:
 2. Behavioral tests against a real Postgres - skipped unless
    TEST_POSTGRES_URL is set. Point it at a throwaway database, e.g.:
      docker run --rm -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test \
-       -p 5433:5432 postgres:16-alpine
+       -p 5433:5432 postgres:18-alpine
      export TEST_POSTGRES_URL=postgresql://postgres:test@localhost:5433/atl_test
 
 Do NOT copy the raw-SQL fixture pattern from test_v2_http_runs.py /

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -259,6 +259,166 @@ def test_builtin_listing_and_delete_postgres(pg_agent_store):
     assert pg_agent_store.get_agent(builtin["agent_id"]) is None
 
 
+@pg_only
+def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
+    """#135: the twin must ADD COLUMN IF NOT EXISTS for post-ship columns.
+
+    Simulate a deployment created before the five lazy-migration columns
+    (agent_type, description, pipeline_config, cash_allocation, scopes) existed:
+    a table with only the original base schema. Re-running _init_schema() -- what
+    every redeploy does -- must bring it up to the current shape. CREATE TABLE IF
+    NOT EXISTS no-ops on the existing table, so without an ALTER path the columns
+    never appear and the first real create_agent (which names them) raises
+    UndefinedColumn: exactly the silent prod-500 this issue describes.
+    """
+    from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore
+
+    with pg_agent_store._get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("DROP TABLE IF EXISTS external_agents CASCADE")
+            cur.execute(
+                """
+                CREATE TABLE external_agents (
+                    agent_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    session_id TEXT NOT NULL UNIQUE,
+                    api_key_hash TEXT NOT NULL UNIQUE,
+                    api_key_prefix TEXT NOT NULL,
+                    model_name TEXT NOT NULL DEFAULT 'local-model',
+                    owner_user_id INTEGER,
+                    owner_browser_session TEXT,
+                    created_at TEXT,
+                    last_used_at TEXT
+                )
+                """
+            )
+
+    # A redeploy re-runs _init_schema() against the existing "old" table.
+    PostgresAgentStore(TEST_POSTGRES_URL)
+
+    with pg_agent_store._get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'external_agents'"
+            )
+            columns = {r["column_name"] for r in cur.fetchall()}
+    assert {
+        "agent_type",
+        "description",
+        "pipeline_config",
+        "cash_allocation",
+        "scopes",
+    } <= columns
+
+    # The store is actually usable after the migration: a real registration
+    # writes every migrated column, and the scopes column default applies.
+    created = pg_agent_store.create_agent(name="Post-migration", cash_allocation=123.0)
+    assert created["cash_allocation"] == 123.0
+
+
+@pg_only
+def test_claim_and_reclaim_agent_postgres(pg_agent_store):
+    """#137 gap 1: claim_agent / reclaim_agent had zero Postgres coverage.
+
+    claim_agent COALESCEs owner_browser_session (a None arg keeps the stored
+    one); reclaim_agent overwrites it unconditionally. Swapping those two
+    semantics is the mutation this pins.
+    """
+    created = pg_agent_store.create_agent(
+        name="Claimable2", owner_browser_session="bs_old"
+    )
+
+    pg_agent_store.claim_agent(created["agent_id"], owner_user_id=7)
+    assert pg_agent_store.owns_agent(created, owner_user_id=7) is True
+    # COALESCE kept the original browser session (no owner_browser_session arg).
+    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_old") is True
+
+    pg_agent_store.reclaim_agent(created["agent_id"], owner_browser_session="bs_new")
+    # reclaim overwrote it: the new session matches, the old one no longer does.
+    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_new") is True
+    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_old") is False
+    # The user binding from claim survives reclaim (owner_user_id is COALESCEd).
+    assert pg_agent_store.owns_agent(created, owner_user_id=7) is True
+
+
+@pg_only
+def test_create_agent_stores_default_scopes_verbatim_postgres(pg_agent_store):
+    """#137 gap 2: scopes is an authorization surface with no @pg_only assertion.
+
+    create_agent omits scopes from its INSERT, so the column DEFAULT fills it.
+    Read the raw column, not the public dict: _public_agent does
+    ``data.get("scopes") or DEFAULT_SCOPES``, so an empty/dropped default is
+    masked back to DEFAULT_SCOPES in the public view -- only the stored value
+    proves the column default itself is right.
+    """
+    from dashboard.backend.domain.agents.repository import DEFAULT_SCOPES
+
+    created = pg_agent_store.create_agent(name="Scoped")  # no scopes passed
+    with pg_agent_store._get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT scopes FROM external_agents WHERE agent_id = %s",
+                (created["agent_id"],),
+            )
+            raw = cur.fetchone()["scopes"]
+    assert raw == DEFAULT_SCOPES
+
+
+@pg_only
+def test_resolve_api_key_touches_last_used_at_postgres(pg_agent_store, monkeypatch):
+    """#137 gap 3: touch-on-use was only asserted `is not None`.
+
+    create_agent already sets last_used_at non-None, so a dropped touch-on-use
+    UPDATE in resolve_api_key would go uncaught. Force a distinct, strictly-later
+    timestamp so the assertion can't hide behind 1-second timestamp resolution
+    (create and resolve otherwise land in the same second).
+    """
+    import dashboard.backend.domain.agents.repository_postgres as repo_pg
+
+    created = pg_agent_store.create_agent(name="Toucher")
+    before = pg_agent_store.get_agent(created["agent_id"])["last_used_at"]
+
+    monkeypatch.setattr(repo_pg, "_utcnow_iso", lambda: "2099-01-01T00:00:00+00:00")
+    pg_agent_store.resolve_api_key(created["api_key"])
+
+    after = pg_agent_store.get_agent(created["agent_id"])["last_used_at"]
+    assert after == "2099-01-01T00:00:00+00:00"
+    assert after != before
+
+
+@pg_only
+def test_listings_order_newest_first_postgres(pg_agent_store, monkeypatch):
+    """#137 gap 4: nothing exercised ORDER BY on list_agents / list_builtin_agents.
+
+    Both queries are ``ORDER BY created_at DESC``; an ASC/DESC swap in either was
+    invisible. Feed monotonically increasing created_at values -- 1s resolution
+    would otherwise make same-second ties non-deterministic.
+    """
+    import dashboard.backend.domain.agents.repository_postgres as repo_pg
+
+    times = iter([f"2020-01-0{n}T00:00:00+00:00" for n in range(1, 7)])
+    monkeypatch.setattr(repo_pg, "_utcnow_iso", lambda: next(times))
+
+    a = pg_agent_store.create_agent(name="A", owner_user_id=99)
+    b = pg_agent_store.create_agent(name="B", owner_user_id=99)
+    c = pg_agent_store.create_agent(name="C", owner_user_id=99)
+    assert [x["agent_id"] for x in pg_agent_store.list_agents(owner_user_id=99)] == [
+        c["agent_id"],
+        b["agent_id"],
+        a["agent_id"],
+    ]
+
+    d = pg_agent_store.create_agent(name="D", agent_type="builtin")
+    e = pg_agent_store.create_agent(name="E", agent_type="builtin")
+    f = pg_agent_store.create_agent(name="F", agent_type="builtin")
+    assert [x["agent_id"] for x in pg_agent_store.list_builtin_agents()] == [
+        f["agent_id"],
+        e["agent_id"],
+        d["agent_id"],
+    ]
+
+
 # --- dispatch tests (agent version store) ------------------------------------
 
 def test_build_agent_version_store_defaults_to_sqlite(monkeypatch, capsys):

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -265,12 +265,20 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
 
     Simulate a deployment created before the five lazy-migration columns
     (agent_type, description, pipeline_config, cash_allocation, scopes) existed:
-    a table with only the original base schema. Re-running _init_schema() -- what
-    every redeploy does -- must bring it up to the current shape. CREATE TABLE IF
-    NOT EXISTS no-ops on the existing table, so without an ALTER path the columns
-    never appear and the first real create_agent (which names them) raises
+    a table with only the original base schema, already holding a real agent row
+    that predates those columns. Re-running _init_schema() -- what every redeploy
+    does -- must bring it up to the current shape. CREATE TABLE IF NOT EXISTS
+    no-ops on the existing table, so without an ALTER path the columns never
+    appear and the first real create_agent (which names them) raises
     UndefinedColumn: exactly the silent prod-500 this issue describes.
+
+    The pre-existing row -- not the empty table -- is the real prod scenario and
+    the real risk surface. `scopes` is an authorization input, so a legacy row
+    must emerge from the migration carrying the column DEFAULT; a NULL scopes
+    would be an authz hole. That backfill is precisely what ADD COLUMN ... NOT
+    NULL DEFAULT does for existing rows, and it is what this asserts.
     """
+    from dashboard.backend.domain.agents.repository import DEFAULT_SCOPES
     from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore
 
     with pg_agent_store._get_connection() as conn:
@@ -292,6 +300,15 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
                 )
                 """
             )
+            # A real agent registered against the pre-migration schema.
+            cur.execute(
+                """
+                INSERT INTO external_agents (
+                    agent_id, name, session_id, api_key_hash, api_key_prefix
+                ) VALUES ('agent_legacy', 'Legacy', 'sess_legacy',
+                          'hash_legacy', 'ag_legacy')
+                """
+            )
 
     # A redeploy re-runs _init_schema() against the existing "old" table.
     PostgresAgentStore(TEST_POSTGRES_URL)
@@ -303,6 +320,15 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
                 "WHERE table_name = 'external_agents'"
             )
             columns = {r["column_name"] for r in cur.fetchall()}
+            # Read the raw columns straight from the legacy row: _public_agent
+            # masks a NULL/empty scopes back to DEFAULT_SCOPES, so only the stored
+            # value proves the ADD COLUMN carried its NOT NULL DEFAULT for the
+            # pre-existing row rather than leaving it NULL.
+            cur.execute(
+                "SELECT agent_type, scopes FROM external_agents "
+                "WHERE agent_id = 'agent_legacy'"
+            )
+            legacy = cur.fetchone()
     assert {
         "agent_type",
         "description",
@@ -310,6 +336,9 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
         "cash_allocation",
         "scopes",
     } <= columns
+    # The pre-existing row was backfilled with the column defaults, not NULL.
+    assert legacy["agent_type"] == "external"
+    assert legacy["scopes"] == DEFAULT_SCOPES
 
     # The store is actually usable after the migration: a real registration
     # writes every migrated column, and the scopes column default applies.
@@ -395,10 +424,17 @@ def test_listings_order_newest_first_postgres(pg_agent_store, monkeypatch):
     invisible. Feed monotonically increasing created_at values -- 1s resolution
     would otherwise make same-second ties non-deterministic.
     """
+    import itertools
+
     import dashboard.backend.domain.agents.repository_postgres as repo_pg
 
-    times = iter([f"2020-01-0{n}T00:00:00+00:00" for n in range(1, 7)])
-    monkeypatch.setattr(repo_pg, "_utcnow_iso", lambda: next(times))
+    # Unbounded monotonic clock: robust if create_agent ever calls _utcnow_iso a
+    # different number of times (a fixed-length iterator would raise an opaque
+    # StopIteration instead of a clean assertion failure).
+    day = itertools.count(1)
+    monkeypatch.setattr(
+        repo_pg, "_utcnow_iso", lambda: f"2020-01-{next(day):02d}T00:00:00+00:00"
+    )
 
     a = pg_agent_store.create_agent(name="A", owner_user_id=99)
     b = pg_agent_store.create_agent(name="B", owner_user_id=99)

--- a/dashboard/backend/tests/test_strategy_store_postgres.py
+++ b/dashboard/backend/tests/test_strategy_store_postgres.py
@@ -154,13 +154,15 @@ def test_create_widens_code_space_after_20_collisions_postgres(
     pg_strategy_store, monkeypatch
 ):
     import dashboard.backend.domain.strategies.repository_postgres as strategies_pg_module
+    from dashboard.backend.domain.strategies.repository import _CODE_LENGTH
 
     first = pg_strategy_store.create(prompt="first strategy")
 
-    calls = {"n": 0}
+    calls = {"n": 0, "nbytes": []}
 
     def fake_token_hex(nbytes):
         calls["n"] += 1
+        calls["nbytes"].append(nbytes)
         if calls["n"] <= 20:
             return first["code"]
         return "w" * 16
@@ -170,6 +172,11 @@ def test_create_widens_code_space_after_20_collisions_postgres(
     second = pg_strategy_store.create(prompt="second strategy")
     assert second["code"] == "w" * 16
     assert calls["n"] == 21
+    # #137 gap 5: the 20 narrow attempts request _CODE_LENGTH // 2 bytes; only the
+    # widened 21st requests the full _CODE_LENGTH. Swapping the two call sites is
+    # otherwise invisible -- both still produce a valid code.
+    assert calls["nbytes"][:20] == [_CODE_LENGTH // 2] * 20
+    assert calls["nbytes"][20] == _CODE_LENGTH
 
 
 @pg_only

--- a/dashboard/backend/tests/test_users_postgres.py
+++ b/dashboard/backend/tests/test_users_postgres.py
@@ -7,7 +7,7 @@ Two tiers:
 2. Behavioral tests against a real Postgres - skipped unless
    TEST_POSTGRES_URL is set. Point it at a throwaway database, e.g.:
      docker run --rm -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test \
-       -p 5433:5432 postgres:16-alpine
+       -p 5433:5432 postgres:18-alpine
      export TEST_POSTGRES_URL=postgresql://postgres:test@localhost:5433/atl_test
 """
 

--- a/docs/superpowers/plans/2026-07-08-user-account-persistence-fix.md
+++ b/docs/superpowers/plans/2026-07-08-user-account-persistence-fix.md
@@ -70,7 +70,7 @@ git commit -m "deps: add psycopg for optional Postgres-backed user accounts"
 This task needs a real Postgres to run its behavioral tests against. Start a throwaway one now (skip this if you already have `TEST_POSTGRES_URL` pointed at something disposable):
 
 ```bash
-docker run --rm -d --name atl-test-pg -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test -p 5433:5432 postgres:16-alpine
+docker run --rm -d --name atl-test-pg -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test -p 5433:5432 postgres:18-alpine
 export TEST_POSTGRES_URL=postgresql://postgres:test@localhost:5433/atl_test
 ```
 
@@ -88,7 +88,7 @@ Two tiers:
 2. Behavioral tests against a real Postgres - skipped unless
    TEST_POSTGRES_URL is set. Point it at a throwaway database, e.g.:
      docker run --rm -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test \
-       -p 5433:5432 postgres:16-alpine
+       -p 5433:5432 postgres:18-alpine
      export TEST_POSTGRES_URL=postgresql://postgres:test@localhost:5433/atl_test
 """
 

--- a/docs/superpowers/plans/2026-07-15-agent-strategy-persistence.md
+++ b/docs/superpowers/plans/2026-07-15-agent-strategy-persistence.md
@@ -31,7 +31,7 @@
 |---|---|---|---|
 | `dashboard/backend/tests/conftest.py` | Modify | 1 | Strip `CONTENT_DATABASE_URL` at import time (suite always SQLite) |
 | `dashboard/backend/tests/test_env_isolation.py` | Create | 1 | Pin that the suite never sees the backend-selecting env vars |
-| `.github/workflows/ci.yml` | Modify | 2 | `postgres:16-alpine` service + `TEST_POSTGRES_URL` → the `@pg_only` tier becomes a real gate |
+| `.github/workflows/ci.yml` | Modify | 2 | `postgres:18-alpine` service + `TEST_POSTGRES_URL` → the `@pg_only` tier becomes a real gate |
 | `dashboard/backend/tests/test_ci_postgres_wired.py` | Create | 2 | Make CI red (not silently all-skip) if the postgres service is ever dropped |
 | `dashboard/backend/db_url.py` | Create | 3 | `describe_database_url()` — credential-free host/dbname for logs (shared by all 4 factories) |
 | `dashboard/backend/tests/test_db_url.py` | Create | 3 | Pin that the password never survives the transformation |
@@ -67,7 +67,7 @@
 **Live-Postgres testing (applies to every `@pg_only` test in this plan).** Locally, without `TEST_POSTGRES_URL` these tests skip. That is fine for fast iteration but it is **not** the definition of done: skipping locally *and* in CI is how ~450 lines of new SQL would reach prod unexecuted, and prod's first execution is `_init_schema()` at import time with fail-loud semantics. Task 2 therefore makes CI run them on every PR — that is the gate. Running them locally as well is the fast feedback loop:
 
 ```bash
-docker run --rm -d --name atl-pg-test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test -p 5433:5432 postgres:16-alpine
+docker run --rm -d --name atl-pg-test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test -p 5433:5432 postgres:18-alpine
 export TEST_POSTGRES_URL=postgresql://postgres:test@localhost:5433/atl_test
 # ... run pytest ...
 docker stop atl-pg-test
@@ -247,7 +247,7 @@ In `.github/workflows/ci.yml`, add a `services:` key to the `backend-tests` job 
     # does not boot. Cheap insurance: the container starts in a couple of seconds.
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: atl_test
@@ -617,7 +617,7 @@ Two tiers, mirroring test_users_postgres.py:
 2. Behavioral tests against a real Postgres - skipped unless
    TEST_POSTGRES_URL is set. Point it at a throwaway database, e.g.:
      docker run --rm -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test \
-       -p 5433:5432 postgres:16-alpine
+       -p 5433:5432 postgres:18-alpine
      export TEST_POSTGRES_URL=postgresql://postgres:test@localhost:5433/atl_test
 
 Do NOT copy the raw-SQL fixture pattern from test_v2_http_runs.py /
@@ -2192,7 +2192,7 @@ Expected: everything passes locally; the only skips are the `@pg_only` tests, `t
 - [ ] **Step 3: Run the `@pg_only` tier against a throwaway Postgres**
 
 ```bash
-docker run --rm -d --name atl-pg-test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test -p 5433:5432 postgres:16-alpine
+docker run --rm -d --name atl-pg-test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=atl_test -p 5433:5432 postgres:18-alpine
 sleep 3
 TEST_POSTGRES_URL=postgresql://postgres:test@localhost:5433/atl_test pytest \
   dashboard/backend/tests/test_agent_store_postgres.py \

--- a/docs/superpowers/specs/2026-07-15-agent-strategy-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-15-agent-strategy-persistence-design.md
@@ -229,14 +229,23 @@ stores already write `_utcnow_iso()` strings, so ordering/comparison parity is e
 JSON kept as `TEXT` (not JSONB), `DOUBLE PRECISION` for `cash_allocation`, idempotent
 `CREATE TABLE IF NOT EXISTS` in `_init_schema()`.
 
-**No lazy `ALTER TABLE ADD COLUMN` migrations, unlike `users_postgres.py`** — and the
-difference is not an oversight. That module needs its `ADD COLUMN IF NOT EXISTS
-discord_user_id` because its `users` table already exists in prod Neon from before
-Discord linking shipped. All three tables here are created *fresh* on first Postgres
-startup (there is no data to migrate — see Migration below), so `CREATE TABLE` alone
-already declares every column and there is nothing an `ALTER` could add. Columns added
-in *future* work use `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, the Postgres analogue
-of the SQLite stores' `PRAGMA table_info` probing.
+**Lazy `ALTER TABLE ADD COLUMN` migrations — none as designed, since amended for the
+agent twin.** As specified, this section argued none were needed: `users_postgres.py`
+needs its `ADD COLUMN IF NOT EXISTS discord_user_id` because its `users` table already
+exists in prod Neon from before Discord linking shipped, whereas all three tables here
+are created *fresh* on first Postgres startup (there is no data to migrate — see
+Migration below), so `CREATE TABLE` alone already declares every column.
+
+That reasoning holds for the *first* deploy and fails for every one after it. Once the
+table exists, `CREATE TABLE IF NOT EXISTS` silently no-ops, so a column added later to
+the `CREATE` block alone never reaches an existing deployment, and every query naming it
+raises `UndefinedColumn` — 500ing that surface while `/health` stays green. Issue #135
+closed that gap for `agents/repository_postgres.py`, which now carries five
+`ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements mirroring the SQLite store's
+accreted migrations. `agent_versions` and `strategies` still carry none: they shipped
+complete and have accreted no columns since, so for those two the original rule stands —
+columns added in *future* work use `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, the
+Postgres analogue of the SQLite stores' `PRAGMA table_info` probing.
 
 All unique constraints and indexes carry over:
 `api_key_hash` UNIQUE, `session_id` UNIQUE, indexes on `owner_user_id`,

--- a/docs/superpowers/specs/2026-07-15-agent-strategy-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-15-agent-strategy-persistence-design.md
@@ -342,7 +342,7 @@ most important item in this section.
    runs at **import time** and this design mandates fail-loud, so a single DDL typo
    means the app raises on boot. Merging `main` auto-deploys, and the free tier has
    no zero-downtime deploys — so a typo plausibly takes prod down rather than merely
-   failing a deploy. Add a `postgres:16-alpine` service to the `backend-tests` job
+   failing a deploy. Add a `postgres:18-alpine` service to the `backend-tests` job
    and set `TEST_POSTGRES_URL` (~8 lines of YAML). This lands *early* in the plan, not
    at the end: it also switches on the shipped-but-never-CI-run
    `test_users_postgres.py` live tier, and that wants to shake out on its own commit
@@ -395,7 +395,7 @@ tests across two identically-named files.
   durable Postgres for user-created content).
 - `render.yaml`: optionally add `CONTENT_DATABASE_URL` with `sync: false` as documentation —
   the real mechanism is the Render dashboard (see Rollout).
-- `.github/workflows/ci.yml`: add a `postgres:16-alpine` service + `TEST_POSTGRES_URL`
+- `.github/workflows/ci.yml`: add a `postgres:18-alpine` service + `TEST_POSTGRES_URL`
   to the `backend-tests` job, so the `@pg_only` tier runs (Testing tier 0). Not
   cosmetic — this is the only thing that executes the new SQL before prod does.
 - CLAUDE.md: extend the env/credentials section and the user-account-persistence


### PR DESCRIPTION
Batch B of the agent-persistence follow-ups — three issues, one tier.

- **Closes #135** — the agent twin gains a lazy-migration path (`ALTER … ADD COLUMN IF NOT EXISTS` for the 5 folded columns). Without it, a future column added only to `CREATE TABLE` no-ops on prod's existing table → `UndefinedColumn` 500s the whole agent surface while `/health` stays green. New `@pg_only` test recreates the pre-migration table to force the migrate path (RED before the fix, GREEN after). Scoped to the agent twin deliberately: it's the only twin with a folded migration history; version/strategy shipped complete and keep their documented convention.
- **Closes #137** — five `@pg_only` coverage gaps closed: claim/reclaim, raw `scopes` default (read straight from the column, since `_public_agent`'s `or DEFAULT_SCOPES` masks a wrong empty default), `last_used_at` touch-on-use, listing `ORDER BY`, and widen-path `nbytes`. Each was mutation-tested — inject the targeted bug, confirm the test goes red, revert.
- **Closes #138** — CI Postgres `16 → 18-alpine` to match prod Neon 18.x.

Verified on a local `postgres:18-alpine`: full suite **1113 passed / 5 skipped / 0 failed** with the live tier on.