### PR TITLE
fix: disable reasoning for Nemotron leaderboard runs

### DIFF
--- a/dashboard/backend/domain/leaderboard/strategies/llm_agent.py
+++ b/dashboard/backend/domain/leaderboard/strategies/llm_agent.py
@@ -41,6 +41,7 @@ class LLMAgentStrategy(BaselineStrategy):
         # Gateway selection: "commonstack" | "openrouter" | "anthropic".
         # Omitted → env auto-detect (CommonStack key prefers CommonStack).
         self.integration = self.config.get("integration")
+        self.reasoning_effort = self.config.get("reasoning_effort")
         # Populated during run() for reporting / cost tracking.
         self.llm_calls = 0
         self.llm_decisions = 0  # steps the model actually drove (H6 guard numerator)
@@ -58,7 +59,10 @@ class LLMAgentStrategy(BaselineStrategy):
         if not HAS_ANTHROPIC:
             print("⚠️  Anthropic SDK unavailable — llm_agent falls back to rule-based.")
             return None
-        client = make_llm_client(self.integration)
+        client = make_llm_client(
+            self.integration,
+            reasoning_effort=self.reasoning_effort,
+        )
         if client is None:
             chosen = self.integration or "auto"
             print(

--- a/dashboard/backend/infrastructure/llm/backtest_harness.py
+++ b/dashboard/backend/infrastructure/llm/backtest_harness.py
@@ -72,7 +72,11 @@ OPENROUTER_MODEL_NAME = openrouter.DEFAULT_MODEL
 OPENROUTER_BASE_URL = openrouter.base_url()
 
 
-def make_llm_client(integration: Optional[str] = None):
+def make_llm_client(
+    integration: Optional[str] = None,
+    *,
+    reasoning_effort: Optional[str] = None,
+):
     """Create an Anthropic-compatible client for trading decisions.
 
     ``integration`` selects a gateway (``commonstack``, ``openrouter``, or
@@ -81,7 +85,10 @@ def make_llm_client(integration: Optional[str] = None):
     ``None`` when the SDK or the chosen integration's key is unavailable, so
     callers fall back to rule-based trading.
     """
-    return _providers_make_llm_client(integration)
+    return _providers_make_llm_client(
+        integration,
+        reasoning_effort=reasoning_effort,
+    )
 
 
 def default_model_name(integration: Optional[str] = None) -> str:

--- a/dashboard/backend/infrastructure/llm/providers/__init__.py
+++ b/dashboard/backend/infrastructure/llm/providers/__init__.py
@@ -23,6 +23,7 @@ from . import anthropic_native, commonstack, openrouter
 # optional-import side effects / print noise from the harness.
 try:
     from anthropic import Anthropic as _Anthropic
+
     HAS_ANTHROPIC = True
 except ImportError:  # pragma: no cover - exercised when SDK missing
     _Anthropic = None
@@ -58,7 +59,11 @@ def resolve_integration(integration: Optional[str] = None) -> str:
     return anthropic_native.INTEGRATION_ID
 
 
-def make_llm_client(integration: Optional[str] = None) -> Optional[Any]:
+def make_llm_client(
+    integration: Optional[str] = None,
+    *,
+    reasoning_effort: Optional[str] = None,
+) -> Optional[Any]:
     """Create an Anthropic-compatible client for the chosen integration.
 
     Returns ``None`` when the SDK is missing or the integration's API key is
@@ -67,6 +72,11 @@ def make_llm_client(integration: Optional[str] = None) -> Optional[Any]:
     if not HAS_ANTHROPIC or _Anthropic is None:
         return None
     resolved = resolve_integration(integration)
+    if resolved == openrouter.INTEGRATION_ID:
+        return openrouter.make_client(
+            _Anthropic,
+            reasoning_effort=reasoning_effort,
+        )
     return PROVIDERS[resolved].make_client(_Anthropic)
 
 

--- a/dashboard/backend/infrastructure/llm/providers/openrouter.py
+++ b/dashboard/backend/infrastructure/llm/providers/openrouter.py
@@ -53,8 +53,10 @@ def default_model_name() -> str:
     return DEFAULT_MODEL
 
 
-def _reasoning_effort() -> str:
-    raw = os.getenv("OPENROUTER_REASONING_EFFORT", _DEFAULT_REASONING_EFFORT)
+def _reasoning_effort(override: Optional[str] = None) -> str:
+    raw = override
+    if raw is None or not str(raw).strip():
+        raw = os.getenv("OPENROUTER_REASONING_EFFORT", _DEFAULT_REASONING_EFFORT)
     return (raw or "").strip().lower()
 
 
@@ -69,13 +71,13 @@ def _reasoning_max_tokens_override() -> Optional[int]:
     return value if value >= 1024 else None
 
 
-def reasoning_is_disabled() -> bool:
+def reasoning_is_disabled(override: Optional[str] = None) -> bool:
     """True when we force non-reasoning (``OPENROUTER_REASONING_EFFORT=none``)."""
-    effort = _reasoning_effort()
+    effort = _reasoning_effort(override)
     return effort in _OFF_VALUES
 
 
-def reasoning_extra_body() -> Optional[dict[str, Any]]:
+def reasoning_extra_body(override: Optional[str] = None) -> Optional[dict[str, Any]]:
     """OpenRouter ``reasoning`` payload to merge into ``extra_body``, or ``None``.
 
     ``OPENROUTER_REASONING_EFFORT``:
@@ -88,10 +90,10 @@ def reasoning_extra_body() -> Optional[dict[str, Any]]:
     ``OPENROUTER_REASONING_MAX_TOKENS`` (optional, ≥1024) overrides the mapped
     budget whenever reasoning is enabled.
     """
-    effort = _reasoning_effort()
+    effort = _reasoning_effort(override)
     if effort in _PASSTHROUGH_VALUES:
         return None
-    if reasoning_is_disabled():
+    if effort in _OFF_VALUES:
         # ``effort: none`` is the documented disable; ``enabled: false`` and
         # ``exclude: true`` cover providers that ignore effort alone.
         return {
@@ -110,19 +112,22 @@ def reasoning_extra_body() -> Optional[dict[str, Any]]:
     return {"reasoning": {"effort": effort, "enabled": True}}
 
 
-def _reasoning_budget_tokens() -> Optional[int]:
+def _reasoning_budget_tokens(override: Optional[str] = None) -> Optional[int]:
     """Resolved thinking budget (≥1024), or None when passthrough/disabled."""
-    if reasoning_is_disabled():
+    effort = _reasoning_effort(override)
+    if effort in _OFF_VALUES:
         return None
-    if _reasoning_effort() in _PASSTHROUGH_VALUES:
+    if effort in _PASSTHROUGH_VALUES:
         return None
-    override = _reasoning_max_tokens_override()
-    if override is not None:
-        return override
-    return _EFFORT_TO_REASONING_BUDGET.get(_reasoning_effort(), 2048)
+    max_tokens_override = _reasoning_max_tokens_override()
+    if max_tokens_override is not None:
+        return max_tokens_override
+    return _EFFORT_TO_REASONING_BUDGET.get(effort, 2048)
 
 
-def anthropic_thinking_kwarg() -> Optional[dict[str, Any]]:
+def anthropic_thinking_kwarg(
+    override: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
     """Anthropic Messages ``thinking`` kwarg for OpenRouter's Anthropic skin.
 
     When reasoning is disabled → ``{"type": "disabled"}``.
@@ -130,9 +135,9 @@ def anthropic_thinking_kwarg() -> Optional[dict[str, Any]]:
     so thinking cannot consume the entire ``max_tokens`` ceiling (Nemotron
     otherwise often returns only thinking/redacted_thinking).
     """
-    if reasoning_is_disabled():
+    if reasoning_is_disabled(override):
         return {"type": "disabled"}
-    budget = _reasoning_budget_tokens()
+    budget = _reasoning_budget_tokens(override)
     if budget is None:
         return None
     return {"type": "enabled", "budget_tokens": budget}
@@ -153,17 +158,18 @@ def _default_headers() -> dict[str, str]:
 class _OpenRouterMessages:
     """Proxy that injects OpenRouter reasoning-off defaults when unset by caller."""
 
-    def __init__(self, inner: Any):
+    def __init__(self, inner: Any, reasoning_effort: Optional[str] = None):
         self._inner = inner
+        self._reasoning_effort = reasoning_effort
 
     def create(self, **kwargs: Any) -> Any:
-        extras = reasoning_extra_body()
+        extras = reasoning_extra_body(self._reasoning_effort)
         if extras:
             body = dict(kwargs.get("extra_body") or {})
             if "reasoning" not in body:
                 body.update(extras)
                 kwargs["extra_body"] = body
-        thinking = anthropic_thinking_kwarg()
+        thinking = anthropic_thinking_kwarg(self._reasoning_effort)
         if thinking is not None and "thinking" not in kwargs:
             kwargs["thinking"] = thinking
         return self._inner.create(**kwargs)
@@ -172,15 +178,22 @@ class _OpenRouterMessages:
 class OpenRouterClient:
     """Anthropic client wrapper with OpenRouter-specific ``messages.create`` defaults."""
 
-    def __init__(self, client: Any):
+    def __init__(self, client: Any, reasoning_effort: Optional[str] = None):
         self._client = client
-        self.messages = _OpenRouterMessages(client.messages)
+        self.messages = _OpenRouterMessages(
+            client.messages,
+            reasoning_effort=reasoning_effort,
+        )
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._client, name)
 
 
-def make_client(anthropic_cls: Any) -> Optional[Any]:
+def make_client(
+    anthropic_cls: Any,
+    *,
+    reasoning_effort: Optional[str] = None,
+) -> Optional[Any]:
     """Build an Anthropic-compatible OpenRouter client, or ``None``."""
     key = os.getenv("OPENROUTER_API_KEY")
     if not key:
@@ -193,14 +206,17 @@ def make_client(anthropic_cls: Any) -> Optional[Any]:
     if headers:
         kwargs["default_headers"] = headers
     try:
-        client = OpenRouterClient(anthropic_cls(**kwargs))
-        if reasoning_is_disabled():
+        client = OpenRouterClient(
+            anthropic_cls(**kwargs),
+            reasoning_effort=reasoning_effort,
+        )
+        if reasoning_is_disabled(reasoning_effort):
             print(
                 "ℹ️  OpenRouter: reasoning disabled "
                 "(OPENROUTER_REASONING_EFFORT=none)"
             )
         else:
-            effort = _reasoning_effort() or _DEFAULT_REASONING_EFFORT
+            effort = _reasoning_effort(reasoning_effort) or _DEFAULT_REASONING_EFFORT
             print(
                 f"ℹ️  OpenRouter: reasoning on "
                 f"(OPENROUTER_REASONING_EFFORT={effort}; "

--- a/dashboard/backend/tests/domain/leaderboard/test_strategies_move.py
+++ b/dashboard/backend/tests/domain/leaderboard/test_strategies_move.py
@@ -5,9 +5,15 @@ package and characterizes registry lookup, aliases, and unknown-strategy
 behavior.
 """
 
+import json
+
 import pytest
 
+from dashboard.backend.paths import CONFIG_DIR
 from dashboard.backend.domain.leaderboard import strategies as canon
+from dashboard.backend.domain.leaderboard.strategies import (
+    llm_agent as llm_agent_module,
+)
 from dashboard.backend.domain.leaderboard.strategies.base import BaselineStrategy
 from dashboard.backend.domain.leaderboard.strategies.buy_hold import BuyHoldStrategy
 from dashboard.backend.domain.leaderboard.strategies.equal_weight_buyhold import (
@@ -80,3 +86,64 @@ def test_required_symbols_defaults_and_overrides():
     assert custom == ["AAPL", "MSFT"]
     # market_index excludes ^-prefixed index symbols from the Alpaca fetch.
     assert MarketIndexStrategy({"symbols": ["^DJI"]}).required_symbols() == []
+
+
+def test_llm_agent_passes_model_reasoning_to_client_factory(monkeypatch):
+    captured = {}
+    expected_client = object()
+
+    def _fake_factory(integration=None, *, reasoning_effort=None):
+        captured["integration"] = integration
+        captured["reasoning_effort"] = reasoning_effort
+        return expected_client
+
+    monkeypatch.setattr(llm_agent_module, "HAS_ANTHROPIC", True)
+    monkeypatch.setattr(llm_agent_module, "make_llm_client", _fake_factory)
+
+    strategy = LLMAgentStrategy(
+        {
+            "integration": "openrouter",
+            "reasoning_effort": "none",
+        }
+    )
+
+    assert strategy.reasoning_effort == "none"
+    assert strategy._make_client() is expected_client
+    assert captured == {
+        "integration": "openrouter",
+        "reasoning_effort": "none",
+    }
+
+
+def test_llm_agent_without_reasoning_keeps_legacy_factory_behavior(monkeypatch):
+    captured = {}
+
+    def _fake_factory(integration=None, *, reasoning_effort=None):
+        captured["integration"] = integration
+        captured["reasoning_effort"] = reasoning_effort
+        return object()
+
+    monkeypatch.setattr(llm_agent_module, "HAS_ANTHROPIC", True)
+    monkeypatch.setattr(llm_agent_module, "make_llm_client", _fake_factory)
+
+    strategy = LLMAgentStrategy({"integration": "commonstack"})
+    strategy._make_client()
+
+    assert strategy.reasoning_effort is None
+    assert captured == {
+        "integration": "commonstack",
+        "reasoning_effort": None,
+    }
+
+
+def test_only_nemotron_leaderboard_entry_disables_reasoning():
+    config = json.loads((CONFIG_DIR / "leaderboard.json").read_text(encoding="utf-8"))
+    strategies = config["strategies"]
+    nemotron = next(s for s in strategies if s["id"] == "nemotron_3_nano_30b")
+
+    assert nemotron["reasoning_effort"] == "none"
+    assert all(
+        "reasoning_effort" not in strategy
+        for strategy in strategies
+        if strategy["id"] != "nemotron_3_nano_30b"
+    )

--- a/dashboard/backend/tests/llm/test_backtest_harness.py
+++ b/dashboard/backend/tests/llm/test_backtest_harness.py
@@ -68,6 +68,23 @@ def test_harness_imports_without_api_key():
     assert hasattr(harness, "request_trading_decision")
 
 
+def test_harness_forwards_reasoning_effort_to_provider_factory(monkeypatch):
+    captured = {}
+
+    def _fake_factory(integration=None, *, reasoning_effort=None):
+        captured["integration"] = integration
+        captured["reasoning_effort"] = reasoning_effort
+        return "client"
+
+    monkeypatch.setattr(harness, "_providers_make_llm_client", _fake_factory)
+
+    assert harness.make_llm_client("openrouter", reasoning_effort="none") == "client"
+    assert captured == {
+        "integration": "openrouter",
+        "reasoning_effort": "none",
+    }
+
+
 def test_script_reexports_symbols():
     assert hasattr(bha, "Anthropic")
     assert hasattr(bha, "HAS_ANTHROPIC")

--- a/dashboard/backend/tests/llm/test_providers.py
+++ b/dashboard/backend/tests/llm/test_providers.py
@@ -82,6 +82,37 @@ def test_make_llm_client_openrouter_uses_openrouter_key(monkeypatch):
     assert captured["default_headers"]["X-Title"] == "ATL Test"
 
 
+def test_make_llm_client_passes_reasoning_only_to_openrouter(monkeypatch):
+    captured = {}
+
+    def _openrouter_client(anthropic_cls, *, reasoning_effort=None):
+        captured["openrouter"] = (anthropic_cls, reasoning_effort)
+        return "openrouter-client"
+
+    def _commonstack_client(anthropic_cls):
+        captured["commonstack"] = anthropic_cls
+        return "commonstack-client"
+
+    def _anthropic_client(anthropic_cls):
+        captured["anthropic"] = anthropic_cls
+        return "anthropic-client"
+
+    monkeypatch.setattr(openrouter, "make_client", _openrouter_client)
+    monkeypatch.setattr(commonstack, "make_client", _commonstack_client)
+    monkeypatch.setattr(anthropic_native, "make_client", _anthropic_client)
+
+    assert make_llm_client("openrouter", reasoning_effort="none") == "openrouter-client"
+    assert captured["openrouter"] == (providers_pkg._Anthropic, "none")
+
+    assert (
+        make_llm_client("commonstack", reasoning_effort="none") == "commonstack-client"
+    )
+    assert captured["commonstack"] is providers_pkg._Anthropic
+
+    assert make_llm_client("anthropic", reasoning_effort="none") == "anthropic-client"
+    assert captured["anthropic"] is providers_pkg._Anthropic
+
+
 def test_openrouter_messages_enable_medium_reasoning_by_default(monkeypatch):
     """Default maps medium → reasoning.max_tokens=2048 so JSON still fits."""
     monkeypatch.delenv("OPENROUTER_REASONING_EFFORT", raising=False)
@@ -97,6 +128,55 @@ def test_openrouter_messages_enable_medium_reasoning_by_default(monkeypatch):
     assert proxy.create(model="nvidia/nemotron-3-nano-30b-a3b", max_tokens=8000) == "ok"
     assert recorded["extra_body"]["reasoning"] == {"max_tokens": 2048, "enabled": True}
     assert recorded["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+
+
+def test_openrouter_instance_reasoning_overrides_environment(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_REASONING_EFFORT", "medium")
+    recorded = {}
+
+    class _Inner:
+        def create(self, **kwargs):
+            recorded.update(kwargs)
+            return "ok"
+
+    proxy = openrouter._OpenRouterMessages(_Inner(), reasoning_effort="none")
+    assert proxy.create(model="nvidia/nemotron-3-nano-30b-a3b") == "ok"
+    assert recorded["extra_body"]["reasoning"] == {
+        "effort": "none",
+        "enabled": False,
+        "exclude": True,
+    }
+    assert recorded["thinking"] == {"type": "disabled"}
+
+
+def test_openrouter_instances_keep_reasoning_overrides_isolated(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_REASONING_EFFORT", "high")
+    disabled_recorded = {}
+    medium_recorded = {}
+
+    class _Inner:
+        def __init__(self, recorder):
+            self.recorder = recorder
+
+        def create(self, **kwargs):
+            self.recorder.update(kwargs)
+            return "ok"
+
+    disabled = openrouter._OpenRouterMessages(
+        _Inner(disabled_recorded), reasoning_effort="none"
+    )
+    medium = openrouter._OpenRouterMessages(
+        _Inner(medium_recorded), reasoning_effort="medium"
+    )
+
+    assert disabled.create(model="nemotron") == "ok"
+    assert medium.create(model="nemotron") == "ok"
+
+    assert disabled_recorded["thinking"] == {"type": "disabled"}
+    assert medium_recorded["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": 2048,
+    }
 
 
 def test_openrouter_messages_inject_reasoning_none_when_disabled(monkeypatch):
@@ -126,7 +206,9 @@ def test_openrouter_messages_respect_caller_reasoning(monkeypatch):
             return "ok"
 
     proxy = openrouter._OpenRouterMessages(_Inner())
-    proxy.create(extra_body={"reasoning": {"effort": "high"}}, thinking={"type": "enabled"})
+    proxy.create(
+        extra_body={"reasoning": {"effort": "high"}}, thinking={"type": "enabled"}
+    )
     assert recorded["extra_body"] == {"reasoning": {"effort": "high"}}
     assert recorded["thinking"] == {"type": "enabled"}
 

--- a/dashboard/config/leaderboard.json
+++ b/dashboard/config/leaderboard.json
@@ -138,6 +138,7 @@
       "strategy": "llm_agent",
       "integration": "openrouter",
       "model_id": "nvidia/nemotron-3-nano-30b-a3b",
+      "reasoning_effort": "none",
       "mode": "safe_trading",
       "symbols": [],
       "auto_compute": false

--- a/docs/superpowers/plans/2026-07-19-nemotron-reasoning-none-fix.md
+++ b/docs/superpowers/plans/2026-07-19-nemotron-reasoning-none-fix.md
@@ -1,0 +1,301 @@
+# Nemotron reasoning=none 最小修复实施计划
+
+> 本计划按 loop engineering 执行：每个任务遵循“失败测试 -> 最小实现 -> 验证 -> 提交”。必须按顺序完成，不把调查分支中的诊断框架带入本分支。
+
+**目标：** 只为排行榜中的 Nemotron 显式关闭 OpenRouter reasoning，使模型稳定返回 ATL 可解析的交易 JSON，并通过相同真实行情窗口验证调用链可靠性。
+
+**架构：** `leaderboard.json` 提供模型级 `reasoning_effort`；`LLMAgentStrategy` 将它传给 LLM provider 工厂；OpenRouter 客户端实例保存该覆盖值并在每次请求时注入 reasoning/thinking disabled。没有模型级配置时继续使用环境变量和现有默认值。
+
+**技术栈：** Python 3.10+、Anthropic Python SDK、OpenRouter Anthropic Messages 兼容接口、pytest、Alpaca 小时行情。
+
+**设计规格：** `docs/superpowers/specs/2026-07-19-nemotron-reasoning-none-fix-design.zh-CN.md`
+
+## 全局约束
+
+- 从 `fix/issue-148-nemotron-reasoning` 分支实施；该分支基于最新 `origin/main`。
+- 不 cherry-pick `fix/issue-148-diagnostics` 的数据库、引擎或诊断表改动。
+- 不修改提示词、交易规则、仓位管理、模拟成交或数据库结构。
+- 不修改 CommonStack、Anthropic 或未配置 reasoning 的 OpenRouter 模型行为。
+- 正常请求路径不得修改 `os.environ`。
+- 单元测试不得进行真实网络请求。
+- 真实实验不打印 API Key、完整回复或 reasoning 原文。
+- 收益率不作为修复成功门槛；响应覆盖率和回退率才是本轮标准。
+- 每个代码任务独立提交，便于仓库维护者审阅和回滚。
+
+---
+
+## Task 1：支持 OpenRouter 客户端实例级 reasoning 覆盖
+
+**文件：**
+
+- 修改：`dashboard/backend/infrastructure/llm/providers/openrouter.py`
+- 修改：`dashboard/backend/infrastructure/llm/providers/__init__.py`
+- 修改：`dashboard/backend/infrastructure/llm/backtest_harness.py`
+- 修改：`dashboard/backend/tests/llm/test_providers.py`
+- 修改：`dashboard/backend/tests/llm/test_backtest_harness.py`
+
+**接口变化：**
+
+```python
+def make_llm_client(
+    integration: Optional[str] = None,
+    *,
+    reasoning_effort: Optional[str] = None,
+) -> Optional[Any]: ...
+```
+
+OpenRouter 内部对象增加同名可选参数；未传入时完全沿用环境变量和默认行为。
+
+- [ ] **Step 1：写失败测试**
+
+在 `test_providers.py` 覆盖：
+
+- 环境变量为 `medium`、客户端实例为 `none` 时，请求仍注入 reasoning disabled 和 thinking disabled。
+- 客户端实例没有覆盖值时，继续从环境变量读取 `medium`。
+- provider 工厂只把 `reasoning_effort` 传给 OpenRouter，CommonStack 和 Anthropic 构造签名不变。
+- 两个不同 OpenRouter 客户端可以分别使用 `none` 和 `medium`，证明没有共享全局状态。
+
+在 `test_backtest_harness.py` 覆盖：
+
+- harness 的 `make_llm_client` 将显式 `reasoning_effort` 原样转发给 provider 工厂。
+- 旧调用只传 `integration` 时仍然有效。
+
+- [ ] **Step 2：运行测试并确认失败**
+
+```bash
+pytest dashboard/backend/tests/llm/test_providers.py \
+  dashboard/backend/tests/llm/test_backtest_harness.py -v
+```
+
+预期：FAIL，现有工厂和 OpenRouter 客户端不接受实例级 reasoning 参数。
+
+- [ ] **Step 3：实现最小 reasoning 解析**
+
+在 `openrouter.py` 中让现有 reasoning helper 接受可选覆盖值：
+
+```python
+def _reasoning_effort(override: Optional[str] = None) -> str: ...
+def reasoning_extra_body(override: Optional[str] = None) -> Optional[dict]: ...
+def anthropic_thinking_kwarg(override: Optional[str] = None) -> Optional[dict]: ...
+```
+
+解析优先级必须是：
+
+```text
+实例级覆盖值 > OPENROUTER_REASONING_EFFORT > provider 默认值
+```
+
+`_OpenRouterMessages` 保存覆盖值，并在 `create()` 时传给两个 helper。`OpenRouterClient` 和 `make_client` 只负责传递，不复制 reasoning 判断逻辑。
+
+- [ ] **Step 4：扩展 provider 工厂和 harness**
+
+`providers.make_llm_client` 解析 integration 后：
+
+- OpenRouter：调用 `make_client(_Anthropic, reasoning_effort=...)`；
+- 其他 provider：继续调用 `make_client(_Anthropic)`，不传 OpenRouter 专属参数。
+
+`backtest_harness.make_llm_client` 只做薄转发，不加入 provider 判断。
+
+- [ ] **Step 5：运行聚焦测试**
+
+```bash
+pytest dashboard/backend/tests/llm/test_providers.py \
+  dashboard/backend/tests/llm/test_backtest_harness.py -v
+```
+
+预期：PASS。
+
+- [ ] **Step 6：提交**
+
+```bash
+git add dashboard/backend/infrastructure/llm/providers/openrouter.py \
+  dashboard/backend/infrastructure/llm/providers/__init__.py \
+  dashboard/backend/infrastructure/llm/backtest_harness.py \
+  dashboard/backend/tests/llm/test_providers.py \
+  dashboard/backend/tests/llm/test_backtest_harness.py
+git commit -m "fix(llm): support per-client OpenRouter reasoning"
+```
+
+---
+
+## Task 2：只为 Nemotron 关闭 reasoning
+
+**文件：**
+
+- 修改：`dashboard/config/leaderboard.json`
+- 修改：`dashboard/backend/domain/leaderboard/strategies/llm_agent.py`
+- 修改：`dashboard/backend/tests/domain/leaderboard/test_strategies_move.py`
+
+- [ ] **Step 1：写失败测试**
+
+在 `test_strategies_move.py` 增加：
+
+- `LLMAgentStrategy` 从配置读取 `reasoning_effort`。
+- `_make_client()` 把 `integration="openrouter"` 和 `reasoning_effort="none"` 一起传给 canonical client factory。
+- 未配置 `reasoning_effort` 时传递 `None`，保持旧条目行为。
+- 读取 `leaderboard.json` 后，只有 `nemotron_3_nano_30b` 条目包含 `reasoning_effort="none"`。
+
+测试使用 monkeypatch/fake client，不进行真实网络请求。
+
+- [ ] **Step 2：运行测试并确认失败**
+
+```bash
+pytest dashboard/backend/tests/domain/leaderboard/test_strategies_move.py -v
+```
+
+预期：FAIL，策略尚未读取或传递模型级 reasoning 配置。
+
+- [ ] **Step 3：实现策略传递**
+
+在构造函数中读取：
+
+```python
+self.reasoning_effort = self.config.get("reasoning_effort")
+```
+
+创建客户端时调用：
+
+```python
+make_llm_client(
+    self.integration,
+    reasoning_effort=self.reasoning_effort,
+)
+```
+
+不得在策略中修改环境变量，不得对模型 ID 做硬编码判断。
+
+- [ ] **Step 4：配置 Nemotron**
+
+只在 `nemotron_3_nano_30b` 条目增加：
+
+```json
+"reasoning_effort": "none"
+```
+
+其他排行榜条目保持业务配置不变。
+
+- [ ] **Step 5：运行策略和 provider 回归测试**
+
+```bash
+pytest dashboard/backend/tests/domain/leaderboard/test_strategies_move.py \
+  dashboard/backend/tests/llm/test_providers.py \
+  dashboard/backend/tests/llm/test_backtest_harness.py -v
+```
+
+预期：PASS。
+
+- [ ] **Step 6：提交**
+
+```bash
+git add dashboard/config/leaderboard.json \
+  dashboard/backend/domain/leaderboard/strategies/llm_agent.py \
+  dashboard/backend/tests/domain/leaderboard/test_strategies_move.py
+git commit -m "fix(leaderboard): disable reasoning for Nemotron"
+```
+
+---
+
+## Task 3：回归验证和真实行情复测
+
+**代码文件：** 无新增产品代码。仅运行测试和只读/内存实验。
+
+空文本、重试和响应结束原因使用临时的进程内 wrapper 采集并在命令结束后丢弃；不得为复测引入诊断表、修改产品数据库或提交实验脚本。
+
+- [ ] **Step 1：运行相关测试组**
+
+```bash
+pytest dashboard/backend/tests/llm \
+  dashboard/backend/tests/domain/leaderboard \
+  dashboard/backend/tests/backtesting/test_canonical_consumers.py -v
+```
+
+预期：PASS。
+
+- [ ] **Step 2：运行完整 backend 测试**
+
+```bash
+pytest dashboard/backend/tests -q
+```
+
+若仓库基线中存在与本修复无关的失败，必须在未修改的 `origin/main` 上复现后单独报告，不顺带修复。
+
+- [ ] **Step 3：运行相同前 16 个真实决策点**
+
+固定：
+
+- 日期：2026-04-15 至 2026-05-15；
+- 数据：Alpaca DJIA 30 小时线；
+- 模型：`nvidia/nemotron-3-nano-30b-a3b`；
+- integration：OpenRouter；
+- 模式：`safe_trading`；
+- 初始资金和资产集合不变；
+- 只在内存中计算，不发布排行榜结果。
+
+记录：决策点、API 调用数、有效决策、空文本、重试、解析失败、回退、平均延迟、模拟成交数。
+
+预期：
+
+- `no_text_steps=0`；
+- `total_retries=0`；
+- 有效决策覆盖率不低于 95%；
+- API 调用数基本等于决策点数。
+
+- [ ] **Step 4：运行完整 154 点真实窗口**
+
+沿用 Step 3 的固定条件，只扩大到完整窗口。不得使用 `--allow-fallback` 发布失败曲线；本步骤仍不写排行榜数据库。
+
+预期：
+
+- 生成完整投资曲线和模拟成交；
+- 有效决策覆盖率不低于 95%；
+- 空文本和重试保持为 0；
+- 收益率、Sharpe 和最大回撤仅记录，不作为通过条件。
+
+- [ ] **Step 5：检查分支范围**
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+git status --short --branch
+```
+
+确认最终分支只包含本设计文档、实施计划、模型级 reasoning 传递、Nemotron 配置和聚焦测试。
+
+---
+
+## Task 4：准备 Issue #148 短总结
+
+**外部状态变更：** 在用户确认文本后，才向 GitHub Issue #148 发布评论或创建 PR。
+
+- [ ] **Step 1：生成英文总结草稿**
+
+严格对应 Issue 的 Expected Outcome：
+
+1. What was checked；
+2. What problem was found；
+3. Evidence supporting the conclusion；
+4. Recommended fix and post-fix experiment results。
+
+- [ ] **Step 2：向用户展示草稿**
+
+评论必须清楚区分：
+
+- 原曲线受调用链回退污染；
+- 修复后调用链是否稳定；
+- 修复后收益属于模型真实决策观察值，不保证优于其他模型。
+
+- [ ] **Step 3：用户授权后再发布**
+
+不得自动关闭 Issue，不使用 `Closes #148`。需要 PR 时使用 `Refs #148`，并保持 PR 改动范围与本计划一致。
+
+---
+
+## 最终完成检查
+
+- [ ] 设计文档与计划文档已提交。
+- [ ] 两个代码任务均按 TDD 完成并独立提交。
+- [ ] 聚焦测试和完整 backend 测试已运行。
+- [ ] 16 点和完整窗口的真实数据复测满足可靠性标准。
+- [ ] 分支没有诊断数据库、前端或无关重构。
+- [ ] Issue 英文总结已由用户审阅。
+- [ ] 用户明确授权后才执行 GitHub 评论、push 或 PR 操作。

--- a/docs/superpowers/specs/2026-07-19-nemotron-reasoning-none-fix-design.zh-CN.md
+++ b/docs/superpowers/specs/2026-07-19-nemotron-reasoning-none-fix-design.zh-CN.md
@@ -1,0 +1,199 @@
+# Nemotron reasoning=none 最小修复设计
+
+## 1. 背景
+
+Issue #148 要求解释 Nemotron 通过 OpenRouter 接入排行榜后曲线明显偏差的原因，并给出小范围修复或下一步实验。调查在相同行情窗口、模型和交易配置下对 `reasoning=medium` 与 `reasoning=none` 进行了对照。
+
+实际响应元数据表明，当前 OpenRouter 默认配置将 `medium` 映射为 2048 个 reasoning token，而 ATL 交易请求的默认总输出上限是 2000 token。四个真实行情决策点的首次响应均出现以下特征：
+
+- `stop_reason=max_tokens`；
+- `output_tokens=2000`；
+- 只有 `thinking` 和 `redacted_thinking` 内容块；
+- 没有可供 ATL 解析的交易 JSON。
+
+因此系统会重复请求，最终进入关闭 reasoning 的救援调用、空动作或规则策略回退。当前排行榜曲线由模型决策和调用链回退共同形成，不能直接视为 Nemotron 交易能力的纯粹表现。
+
+## 2. 目标
+
+1. 只对排行榜中的 Nemotron 配置关闭 reasoning。
+2. 让 Nemotron 稳定返回 ATL 期望的交易 JSON。
+3. 保持其他 OpenRouter、CommonStack 和 Anthropic 模型的现有行为。
+4. 保持提示词、交易规则、仓位管理、模拟成交和数据库结构不变。
+5. 使用相同真实行情窗口复测调用覆盖率和完整回测曲线。
+
+## 3. 非目标
+
+- 不建设新的评估框架或诊断页面。
+- 不把调查分支中的诊断数据库改动带入最终修复 PR。
+- 不改变模型提示词或要求模型保证盈利。
+- 不重写现有通用重试和规则回退机制。
+- 不保存完整 prompt、模型回复、reasoning 原文或 API Key。
+- 不以短样本收益率作为修复成功标准。
+
+## 4. 分支策略
+
+已有 `fix/issue-148-diagnostics` 分支保留为调查取证分支，不改写历史、不删除提交，也不作为最终小修复 PR 的来源。
+
+最终修复从最新 `origin/main` 创建独立分支：
+
+```text
+origin/main
+    └── fix/issue-148-nemotron-reasoning
+```
+
+该分支只包含模型级 reasoning 配置传递、必要测试和本设计文档。真实实验结果在 Issue #148 的短总结中报告，不通过新增数据库表进入产品代码。
+
+## 5. 方案比较
+
+### 方案 A：Nemotron 模型级 `reasoning=none`（采用）
+
+在排行榜配置中为 Nemotron 增加显式 reasoning 字段，并通过策略和 OpenRouter 客户端传递。该方案已由真实行情对照验证，且不会改变其他模型。
+
+### 方案 B：保留 `medium`，扩大输出上限
+
+将总输出从 2000 增加到 4000 后，16 个决策点的空文本从 12 次降至 9 次，但仍有 33 次重试，平均延迟从约 47 秒上升到约 56 秒。该方案只能缓解，不能稳定解决。
+
+### 方案 C：保留 `medium`，遇到截断后提前救援
+
+检测 `max_tokens` 且无文本后立即关闭 reasoning 重试，可以减少浪费，但第一次调用仍然产生高延迟和无效 token。该方案可作为后续通用优化，不属于本次最小修复。
+
+采用方案 A，因为它的修改范围最小，现有对照证据最强，并能直接恢复交易 JSON 覆盖率。
+
+## 6. 架构
+
+### 6.1 排行榜配置
+
+Nemotron 条目增加模型级配置：
+
+```json
+{
+  "id": "nemotron_3_nano_30b",
+  "integration": "openrouter",
+  "model_id": "nvidia/nemotron-3-nano-30b-a3b",
+  "reasoning_effort": "none"
+}
+```
+
+其他条目不增加该字段。
+
+### 6.2 策略层
+
+`LLMAgentStrategy` 从自身配置读取可选的 `reasoning_effort`，并在创建 LLM 客户端时传递该值。策略不直接修改 `os.environ`，避免并发回测之间共享全局状态。
+
+### 6.3 Provider 工厂
+
+LLM provider 工厂接受可选 `reasoning_effort`。只有解析后的 integration 为 `openrouter` 时才把该选项交给 OpenRouter provider；CommonStack 和 Anthropic 仍使用原来的构造路径。
+
+### 6.4 OpenRouter 客户端
+
+OpenRouter 消息代理保存客户端实例级 reasoning 覆盖值。每次 `messages.create` 时按以下优先级解析：
+
+```text
+模型配置 reasoning_effort
+        ↓ 未配置
+OPENROUTER_REASONING_EFFORT 环境变量
+        ↓ 未配置
+OpenRouter provider 默认值
+```
+
+当解析值为 `none` 时，现有请求载荷保持一致地注入：
+
+```json
+{
+  "reasoning": {
+    "effort": "none",
+    "enabled": false,
+    "exclude": true
+  }
+}
+```
+
+同时使用 Anthropic 兼容参数：
+
+```json
+{
+  "thinking": {
+    "type": "disabled"
+  }
+}
+```
+
+## 7. 数据流
+
+```text
+leaderboard.json
+  reasoning_effort=none
+        ↓
+LLMAgentStrategy
+        ↓
+make_llm_client(openrouter, reasoning_effort=none)
+        ↓
+OpenRouterClient 实例级配置
+        ↓
+Nemotron 直接输出交易 JSON
+        ↓
+现有解析、动作过滤和模拟成交
+        ↓
+现有回测曲线与排行榜存储
+```
+
+除 reasoning 请求参数外，数据流中的业务逻辑保持不变。
+
+## 8. 错误处理与兼容性
+
+- 模型条目没有 `reasoning_effort`：继续使用环境变量或 provider 默认值。
+- Nemotron 使用 `none` 后仍无文本：沿用现有重试和最终回退机制。
+- OpenRouter API 异常：沿用现有规则策略回退。
+- 返回无效 JSON：沿用现有解析失败和空动作行为。
+- 非 OpenRouter integration：不接收 OpenRouter reasoning 覆盖值，行为不变。
+- 旧配置文件：字段可选，无需迁移。
+- 并发运行：正常请求路径不修改全局环境变量。
+
+本次不修改现有救援调用对环境变量的临时操作；消除该全局状态属于独立的通用可靠性改进，避免扩大 Issue #148 的修复范围。
+
+## 9. 测试设计
+
+### 9.1 单元测试
+
+1. Nemotron 配置包含 `reasoning_effort=none`。
+2. `LLMAgentStrategy` 将模型级 reasoning 配置传给客户端工厂。
+3. 模型级 `none` 的优先级高于环境变量中的 `medium`。
+4. OpenRouter 请求包含 reasoning disabled 和 thinking disabled 参数。
+5. 未提供模型级配置时仍沿用环境变量和原默认行为。
+6. CommonStack 与 Anthropic 客户端构造行为不变。
+7. 现有 provider、leaderboard 和回测测试继续通过。
+
+### 9.2 真实行情复测
+
+固定以下条件：
+
+- 模型：`nvidia/nemotron-3-nano-30b-a3b`；
+- integration：OpenRouter；
+- 行情：Alpaca DJIA 30 小时线；
+- 日期：2026-04-15 至 2026-05-15；
+- 初始资金、资产集合和交易模式保持不变。
+
+先跑相同前 16 个决策点，再跑完整 154 个决策点。
+
+## 10. 完成标准
+
+- `no_text_steps=0`；
+- `total_retries=0`；
+- 有效模型决策覆盖率不低于 95%；
+- API 调用次数基本等于决策点数量；
+- 生成完整模拟成交记录和回测曲线；
+- 不因调用链失败发布规则策略冒充的 Nemotron 曲线；
+- 不泄露密钥、完整回复或 reasoning 原文；
+- 单元测试和相关回归测试通过。
+
+收益率和排行榜名次只作为修复后的观察结果，不是完成门槛。调用链稳定后，才能继续判断 Nemotron 的真实交易决策质量。
+
+## 11. Issue #148 交付内容
+
+完成复测后，在 Issue #148 提交简短英文总结，包含：
+
+1. 检查了模型 ID、reasoning 配置、响应块、解析、回退和模拟成交链路。
+2. 发现 `medium=2048` reasoning 预算与 `max_tokens=2000` 总输出上限冲突。
+3. 展示 `stop_reason=max_tokens`、满 2000 输出 token、无 text 块和修复前后重试数字。
+4. 说明原曲线包含回退影响，不能单独归因于模型交易能力。
+5. 推荐 Nemotron 排行榜配置使用 `reasoning=none`，并附完整窗口复测结果。


### PR DESCRIPTION
## Summary

- Diagnose Nemotron's poor leaderboard curve through the model response, parsing, fallback, and simulated execution path.
- Add per-client OpenRouter `reasoning_effort` forwarding without changing other integrations.
- Configure only the Nemotron leaderboard entry with `reasoning_effort: none`.
- Add focused tests and document the design and implementation plan.

## Root cause

OpenRouter's default `medium` reasoning setting maps to a 2048-token reasoning budget, while ATL limits the complete response to 2000 output tokens. In the failing run, Nemotron often exhausted the response budget on thinking blocks and returned no trading JSON. The resulting retries, rescue calls, and effective HOLD/fallback decisions contaminated the displayed curve.

## Validation

A post-fix Alpaca DJIA-30 run over 2026-04-15 through 2026-05-15 produced:

- 161 decision steps and 161 API calls
- 155 model-driven decisions (96.27% coverage)
- 0 no-text responses, 0 retries, and 0 request errors
- 134 simulated trades
- +0.81% total return, 0.58 Sharpe, and -4.48% maximum drawdown

Six responses contained malformed JSON and became effective HOLDs. This is a separate follow-up opportunity for schema-constrained output or a narrowly scoped parse retry.

Focused tests pass. The full backend suite had one pre-existing vn.py simulated-rule-agent failure, reproduced on unmodified `origin/main`; this PR does not touch that path.

Refs #148
