### PR TITLE
Fix My Agents links to open the latest backtest

### DIFF
--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1496,7 +1496,7 @@
     <script src="js/agent-editor.js?v=7"></script>
     <script src="app.js?v=20"></script>
     <script src="js/leaderboard.js?v=13"></script>
-    <script src="home-page.js?v=32"></script>
+    <script src="home-page.js?v=33"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),
          both loaded above — not beside the market-events/* block, which loads

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1494,7 +1494,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=2"></script>
     <script src="js/agent-editor.js?v=7"></script>
-    <script src="app.js?v=21"></script>
+    <script src="app.js?v=22"></script>
     <script src="js/leaderboard.js?v=13"></script>
     <script src="home-page.js?v=33"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1494,7 +1494,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=2"></script>
     <script src="js/agent-editor.js?v=7"></script>
-    <script src="app.js?v=20"></script>
+    <script src="app.js?v=21"></script>
     <script src="js/leaderboard.js?v=13"></script>
     <script src="home-page.js?v=33"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -67,6 +67,7 @@ async function restoreActiveAgentSession() {
 
 function applyActiveAgent(agent, options = {}) {
   if (!agent?.session_id) return;
+  const previousSession = window.SESSION_ID;
   localStorage.setItem('trading-session-id', agent.session_id);
   if (options.persistActiveId !== false) {
     localStorage.setItem(ACTIVE_AGENT_KEY, agent.agent_id);
@@ -74,7 +75,14 @@ function applyActiveAgent(agent, options = {}) {
   }
   window.SESSION_ID = agent.session_id;
   window.ACTIVE_AGENT = agent;
-  localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
+  // Only drop the selected run when the trading session actually changes.
+  // Re-activating the same agent must not wipe a run id we just pinned for navigation.
+  if (
+    options.clearSelectedRun === true ||
+    (options.clearSelectedRun !== false && previousSession && previousSession !== agent.session_id)
+  ) {
+    localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
+  }
 
   const nameEl = document.getElementById('playgroundAgentName');
   if (nameEl) nameEl.textContent = agent.name || 'External Agent';
@@ -441,8 +449,26 @@ function resolvePaperCardMetrics(agent) {
   };
 }
 
+/** Most recent backtest run on an agent card (prefers latest_run, else runs[]). */
+function resolveLatestAgentRun(agent) {
+  const latest = agent?.latest_run;
+  if (latest && (latest.run_id || latest.total_return != null || latest.final_equity != null)) {
+    return latest;
+  }
+  const runs = Array.isArray(agent?.runs) ? agent.runs : [];
+  if (!runs.length) return null;
+  return [...runs].sort(
+    (a, b) => String(b.created_at || '').localeCompare(String(a.created_at || '')),
+  )[0];
+}
+
+function resolveLatestAgentRunId(agent) {
+  const run = resolveLatestAgentRun(agent);
+  return run?.run_id || null;
+}
+
 function resolveBacktestCardMetrics(agent) {
-  const run = agent.latest_run || (Array.isArray(agent.runs) && agent.runs[0]) || null;
+  const run = resolveLatestAgentRun(agent);
   const cash = Number(agent.cash_allocation);
   const initial = Number(run?.initial_equity);
   const startEquity = Number.isFinite(initial)
@@ -715,18 +741,28 @@ function renderAgentsError() {
 
 async function openAgentInBacktest(agent, runId = null) {
   if (!agent) return;
-  await activateAgent(agent);
-  if (runId) localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, runId);
+  // Navigate immediately — never block on the activate ping (cold API starts
+  // left the user stuck on My Agents). Pin the latest run after session switch.
+  applyActiveAgent(agent);
+  const resolvedRunId = runId || resolveLatestAgentRunId(agent);
+  if (resolvedRunId) {
+    localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, resolvedRunId);
+  } else {
+    localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
+  }
   navigateToPage('playground', { playgroundTab: 'backtest' });
   currentMode = 'backtest';
+  // Same-session re-activate must not clear SELECTED_BACKTEST_RUN_KEY (see applyActiveAgent).
+  activateAgent(agent);
   await loadData();
 }
 
 async function openAgentInPaper(agent) {
   if (!agent) return;
-  await activateAgent(agent);
+  applyActiveAgent(agent);
   navigateToPage('playground', { playgroundTab: 'paper' });
   currentMode = 'paper';
+  activateAgent(agent);
   await loadData();
 }
 
@@ -809,11 +845,17 @@ function renderAgentsGrid(agents) {
   });
 
   grid.querySelectorAll('.agent-view-runs-btn').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const agent = agents.find((a) => a.agent_id === btn.dataset.agentId);
-      if (!agent) return;
-      const runId = resolveBacktestCardMetrics(agent).runId;
-      await openAgentInBacktest(agent, runId);
+    btn.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const agent =
+        agents.find((a) => a.agent_id === btn.dataset.agentId) ||
+        allAgents.find((a) => a.agent_id === btn.dataset.agentId);
+      if (!agent) {
+        console.warn('View runs: agent not found', btn.dataset.agentId);
+        return;
+      }
+      await openAgentInBacktest(agent, resolveLatestAgentRunId(agent));
     });
   });
 
@@ -3582,7 +3624,8 @@ function showPlaygroundPanel(tab) {
     updatePlaygroundSubtabs();
 
     const agents = document.getElementById('playgroundAgentsPanel');
-    const backtest = document.querySelector('.main-container');
+    const backtest = document.querySelector('.playground-backtest-panel')
+      || document.querySelector('.main-container');
     const paper = document.getElementById('paperTradingView');
 
     if (agents) agents.style.display = tab === 'agents' ? 'block' : 'none';
@@ -3658,7 +3701,8 @@ function navigateToPage(page, options = {}) {
     const competitionView = document.getElementById('competitionView');
     const communityView = document.getElementById('communityView');
     const accountView = document.getElementById('accountView');
-    const backtestPanel = document.querySelector('.main-container');
+    const backtestPanel = document.querySelector('.playground-backtest-panel')
+      || document.querySelector('.main-container');
     const paperView = document.getElementById('paperTradingView');
     const myAlgoView = document.getElementById('myTradingAlgoView');
     const leaderboardView = document.getElementById('leaderboardView');

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -752,13 +752,18 @@ async function openAgentInBacktest(agent, runId = null) {
   }
   navigateToPage('playground', { playgroundTab: 'backtest' });
   currentMode = 'backtest';
-  // Same-session re-activate must not clear SELECTED_BACKTEST_RUN_KEY (see applyActiveAgent).
+  // applyActiveAgent ran once above for immediate navigation; activateAgent
+  // re-applies it (idempotent) and fires the server ping we deliberately did
+  // NOT await. The same-session re-apply must not clear SELECTED_BACKTEST_RUN_KEY
+  // (see applyActiveAgent's previousSession guard).
   activateAgent(agent);
   await loadData();
 }
 
 async function openAgentInPaper(agent) {
   if (!agent) return;
+  // Navigate immediately; activateAgent below re-applies (idempotent) and pings
+  // the server fire-and-forget, so a cold API start never blocks the UI.
   applyActiveAgent(agent);
   navigateToPage('playground', { playgroundTab: 'paper' });
   currentMode = 'paper';

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -1148,6 +1148,9 @@ function renderHomeAgentStatusCard(agent) {
     const body = (typeof renderAgentCardBody === 'function')
         ? renderAgentCardBody(agent, status.key)
         : '';
+    const actions = (typeof renderAgentCardActions === 'function')
+        ? renderAgentCardActions(agent, status.key)
+        : '';
 
     return `
       <div class="agent-card agent-card--status agent-card--home agent-card--${status.key}">
@@ -1162,6 +1165,7 @@ function renderHomeAgentStatusCard(agent) {
           <span class="status-badge ${status.className}"><span class="status-badge-dot" aria-hidden="true"></span>${status.label}</span>
         </div>
         ${body}
+        ${actions}
       </div>`;
 }
 
@@ -1193,16 +1197,40 @@ function updateHomeAgentModule() {
     filled.innerHTML = renderHomeAgentStatusCard(agent);
 
     filled.querySelectorAll('.agent-view-runs-btn').forEach((btn) => {
-        btn.addEventListener('click', async () => {
-            if (typeof openAgentInBacktest === 'function') {
-                const runId = typeof resolveBacktestCardMetrics === 'function'
-                    ? resolveBacktestCardMetrics(agent).runId
-                    : null;
-                await openAgentInBacktest(agent, runId);
+        btn.addEventListener('click', async (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (typeof openAgentInBacktest !== 'function') {
+                if (typeof navigateToPage === 'function') {
+                    navigateToPage('playground', { playgroundTab: 'backtest' });
+                }
                 return;
             }
-            if (typeof navigateToPage === 'function') {
-                navigateToPage('playground', { playgroundTab: 'backtest' });
+            const runId = typeof resolveLatestAgentRunId === 'function'
+                ? resolveLatestAgentRunId(agent)
+                : (typeof resolveBacktestCardMetrics === 'function'
+                    ? resolveBacktestCardMetrics(agent).runId
+                    : null);
+            await openAgentInBacktest(agent, runId);
+        });
+    });
+
+    filled.querySelectorAll('.agent-run-backtest-btn').forEach((btn) => {
+        btn.addEventListener('click', async (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (typeof openAgentInBacktest === 'function') {
+                await openAgentInBacktest(agent);
+            }
+        });
+    });
+
+    filled.querySelectorAll('.agent-open-btn').forEach((btn) => {
+        btn.addEventListener('click', async (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (typeof openAgentInPaper === 'function') {
+                await openAgentInPaper(agent);
             }
         });
     });


### PR DESCRIPTION
## Summary
- Clicking **1 backtest** / **View All Runs** on My Agents now jumps straight to Playground → Backtest with the agent's latest run selected.
- Root causes: navigation awaited a potentially slow `activate` ping, and `applyActiveAgent` cleared the pinned `selected-backtest-run-id` on same-session re-activate.
- Home agent card also renders/wires the same CTAs.

## Test plan
- [ ] Hard-refresh `/app` (`app.js?v=20`)
- [ ] My Agents → click **1 backtest** → lands on Backtest tab with latest run chart/metrics
- [ ] Click **View All Runs** → same behavior
- [ ] Home → My Agents module CTAs also open latest backtest
- [ ] Switching to a different agent still clears the previous selected run


Made with [Cursor](https://cursor.com)