### PR TITLE
Decouple Discord backtest delivery from long-running execution

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -612,7 +612,23 @@ async def run_backtest_endpoint(
     # Mint run id before the worker starts so callers (Discord job watcher)
     # can key notifications on a stable id from the HTTP response.
     live_run_id = f"agent_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
-    
+
+    # Publish "running" synchronously — before thread.start() — so a status poll
+    # landing in the gap between this return and the worker's first line cannot
+    # read a PRIOR run's completed state (running=False, runs_count>0) and report
+    # it as this run's result. Clearing runs_count/error retires the previous
+    # run's terminal signal; setting live_run_id lets the watcher key on this
+    # exact run. (PR #163 completion-detection race.) Item assignment on this
+    # global dict is atomic under the GIL, same as the worker's own writes.
+    global backtest_session_id
+    backtest_status["running"] = True
+    backtest_status["error"] = None
+    backtest_status["runs_count"] = 0
+    backtest_status["started_at"] = time.time()
+    backtest_status["live_run_id"] = live_run_id
+    backtest_status["progress_file"] = None
+    backtest_session_id = session_id
+
     # Start backtest in background thread
     print(f"🧵 Starting background thread for backtest", flush=True)
     thread = threading.Thread(

--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -218,6 +218,7 @@ def run_backtest_background(
     pipeline: Optional[List[Dict[str, Any]]] = None,
     agent_id: Optional[str] = None,
     data_source: str = ALPACA,
+    live_run_id: Optional[str] = None,
 ):
     """Run backtest in background thread."""
     global backtest_status, backtest_session_id
@@ -225,7 +226,6 @@ def run_backtest_background(
     strategy_prompt_path = None
     pipeline_path = None
     progress_file = None
-    live_run_id = None
     try:
         import subprocess
         import sys
@@ -237,7 +237,10 @@ def run_backtest_background(
         backtest_status["started_at"] = time.time()
         backtest_session_id = session_id  # Store session for status polling
 
-        live_run_id = f"agent_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+        if not live_run_id:
+            live_run_id = (
+                f"agent_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            )
         progress_file = str(Path(tempfile.gettempdir()) / f"backtest_progress_{live_run_id}.json")
         backtest_status["live_run_id"] = live_run_id
         backtest_status["progress_file"] = progress_file
@@ -605,6 +608,10 @@ async def run_backtest_endpoint(
             "success": False,
             "error": "Backtest already running. Please wait for it to complete."
         }
+
+    # Mint run id before the worker starts so callers (Discord job watcher)
+    # can key notifications on a stable id from the HTTP response.
+    live_run_id = f"agent_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
     
     # Start backtest in background thread
     print(f"🧵 Starting background thread for backtest", flush=True)
@@ -619,6 +626,7 @@ async def run_backtest_endpoint(
             pipeline,
             agent_id,
             data_source,
+            live_run_id,
         ),
         daemon=True
     )
@@ -630,6 +638,8 @@ async def run_backtest_endpoint(
         "status_url": "/backtest/status",
         "session_id": session_id,
         "data_source": data_source,
+        "live_run_id": live_run_id,
+        "run_id": live_run_id,
     }
 
 @router.get("/backtest/status")
@@ -654,6 +664,8 @@ async def get_backtest_status(request: Request):
             "running": True,
             "message": message,
             "elapsed_seconds": elapsed,
+            "live_run_id": backtest_status.get("live_run_id"),
+            "session_id": backtest_session_id,
         }
         if progress:
             payload["progress"] = progress

--- a/dashboard/backend/integrations/discord_bot.py
+++ b/dashboard/backend/integrations/discord_bot.py
@@ -591,6 +591,12 @@ async def watch_and_deliver_backtest(
                 store.update(job_id, status=STATUS_NOTIFY_FAILED, error=str(exc))
             return
 
+        # Resolve metrics for THIS run. Prefer the exact id we minted up front.
+        # The "/runs/latest/metrics" fallback is deliberately identity-gated:
+        # Discord sessions are stable per user, so "latest" can be a PRIOR
+        # backtest from this same session and would post stale numbers under a
+        # fresh run. Accept it only when it *is* this run, or when we have no
+        # live_run_id to key on (legacy jobs). (PR #163 completion-race finding.)
         metrics: Optional[dict[str, Any]] = None
         if job.live_run_id:
             try:
@@ -599,29 +605,35 @@ async def watch_and_deliver_backtest(
                 metrics = None
         if metrics is None:
             try:
-                metrics = await api_get("/runs/latest/metrics", headers=headers)
-            except Exception as exc:
-                err = f"Backtest finished, but metrics could not be read: {exc}"
-                store.update(job_id, status=STATUS_FAILED, error=err)
-                try:
-                    await _post_channel_result(
-                        channel_id=job.channel_id,
-                        discord_user_id=job.discord_user_id,
-                        content=(
-                            f"**Backtest finished** · `{job.label}`\n{err}\n"
-                            "Check the dashboard."
-                        ),
-                    )
-                    store.update(
-                        job_id,
-                        status=STATUS_NOTIFIED,
-                        notified_at=time.time(),
-                    )
-                except Exception as notify_exc:
-                    store.update(
-                        job_id, status=STATUS_NOTIFY_FAILED, error=str(notify_exc)
-                    )
-                return
+                latest = await api_get("/runs/latest/metrics", headers=headers)
+            except Exception:
+                latest = None
+            if latest is not None and (
+                not job.live_run_id or latest.get("run_id") == job.live_run_id
+            ):
+                metrics = latest
+        if metrics is None:
+            err = "Backtest finished, but metrics for this run could not be read."
+            store.update(job_id, status=STATUS_FAILED, error=err)
+            try:
+                await _post_channel_result(
+                    channel_id=job.channel_id,
+                    discord_user_id=job.discord_user_id,
+                    content=(
+                        f"**Backtest finished** · `{job.label}`\n{err}\n"
+                        "Check the dashboard."
+                    ),
+                )
+                store.update(
+                    job_id,
+                    status=STATUS_NOTIFIED,
+                    notified_at=time.time(),
+                )
+            except Exception as notify_exc:
+                store.update(
+                    job_id, status=STATUS_NOTIFY_FAILED, error=str(notify_exc)
+                )
+            return
 
         summary, run_id = format_backtest_summary(
             metrics,
@@ -641,6 +653,11 @@ async def watch_and_deliver_backtest(
             except Exception as exc:
                 print("Discord /backtest plot failed:", repr(exc))
 
+        # Delivery is at-least-once: we post, then mark NOTIFIED. If the process
+        # dies in that gap the job stays open and resume_open_backtest_jobs()
+        # re-posts on restart (a possible duplicate message, never a lost one).
+        # Exactly-once would need a transactional send+mark we don't have here;
+        # a duplicate result post is an acceptable failure mode for this feature.
         try:
             await _post_channel_result(
                 channel_id=job.channel_id,

--- a/dashboard/backend/integrations/discord_bot.py
+++ b/dashboard/backend/integrations/discord_bot.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import io
 import os
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Optional
@@ -20,6 +21,14 @@ from dashboard.backend.domain.chat.service import (
     synthesize_strategy_prompt,
 )
 from dashboard.backend.infrastructure.llm.token_cost import is_free_model
+from dashboard.backend.integrations.discord_jobs import (
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_NOTIFIED,
+    STATUS_NOTIFY_FAILED,
+    STATUS_WATCHING,
+    get_job_store,
+)
 
 
 def _model_override(model_name: Optional[str]) -> Optional[str]:
@@ -60,6 +69,12 @@ def selected_agent_for(user_id: str) -> Optional[dict[str, Any]]:
 # Stable namespace so each Discord user maps to a fixed backtest session UUID
 # (the /backtest routes require a valid UUID X-Session-Id).
 _SESSION_NAMESPACE = uuid.UUID("8f1b2c3d-0000-4000-8000-a9b8c7d6e5f4")
+
+# Background watchers: poll longer than Discord's ~15m interaction token so
+# results still post to the channel when the API's 30m backtest budget is used.
+_POLL_INTERVAL_SEC = 5
+_MAX_POLLS = 360  # 30 minutes
+_active_watchers: set[str] = set()
 
 
 def api_base() -> str:
@@ -436,6 +451,246 @@ class StrategyRunBacktestView(discord.ui.View):
         )
 
 
+def format_backtest_summary(
+    metrics: dict[str, Any],
+    *,
+    label: str,
+    agent_id: Optional[str] = None,
+    agent_name: Optional[str] = None,
+    share_url: Optional[str] = None,
+) -> tuple[str, Optional[str]]:
+    """Build the Discord result text. Returns (summary, run_id)."""
+
+    def pct(v: Any) -> str:
+        return "—" if v is None else f"{float(v) * 100:.2f}%"
+
+    def num(v: Any) -> str:
+        return "—" if v is None else f"{float(v):.2f}"
+
+    run_id = metrics.get("run_id")
+    summary = (
+        f"**Backtest complete** · `{label}`\n"
+        f"Window: {metrics.get('start_date', '?')} → {metrics.get('end_date', '?')}  ·  "
+        f"model: {metrics.get('llm_model', '?')}\n"
+        f"Return: **{pct(metrics.get('total_return'))}**  ·  "
+        f"Sharpe: {num(metrics.get('sharpe_ratio'))}  ·  "
+        f"Max DD: {pct(metrics.get('max_drawdown'))}  ·  "
+        f"Trades: {metrics.get('num_trades', 0)}\n"
+        f"Final equity: ${float(metrics.get('final_equity') or 0):,.0f}"
+    )
+    dash_url = dashboard_backtest_url(agent_id=agent_id, run_id=run_id)
+    summary += f"\nDashboard: {dash_url}"
+    if share_url:
+        summary += f"\nView: {share_url}"
+    if agent_id and agent_name:
+        summary += (
+            f"\nSaved to **{agent_name}**'s card — open the Dashboard link above."
+        )
+    return summary, run_id if isinstance(run_id, str) else None
+
+
+async def _edit_ack(
+    interaction: Optional[discord.Interaction],
+    content: str,
+) -> None:
+    if interaction is None:
+        return
+    try:
+        await interaction.edit_original_response(content=content)
+    except Exception as exc:
+        print("Discord ack edit failed:", repr(exc))
+
+
+async def _post_channel_result(
+    *,
+    channel_id: int,
+    discord_user_id: str,
+    content: str,
+    chart: Optional[discord.File] = None,
+) -> None:
+    """Post final results in-channel (survives interaction-token expiry)."""
+    channel = bot.get_channel(channel_id)
+    if channel is None:
+        channel = await bot.fetch_channel(channel_id)
+    mention = f"<@{discord_user_id}>"
+    kwargs: dict[str, Any] = {"content": f"{mention}\n{content}"}
+    if chart is not None:
+        kwargs["file"] = chart
+    await channel.send(**kwargs)  # type: ignore[union-attr]
+
+
+async def watch_and_deliver_backtest(
+    job_id: str,
+    *,
+    interaction: Optional[discord.Interaction] = None,
+) -> None:
+    """Poll API status for a persisted job and post results when done."""
+    if job_id in _active_watchers:
+        return
+    _active_watchers.add(job_id)
+    store = get_job_store()
+    try:
+        job = store.get(job_id)
+        if job is None:
+            return
+        if job.status in (STATUS_NOTIFIED, STATUS_NOTIFY_FAILED):
+            return
+
+        store.update(job_id, status=STATUS_WATCHING)
+        headers = {"X-Session-Id": job.session_id}
+        terminal_error: Optional[str] = None
+
+        for i in range(_MAX_POLLS):
+            await asyncio.sleep(_POLL_INTERVAL_SEC)
+            try:
+                status = await api_get("/backtest/status", headers=headers)
+            except Exception:
+                continue
+
+            if status.get("running"):
+                # Best-effort progress on the ephemeral ACK while the token lives.
+                if interaction is not None and (i + 1) % 12 == 0:
+                    elapsed = (i + 1) * _POLL_INTERVAL_SEC
+                    await _edit_ack(
+                        interaction,
+                        (
+                            f"Backtest running (`{job.label}`)… "
+                            f"({elapsed}s elapsed). Results will post here when done."
+                        ),
+                    )
+                continue
+
+            if status.get("error"):
+                terminal_error = str(status["error"])[:1500]
+                break
+
+            if status.get("success") or status.get("runs_count"):
+                break
+        else:
+            terminal_error = (
+                "Backtest is still running after 30 minutes. "
+                "Check the dashboard later, or ask an admin to inspect the API worker."
+            )
+
+        if terminal_error:
+            store.update(job_id, status=STATUS_FAILED, error=terminal_error)
+            fail_text = f"**Backtest failed** · `{job.label}`\n{terminal_error}"
+            try:
+                await _post_channel_result(
+                    channel_id=job.channel_id,
+                    discord_user_id=job.discord_user_id,
+                    content=fail_text,
+                )
+                await _edit_ack(
+                    interaction,
+                    f"Backtest failed (`{job.label}`). Details posted in-channel.",
+                )
+                store.update(job_id, status=STATUS_NOTIFIED, notified_at=time.time())
+            except Exception as exc:
+                print("Discord failure notify failed:", repr(exc))
+                store.update(job_id, status=STATUS_NOTIFY_FAILED, error=str(exc))
+            return
+
+        metrics: Optional[dict[str, Any]] = None
+        if job.live_run_id:
+            try:
+                metrics = await api_get(f"/runs/{job.live_run_id}", headers=headers)
+            except Exception:
+                metrics = None
+        if metrics is None:
+            try:
+                metrics = await api_get("/runs/latest/metrics", headers=headers)
+            except Exception as exc:
+                err = f"Backtest finished, but metrics could not be read: {exc}"
+                store.update(job_id, status=STATUS_FAILED, error=err)
+                try:
+                    await _post_channel_result(
+                        channel_id=job.channel_id,
+                        discord_user_id=job.discord_user_id,
+                        content=(
+                            f"**Backtest finished** · `{job.label}`\n{err}\n"
+                            "Check the dashboard."
+                        ),
+                    )
+                    store.update(
+                        job_id,
+                        status=STATUS_NOTIFIED,
+                        notified_at=time.time(),
+                    )
+                except Exception as notify_exc:
+                    store.update(
+                        job_id, status=STATUS_NOTIFY_FAILED, error=str(notify_exc)
+                    )
+                return
+
+        summary, run_id = format_backtest_summary(
+            metrics,
+            label=job.label,
+            agent_id=job.agent_id,
+            agent_name=job.agent_name,
+            share_url=job.share_url,
+        )
+        run_id = run_id or job.live_run_id
+        store.update(job_id, status=STATUS_COMPLETED, run_id=run_id)
+
+        chart: Optional[discord.File] = None
+        if run_id:
+            try:
+                png = await api_get_bytes(f"/runs/{run_id}/plot.png", headers=headers)
+                chart = discord.File(io.BytesIO(png), filename=f"backtest_{run_id}.png")
+            except Exception as exc:
+                print("Discord /backtest plot failed:", repr(exc))
+
+        try:
+            await _post_channel_result(
+                channel_id=job.channel_id,
+                discord_user_id=job.discord_user_id,
+                content=summary,
+                chart=chart,
+            )
+            await _edit_ack(
+                interaction,
+                (
+                    f"Backtest complete (`{job.label}`). "
+                    "Results (+ chart) were posted in this channel."
+                ),
+            )
+            store.update(
+                job_id,
+                status=STATUS_NOTIFIED,
+                run_id=run_id,
+                notified_at=time.time(),
+            )
+        except Exception as exc:
+            print("Discord result notify failed:", repr(exc))
+            store.update(job_id, status=STATUS_NOTIFY_FAILED, error=str(exc))
+    finally:
+        _active_watchers.discard(job_id)
+
+
+def schedule_backtest_watch(
+    job_id: str,
+    *,
+    interaction: Optional[discord.Interaction] = None,
+) -> None:
+    """Fire-and-forget watcher; safe to call from slash handlers and resume."""
+    asyncio.create_task(
+        watch_and_deliver_backtest(job_id, interaction=interaction),
+        name=f"discord-backtest-{job_id}",
+    )
+
+
+async def resume_open_backtest_jobs() -> None:
+    """On bot startup, re-attach watchers for unfinished persisted jobs."""
+    store = get_job_store()
+    open_jobs = store.list_open()
+    if not open_jobs:
+        return
+    print(f"Resuming {len(open_jobs)} Discord backtest job(s)…")
+    for job in open_jobs:
+        schedule_backtest_watch(job.job_id)
+
+
 async def execute_backtest(
     interaction: discord.Interaction,
     discord_user_id: str,
@@ -445,9 +700,11 @@ async def execute_backtest(
     start: Optional[str] = None,
     end: Optional[str] = None,
 ) -> None:
-    """Shared backtest runner for ``/backtest`` and strategy buttons.
+    """Start a backtest and return immediately; results post when the job finishes.
 
-    The interaction must already be deferred.
+    The interaction must already be deferred. Final metrics + chart are posted
+    in-channel (mentioning the user) so delivery survives Discord's 15-minute
+    interaction token and long LLM backtests.
     """
     selected = selected_agent_for(discord_user_id)
     session_id = session_for(discord_user_id)
@@ -506,92 +763,40 @@ async def execute_backtest(
         return
 
     effective_session = started.get("session_id") or session_id
-    headers = {"X-Session-Id": effective_session}
+    live_run_id = started.get("live_run_id") or started.get("run_id")
+    attached_agent_id = payload.get("agent_id")
+    agent_name = selected.get("name") if selected and attached_agent_id else None
 
-    await interaction.edit_original_response(
-        content=(
-            f"Backtest started (`{label}`) with real Alpaca bars + hosted model. "
-            "Running… this can take a few minutes."
-        )
-    )
-
-    max_polls = 130
-    for i in range(max_polls):
-        await asyncio.sleep(5)
-        try:
-            status = await api_get("/backtest/status", headers=headers)
-        except Exception:
-            continue
-
-        if status.get("running"):
-            if (i + 1) % 6 == 0:
-                await interaction.edit_original_response(
-                    content=f"Backtest running (`{label}`)… ({(i + 1) * 5}s elapsed)"
-                )
-            continue
-
-        if status.get("error"):
-            await interaction.edit_original_response(
-                content=f"Backtest failed: {status['error'][:1500]}"
-            )
-            return
-
-        if status.get("success") or status.get("runs_count"):
-            break
-    else:
+    if interaction.channel_id is None:
         await interaction.edit_original_response(
             content=(
-                "Backtest is taking longer than expected. "
-                "Check results later on the dashboard."
+                "Backtest started, but this context has no channel to post results to. "
+                "Check the dashboard when it finishes."
             )
         )
         return
 
-    try:
-        m = await api_get("/runs/latest/metrics", headers=headers)
-    except Exception:
-        await interaction.edit_original_response(
-            content="Backtest finished, but metrics could not be read. Check the dashboard."
-        )
-        return
-
-    def pct(v: Any) -> str:
-        return "—" if v is None else f"{float(v) * 100:.2f}%"
-
-    def num(v: Any) -> str:
-        return "—" if v is None else f"{float(v):.2f}"
-
-    summary = (
-        f"**Backtest complete** · `{label}`\n"
-        f"Window: {m.get('start_date', '?')} → {m.get('end_date', '?')}  ·  "
-        f"model: {m.get('llm_model', '?')}\n"
-        f"Return: **{pct(m.get('total_return'))}**  ·  Sharpe: {num(m.get('sharpe_ratio'))}  ·  "
-        f"Max DD: {pct(m.get('max_drawdown'))}  ·  Trades: {m.get('num_trades', 0)}\n"
-        f"Final equity: ${float(m.get('final_equity') or 0):,.0f}"
+    job = get_job_store().create_job(
+        discord_user_id=discord_user_id,
+        channel_id=int(interaction.channel_id),
+        guild_id=interaction.guild_id,
+        session_id=effective_session,
+        label=label,
+        live_run_id=live_run_id,
+        agent_id=attached_agent_id,
+        agent_name=agent_name,
+        share_url=share_url,
     )
-    run_id = m.get("run_id")
-    # Only a builtin agent gets agent_id attached to the run (see payload above).
-    # Key the deep link + "saved to card" line off what was actually sent so we
-    # never claim a run landed on an agent's card when it didn't.
-    attached_agent_id = payload.get("agent_id")
-    # Always include a clickable Playground URL (Vercel in prod; full deep link when ids exist).
-    dash_url = dashboard_backtest_url(agent_id=attached_agent_id, run_id=run_id)
-    summary += f"\nDashboard: {dash_url}"
-    if share_url:
-        summary += f"\nView: {share_url}"
-    if attached_agent_id and selected and selected.get("name"):
-        summary += (
-            f"\nSaved to **{selected['name']}**'s card — open the Dashboard link above."
-        )
-    await interaction.edit_original_response(content=summary)
 
-    if run_id:
-        try:
-            png = await api_get_bytes(f"/runs/{run_id}/plot.png", headers=headers)
-            chart = discord.File(io.BytesIO(png), filename=f"backtest_{run_id}.png")
-            await interaction.followup.send(file=chart, ephemeral=True)
-        except Exception as exc:
-            print("Discord /backtest plot failed:", repr(exc))
+    run_hint = f" · run `{live_run_id}`" if live_run_id else ""
+    await interaction.edit_original_response(
+        content=(
+            f"Backtest queued (`{label}`){run_hint} with real Alpaca bars + hosted model.\n"
+            "I'll post the results (+ chart) in this channel when it finishes — "
+            "no need to keep this message open."
+        )
+    )
+    schedule_backtest_watch(job.job_id, interaction=interaction)
 
 
 class RestrictedCommandTree(app_commands.CommandTree):
@@ -657,6 +862,9 @@ class AgenticTradingDiscordBot(commands.Bot):
                 "Free chat: DMs, @mention, or reply-to-bot. "
                 "Set DISCORD_CHANNEL_ID for open chat in specific channels."
             )
+
+        # Re-attach watchers for jobs that were mid-flight when the bot restarted.
+        await resume_open_backtest_jobs()
 
 
 bot = AgenticTradingDiscordBot()

--- a/dashboard/backend/integrations/discord_jobs.py
+++ b/dashboard/backend/integrations/discord_jobs.py
@@ -1,0 +1,283 @@
+"""Persist Discord-triggered backtest notification jobs.
+
+The Discord bot starts a backtest via HTTP, then watches in the background and
+posts results when the API job finishes. Jobs are stored in a small SQLite file
+so a bot restart can resume in-flight watches (delivery does not rely on the
+15-minute Discord interaction token).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from dashboard.backend.paths import DATA_DIR
+
+DEFAULT_JOBS_DB = DATA_DIR / "discord_backtest_jobs.db"
+
+STATUS_PENDING = "pending"
+STATUS_WATCHING = "watching"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+STATUS_NOTIFIED = "notified"
+STATUS_NOTIFY_FAILED = "notify_failed"
+
+_OPEN_STATUSES = (STATUS_PENDING, STATUS_WATCHING)
+
+
+@dataclass(frozen=True)
+class DiscordBacktestJob:
+    job_id: str
+    discord_user_id: str
+    channel_id: int
+    session_id: str
+    label: str
+    status: str
+    created_at: float
+    live_run_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    agent_name: Optional[str] = None
+    share_url: Optional[str] = None
+    run_id: Optional[str] = None
+    error: Optional[str] = None
+    notified_at: Optional[float] = None
+    guild_id: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "discord_user_id": self.discord_user_id,
+            "channel_id": self.channel_id,
+            "guild_id": self.guild_id,
+            "session_id": self.session_id,
+            "label": self.label,
+            "status": self.status,
+            "created_at": self.created_at,
+            "live_run_id": self.live_run_id,
+            "agent_id": self.agent_id,
+            "agent_name": self.agent_name,
+            "share_url": self.share_url,
+            "run_id": self.run_id,
+            "error": self.error,
+            "notified_at": self.notified_at,
+        }
+
+
+class DiscordJobStore:
+    """Thread-safe SQLite store for Discord backtest notify jobs."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self.db_path = Path(db_path) if db_path else DEFAULT_JOBS_DB
+        self._lock = threading.Lock()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path), timeout=30)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _init_schema(self) -> None:
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS discord_backtest_jobs (
+                        job_id TEXT PRIMARY KEY,
+                        discord_user_id TEXT NOT NULL,
+                        channel_id INTEGER NOT NULL,
+                        guild_id INTEGER,
+                        session_id TEXT NOT NULL,
+                        label TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        created_at REAL NOT NULL,
+                        live_run_id TEXT,
+                        agent_id TEXT,
+                        agent_name TEXT,
+                        share_url TEXT,
+                        run_id TEXT,
+                        error TEXT,
+                        notified_at REAL,
+                        meta_json TEXT
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_discord_jobs_status
+                    ON discord_backtest_jobs(status)
+                    """
+                )
+                conn.commit()
+
+    @staticmethod
+    def _row_to_job(row: sqlite3.Row) -> DiscordBacktestJob:
+        return DiscordBacktestJob(
+            job_id=row["job_id"],
+            discord_user_id=row["discord_user_id"],
+            channel_id=int(row["channel_id"]),
+            session_id=row["session_id"],
+            label=row["label"],
+            status=row["status"],
+            created_at=float(row["created_at"]),
+            live_run_id=row["live_run_id"],
+            agent_id=row["agent_id"],
+            agent_name=row["agent_name"],
+            share_url=row["share_url"],
+            run_id=row["run_id"],
+            error=row["error"],
+            notified_at=row["notified_at"],
+            guild_id=int(row["guild_id"]) if row["guild_id"] is not None else None,
+        )
+
+    def create_job(
+        self,
+        *,
+        discord_user_id: str,
+        channel_id: int,
+        session_id: str,
+        label: str,
+        live_run_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        agent_name: Optional[str] = None,
+        share_url: Optional[str] = None,
+        guild_id: Optional[int] = None,
+        job_id: Optional[str] = None,
+    ) -> DiscordBacktestJob:
+        job = DiscordBacktestJob(
+            job_id=job_id or uuid.uuid4().hex[:12],
+            discord_user_id=str(discord_user_id),
+            channel_id=int(channel_id),
+            session_id=session_id,
+            label=label,
+            status=STATUS_PENDING,
+            created_at=time.time(),
+            live_run_id=live_run_id,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            share_url=share_url,
+            guild_id=guild_id,
+        )
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO discord_backtest_jobs (
+                        job_id, discord_user_id, channel_id, guild_id, session_id,
+                        label, status, created_at, live_run_id, agent_id, agent_name,
+                        share_url, meta_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        job.job_id,
+                        job.discord_user_id,
+                        job.channel_id,
+                        job.guild_id,
+                        job.session_id,
+                        job.label,
+                        job.status,
+                        job.created_at,
+                        job.live_run_id,
+                        job.agent_id,
+                        job.agent_name,
+                        job.share_url,
+                        json.dumps({}),
+                    ),
+                )
+                conn.commit()
+        return job
+
+    def get(self, job_id: str) -> Optional[DiscordBacktestJob]:
+        with self._lock:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT * FROM discord_backtest_jobs WHERE job_id = ?",
+                    (job_id,),
+                ).fetchone()
+        return self._row_to_job(row) if row else None
+
+    def list_open(self) -> list[DiscordBacktestJob]:
+        placeholders = ",".join("?" for _ in _OPEN_STATUSES)
+        with self._lock:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    f"""
+                    SELECT * FROM discord_backtest_jobs
+                    WHERE status IN ({placeholders})
+                    ORDER BY created_at ASC
+                    """,
+                    _OPEN_STATUSES,
+                ).fetchall()
+        return [self._row_to_job(r) for r in rows]
+
+    def update(
+        self,
+        job_id: str,
+        *,
+        status: Optional[str] = None,
+        run_id: Optional[str] = None,
+        error: Optional[str] = None,
+        notified_at: Optional[float] = None,
+        live_run_id: Optional[str] = None,
+    ) -> Optional[DiscordBacktestJob]:
+        fields: list[str] = []
+        values: list[Any] = []
+        if status is not None:
+            fields.append("status = ?")
+            values.append(status)
+        if run_id is not None:
+            fields.append("run_id = ?")
+            values.append(run_id)
+        if error is not None:
+            fields.append("error = ?")
+            values.append(error)
+        if notified_at is not None:
+            fields.append("notified_at = ?")
+            values.append(notified_at)
+        if live_run_id is not None:
+            fields.append("live_run_id = ?")
+            values.append(live_run_id)
+        if not fields:
+            return self.get(job_id)
+        values.append(job_id)
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    f"UPDATE discord_backtest_jobs SET {', '.join(fields)} WHERE job_id = ?",
+                    values,
+                )
+                conn.commit()
+        return self.get(job_id)
+
+
+_store: Optional[DiscordJobStore] = None
+_store_lock = threading.Lock()
+
+
+def get_job_store(db_path: Optional[Path] = None) -> DiscordJobStore:
+    """Process-wide job store (override path mainly for tests)."""
+    global _store
+    with _store_lock:
+        if db_path is not None:
+            return DiscordJobStore(db_path)
+        if _store is None:
+            import os
+
+            raw = (os.getenv("DISCORD_JOBS_DB") or "").strip()
+            path = Path(raw) if raw else DEFAULT_JOBS_DB
+            _store = DiscordJobStore(path)
+        return _store
+
+
+def reset_job_store_for_tests() -> None:
+    """Drop the cached store so the next get_job_store() rebuilds (tests only)."""
+    global _store
+    with _store_lock:
+        _store = None

--- a/dashboard/backend/integrations/discord_jobs.py
+++ b/dashboard/backend/integrations/discord_jobs.py
@@ -8,7 +8,6 @@ so a bot restart can resume in-flight watches (delivery does not rely on the
 
 from __future__ import annotations
 
-import json
 import sqlite3
 import threading
 import time
@@ -104,8 +103,7 @@ class DiscordJobStore:
                         share_url TEXT,
                         run_id TEXT,
                         error TEXT,
-                        notified_at REAL,
-                        meta_json TEXT
+                        notified_at REAL
                     )
                     """
                 )
@@ -172,8 +170,8 @@ class DiscordJobStore:
                     INSERT INTO discord_backtest_jobs (
                         job_id, discord_user_id, channel_id, guild_id, session_id,
                         label, status, created_at, live_run_id, agent_id, agent_name,
-                        share_url, meta_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        share_url
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         job.job_id,
@@ -188,7 +186,6 @@ class DiscordJobStore:
                         job.agent_id,
                         job.agent_name,
                         job.share_url,
-                        json.dumps({}),
                     ),
                 )
                 conn.commit()

--- a/dashboard/backend/tests/domain/chat/test_discord_bot.py
+++ b/dashboard/backend/tests/domain/chat/test_discord_bot.py
@@ -142,6 +142,31 @@ def test_fetch_owned_agents_other_404_is_fetch_failed(monkeypatch):
     assert err == "fetch_failed"
 
 
+def test_format_backtest_summary_includes_dashboard_link():
+    summary, run_id = bot_mod.format_backtest_summary(
+        {
+            "run_id": "agent_test",
+            "start_date": "2026-05-01",
+            "end_date": "2026-05-07",
+            "llm_model": "claude-haiku",
+            "total_return": 0.12,
+            "sharpe_ratio": 1.5,
+            "max_drawdown": -0.05,
+            "num_trades": 3,
+            "final_equity": 112000,
+        },
+        label="e23badad",
+        agent_id="ag1",
+        agent_name="Berkshire",
+    )
+    assert run_id == "agent_test"
+    assert "Backtest complete" in summary
+    assert "e23badad" in summary
+    assert "Berkshire" in summary
+    assert "view=backtest" in summary
+    assert "agent_id=ag1" in summary
+
+
 def test_discord_bot_imports_without_secrets():
     code = textwrap.dedent(
         """

--- a/dashboard/backend/tests/integrations/test_discord_jobs.py
+++ b/dashboard/backend/tests/integrations/test_discord_jobs.py
@@ -1,0 +1,85 @@
+"""Tests for Discord backtest job persistence."""
+
+from pathlib import Path
+
+from dashboard.backend.integrations.discord_jobs import (
+    STATUS_NOTIFIED,
+    STATUS_PENDING,
+    STATUS_WATCHING,
+    DiscordJobStore,
+    get_job_store,
+    reset_job_store_for_tests,
+)
+
+
+def test_job_store_create_get_update(tmp_path: Path):
+    store = DiscordJobStore(tmp_path / "jobs.db")
+    job = store.create_job(
+        discord_user_id="42",
+        channel_id=99,
+        session_id="sess-1",
+        label="e23badad",
+        live_run_id="agent_20260722_abc",
+        agent_id="builtin-1",
+        agent_name="My Agent",
+        share_url="https://example/s/e23badad",
+        guild_id=7,
+    )
+    assert job.status == STATUS_PENDING
+    assert job.job_id
+    loaded = store.get(job.job_id)
+    assert loaded is not None
+    assert loaded.discord_user_id == "42"
+    assert loaded.channel_id == 99
+    assert loaded.live_run_id == "agent_20260722_abc"
+    assert loaded.agent_name == "My Agent"
+
+    store.update(job.job_id, status=STATUS_WATCHING)
+    assert store.get(job.job_id).status == STATUS_WATCHING
+
+    store.update(
+        job.job_id,
+        status=STATUS_NOTIFIED,
+        run_id="agent_20260722_abc",
+        notified_at=1.0,
+    )
+    done = store.get(job.job_id)
+    assert done.status == STATUS_NOTIFIED
+    assert done.run_id == "agent_20260722_abc"
+    assert done.notified_at == 1.0
+
+
+def test_list_open_excludes_notified(tmp_path: Path):
+    store = DiscordJobStore(tmp_path / "jobs.db")
+    open_job = store.create_job(
+        discord_user_id="1",
+        channel_id=2,
+        session_id="s",
+        label="a",
+    )
+    closed = store.create_job(
+        discord_user_id="1",
+        channel_id=2,
+        session_id="s",
+        label="b",
+    )
+    store.update(closed.job_id, status=STATUS_NOTIFIED, notified_at=1.0)
+    open_ids = {j.job_id for j in store.list_open()}
+    assert open_job.job_id in open_ids
+    assert closed.job_id not in open_ids
+
+
+def test_get_job_store_respects_env(tmp_path: Path, monkeypatch):
+    reset_job_store_for_tests()
+    path = tmp_path / "env_jobs.db"
+    monkeypatch.setenv("DISCORD_JOBS_DB", str(path))
+    store = get_job_store()
+    job = store.create_job(
+        discord_user_id="9",
+        channel_id=1,
+        session_id="s",
+        label="x",
+    )
+    assert path.is_file()
+    assert store.get(job.job_id) is not None
+    reset_job_store_for_tests()

--- a/dashboard/backend/tests/integrations/test_discord_watcher.py
+++ b/dashboard/backend/tests/integrations/test_discord_watcher.py
@@ -1,0 +1,233 @@
+"""Behavioral tests for the Discord backtest watcher.
+
+These exercise ``watch_and_deliver_backtest`` end-to-end against a fake API
+layer (no Discord connection, no HTTP). The API seams (``api_get``,
+``api_get_bytes``, ``_post_channel_result``) are monkeypatched; the real
+SQLite job store is used via a temp DB so status transitions are asserted.
+
+Requires the optional ``discord`` dependency; skipped when absent so the
+suite stays green on minimal interpreters (CI installs core requirements only).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+discord = pytest.importorskip("discord")
+
+import dashboard.backend.integrations.discord_bot as bot
+from dashboard.backend.integrations.discord_jobs import (
+    STATUS_NOTIFIED,
+    get_job_store,
+    reset_job_store_for_tests,
+)
+
+
+@pytest.fixture
+def job_store(tmp_path: Path, monkeypatch):
+    """Point the singleton job store at a temp DB for this test."""
+    monkeypatch.setenv("DISCORD_JOBS_DB", str(tmp_path / "jobs.db"))
+    reset_job_store_for_tests()
+    store = get_job_store()
+    yield store
+    reset_job_store_for_tests()
+
+
+class _PostRecorder:
+    """Stand-in for ``_post_channel_result`` that records what was posted."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(
+        self,
+        *,
+        channel_id: int,
+        discord_user_id: str,
+        content: str,
+        chart: Optional[Any] = None,
+    ) -> None:
+        self.calls.append(
+            {
+                "channel_id": channel_id,
+                "discord_user_id": discord_user_id,
+                "content": content,
+                "chart": chart,
+            }
+        )
+
+
+def _metrics(run_id: str, *, total_return: float) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "start_date": "2024-01-01",
+        "end_date": "2024-01-31",
+        "llm_model": "claude-haiku-4-5",
+        "total_return": total_return,
+        "sharpe_ratio": 1.2,
+        "max_drawdown": -0.05,
+        "num_trades": 4,
+        "final_equity": 110000.0,
+    }
+
+
+def _install_common(monkeypatch, poster: _PostRecorder) -> None:
+    monkeypatch.setattr(bot, "_POLL_INTERVAL_SEC", 0)  # no real sleeps
+    monkeypatch.setattr(bot, "_post_channel_result", poster)
+
+    async def _fake_bytes(path: str, *, headers=None, timeout: int = 60) -> bytes:
+        return b"\x89PNG-fake"
+
+    monkeypatch.setattr(bot, "api_get_bytes", _fake_bytes)
+
+
+def test_watcher_happy_path_posts_summary_and_marks_notified(job_store, monkeypatch):
+    live_run_id = "agent_20260722_new00001"
+    job = job_store.create_job(
+        discord_user_id="42",
+        channel_id=99,
+        session_id="sess-1",
+        label="e23badad",
+        live_run_id=live_run_id,
+    )
+    poster = _PostRecorder()
+    _install_common(monkeypatch, poster)
+
+    status_calls = {"n": 0}
+
+    async def fake_api_get(path: str, *, headers=None, timeout: int = 30):
+        if path == "/backtest/status":
+            status_calls["n"] += 1
+            # First poll: still running; second poll: completed. Exercises the loop.
+            if status_calls["n"] == 1:
+                return {"running": True}
+            return {"running": False, "success": True, "runs_count": 1}
+        if path == f"/runs/{live_run_id}":
+            return _metrics(live_run_id, total_return=0.10)
+        raise AssertionError(f"unexpected api_get path: {path}")
+
+    monkeypatch.setattr(bot, "api_get", fake_api_get)
+
+    asyncio.run(bot.watch_and_deliver_backtest(job.job_id))
+
+    assert len(poster.calls) == 1
+    posted = poster.calls[0]
+    assert "Backtest complete" in posted["content"]
+    assert "10.00%" in posted["content"]  # this run's return
+    assert posted["chart"] is not None  # plot.png attached
+
+    done = job_store.get(job.job_id)
+    assert done.status == STATUS_NOTIFIED
+    assert done.run_id == live_run_id
+
+
+def test_watcher_does_not_post_a_different_runs_metrics(job_store, monkeypatch):
+    """Regression: the ``latest/metrics`` fallback must be identity-gated.
+
+    Discord sessions are stable per user, so ``/runs/latest/metrics`` can return
+    a PRIOR run. If the exact-run fetch fails, the watcher must NOT post that
+    stale run's numbers under this fresh backtest — it soft-fails instead.
+    """
+    live_run_id = "agent_20260722_fresh0002"
+    stale_run_id = "agent_20260101_old00001"
+    job = job_store.create_job(
+        discord_user_id="42",
+        channel_id=99,
+        session_id="sess-1",
+        label="fresh-label",
+        live_run_id=live_run_id,
+    )
+    poster = _PostRecorder()
+    _install_common(monkeypatch, poster)
+
+    async def fake_api_get(path: str, *, headers=None, timeout: int = 30):
+        if path == "/backtest/status":
+            return {"running": False, "success": True, "runs_count": 1}
+        if path == f"/runs/{live_run_id}":
+            raise RuntimeError("run not queryable yet")  # transient exact-run failure
+        if path == "/runs/latest/metrics":
+            # A DIFFERENT (older) run — must never be posted as this job's result.
+            return _metrics(stale_run_id, total_return=0.99)
+        raise AssertionError(f"unexpected api_get path: {path}")
+
+    monkeypatch.setattr(bot, "api_get", fake_api_get)
+
+    asyncio.run(bot.watch_and_deliver_backtest(job.job_id))
+
+    assert len(poster.calls) == 1
+    posted = poster.calls[0]
+    assert "could not be read" in posted["content"]
+    assert "99.00%" not in posted["content"]  # stale return must NOT leak through
+
+    done = job_store.get(job.job_id)
+    # Delivered (a soft-failure message), so the job is closed, not left open.
+    assert done.status == STATUS_NOTIFIED
+
+
+def test_watcher_accepts_latest_when_it_is_this_run(job_store, monkeypatch):
+    """The fallback is allowed when ``latest`` IS this run (ids match)."""
+    live_run_id = "agent_20260722_match0003"
+    job = job_store.create_job(
+        discord_user_id="42",
+        channel_id=99,
+        session_id="sess-1",
+        label="match-label",
+        live_run_id=live_run_id,
+    )
+    poster = _PostRecorder()
+    _install_common(monkeypatch, poster)
+
+    async def fake_api_get(path: str, *, headers=None, timeout: int = 30):
+        if path == "/backtest/status":
+            return {"running": False, "success": True, "runs_count": 1}
+        if path == f"/runs/{live_run_id}":
+            raise RuntimeError("exact-run endpoint hiccup")
+        if path == "/runs/latest/metrics":
+            return _metrics(live_run_id, total_return=0.07)  # same id → acceptable
+        raise AssertionError(f"unexpected api_get path: {path}")
+
+    monkeypatch.setattr(bot, "api_get", fake_api_get)
+
+    asyncio.run(bot.watch_and_deliver_backtest(job.job_id))
+
+    assert len(poster.calls) == 1
+    posted = poster.calls[0]
+    assert "Backtest complete" in posted["content"]
+    assert "7.00%" in posted["content"]
+
+    done = job_store.get(job.job_id)
+    assert done.status == STATUS_NOTIFIED
+    assert done.run_id == live_run_id
+
+
+def test_watcher_reports_api_error_status(job_store, monkeypatch):
+    """A terminal error from /backtest/status is delivered as a failure post."""
+    job = job_store.create_job(
+        discord_user_id="42",
+        channel_id=99,
+        session_id="sess-1",
+        label="err-label",
+        live_run_id="agent_20260722_err00004",
+    )
+    poster = _PostRecorder()
+    _install_common(monkeypatch, poster)
+
+    async def fake_api_get(path: str, *, headers=None, timeout: int = 30):
+        if path == "/backtest/status":
+            return {"running": False, "error": "boom in worker"}
+        raise AssertionError(f"unexpected api_get path: {path}")
+
+    monkeypatch.setattr(bot, "api_get", fake_api_get)
+
+    asyncio.run(bot.watch_and_deliver_backtest(job.job_id))
+
+    assert len(poster.calls) == 1
+    assert "Backtest failed" in poster.calls[0]["content"]
+    assert "boom in worker" in poster.calls[0]["content"]
+
+    done = job_store.get(job.job_id)
+    assert done.status == STATUS_NOTIFIED

--- a/dashboard/backend/tests/integrations/test_discord_wiring.py
+++ b/dashboard/backend/tests/integrations/test_discord_wiring.py
@@ -86,7 +86,24 @@ def test_bot_builds_dashboard_backtest_deep_link():
     assert "Dashboard:" in src
     assert "agentic-trading-lab.vercel.app" in src
     assert "onrender.com" in src  # prod API detection / never deep-link that host
-    assert "dashboard_backtest_url(agent_id=attached_agent_id, run_id=run_id)" in src
+    assert "dashboard_backtest_url(agent_id=agent_id, run_id=run_id)" in src
+
+
+def test_bot_decouples_backtest_wait_from_interaction():
+    """Discord must ACK immediately and deliver results via a background job.
+
+    Long LLM backtests exceed Discord's ~15m interaction token; polling inside
+    the slash handler used to drop the chart. Results post in-channel instead.
+    """
+    src = _source()
+    assert "schedule_backtest_watch" in src
+    assert "watch_and_deliver_backtest" in src
+    assert "get_job_store().create_job" in src
+    assert "_post_channel_result" in src
+    assert "resume_open_backtest_jobs" in src
+    # Old blocking poll budget must not live inside execute_backtest anymore.
+    assert "max_polls = 130" not in src
+    assert "I'll post the results" in src
 
 
 def test_bot_sends_per_user_id_on_strategy_post():

--- a/dashboard/backend/tests/test_market_data_features.py
+++ b/dashboard/backend/tests/test_market_data_features.py
@@ -156,9 +156,16 @@ def test_enabled_simulation_is_passed_to_background_runner(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert response.json()["success"] is True
+    body = response.json()
+    assert body["success"] is True
+    assert body["data_source"] == VNPY_SIMULATION
     assert len(spy.calls) == 1
-    assert spy.calls[0][0][-1] == VNPY_SIMULATION
+    # Positional args: start, end, session, prompt, model, pipeline, agent_id,
+    # data_source, live_run_id (live_run_id is minted by /backtest/run).
+    args = spy.calls[0][0]
+    assert args[7] == VNPY_SIMULATION
+    assert args[8] == body["live_run_id"]
+    assert str(args[8]).startswith("agent_")
 
 
 @pytest.mark.parametrize(

--- a/docs/architecture/discord-to-backtest.md
+++ b/docs/architecture/discord-to-backtest.md
@@ -14,7 +14,7 @@ Full path that lands a run on a website agent card and opens it in Playground:
    - `prompt: …` (inline strategy text), or
    - `code: …` (saved strategy share code);
    optional `start:` / `end:` dates.
-6. Wait for the bot reply: metrics summary + equity PNG. If an agent was selected, open the **Dashboard** deep link (`/app?view=backtest&agent_id=…&run_id=…`) to inspect the same run in Playground.
+6. The bot ACKs immediately ("queued"). When the background job finishes, it **posts metrics + equity PNG in-channel** (with an @mention). If an agent was selected, the message includes a **Dashboard** deep link (`/app?view=backtest&agent_id=…&run_id=…`).
 
 Shortcut (no account link / no agent card): skip steps 1–3 and run `/backtest prompt:…` alone — results stay on the Discord session only.
 
@@ -26,22 +26,23 @@ Operator cheat sheet: [`docs/discord-bot-instructions.md`](../discord-bot-instru
 User steps above
     │  /agent     →  GET /api/v1/discord/agents  (bot secret + Discord user id)
     │  /ask|/strategy → chat / strategy APIs
-    │  /backtest  →  POST /backtest/run  (X-Session-Id)
+    │  /backtest  →  POST /backtest/run  (X-Session-Id) → persist notify job
     ▼
 FastAPI (dashboard.backend.app)
-    │  hourly engine + Alpaca bars + hosted LLM
+    │  hourly engine + Alpaca bars + hosted LLM (background thread)
     │  persist run (config, trades, equity, errors) in SQLite
     ▼
-Discord: metrics + PNG + Dashboard deep link → Playground
+Discord bot watcher → channel: metrics + PNG + Dashboard deep link → Playground
 ```
 
 | Piece | Role today |
 | --- | --- |
-| **Account link** | **Open Discord** → OAuth `identify` → `users.discord_user_id`. `/agent` lists that account’s agents only. |
+| **Account link** | **Open Discord** → OAuth `identify` → `users.discord_user_id`. `/agent` lists that account's agents only. |
 | **Entrypoint** | `dashboard/backend/integrations/discord_bot.py` — HTTP client to the same API the website uses. |
-| **Run** | `POST /backtest/run` + poll `GET /backtest/status`; builtin `agent_id` attaches the run to that agent’s card. |
-| **Record** | Unique `run_id`; equity/metrics/plot via `/runs/...`. |
-| **Hand-off** | Selected agent → Playground deep link in the bot reply. |
+| **Run** | `POST /backtest/run` returns immediately with `session_id` + `live_run_id`; Discord persists a notify job (`discord_jobs.py`) and watches in a background task. Builtin `agent_id` attaches the run to that agent's card. |
+| **Deliver** | On completion, bot posts metrics + PNG **in-channel** (not via the slash interaction token), so delivery survives Discord's ~15m token and long LLM runs. Open jobs resume after bot restart. |
+| **Record** | Unique `run_id` (= `live_run_id`); equity/metrics/plot via `/runs/...`. |
+| **Hand-off** | Selected agent → Playground deep link in the channel result message. |
 
 `/api/v1` is the compatibility surface the bot uses. New agent-facing work should prefer `/api/v2`; migrating Discord onto v2 is future work, not required for this demo.
 

--- a/docs/discord-bot-instructions.md
+++ b/docs/discord-bot-instructions.md
@@ -55,3 +55,4 @@ When a backtest finishes for a selected agent, the bot includes a **Dashboard** 
 - Only one backtest runs on the server at a time.
 - Prefer **built-in** agents for Discord backtests (results land on that agent's website card).
 - If `/agent` says you are not linked, use **Open Discord** on the site while signed in.
+- `/backtest` returns immediately ("queued"). When the job finishes, the bot **posts results + chart in the channel** and @mentions you — you do not need to keep the ephemeral "thinking" message open. Long runs (10–30 min) still deliver.


### PR DESCRIPTION
## Summary
- Discord `/backtest` now ACKs immediately and persists a notify job instead of blocking the interaction while polling (which dropped charts after ~11 minutes / Discord’s ~15m token).
- A background watcher posts metrics + equity PNG **in-channel** (with an @mention) when the API job finishes; open jobs resume after bot restart.
- `/backtest/run` returns a stable `live_run_id` so the notifier can key the exact run.

## Notes
- Final results are **channel-visible** (not ephemeral) by design so delivery survives long LLM runs.
- Job rows live in a bot-local SQLite file (`DISCORD_JOBS_DB` / `dashboard/storage/data/discord_backtest_jobs.db`). On Render workers the disk is ephemeral: a redeploy mid-run can lose the notify job (the backtest itself still completes on the API). Acceptable for now; durable Postgres notify queue can come later if needed.
- Bot needs **Send Messages** + **Attach Files** in the target channel.

## Test plan
- [ ] `pytest dashboard/backend/tests/integrations/test_discord_jobs.py dashboard/backend/tests/integrations/test_discord_wiring.py dashboard/backend/tests/domain/chat/test_discord_bot.py -q`
- [ ] Redeploy/restart Discord bot worker with this branch
- [ ] `/backtest` (or strategy **Run backtest**) → immediate “queued” ACK
- [ ] When run finishes → channel message with @mention, metrics, chart, Dashboard link
- [ ] Confirm bot role has Send Messages + Attach Files in that channel


Made with [Cursor](https://cursor.com)