### PR TITLE
feat: My Agents configure-and-run rebuild

### DIFF
--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -10,7 +10,7 @@ unchanged; only the module location moved.
 from typing import List, Optional
 
 from fastapi import APIRouter, Header, HTTPException, Request
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from dashboard.backend.domain.backtesting.constants import (
     DEFAULT_AGENT_CASH_ALLOCATION,
@@ -65,6 +65,18 @@ class UpdateAgentBody(BaseModel):
         ge=0,
         le=MAX_AGENT_CASH_ALLOCATION,
     )
+
+    @field_validator("name", "model_name")
+    @classmethod
+    def _reject_blank(cls, value: Optional[str]) -> Optional[str]:
+        # ``min_length=1`` counts the raw length, so a whitespace-only value
+        # ("   ") passes it and then strips to "" in the route below — an empty
+        # write into a NOT NULL column. Reject it as a 422 instead of storing "".
+        # (Create is deliberately lenient here: ``CreateAgentBody.model_name``
+        # coerces empties to "local-model" rather than 422-ing.)
+        if value is not None and not value.strip():
+            raise ValueError("must not be blank")
+        return value
 
 
 @router.post("")

--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -57,6 +57,7 @@ class PipelineStep(BaseModel):
 
 class UpdateAgentBody(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    model_name: Optional[str] = Field(default=None, min_length=1, max_length=100)
     description: Optional[str] = Field(default=None, max_length=280)
     pipeline: Optional[List[PipelineStep]] = Field(default=None, max_length=50)
     cash_allocation: Optional[float] = Field(
@@ -243,7 +244,13 @@ async def update_agent(
     fields_set = body.model_fields_set
     pipeline_provided = "pipeline" in fields_set
     cash_allocation_provided = "cash_allocation" in fields_set
-    if body.name is None and body.description is None and not pipeline_provided and not cash_allocation_provided:
+    if (
+        body.name is None
+        and body.model_name is None
+        and body.description is None
+        and not pipeline_provided
+        and not cash_allocation_provided
+    ):
         raise HTTPException(status_code=400, detail="No fields to update")
 
     if pipeline_provided:
@@ -261,6 +268,7 @@ async def update_agent(
         agent = agent_service.update_agent(
             agent_id,
             name=body.name.strip() if body.name is not None else None,
+            model_name=body.model_name.strip() if body.model_name is not None else None,
             description=body.description,
             pipeline=pipeline_arg,
             cash_allocation=cash_allocation_arg,

--- a/dashboard/backend/domain/agents/repository.py
+++ b/dashboard/backend/domain/agents/repository.py
@@ -459,6 +459,7 @@ class AgentStore:
         agent_id: str,
         *,
         name: Optional[str] = None,
+        model_name: Optional[str] = None,
         description: Optional[str] = None,
         pipeline: Any = _UNSET,
         cash_allocation: Any = _UNSET,
@@ -474,6 +475,9 @@ class AgentStore:
         if name is not None:
             sets.append("name = ?")
             params.append(name.strip())
+        if model_name is not None:
+            sets.append("model_name = ?")
+            params.append(model_name.strip())
         if description is not None:
             sets.append("description = ?")
             params.append(description.strip() if description else None)

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -416,6 +416,7 @@ class PostgresAgentStore:
         agent_id: str,
         *,
         name: Optional[str] = None,
+        model_name: Optional[str] = None,
         description: Optional[str] = None,
         pipeline: Any = _UNSET,
         cash_allocation: Any = _UNSET,
@@ -431,6 +432,9 @@ class PostgresAgentStore:
         if name is not None:
             sets.append("name = %s")
             params.append(name.strip())
+        if model_name is not None:
+            sets.append("model_name = %s")
+            params.append(model_name.strip())
         if description is not None:
             sets.append("description = %s")
             params.append(description.strip() if description else None)

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -181,6 +181,7 @@ class AgentService:
         agent_id: str,
         *,
         name: Optional[str] = None,
+        model_name: Optional[str] = None,
         description: Optional[str] = None,
         pipeline: Any = _UNSET,
         cash_allocation: Any = _UNSET,
@@ -188,6 +189,7 @@ class AgentService:
         agent = self.agents.update_agent(
             agent_id,
             name=name,
+            model_name=model_name,
             description=description,
             pipeline=pipeline,
             cash_allocation=cash_allocation,

--- a/dashboard/backend/domain/backtesting/constants.py
+++ b/dashboard/backend/domain/backtesting/constants.py
@@ -9,9 +9,11 @@ for backward compatibility (``bha.INITIAL_CAPITAL``).
 here.
 
 Capital scale (product):
-- User portfolio budget: ``DEFAULT_PORTFOLIO_EQUITY`` ($10,000)
+- Portfolio-view equity: ``DEFAULT_PORTFOLIO_EQUITY`` ($10,000) — a display
+  default only, NOT a cap on the sum of agent allocations
 - Per-agent starting cash: default ``DEFAULT_AGENT_CASH_ALLOCATION`` ($1,000),
-  max ``MAX_AGENT_CASH_ALLOCATION`` ($1,000,000)
+  max ``MAX_AGENT_CASH_ALLOCATION`` ($1,000,000) — so a single agent may
+  allocate far above the portfolio-view figure above
 - Backtests / protocol use the agent's cash allocation (falling back to
   ``INITIAL_CAPITAL``)
 """
@@ -23,7 +25,9 @@ from typing import Any, Optional
 # Default starting capital for a backtest when no agent allocation is set.
 INITIAL_CAPITAL = 1000
 
-# User-level portfolio budget (sum of agent allocations should fit under this).
+# Portfolio-view equity default (display/simulation). NOT a cap on agent cash
+# allocations — a single agent may allocate up to MAX_AGENT_CASH_ALLOCATION,
+# which is 100x this figure.
 DEFAULT_PORTFOLIO_EQUITY = 10_000
 
 # Per-agent cash allocation bounds (also enforced by the agents API).

--- a/dashboard/backend/domain/backtesting/constants.py
+++ b/dashboard/backend/domain/backtesting/constants.py
@@ -11,7 +11,7 @@ here.
 Capital scale (product):
 - User portfolio budget: ``DEFAULT_PORTFOLIO_EQUITY`` ($10,000)
 - Per-agent starting cash: default ``DEFAULT_AGENT_CASH_ALLOCATION`` ($1,000),
-  max ``MAX_AGENT_CASH_ALLOCATION`` ($3,000)
+  max ``MAX_AGENT_CASH_ALLOCATION`` ($1,000,000)
 - Backtests / protocol use the agent's cash allocation (falling back to
   ``INITIAL_CAPITAL``)
 """
@@ -28,7 +28,7 @@ DEFAULT_PORTFOLIO_EQUITY = 10_000
 
 # Per-agent cash allocation bounds (also enforced by the agents API).
 DEFAULT_AGENT_CASH_ALLOCATION = 1000
-MAX_AGENT_CASH_ALLOCATION = 3000
+MAX_AGENT_CASH_ALLOCATION = 1_000_000
 
 
 def resolve_initial_capital(cash_allocation: Optional[Any] = None) -> float:

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -218,6 +218,24 @@ def test_update_agent_partial_updates_postgres(pg_agent_store):
 
 
 @pg_only
+def test_update_agent_model_name_postgres(pg_agent_store):
+    created = pg_agent_store.create_agent(
+        name="Model Swap PG",
+        model_name="anthropic/claude-haiku-4-5",
+        owner_user_id=None,
+        owner_browser_session="pg-model-swap",
+    )
+    updated = pg_agent_store.update_agent(
+        created["agent_id"], model_name="deepseek/deepseek-v4-pro"
+    )
+    assert updated["model_name"] == "deepseek/deepseek-v4-pro"
+
+    # Omitting model_name leaves it unchanged.
+    renamed = pg_agent_store.update_agent(created["agent_id"], name="Renamed")
+    assert renamed["model_name"] == "deepseek/deepseek-v4-pro"
+
+
+@pg_only
 def test_cash_allocation_round_trips_as_a_float_postgres(pg_agent_store):
     """Pin the feature's only non-TEXT column against a real Postgres.
 

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -416,3 +416,55 @@ def test_cash_allocation_cap_is_one_million(client):
         headers=headers,
     )
     assert too_big.status_code == 422
+
+
+def test_patch_agent_model_name(client):
+    """Demo 1: the Configure screen can change the model after creation."""
+    browser_session = str(uuid.uuid4())
+    headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}
+
+    created = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "Model Swapper",
+            "model_name": "anthropic/claude-haiku-4-5",
+            "agent_type": "builtin",
+        },
+        headers=headers,
+    )
+    assert created.status_code == 200
+    agent_id = created.json()["agent"]["agent_id"]
+
+    patched = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"model_name": "deepseek/deepseek-v4-pro"},
+        headers=headers,
+    )
+    assert patched.status_code == 200
+    assert patched.json()["agent"]["model_name"] == "deepseek/deepseek-v4-pro"
+
+    # Absent field leaves the model untouched.
+    renamed = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"name": "Still Swapped"},
+        headers=headers,
+    )
+    assert renamed.status_code == 200
+    assert renamed.json()["agent"]["model_name"] == "deepseek/deepseek-v4-pro"
+
+    # Empty string is rejected by validation.
+    empty = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"model_name": ""},
+        headers=headers,
+    )
+    assert empty.status_code == 422
+
+    # model_name alone is a valid update (not "No fields to update").
+    only_model = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"model_name": "openai/gpt-5.5"},
+        headers=headers,
+    )
+    assert only_model.status_code == 200
+    assert only_model.json()["agent"]["model_name"] == "openai/gpt-5.5"

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -381,3 +381,38 @@ def test_builtin_listing_batches_run_stats_queries(client, monkeypatch):
     assert len(listing.json()["agents"]) == 3
     assert calls["per_session"] == 0, "listing still queries per agent (N+1)"
     assert calls["batch"] == 1, "listing must fetch all stats in one query"
+
+
+def test_cash_allocation_cap_is_one_million(client):
+    """Demo 1: the per-agent cap was raised 3,000 -> 1,000,000."""
+    from dashboard.backend.domain.backtesting.constants import (
+        MAX_AGENT_CASH_ALLOCATION,
+        resolve_initial_capital,
+    )
+
+    assert MAX_AGENT_CASH_ALLOCATION == 1_000_000
+    # Clamp behavior follows the constant.
+    assert resolve_initial_capital(1_000_000) == 1_000_000.0
+    assert resolve_initial_capital(2_000_000) == 1_000_000.0
+
+    browser_session = str(uuid.uuid4())
+    headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}
+
+    ok = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "Whale",
+            "agent_type": "builtin",
+            "cash_allocation": 1_000_000,
+        },
+        headers=headers,
+    )
+    assert ok.status_code == 200
+    assert ok.json()["agent"]["cash_allocation"] == 1_000_000
+
+    too_big = client.post(
+        "/api/v1/agents",
+        json={"name": "Too big", "agent_type": "builtin", "cash_allocation": 1_000_001},
+        headers=headers,
+    )
+    assert too_big.status_code == 422

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -460,6 +460,27 @@ def test_patch_agent_model_name(client):
     )
     assert empty.status_code == 422
 
+    # Whitespace-only is also rejected: min_length=1 counts the raw length, so
+    # "   " would otherwise pass and then strip to "" in a NOT NULL column.
+    blank_model = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"model_name": "   "},
+        headers=headers,
+    )
+    assert blank_model.status_code == 422
+
+    # The same blank guard covers name (identical strip-to-empty hazard).
+    blank_name = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"name": "   "},
+        headers=headers,
+    )
+    assert blank_name.status_code == 422
+
+    # The model was never mutated by the rejected requests.
+    unchanged = client.get(f"/api/v1/agents/{agent_id}", headers=headers)
+    assert unchanged.json()["agent"]["model_name"] == "deepseek/deepseek-v4-pro"
+
     # model_name alone is a valid update (not "No fields to update").
     only_model = client.patch(
         f"/api/v1/agents/{agent_id}",

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -789,7 +789,7 @@
                         <h3 class="agent-editor-intro-title">Trading instruction</h3>
                         <p class="agent-editor-intro-text">Tell the agent how to trade in plain language. Each market hour it sees prices and its portfolio, follows your instruction, and decides what to buy or sell.</p>
                         <textarea id="agentEditorSimpleInstruction" rows="6" maxlength="8000" placeholder="e.g. Spread the money across a few of the strongest available stocks. Buy on meaningful dips and take profits after strong run-ups." aria-label="Trading instruction"></textarea>
-                        <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note" hidden>This agent currently uses a multi-step pipeline. Saving in Simple mode replaces the pipeline with this one instruction.</p>
+                        <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note" hidden>This agent currently uses a custom pipeline. Saving in Simple mode replaces it with this one instruction.</p>
                     </div>
                     <div id="agentEditorAdvancedPanel">
                         <div class="agent-editor-intro section-card compact">

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -745,6 +745,7 @@
                             <p class="agents-category-sub">Bring your own agent and connect it with an API key.</p>
                         </div>
                         <div id="agentsGridExternal" class="agents-grid"></div>
+                        <p id="agentsEmptyExternal" class="control-helper" hidden>No external agents match your search.</p>
                     </section>
                 </div>
                 <p id="agentsErrorState" class="control-helper" hidden style="color:#f87171;">Couldn't reach the server to load agents. Check your connection and try again.</p>
@@ -1517,8 +1518,8 @@
     <script src="market-events/MarketEventCard.js"></script>
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=2"></script>
-    <script src="js/agent-editor.js?v=7"></script>
-    <script src="app.js?v=20"></script>
+    <script src="js/agent-editor.js?v=8"></script>
+    <script src="app.js?v=21"></script>
     <script src="js/leaderboard.js?v=13"></script>
     <script src="home-page.js?v=32"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -774,8 +774,8 @@
             </div>
             <div class="agent-editor-header-actions">
                 <div class="agent-editor-mode-toggle" role="group" aria-label="Editor mode">
-                    <button id="agentEditorModeSimple" class="agent-editor-mode-btn" type="button">Simple</button>
-                    <button id="agentEditorModeAdvanced" class="agent-editor-mode-btn" type="button">Advanced</button>
+                    <button id="agentEditorModeSimple" class="agent-editor-mode-btn" type="button" aria-pressed="true">Simple</button>
+                    <button id="agentEditorModeAdvanced" class="agent-editor-mode-btn" type="button" aria-pressed="false">Advanced</button>
                 </div>
                 <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>
                 <button id="agentEditorResetBtn" class="home-btn home-btn-secondary agent-editor-reset-btn" type="button">Reset pipeline</button>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -715,13 +715,6 @@
                         <a id="agentsSectionDiscordBtn" class="discord-nav-btn discord-nav-btn-sm" data-discord-link href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">Open Discord</a>
                     </div>
                     <div class="agent-toolbar">
-                        <select id="agentFilterSelect" class="agent-toolbar-select" aria-label="Filter agents">
-                            <option value="all">All Agents</option>
-                            <option value="builtin">Built-in</option>
-                            <option value="external">External</option>
-                            <option value="active">Active</option>
-                            <option value="registered">Registered</option>
-                        </select>
                         <div class="agent-toolbar-search">
                             <svg class="agent-toolbar-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
                             <input id="agentSearchInput" type="search" placeholder="Search agents..." aria-label="Search agents">
@@ -737,8 +730,23 @@
                         <button id="addAgentBtnToolbar" class="home-btn home-btn-primary agent-toolbar-add" type="button">Add Agent +</button>
                     </div>
                 </div>
-                <div id="agentsGrid" class="agents-grid"></div>
-                <p id="agentsEmptyState" class="control-helper" hidden>No agents yet. Run a backtest with the CLI, or click <strong>Add Agent</strong> to register one.</p>
+                <div id="agentsCategories">
+                    <section class="agents-category" data-category="builtin">
+                        <div class="agents-category-head">
+                            <h3 class="agents-category-title">Foundation Models</h3>
+                            <p class="agents-category-sub">A prompting game — give it money, an instruction, and a model, then backtest.</p>
+                        </div>
+                        <div id="agentsGridBuiltin" class="agents-grid"></div>
+                        <p id="agentsEmptyBuiltin" class="control-helper" hidden>No foundation agents yet. Click <strong>Add Agent</strong> to create one.</p>
+                    </section>
+                    <section class="agents-category" data-category="external">
+                        <div class="agents-category-head">
+                            <h3 class="agents-category-title">External Agents</h3>
+                            <p class="agents-category-sub">Bring your own agent and connect it with an API key.</p>
+                        </div>
+                        <div id="agentsGridExternal" class="agents-grid"></div>
+                    </section>
+                </div>
                 <p id="agentsErrorState" class="control-helper" hidden style="color:#f87171;">Couldn't reach the server to load agents. Check your connection and try again.</p>
             </div>
         </div>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -568,8 +568,8 @@
                     <input id="externalAgentModel" type="text" maxlength="100" placeholder="gpt-4 / rule-based" autocomplete="off">
                 </label>
                 <label class="auth-field">
-                    <span>Initial cash (max $3,000)</span>
-                    <input id="externalAgentCashAllocation" type="number" min="0" max="3000" step="1" value="1000" required aria-describedby="externalAgentCashHint">
+                    <span>Initial cash (max $1,000,000)</span>
+                    <input id="externalAgentCashAllocation" type="number" min="0" max="1000000" step="1" value="1000" required aria-describedby="externalAgentCashHint">
                 </label>
                 <p id="externalAgentCashHint" class="credential-hint">Starting capital budget for this agent's backtests and trading sessions.</p>
                 <p id="createExternalAgentError" class="auth-error" hidden></p>
@@ -605,8 +605,8 @@
                     <input id="builtinAgentDescription" type="text" maxlength="280" placeholder="What is this agent's edge?" autocomplete="off">
                 </label>
                 <label class="auth-field">
-                    <span>Initial cash (max $3,000)</span>
-                    <input id="builtinAgentCashAllocation" type="number" min="0" max="3000" step="1" value="1000" required aria-describedby="builtinAgentCashHint">
+                    <span>Initial cash (max $1,000,000)</span>
+                    <input id="builtinAgentCashAllocation" type="number" min="0" max="1000000" step="1" value="1000" required aria-describedby="builtinAgentCashHint">
                 </label>
                 <p id="builtinAgentCashHint" class="credential-hint">Starting capital budget for this agent's backtests and trading sessions.</p>
                 <p id="createBuiltinAgentError" class="auth-error" hidden></p>
@@ -756,8 +756,8 @@
                 <p id="agentEditorMeta" class="agent-editor-meta"></p>
                 <textarea id="agentEditorDescription" class="agent-editor-description" rows="2" maxlength="280" placeholder="Optional description for this agent…" aria-label="Agent description"></textarea>
                 <label class="agent-editor-cash-field" for="agentEditorCashAllocation">
-                    <span class="agent-editor-cash-label">Initial cash (max $3,000)</span>
-                    <input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="3000" step="1" placeholder="0" aria-label="Initial cash">
+                    <span class="agent-editor-cash-label">Initial cash (max $1,000,000)</span>
+                    <input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="1000000" step="1" placeholder="0" aria-label="Initial cash">
                 </label>
             </div>
             <div class="agent-editor-header-actions">

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -762,6 +762,10 @@
             <div class="agent-editor-title-wrap">
                 <input id="agentEditorNameInput" class="agent-editor-name-input" type="text" maxlength="100" placeholder="Agent name" aria-label="Agent name" autocomplete="off">
                 <p id="agentEditorMeta" class="agent-editor-meta"></p>
+                <label class="agent-editor-model-field" for="agentEditorModelSelect">
+                    <span class="agent-editor-model-label">Model</span>
+                    <select id="agentEditorModelSelect" class="agent-editor-model-select" aria-label="Agent model"></select>
+                </label>
                 <textarea id="agentEditorDescription" class="agent-editor-description" rows="2" maxlength="280" placeholder="Optional description for this agent…" aria-label="Agent description"></textarea>
                 <label class="agent-editor-cash-field" for="agentEditorCashAllocation">
                     <span class="agent-editor-cash-label">Initial cash (max $1,000,000)</span>
@@ -769,6 +773,10 @@
                 </label>
             </div>
             <div class="agent-editor-header-actions">
+                <div class="agent-editor-mode-toggle" role="group" aria-label="Editor mode">
+                    <button id="agentEditorModeSimple" class="agent-editor-mode-btn" type="button">Simple</button>
+                    <button id="agentEditorModeAdvanced" class="agent-editor-mode-btn" type="button">Advanced</button>
+                </div>
                 <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>
                 <button id="agentEditorResetBtn" class="home-btn home-btn-secondary agent-editor-reset-btn" type="button">Reset pipeline</button>
                 <button id="agentEditorSaveBtn" class="home-btn home-btn-primary" type="button">Save</button>
@@ -777,24 +785,32 @@
         <div class="agent-editor-body">
             <div class="agent-editor-layout">
                 <div class="agent-editor-main">
-                    <div class="agent-editor-intro section-card compact">
-                        <div class="agent-editor-intro-head">
-                            <div>
-                                <h3 class="agent-editor-intro-title">Sub-agent pipeline</h3>
-                                <p class="agent-editor-intro-text">Configure sub-agents in order. Each step defines a task prompt and the output format passed to the next model.</p>
-                            </div>
-                            <span id="agentEditorStepCount" class="agent-editor-step-count">0 steps</span>
-                        </div>
+                    <div id="agentEditorSimplePanel" class="agent-editor-simple section-card compact" hidden>
+                        <h3 class="agent-editor-intro-title">Trading instruction</h3>
+                        <p class="agent-editor-intro-text">Tell the agent how to trade in plain language. Each market hour it sees prices and its portfolio, follows your instruction, and decides what to buy or sell.</p>
+                        <textarea id="agentEditorSimpleInstruction" rows="6" maxlength="8000" placeholder="e.g. Spread the money across a few of the strongest available stocks. Buy on meaningful dips and take profits after strong run-ups." aria-label="Trading instruction"></textarea>
+                        <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note" hidden>This agent currently uses a multi-step pipeline. Saving in Simple mode replaces the pipeline with this one instruction.</p>
                     </div>
-                    <div id="agentEditorPipeline" class="agent-editor-pipeline" role="list"></div>
-                    <div class="agent-editor-add-row section-card compact">
-                        <label class="agent-editor-add-label" for="agentEditorAddSelect">Add sub-agent</label>
-                        <div class="agent-editor-add-controls">
-                            <select id="agentEditorAddSelect" class="agent-editor-add-select" aria-label="Select sub-agent type to add">
-                                <option value="">— Select type —</option>
-                            </select>
-                            <input id="agentEditorCustomName" class="agent-editor-custom-name" type="text" maxlength="80" placeholder="Custom name (optional)" hidden aria-label="Custom sub-agent name">
-                            <button id="agentEditorAddBtn" class="home-btn home-btn-secondary" type="button">+ Add</button>
+                    <div id="agentEditorAdvancedPanel">
+                        <div class="agent-editor-intro section-card compact">
+                            <div class="agent-editor-intro-head">
+                                <div>
+                                    <h3 class="agent-editor-intro-title">Sub-agent pipeline</h3>
+                                    <p class="agent-editor-intro-text">Configure sub-agents in order. Each step defines a task prompt and the output format passed to the next model.</p>
+                                </div>
+                                <span id="agentEditorStepCount" class="agent-editor-step-count">0 steps</span>
+                            </div>
+                        </div>
+                        <div id="agentEditorPipeline" class="agent-editor-pipeline" role="list"></div>
+                        <div class="agent-editor-add-row section-card compact">
+                            <label class="agent-editor-add-label" for="agentEditorAddSelect">Add sub-agent</label>
+                            <div class="agent-editor-add-controls">
+                                <select id="agentEditorAddSelect" class="agent-editor-add-select" aria-label="Select sub-agent type to add">
+                                    <option value="">— Select type —</option>
+                                </select>
+                                <input id="agentEditorCustomName" class="agent-editor-custom-name" type="text" maxlength="80" placeholder="Custom name (optional)" hidden aria-label="Custom sub-agent name">
+                                <button id="agentEditorAddBtn" class="home-btn home-btn-secondary" type="button">+ Add</button>
+                            </div>
                         </div>
                     </div>
                     <p id="agentEditorSaveStatus" class="agent-editor-save-status" hidden></p>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -134,6 +134,28 @@ const DEFAULT_AGENT_CASH_ALLOCATION = 1000;
 const DEFAULT_PORTFOLIO_EQUITY = 10000;
 const AGENT_CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
 
+const DEFAULT_AGENT_KEY_PREFIX = 'default-agent-id:';
+
+function defaultAgentKey() {
+  return `${DEFAULT_AGENT_KEY_PREFIX}${window.BROWSER_OWNER_ID || 'anon'}`;
+}
+
+function getDefaultAgentId() {
+  try {
+    return localStorage.getItem(defaultAgentKey());
+  } catch (e) {
+    return null;
+  }
+}
+
+function setDefaultAgentId(agentId) {
+  try {
+    localStorage.setItem(defaultAgentKey(), agentId);
+  } catch (e) {
+    /* storage unavailable — badge simply won't persist */
+  }
+}
+
 function formatAgentCashAllocation(value) {
   if (value == null || value === '') return '—';
   return new Intl.NumberFormat('en-US', {
@@ -630,21 +652,9 @@ function applyAgentNameOverride(agent) {
 }
 
 function applyAgentFilters() {
-  const filter = document.getElementById('agentFilterSelect')?.value || 'all';
   const query = (document.getElementById('agentSearchInput')?.value || '').trim().toLowerCase();
-  const activeId = localStorage.getItem(ACTIVE_AGENT_KEY);
 
   let list = allAgents.map(decorateAgent);
-  if (filter === 'builtin') {
-    list = list.filter((a) => a.agent_type === 'builtin');
-  } else if (filter === 'external') {
-    list = list.filter((a) => a.agent_type !== 'builtin');
-  } else if (filter === 'active') {
-    list = list.filter((a) => a.is_active || a.agent_id === activeId);
-  } else if (filter === 'registered') {
-    list = list.filter((a) => !(a.is_active || a.agent_id === activeId));
-  }
-
   if (query) {
     list = list.filter(
       (a) =>
@@ -653,13 +663,14 @@ function applyAgentFilters() {
     );
   }
 
-  renderAgentsGrid(list);
+  renderAgentCategories(list);
 }
 
 function setAgentViewMode(mode) {
   agentViewMode = mode === 'list' ? 'list' : 'grid';
-  const grid = document.getElementById('agentsGrid');
-  if (grid) grid.classList.toggle('agents-grid--list', agentViewMode === 'list');
+  document.querySelectorAll('.agents-section .agents-grid').forEach((grid) => {
+    grid.classList.toggle('agents-grid--list', agentViewMode === 'list');
+  });
   document.getElementById('agentViewGrid')?.classList.toggle('active', agentViewMode === 'grid');
   document.getElementById('agentViewList')?.classList.toggle('active', agentViewMode === 'list');
 }
@@ -705,11 +716,12 @@ function isDemoMode() {
 // Distinct error-state shown when the agents API is unreachable — never mask a
 // backend outage by rendering fake data.
 function renderAgentsError() {
-  const grid = document.getElementById('agentsGrid');
-  const empty = document.getElementById('agentsEmptyState');
   const errorEl = document.getElementById('agentsErrorState');
-  if (grid) grid.innerHTML = '';
-  if (empty) empty.hidden = true;
+  document.querySelectorAll('.agents-section .agents-grid').forEach((grid) => {
+    grid.innerHTML = '';
+  });
+  const builtinEmpty = document.getElementById('agentsEmptyBuiltin');
+  if (builtinEmpty) builtinEmpty.hidden = true;
   if (errorEl) errorEl.hidden = false;
 }
 
@@ -750,19 +762,8 @@ function bindAgentCardMenus(grid) {
   });
 }
 
-function renderAgentsGrid(agents) {
-  const grid = document.getElementById('agentsGrid');
-  const empty = document.getElementById('agentsEmptyState');
-  const errorEl = document.getElementById('agentsErrorState');
-  if (!grid) return;
-
-  if (errorEl) errorEl.hidden = true;  // a successful render clears any prior error
+function renderAgentCards(grid, agents) {
   grid.innerHTML = '';
-  if (!agents.length) {
-    if (empty) empty.hidden = false;
-    return;
-  }
-  if (empty) empty.hidden = true;
 
   agents.forEach((agent) => {
     const isBuiltin = agent.agent_type === 'builtin';
@@ -869,12 +870,50 @@ function renderAgentsGrid(agents) {
   });
 }
 
+function renderAgentCategories(agents) {
+  const builtinGrid = document.getElementById('agentsGridBuiltin');
+  const externalGrid = document.getElementById('agentsGridExternal');
+  const errorEl = document.getElementById('agentsErrorState');
+  if (!builtinGrid || !externalGrid) return;
+
+  if (errorEl) errorEl.hidden = true; // a successful render clears any prior error
+
+  const defaultId = getDefaultAgentId();
+  const pinDefaultFirst = (list) =>
+    [...list].sort((a, b) => (b.agent_id === defaultId) - (a.agent_id === defaultId));
+
+  const builtin = pinDefaultFirst(agents.filter((a) => a.agent_type === 'builtin'));
+  const external = pinDefaultFirst(agents.filter((a) => a.agent_type !== 'builtin'));
+
+  renderAgentCards(builtinGrid, builtin);
+  renderAgentCards(externalGrid, external);
+
+  const builtinEmpty = document.getElementById('agentsEmptyBuiltin');
+  if (builtinEmpty) builtinEmpty.hidden = builtin.length > 0;
+  if (!external.length) renderExternalPlaceholderCard(externalGrid);
+}
+
+// Reserved entry point for connect-your-own agents: the connection mechanism
+// is still an open team decision, so this opens the existing creation flow.
+function renderExternalPlaceholderCard(grid) {
+  const card = document.createElement('div');
+  card.className = 'section-card agent-card agent-card--placeholder';
+  card.innerHTML = `
+    <div class="agent-card-identity-text">
+      <h3 class="agent-name">Connect your own agent</h3>
+      <p class="agent-card-submeta">Run your own trading agent against our backtests via an API key.</p>
+    </div>
+    <button class="agent-card-cta agent-card-cta--outline" type="button">Connect agent</button>`;
+  card.querySelector('button')?.addEventListener('click', openCreateExternalAgentModal);
+  grid.appendChild(card);
+}
+
 document.addEventListener('click', (event) => {
   if (event.target.closest?.('.agent-card-menu')) return;
-  document.querySelectorAll('#agentsGrid .agent-menu-dropdown').forEach((el) => {
+  document.querySelectorAll('.agents-grid .agent-menu-dropdown').forEach((el) => {
     el.hidden = true;
   });
-  document.querySelectorAll('#agentsGrid .agent-menu-toggle').forEach((el) => {
+  document.querySelectorAll('.agents-grid .agent-menu-toggle').forEach((el) => {
     el.setAttribute('aria-expanded', 'false');
   });
 });
@@ -1016,7 +1055,7 @@ async function loadAgents() {
 
     // Demo only: seed illustrative agents so the page has content without a
     // backend. Real users get the genuine empty-state (rendered by
-    // renderAgentsGrid) instead of fabricated agents.
+    // renderAgentCategories) instead of fabricated agents.
     if (!agents.length && isDemoMode()) {
       agents = visibleMockAgents();
     }
@@ -3786,7 +3825,6 @@ function initNavigation() {
         });
     });
 
-    document.getElementById('agentFilterSelect')?.addEventListener('change', applyAgentFilters);
     document.getElementById('agentSearchInput')?.addEventListener('input', applyAgentFilters);
     document.getElementById('agentViewGrid')?.addEventListener('click', () => setAgentViewMode('grid'));
     document.getElementById('agentViewList')?.addEventListener('click', () => setAgentViewMode('list'));

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -129,7 +129,7 @@ function formatTokenCount(value) {
 // unavailable). Lets the redesigned My Agents page render without a backend.
 // TODO: Replace mock agent data with backend API data later.
 // ============================================================================
-const MAX_AGENT_CASH_ALLOCATION = 3000;
+const MAX_AGENT_CASH_ALLOCATION = 1000000;
 const DEFAULT_AGENT_CASH_ALLOCATION = 1000;
 const DEFAULT_PORTFOLIO_EQUITY = 10000;
 const AGENT_CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -161,6 +161,11 @@ const DEFAULT_FOUNDATION_MODEL = 'deepseek/deepseek-v4-pro';
 const SIMPLE_INSTRUCTION_PRESET_KEY = 'simple_instruction';
 const SIMPLE_INSTRUCTION_OUTPUT_FORMAT =
   'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }';
+// Single source of truth for the Simple-mode trading-actions contract. Published
+// on `window` so agent-editor.js (which loads BEFORE this file) reads the exact
+// same preset key + output format at call time instead of keeping its own copy.
+window.SIMPLE_INSTRUCTION_PRESET_KEY = SIMPLE_INSTRUCTION_PRESET_KEY;
+window.SIMPLE_INSTRUCTION_OUTPUT_FORMAT = SIMPLE_INSTRUCTION_OUTPUT_FORMAT;
 const DEFAULT_STARTER_INSTRUCTION =
   'Spread the money across a few of the strongest available stocks. Buy on meaningful dips, take profits after strong run-ups, and never put everything into one stock.';
 
@@ -732,6 +737,8 @@ function renderAgentsError() {
   });
   const builtinEmpty = document.getElementById('agentsEmptyBuiltin');
   if (builtinEmpty) builtinEmpty.hidden = true;
+  const externalEmpty = document.getElementById('agentsEmptyExternal');
+  if (externalEmpty) externalEmpty.hidden = true;
   if (errorEl) errorEl.hidden = false;
 }
 
@@ -901,6 +908,11 @@ function renderAgentCategories(agents) {
   const pinDefaultFirst = (list) =>
     [...list].sort((a, b) => (b.agent_id === defaultId) - (a.agent_id === defaultId));
 
+  // A live search narrows the list: distinguish "no agents at all" (onboarding)
+  // from "none match your search" so we neither mis-say "No foundation agents
+  // yet" nor surface the External onboarding card as if it were a search result.
+  const searching = !!(document.getElementById('agentSearchInput')?.value || '').trim();
+
   const builtin = pinDefaultFirst(agents.filter((a) => a.agent_type === 'builtin'));
   const external = pinDefaultFirst(agents.filter((a) => a.agent_type !== 'builtin'));
 
@@ -908,8 +920,24 @@ function renderAgentCategories(agents) {
   renderAgentCards(externalGrid, external);
 
   const builtinEmpty = document.getElementById('agentsEmptyBuiltin');
-  if (builtinEmpty) builtinEmpty.hidden = builtin.length > 0;
-  if (!external.length) renderExternalPlaceholderCard(externalGrid);
+  if (builtinEmpty) {
+    builtinEmpty.hidden = builtin.length > 0;
+    builtinEmpty.innerHTML = searching
+      ? 'No foundation agents match your search.'
+      : 'No foundation agents yet. Click <strong>Add Agent</strong> to create one.';
+  }
+
+  const externalEmpty = document.getElementById('agentsEmptyExternal');
+  if (external.length > 0) {
+    if (externalEmpty) externalEmpty.hidden = true;
+  } else if (searching) {
+    // A search that matched no external agents — show a no-match note, not the
+    // "Connect your own agent" onboarding card.
+    if (externalEmpty) externalEmpty.hidden = false;
+  } else {
+    if (externalEmpty) externalEmpty.hidden = true;
+    renderExternalPlaceholderCard(externalGrid);
+  }
 }
 
 // Reserved entry point for connect-your-own agents: the connection mechanism

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -156,6 +156,14 @@ function setDefaultAgentId(agentId) {
   }
 }
 
+const DEFAULT_AGENT_PROVISION_GUARD_PREFIX = 'default-agent-provisioned:';
+const DEFAULT_FOUNDATION_MODEL = 'deepseek/deepseek-v4-pro';
+const SIMPLE_INSTRUCTION_PRESET_KEY = 'simple_instruction';
+const SIMPLE_INSTRUCTION_OUTPUT_FORMAT =
+  'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }';
+const DEFAULT_STARTER_INSTRUCTION =
+  'Spread the money across a few of the strongest available stocks. Buy on meaningful dips, take profits after strong run-ups, and never put everything into one stock.';
+
 function formatAgentCashAllocation(value) {
   if (value == null || value === '') return '—';
   return new Intl.NumberFormat('en-US', {
@@ -1030,6 +1038,60 @@ async function onBacktestAgentSelectChange() {
   }
 }
 
+// First-visit onboarding: a brand-new owner gets one real Foundation agent so
+// the row is never empty. The guard key means "we provisioned once for this
+// browser identity" — deleting the agent must NOT resurrect it.
+let defaultAgentProvisionInFlight = false;
+
+async function ensureDefaultFoundationAgent(agents) {
+  if (isDemoMode()) return false;
+  if (agents.some((a) => a.agent_type === 'builtin')) return false;
+  const guardKey = `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}${window.BROWSER_OWNER_ID || 'anon'}`;
+  try {
+    if (localStorage.getItem(guardKey)) return false;
+  } catch (e) {
+    return false; // no storage → cannot guard → do not provision
+  }
+  if (defaultAgentProvisionInFlight) return false;
+  defaultAgentProvisionInFlight = true;
+  try {
+    const data = await API.post(`${API_BASE}/api/v1/agents`, {
+      name: 'My Foundation Agent',
+      model_name: DEFAULT_FOUNDATION_MODEL,
+      agent_type: 'builtin',
+      description: 'Your starter agent — configure it and run a backtest.',
+      cash_allocation: DEFAULT_AGENT_CASH_ALLOCATION,
+    });
+    const agent = data?.agent;
+    if (!agent?.agent_id) return false;
+    localStorage.setItem(guardKey, agent.agent_id);
+    try {
+      await API.patch(`${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`, {
+        pipeline: [
+          {
+            id: `sub_starter_${agent.agent_id}`,
+            presetKey: SIMPLE_INSTRUCTION_PRESET_KEY,
+            label: 'Trading instruction',
+            prompt: DEFAULT_STARTER_INSTRUCTION,
+            outputFormat: SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
+          },
+        ],
+      });
+    } catch (seedError) {
+      // Non-fatal: the agent exists; the editor just opens with a blank instruction.
+      console.warn('Starter instruction seed failed:', seedError.message);
+    }
+    if (!getDefaultAgentId()) setDefaultAgentId(agent.agent_id);
+    return true;
+  } catch (error) {
+    // Non-fatal: the row falls back to its empty state with the Add Agent CTA.
+    console.warn('Default agent provisioning skipped:', error.message);
+    return false;
+  } finally {
+    defaultAgentProvisionInFlight = false;
+  }
+}
+
 async function loadAgents() {
   try {
     let data = await API.get(`${API_BASE}/api/v1/agents`);
@@ -1069,6 +1131,15 @@ async function loadAgents() {
     // renderAgentCategories) instead of fabricated agents.
     if (!agents.length && isDemoMode()) {
       agents = visibleMockAgents();
+    }
+
+    if (await ensureDefaultFoundationAgent(agents)) {
+      try {
+        const refreshed = await API.get(`${API_BASE}/api/v1/agents`);
+        agents = refreshed.agents || agents;
+      } catch (refreshError) {
+        console.warn('Refresh after default-agent provisioning failed:', refreshError.message);
+      }
     }
 
     allAgents = agents;

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -612,19 +612,21 @@ function renderAgentCardActions(agent, statusKey) {
   } else {
     primary = `<button class="agent-card-cta agent-run-backtest-btn" type="button" data-agent-id="${id}">Run Backtest</button>`;
   }
+  const configure = `<button class="agent-card-cta agent-card-cta--configure agent-configure-btn" type="button" data-agent-id="${id}">Configure</button>`;
   const rotate =
     agent.agent_type === 'builtin'
       ? ''
       : `<button class="agent-menu-item agent-rotate-key-btn" type="button" data-agent-id="${id}">New API key</button>`;
   return `
     <div class="agent-card-actions agent-card-actions--status">
+      ${configure}
       ${primary}
       <div class="agent-card-menu">
         <button class="agent-menu-toggle" type="button" aria-label="More actions" aria-expanded="false" data-agent-id="${id}">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="6" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="18" cy="12" r="1.6"/></svg>
         </button>
         <div class="agent-menu-dropdown" hidden>
-          <button class="agent-menu-item agent-edit-btn" type="button" data-agent-id="${id}">Edit</button>
+          <button class="agent-menu-item agent-set-default-btn" type="button" data-agent-id="${id}">Set as default</button>
           ${rotate}
           <button class="agent-menu-item agent-menu-item--danger agent-delete-btn" type="button" data-agent-id="${id}">Delete</button>
         </div>
@@ -765,6 +767,8 @@ function bindAgentCardMenus(grid) {
 function renderAgentCards(grid, agents) {
   grid.innerHTML = '';
 
+  const defaultId = getDefaultAgentId();
+
   agents.forEach((agent) => {
     const isBuiltin = agent.agent_type === 'builtin';
     const statusBadge = resolveAgentStatusBadge(agent);
@@ -778,7 +782,7 @@ function renderAgentCards(grid, agents) {
         <div class="agent-card-identity">
           ${agentRobotIcon()}
           <div class="agent-card-identity-text">
-            <h3 class="agent-name">${escapeHtml(agent.name)}</h3>
+            <h3 class="agent-name">${escapeHtml(agent.name)}${agent.agent_id === defaultId ? ' <span class="agent-default-badge">Default</span>' : ''}</h3>
             <p class="agent-card-submeta">${model} · ${type}</p>
           </div>
         </div>
@@ -792,13 +796,20 @@ function renderAgentCards(grid, agents) {
 
   bindAgentCardMenus(grid);
 
-  grid.querySelectorAll('.agent-edit-btn').forEach((btn) => {
+  grid.querySelectorAll('.agent-configure-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
       const agent = agents.find((a) => a.agent_id === btn.dataset.agentId);
       if (!agent || !window.AgentEditor) return;
       navigateToPage('playground', { playgroundTab: 'agents' });
       showPlaygroundPanel('agents');
       window.AgentEditor.open(agent);
+    });
+  });
+
+  grid.querySelectorAll('.agent-set-default-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      setDefaultAgentId(btn.dataset.agentId);
+      applyAgentFilters(); // re-render: badge + pin move to the new default
     });
   });
 

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -1,6 +1,8 @@
 /**
- * agent-editor.js — Fullscreen agent pipeline editor (sub-agent chain).
- * Pipeline config: localStorage. Agent name/description: PATCH /api/v1/agents/{id}.
+ * agent-editor.js — Fullscreen agent Configure screen.
+ * Simple mode: capital + one plain-language instruction (stored as a 1-step
+ * pipeline) + model. Advanced mode: the multi-step sub-agent chain.
+ * Agent fields: PATCH /api/v1/agents/{id}. Pipeline cache: localStorage.
  */
 (function () {
   'use strict';
@@ -9,6 +11,11 @@
   const NAME_OVERRIDE_PREFIX = 'agent-name-override:';
   const CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
   const API_BASE = window.location.origin;
+
+  const SIMPLE_PRESET_KEY = 'simple_instruction';
+  // Must stay byte-identical to SIMPLE_INSTRUCTION_OUTPUT_FORMAT in app.js.
+  const SIMPLE_OUTPUT_FORMAT =
+    'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }';
 
   // Demo/mock agents (see MOCK_AGENTS in app.js) only exist in the frontend —
   // they have no database row, so PATCH would 404. We persist their edits
@@ -81,6 +88,7 @@
   let saveStatusTimer = null;
   let isDirty = false;
   let savedSnapshot = '';
+  let editorMode = 'simple';
 
   function escapeHtml(value) {
     return String(value ?? '')
@@ -146,6 +154,35 @@
     return loadPipeline(agent.agent_id);
   }
 
+  function isSimplePipeline(pipeline) {
+    return (
+      !Array.isArray(pipeline) ||
+      pipeline.length === 0 ||
+      (pipeline.length === 1 && pipeline[0].presetKey === SIMPLE_PRESET_KEY)
+    );
+  }
+
+  // The pipeline the agent ACTUALLY has (backend row, then local cache) — with
+  // NO default-5-step substitution, so a fresh agent opens in Simple mode.
+  // Demo agents keep resolvePipeline's default behavior.
+  function loadStoredPipeline(agent) {
+    if (Array.isArray(agent.pipeline) && agent.pipeline.length) {
+      return agent.pipeline.map(normalizeLoadedSubAgent);
+    }
+    try {
+      const raw = localStorage.getItem(storageKey(agent.agent_id));
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed.subAgents) && parsed.subAgents.length) {
+          return parsed.subAgents.map(normalizeLoadedSubAgent);
+        }
+      }
+    } catch {
+      /* fall through to empty */
+    }
+    return [];
+  }
+
   function loadPipeline(agentId) {
     try {
       const raw = localStorage.getItem(storageKey(agentId));
@@ -184,11 +221,39 @@
     } else {
       cash_allocation = 1000;
     }
+    const modelSelect = document.getElementById('agentEditorModelSelect');
+    let subAgentsOut;
+    if (editorMode === 'simple') {
+      const instruction = (
+        document.getElementById('agentEditorSimpleInstruction')?.value || ''
+      ).trim();
+      if (instruction) {
+        const existing =
+          subAgents.length === 1 && subAgents[0].presetKey === SIMPLE_PRESET_KEY
+            ? subAgents[0]
+            : null;
+        subAgentsOut = [
+          {
+            id: existing ? existing.id : newSubAgentId(),
+            presetKey: SIMPLE_PRESET_KEY,
+            label: 'Trading instruction',
+            prompt: instruction,
+            outputFormat: SIMPLE_OUTPUT_FORMAT,
+          },
+        ];
+      } else {
+        // Empty instruction never destroys an existing pipeline.
+        subAgentsOut = subAgents;
+      }
+    } else {
+      subAgentsOut = collectPipelineFromDom();
+    }
     return {
       name: nameInput ? nameInput.value.trim() : '',
       description: descInput ? descInput.value.trim() : '',
       cash_allocation,
-      subAgents: collectPipelineFromDom(),
+      model_name: modelSelect ? modelSelect.value : '',
+      subAgents: subAgentsOut,
     };
   }
 
@@ -414,6 +479,30 @@
     refreshAddSelect();
   }
 
+  function updateSimpleReplaceNote() {
+    const note = document.getElementById('agentEditorSimpleReplaceNote');
+    if (note) note.hidden = !(editorMode === 'simple' && subAgents.length > 1);
+  }
+
+  function setEditorMode(mode) {
+    editorMode = mode === 'advanced' ? 'advanced' : 'simple';
+    const simplePanel = document.getElementById('agentEditorSimplePanel');
+    const advancedPanel = document.getElementById('agentEditorAdvancedPanel');
+    const resetBtn = document.getElementById('agentEditorResetBtn');
+    if (simplePanel) simplePanel.hidden = editorMode !== 'simple';
+    if (advancedPanel) advancedPanel.hidden = editorMode !== 'advanced';
+    if (resetBtn) resetBtn.hidden = editorMode !== 'advanced';
+    document.getElementById('agentEditorModeSimple')?.classList.toggle('active', editorMode === 'simple');
+    document.getElementById('agentEditorModeAdvanced')?.classList.toggle('active', editorMode === 'advanced');
+    if (editorMode === 'advanced' && subAgents.length === 0) {
+      // First look at Advanced on a fresh agent: start from the default chain.
+      subAgents = defaultPipeline();
+      renderPipeline();
+    }
+    updateSimpleReplaceNote();
+    markDirtyFromInput();
+  }
+
   function fillHeader(agent) {
     const nameInput = document.getElementById('agentEditorNameInput');
     const descInput = document.getElementById('agentEditorDescription');
@@ -426,9 +515,34 @@
       cashInput.value = agent.cash_allocation != null ? String(agent.cash_allocation) : '';
     }
     if (meta) {
-      const type = agent.agent_type === 'builtin' ? 'Built-in' : 'External';
-      meta.textContent = `${agent.model_name || 'local-model'} · ${type}`;
+      meta.textContent = agent.agent_type === 'builtin' ? 'Built-in agent' : 'External agent';
     }
+  }
+
+  function populateModelSelect(agent) {
+    const select = document.getElementById('agentEditorModelSelect');
+    if (!select) return;
+    select.innerHTML = '';
+    const seen = new Set();
+    const source = document.getElementById('builtinAgentModel');
+    if (source) {
+      Array.from(source.options).forEach((opt) => {
+        const clone = document.createElement('option');
+        clone.value = opt.value;
+        clone.textContent = opt.textContent;
+        select.appendChild(clone);
+        seen.add(opt.value);
+      });
+    }
+    const current = agent.model_name || 'local-model';
+    if (!seen.has(current)) {
+      // External / legacy models aren't in the curated list — keep them selectable.
+      const opt = document.createElement('option');
+      opt.value = current;
+      opt.textContent = current;
+      select.insertBefore(opt, select.firstChild);
+    }
+    select.value = current;
   }
 
   function serializePipeline(steps) {
@@ -441,13 +555,14 @@
     }));
   }
 
-  async function patchAgent(agent, name, description, pipeline, cash_allocation) {
+  async function patchAgent(agent, name, description, pipeline, cash_allocation, model_name) {
     const payload = {
       name,
       description: description || null,
       pipeline: serializePipeline(pipeline),
       cash_allocation,
     };
+    if (model_name) payload.model_name = model_name;
     const endpoint = `${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`;
 
     async function requestWithHeaders(extraHeaders) {
@@ -598,9 +713,23 @@
     if (!agent || !agent.agent_id) return;
 
     currentAgent = { ...agent };
-    subAgents = resolvePipeline(agent);
+    if (isDemoAgent(agent.agent_id)) {
+      subAgents = resolvePipeline(agent); // demo agents keep the legacy default chain
+    } else {
+      subAgents = loadStoredPipeline(agent);
+    }
     fillHeader(agent);
+    populateModelSelect(agent);
+    const instructionEl = document.getElementById('agentEditorSimpleInstruction');
+    if (instructionEl) {
+      const simpleStep =
+        subAgents.length === 1 && subAgents[0].presetKey === SIMPLE_PRESET_KEY
+          ? subAgents[0]
+          : null;
+      instructionEl.value = simpleStep ? simpleStep.prompt : '';
+    }
     renderPipeline();
+    setEditorMode(isSimplePipeline(subAgents) ? 'simple' : 'advanced');
     refreshRunHistory(currentAgent);
 
     const view = document.getElementById('agentEditorView');
@@ -652,6 +781,7 @@
     }
 
     subAgents = state.subAgents;
+    updateSimpleReplaceNote();
     const saveBtn = document.getElementById('agentEditorSaveBtn');
     if (saveBtn) {
       saveBtn.disabled = true;
@@ -701,7 +831,8 @@
         state.name,
         state.description,
         subAgents,
-        state.cash_allocation
+        state.cash_allocation,
+        state.model_name
       );
       currentAgent = { ...currentAgent, ...updated, pipeline: subAgents };
       savePipelineLocal(currentAgent.agent_id, subAgents);
@@ -789,6 +920,8 @@
     document.getElementById('agentEditorSaveBtn')?.addEventListener('click', () => save());
     document.getElementById('agentEditorAddBtn')?.addEventListener('click', addSubAgent);
     document.getElementById('agentEditorResetBtn')?.addEventListener('click', resetPipeline);
+    document.getElementById('agentEditorModeSimple')?.addEventListener('click', () => setEditorMode('simple'));
+    document.getElementById('agentEditorModeAdvanced')?.addEventListener('click', () => setEditorMode('advanced'));
 
     document.getElementById('agentEditorAddSelect')?.addEventListener('change', (e) => {
       const customName = document.getElementById('agentEditorCustomName');

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -481,7 +481,7 @@
 
   function updateSimpleReplaceNote() {
     const note = document.getElementById('agentEditorSimpleReplaceNote');
-    if (note) note.hidden = !(editorMode === 'simple' && subAgents.length > 1);
+    if (note) note.hidden = !(editorMode === 'simple' && !isSimplePipeline(subAgents));
   }
 
   function setEditorMode(mode) {

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -223,6 +223,7 @@
     }
     const modelSelect = document.getElementById('agentEditorModelSelect');
     let subAgentsOut;
+    let sendPipeline;
     if (editorMode === 'simple') {
       const instruction = (
         document.getElementById('agentEditorSimpleInstruction')?.value || ''
@@ -241,12 +242,16 @@
             outputFormat: SIMPLE_OUTPUT_FORMAT,
           },
         ];
+        sendPipeline = true;
       } else {
-        // Empty instruction never destroys an existing pipeline.
+        // Empty instruction never touches the stored pipeline: not sent to the
+        // server, not cached locally, not folded into currentAgent.
         subAgentsOut = subAgents;
+        sendPipeline = false;
       }
     } else {
       subAgentsOut = collectPipelineFromDom();
+      sendPipeline = true;
     }
     return {
       name: nameInput ? nameInput.value.trim() : '',
@@ -254,6 +259,7 @@
       cash_allocation,
       model_name: modelSelect ? modelSelect.value : '',
       subAgents: subAgentsOut,
+      sendPipeline,
     };
   }
 
@@ -492,8 +498,12 @@
     if (simplePanel) simplePanel.hidden = editorMode !== 'simple';
     if (advancedPanel) advancedPanel.hidden = editorMode !== 'advanced';
     if (resetBtn) resetBtn.hidden = editorMode !== 'advanced';
-    document.getElementById('agentEditorModeSimple')?.classList.toggle('active', editorMode === 'simple');
-    document.getElementById('agentEditorModeAdvanced')?.classList.toggle('active', editorMode === 'advanced');
+    const modeSimpleBtn = document.getElementById('agentEditorModeSimple');
+    const modeAdvancedBtn = document.getElementById('agentEditorModeAdvanced');
+    modeSimpleBtn?.classList.toggle('active', editorMode === 'simple');
+    modeAdvancedBtn?.classList.toggle('active', editorMode === 'advanced');
+    modeSimpleBtn?.setAttribute('aria-pressed', editorMode === 'simple' ? 'true' : 'false');
+    modeAdvancedBtn?.setAttribute('aria-pressed', editorMode === 'advanced' ? 'true' : 'false');
     if (editorMode === 'advanced' && subAgents.length === 0) {
       // First look at Advanced on a fresh agent: start from the default chain.
       subAgents = defaultPipeline();
@@ -559,9 +569,9 @@
     const payload = {
       name,
       description: description || null,
-      pipeline: serializePipeline(pipeline),
       cash_allocation,
     };
+    if (pipeline) payload.pipeline = serializePipeline(pipeline);
     if (model_name) payload.model_name = model_name;
     const endpoint = `${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`;
 
@@ -781,6 +791,7 @@
     }
 
     subAgents = state.subAgents;
+    renderPipeline();
     updateSimpleReplaceNote();
     const saveBtn = document.getElementById('agentEditorSaveBtn');
     if (saveBtn) {
@@ -807,7 +818,7 @@
           description: state.description,
           cash_allocation: state.cash_allocation,
         };
-        savePipelineLocal(currentAgent.agent_id, subAgents);
+        if (state.sendPipeline) savePipelineLocal(currentAgent.agent_id, subAgents);
         if (localStorage.getItem('active-agent-id') === currentAgent.agent_id) {
           localStorage.setItem('active-agent-name', state.name);
         }
@@ -830,12 +841,14 @@
         currentAgent,
         state.name,
         state.description,
-        subAgents,
+        state.sendPipeline ? subAgents : null,
         state.cash_allocation,
         state.model_name
       );
-      currentAgent = { ...currentAgent, ...updated, pipeline: subAgents };
-      savePipelineLocal(currentAgent.agent_id, subAgents);
+      currentAgent = state.sendPipeline
+        ? { ...currentAgent, ...updated, pipeline: subAgents }
+        : { ...currentAgent, ...updated };
+      if (state.sendPipeline) savePipelineLocal(currentAgent.agent_id, subAgents);
       localStorage.removeItem(`${NAME_OVERRIDE_PREFIX}${currentAgent.agent_id}`);
 
       if (localStorage.getItem('active-agent-id') === currentAgent.agent_id) {
@@ -849,7 +862,7 @@
         new CustomEvent('agent-editor-saved', { detail: { agent: currentAgent } })
       );
     } catch (error) {
-      savePipelineLocal(currentAgent.agent_id, subAgents);
+      if (state.sendPipeline) savePipelineLocal(currentAgent.agent_id, subAgents);
       localStorage.setItem(
         `${NAME_OVERRIDE_PREFIX}${currentAgent.agent_id}`,
         JSON.stringify({ name: state.name, description: state.description })

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -177,8 +177,8 @@
       if (!Number.isFinite(value) || value < 0) {
         throw new Error('Initial cash must be zero or greater.');
       }
-      if (value > 3000) {
-        throw new Error('Initial cash cannot exceed $3,000.');
+      if (value > 1000000) {
+        throw new Error('Initial cash cannot exceed $1,000,000.');
       }
       cash_allocation = Math.round(value);
     } else {

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -12,10 +12,22 @@
   const CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
   const API_BASE = window.location.origin;
 
-  const SIMPLE_PRESET_KEY = 'simple_instruction';
-  // Must stay byte-identical to SIMPLE_INSTRUCTION_OUTPUT_FORMAT in app.js.
-  const SIMPLE_OUTPUT_FORMAT =
-    'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }';
+  // The Simple-mode contract (preset key + trading-actions output format) has a
+  // single source of truth in app.js, published on `window`. app.js loads AFTER
+  // this file, so read lazily at call time — every use below is inside an
+  // event-driven function, by which point window.* is populated. The fallbacks
+  // only matter if app.js somehow failed to load (whole app is broken anyway).
+  function simplePresetKey() {
+    return (
+      (typeof window !== 'undefined' && window.SIMPLE_INSTRUCTION_PRESET_KEY) ||
+      'simple_instruction'
+    );
+  }
+  function simpleOutputFormat() {
+    return (
+      (typeof window !== 'undefined' && window.SIMPLE_INSTRUCTION_OUTPUT_FORMAT) || ''
+    );
+  }
 
   // Demo/mock agents (see MOCK_AGENTS in app.js) only exist in the frontend —
   // they have no database row, so PATCH would 404. We persist their edits
@@ -158,7 +170,7 @@
     return (
       !Array.isArray(pipeline) ||
       pipeline.length === 0 ||
-      (pipeline.length === 1 && pipeline[0].presetKey === SIMPLE_PRESET_KEY)
+      (pipeline.length === 1 && pipeline[0].presetKey === simplePresetKey())
     );
   }
 
@@ -230,16 +242,16 @@
       ).trim();
       if (instruction) {
         const existing =
-          subAgents.length === 1 && subAgents[0].presetKey === SIMPLE_PRESET_KEY
+          subAgents.length === 1 && subAgents[0].presetKey === simplePresetKey()
             ? subAgents[0]
             : null;
         subAgentsOut = [
           {
             id: existing ? existing.id : newSubAgentId(),
-            presetKey: SIMPLE_PRESET_KEY,
+            presetKey: simplePresetKey(),
             label: 'Trading instruction',
             prompt: instruction,
-            outputFormat: SIMPLE_OUTPUT_FORMAT,
+            outputFormat: simpleOutputFormat(),
           },
         ];
         sendPipeline = true;
@@ -733,7 +745,7 @@
     const instructionEl = document.getElementById('agentEditorSimpleInstruction');
     if (instructionEl) {
       const simpleStep =
-        subAgents.length === 1 && subAgents[0].presetKey === SIMPLE_PRESET_KEY
+        subAgents.length === 1 && subAgents[0].presetKey === simplePresetKey()
           ? subAgents[0]
           : null;
       instructionEl.value = simpleStep ? simpleStep.prompt : '';

--- a/dashboard/frontend/js/portfolio.js
+++ b/dashboard/frontend/js/portfolio.js
@@ -11,7 +11,7 @@
 // ---------------------------------------------------------------------------
 // Mock data
 // TODO: Replace mock portfolio data with backend API data later.
-// Portfolio budget defaults to $10,000; agents allocate $1,000–$3,000 each.
+// Portfolio budget defaults to $10,000; agents allocate up to $1,000,000 each.
 // ---------------------------------------------------------------------------
 const PORTFOLIO_MOCK = {
     summary: {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8402,16 +8402,6 @@ body.agent-editor-open {
     color: #f87171;
 }
 
-.agent-action-btn.agent-edit-btn {
-    border-color: rgba(34, 211, 238, 0.45);
-    background: rgba(34, 211, 238, 0.14);
-    color: var(--home-accent-cyan, #22d3ee);
-}
-
-.agent-action-btn.agent-edit-btn:hover {
-    background: rgba(34, 211, 238, 0.24);
-}
-
 @media (max-width: 1100px) {
     .agent-editor-layout {
         grid-template-columns: 1fr;
@@ -8497,4 +8487,24 @@ body.agent-editor-open {
     gap: 14px;
     justify-content: center;
     align-items: flex-start;
+}
+
+/* Configure CTA + Default badge (Demo 1) */
+.agent-card-cta--configure {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+}
+.agent-card-cta--configure:hover { border-color: var(--text-secondary); }
+.agent-default-badge {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 8px;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    vertical-align: middle;
+    color: #10b981;
+    border: 1px solid rgba(16, 185, 129, 0.45);
+    background: rgba(16, 185, 129, 0.12);
 }

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8510,3 +8510,59 @@ body.agent-editor-open {
     border: 1px solid rgba(16, 185, 129, 0.45);
     background: rgba(16, 185, 129, 0.12);
 }
+
+/* Agent editor — Simple/Advanced modes (Demo 1) */
+.agent-editor-mode-toggle {
+    display: inline-flex;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+}
+.agent-editor-mode-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 6px 14px;
+    cursor: pointer;
+}
+.agent-editor-mode-btn.active {
+    background: var(--border-color);
+    color: var(--text-primary);
+}
+.agent-editor-model-field {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+}
+.agent-editor-model-label {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+.agent-editor-model-select {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    padding: 4px 8px;
+}
+.agent-editor-simple textarea {
+    width: 100%;
+    resize: vertical;
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    padding: 10px 12px;
+    margin-top: 10px;
+}
+.agent-editor-simple-note {
+    margin: 10px 0 0;
+    font-size: 0.8rem;
+    color: #fbbf24;
+}

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -7049,21 +7049,6 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     font-size: 13px;
 }
 
-.agent-toolbar-select {
-    padding: 8px 12px;
-    border-radius: 8px;
-    border: 1px solid var(--border-color);
-    background: var(--bg-input);
-    color: var(--text-primary);
-    font-size: 12px;
-    cursor: pointer;
-}
-
-.agent-toolbar-select:focus {
-    outline: none;
-    border-color: var(--info-color);
-}
-
 .agent-toolbar-search {
     position: relative;
     display: flex;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8474,3 +8474,27 @@ body.agent-editor-open {
         justify-content: flex-start;
     }
 }
+
+/* My Agents — category rows (Demo 1) */
+.agents-category { margin-top: 28px; }
+.agents-category:first-child { margin-top: 8px; }
+.agents-category-head { margin-bottom: 14px; }
+.agents-category-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 2px;
+}
+.agents-category-sub {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin: 0;
+}
+.agent-card--placeholder {
+    border-style: dashed;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    justify-content: center;
+    align-items: flex-start;
+}

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8490,10 +8490,12 @@ body.agent-editor-open {
 }
 
 /* Configure CTA + Default badge (Demo 1) */
+.agent-card-actions--status { flex-wrap: wrap; }
 .agent-card-cta--configure {
     background: transparent;
     border: 1px solid var(--border-color);
     color: var(--text-primary);
+    flex-basis: 100%;
 }
 .agent-card-cta--configure:hover { border-color: var(--text-secondary); }
 .agent-default-badge {

--- a/docs/superpowers/plans/2026-07-22-my-agents-configure-run.md
+++ b/docs/superpowers/plans/2026-07-22-my-agents-configure-run.md
@@ -1,0 +1,1229 @@
+# My Agents "Configure & run" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the My Agents tab so a first-time non-technical user sees a default agent in two category rows, presses Configure, sets capital + one plain-language instruction + a model, and runs a backtest unaided.
+
+**Architecture:** Frontend-heavy (vanilla JS, no build step). Simple mode is a *data convention*: a one-step `pipeline` with `presetKey: "simple_instruction"` and a fixed trading-actions `outputFormat` — it reuses the existing PATCH save path and the existing backtest pipeline path end-to-end. The only backend deltas are making `model_name` PATCH-editable (column already exists) and raising the cash cap constant. No new routes, no DB migration.
+
+**Tech Stack:** FastAPI + Pydantic (backend), vanilla JS + Chart.js (frontend, no build), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-my-agents-configure-run-design.md`
+
+## Global Constraints
+
+- Run everything from the **repo root** (`/mnt/d/github/agent-trading-lab`). The backend is the `dashboard.backend` package — never run files directly.
+- Test runner: `~/atl-venv/bin/python -m pytest dashboard/backend/tests/... -v` (pytest is not in requirements.txt; the venv has it).
+- **No new API routes** — three route-contract freeze tests turn CI red on any added route. Adding a *field* to an existing request body is safe.
+- **No DB migration** — `external_agents.model_name` already exists (`repository.py:100`, `NOT NULL DEFAULT 'local-model'`).
+- Default Foundation model value: exactly `deepseek/deepseek-v4-pro` (must match the create-modal option, `app.html:599`).
+- Simple-mode preset key: exactly `simple_instruction`. It is inert on the backend (only `post_trade_analysis` is special-cased) and unknown keys fall back to the custom preset in the Advanced renderer.
+- Simple-mode fixed output contract (single source of drift-risk — copy this exact string everywhere it appears):
+  `JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }`
+  (verbatim the `signal_to_execution` preset contract, `agent-editor.js:43`, which `pipeline_output_to_decision` already normalizes into `{"actions": [...]}`).
+- Starter instruction text (exact): `Spread the money across a few of the strongest available stocks. Buy on meaningful dips, take profits after strong run-ups, and never put everything into one stock.`
+- Cash cap: `MAX_AGENT_CASH_ALLOCATION` = **1_000_000** everywhere (backend constant + 3 HTML inputs + 2 JS clamps). Default stays 1000.
+- localStorage keys: default pointer `default-agent-id:<BROWSER_OWNER_ID>`, provision guard `default-agent-provisioned:<BROWSER_OWNER_ID>`.
+- Frontend has no JS test framework — frontend tasks are verified by serving the app (`~/atl-venv/bin/python -m uvicorn dashboard.backend.app:app`) and clicking the listed checks. Backend tasks are TDD.
+
+---
+
+### Task 1: Backend — raise the cash cap to $1,000,000
+
+**Files:**
+- Modify: `dashboard/backend/domain/backtesting/constants.py:14,31`
+- Test: `dashboard/backend/tests/test_agents_api.py` (append)
+
+**Interfaces:**
+- Produces: `MAX_AGENT_CASH_ALLOCATION == 1_000_000` — consumed by `api/routers/agents.py` validators and `resolve_initial_capital` clamping (both import the constant; no other edits needed).
+
+- [ ] **Step 1: Write the failing test** — append to `dashboard/backend/tests/test_agents_api.py`:
+
+```python
+def test_cash_allocation_cap_is_one_million(client):
+    """Demo 1: the per-agent cap was raised 3,000 -> 1,000,000."""
+    from dashboard.backend.domain.backtesting.constants import (
+        MAX_AGENT_CASH_ALLOCATION,
+        resolve_initial_capital,
+    )
+
+    assert MAX_AGENT_CASH_ALLOCATION == 1_000_000
+    # Clamp behavior follows the constant.
+    assert resolve_initial_capital(1_000_000) == 1_000_000.0
+    assert resolve_initial_capital(2_000_000) == 1_000_000.0
+
+    browser_session = str(uuid.uuid4())
+    headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}
+
+    ok = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "Whale",
+            "agent_type": "builtin",
+            "cash_allocation": 1_000_000,
+        },
+        headers=headers,
+    )
+    assert ok.status_code == 200
+    assert ok.json()["agent"]["cash_allocation"] == 1_000_000
+
+    too_big = client.post(
+        "/api/v1/agents",
+        json={"name": "Too big", "agent_type": "builtin", "cash_allocation": 1_000_001},
+        headers=headers,
+    )
+    assert too_big.status_code == 422
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/atl-venv/bin/python -m pytest dashboard/backend/tests/test_agents_api.py::test_cash_allocation_cap_is_one_million -v`
+Expected: FAIL on `assert MAX_AGENT_CASH_ALLOCATION == 1_000_000` (it is 3000).
+
+- [ ] **Step 3: Raise the constant** — in `dashboard/backend/domain/backtesting/constants.py` change line 31:
+
+```python
+MAX_AGENT_CASH_ALLOCATION = 1_000_000
+```
+
+and update the docstring line 13-14 to read:
+
+```
+- Per-agent starting cash: default ``DEFAULT_AGENT_CASH_ALLOCATION`` ($1,000),
+  max ``MAX_AGENT_CASH_ALLOCATION`` ($1,000,000)
+```
+
+- [ ] **Step 4: Run the test and the full backend suite**
+
+Run: `~/atl-venv/bin/python -m pytest dashboard/backend/tests/ -q`
+Expected: all green (no existing test pins the 3000 cap — verified by grep before this plan was written; a failure here means a real interaction, stop and read it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/domain/backtesting/constants.py dashboard/backend/tests/test_agents_api.py
+git commit -m "feat: raise per-agent cash cap to \$1,000,000"
+```
+
+---
+
+### Task 2: Backend — make `model_name` PATCH-editable
+
+**Files:**
+- Modify: `dashboard/backend/api/routers/agents.py:58-66` (UpdateAgentBody), `:233-270` (PATCH handler)
+- Modify: `dashboard/backend/domain/agents/service.py:179-197`
+- Modify: `dashboard/backend/domain/agents/repository.py:457-505`
+- Modify: `dashboard/backend/domain/agents/repository_postgres.py:414-456`
+- Test: `dashboard/backend/tests/test_agents_api.py`, `dashboard/backend/tests/test_agent_store_postgres.py`
+
+**Interfaces:**
+- Produces: `PATCH /api/v1/agents/{agent_id}` accepts optional `model_name: str` (1..100 chars); omitted/null → unchanged. `AgentStore.update_agent(..., model_name: Optional[str] = None)` in both stores. Task 7's frontend sends this field.
+
+- [ ] **Step 1: Write the failing API test** — append to `dashboard/backend/tests/test_agents_api.py`:
+
+```python
+def test_patch_agent_model_name(client):
+    """Demo 1: the Configure screen can change the model after creation."""
+    browser_session = str(uuid.uuid4())
+    headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}
+
+    created = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "Model Swapper",
+            "model_name": "anthropic/claude-haiku-4-5",
+            "agent_type": "builtin",
+        },
+        headers=headers,
+    )
+    assert created.status_code == 200
+    agent_id = created.json()["agent"]["agent_id"]
+
+    patched = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"model_name": "deepseek/deepseek-v4-pro"},
+        headers=headers,
+    )
+    assert patched.status_code == 200
+    assert patched.json()["agent"]["model_name"] == "deepseek/deepseek-v4-pro"
+
+    # Absent field leaves the model untouched.
+    renamed = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"name": "Still Swapped"},
+        headers=headers,
+    )
+    assert renamed.status_code == 200
+    assert renamed.json()["agent"]["model_name"] == "deepseek/deepseek-v4-pro"
+
+    # Empty string is rejected by validation.
+    empty = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"model_name": ""},
+        headers=headers,
+    )
+    assert empty.status_code == 422
+
+    # model_name alone is a valid update (not "No fields to update").
+    only_model = client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"model_name": "openai/gpt-5.5"},
+        headers=headers,
+    )
+    assert only_model.status_code == 200
+    assert only_model.json()["agent"]["model_name"] == "openai/gpt-5.5"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `~/atl-venv/bin/python -m pytest dashboard/backend/tests/test_agents_api.py::test_patch_agent_model_name -v`
+Expected: FAIL — first PATCH returns 400 "No fields to update" (model_name is silently ignored by the current body model).
+
+- [ ] **Step 3: Add the field through the chain.**
+
+In `dashboard/backend/api/routers/agents.py`, `UpdateAgentBody` becomes:
+
+```python
+class UpdateAgentBody(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    model_name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    description: Optional[str] = Field(default=None, max_length=280)
+    pipeline: Optional[List[PipelineStep]] = Field(default=None, max_length=50)
+    cash_allocation: Optional[float] = Field(
+        default=None,
+        ge=0,
+        le=MAX_AGENT_CASH_ALLOCATION,
+    )
+```
+
+In the PATCH handler (`update_agent`, `:233-270`), change the no-op guard and the service call (keep everything else identical):
+
+```python
+    if (
+        body.name is None
+        and body.model_name is None
+        and body.description is None
+        and not pipeline_provided
+        and not cash_allocation_provided
+    ):
+        raise HTTPException(status_code=400, detail="No fields to update")
+```
+
+```python
+        agent = agent_service.update_agent(
+            agent_id,
+            name=body.name.strip() if body.name is not None else None,
+            model_name=body.model_name.strip() if body.model_name is not None else None,
+            description=body.description,
+            pipeline=pipeline_arg,
+            cash_allocation=cash_allocation_arg,
+        )
+```
+
+In `dashboard/backend/domain/agents/service.py`, `AgentService.update_agent` becomes:
+
+```python
+    def update_agent(
+        self,
+        agent_id: str,
+        *,
+        name: Optional[str] = None,
+        model_name: Optional[str] = None,
+        description: Optional[str] = None,
+        pipeline: Any = _UNSET,
+        cash_allocation: Any = _UNSET,
+    ) -> Dict[str, Any]:
+        agent = self.agents.update_agent(
+            agent_id,
+            name=name,
+            model_name=model_name,
+            description=description,
+            pipeline=pipeline,
+            cash_allocation=cash_allocation,
+        )
+        if not agent:
+            raise AgentNotFoundError()
+        return self.agent_with_stats(agent)
+```
+
+In `dashboard/backend/domain/agents/repository.py`, `update_agent` signature gains `model_name: Optional[str] = None` (after `name`), and after the `if name is not None:` block add:
+
+```python
+        if model_name is not None:
+            sets.append("model_name = ?")
+            params.append(model_name.strip())
+```
+
+In `dashboard/backend/domain/agents/repository_postgres.py`, identical change with `%s`:
+
+```python
+        if model_name is not None:
+            sets.append("model_name = %s")
+            params.append(model_name.strip())
+```
+
+(Both repos: `model_name=None` means "leave unchanged" — same convention as `name`; the column is NOT NULL so there is deliberately no "clear it" path.)
+
+- [ ] **Step 4: Run the API test**
+
+Run: `~/atl-venv/bin/python -m pytest dashboard/backend/tests/test_agents_api.py::test_patch_agent_model_name -v`
+Expected: PASS
+
+- [ ] **Step 5: Add the Postgres-parity test** — append to `dashboard/backend/tests/test_agent_store_postgres.py` (follow the existing `@pg_only` + `pg_agent_store` fixture pattern used by `test_update_agent_partial_updates_postgres`):
+
+```python
+@pg_only
+def test_update_agent_model_name_postgres(pg_agent_store):
+    created = pg_agent_store.create_agent(
+        name="Model Swap PG",
+        model_name="anthropic/claude-haiku-4-5",
+        owner_user_id=None,
+        owner_browser_session="pg-model-swap",
+    )
+    updated = pg_agent_store.update_agent(
+        created["agent_id"], model_name="deepseek/deepseek-v4-pro"
+    )
+    assert updated["model_name"] == "deepseek/deepseek-v4-pro"
+
+    # Omitting model_name leaves it unchanged.
+    renamed = pg_agent_store.update_agent(created["agent_id"], name="Renamed")
+    assert renamed["model_name"] == "deepseek/deepseek-v4-pro"
+```
+
+NOTE: `@pg_only` skips (fails OPEN) without `TEST_POSTGRES_URL`; green CI does not prove this ran. Run it locally only against a **localhost** Postgres if available — never point `TEST_POSTGRES_URL` at a remote/prod URL. If no local PG, the skip is acceptable: the SQL delta is four lines and mirrors the SQLite twin verbatim.
+
+- [ ] **Step 6: Run the full backend suite**
+
+Run: `~/atl-venv/bin/python -m pytest dashboard/backend/tests/ -q`
+Expected: all green (PG test skips without TEST_POSTGRES_URL).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/backend/api/routers/agents.py dashboard/backend/domain/agents/service.py \
+  dashboard/backend/domain/agents/repository.py dashboard/backend/domain/agents/repository_postgres.py \
+  dashboard/backend/tests/test_agents_api.py dashboard/backend/tests/test_agent_store_postgres.py
+git commit -m "feat: allow PATCH to update agent model_name"
+```
+
+---
+
+### Task 3: Frontend — mirror the new cash cap
+
+**Files:**
+- Modify: `dashboard/frontend/app.js:132`
+- Modify: `dashboard/frontend/app.html:571-572,608-609,759-760`
+- Modify: `dashboard/frontend/js/agent-editor.js:180-181`
+
+**Interfaces:**
+- Consumes: Task 1's backend cap (client caps must never exceed the server's).
+- Produces: all three cash inputs accept up to 1,000,000.
+
+- [ ] **Step 1: app.js constant** — line 132 becomes:
+
+```js
+const MAX_AGENT_CASH_ALLOCATION = 1000000;
+```
+
+(`parseAgentCashAllocationInput` already builds its error strings from the constant via `toLocaleString()` — no other app.js change.)
+
+- [ ] **Step 2: app.html — all three cash inputs.** Replace the label text and `max` attribute in each of these pairs (external modal :571-572, builtin modal :608-609, editor header :759-760):
+
+```html
+<span>Initial cash (max $1,000,000)</span>
+<input id="externalAgentCashAllocation" type="number" min="0" max="1000000" step="1" value="1000" required aria-describedby="externalAgentCashHint">
+```
+
+```html
+<span>Initial cash (max $1,000,000)</span>
+<input id="builtinAgentCashAllocation" type="number" min="0" max="1000000" step="1" value="1000" required aria-describedby="builtinAgentCashHint">
+```
+
+```html
+<span class="agent-editor-cash-label">Initial cash (max $1,000,000)</span>
+<input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="1000000" step="1" placeholder="0" aria-label="Initial cash">
+```
+
+- [ ] **Step 3: agent-editor.js clamp** — in `getEditorState` (:180-181) replace:
+
+```js
+      if (value > 1000000) {
+        throw new Error('Initial cash cannot exceed $1,000,000.');
+      }
+```
+
+- [ ] **Step 4: Verify by grep (no build step, so drift is the failure mode)**
+
+Run: `grep -rn "3,000\|max=\"3000\"\|> 3000" dashboard/frontend/`
+Expected: no matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/app.js dashboard/frontend/app.html dashboard/frontend/js/agent-editor.js
+git commit -m "feat: raise frontend cash caps to \$1,000,000"
+```
+
+---
+
+### Task 4: Frontend — two category rows (Foundation Models / External Agents)
+
+**Files:**
+- Modify: `dashboard/frontend/app.html:717-724,740-742` (toolbar + grid)
+- Modify: `dashboard/frontend/app.js:632-657` (applyAgentFilters), `:659-665` (setAgentViewMode), `:707-714` (renderAgentsError), `:753-870` (renderAgentsGrid → renderAgentCards + renderAgentCategories), `:872-880` (document click closer), `:3789` (filter binding)
+- Modify: `dashboard/frontend/styles.css` (append)
+
+**Interfaces:**
+- Consumes: `agent_type` on each agent (`'builtin'` vs anything else), existing `decorateAgent`, `bindAgentCardMenus`, card renderers.
+- Produces: `renderAgentCategories(agents)` (called by `applyAgentFilters`), `renderAgentCards(grid, agents)`, `renderExternalPlaceholderCard(grid)`, `getDefaultAgentId()` / `setDefaultAgentId(id)` / `defaultAgentKey()` (used by Tasks 5-6), grid ids `agentsGridBuiltin` / `agentsGridExternal`.
+
+- [ ] **Step 1: app.html — remove the type-filter dropdown.** Delete lines 718-724 (the whole `<select id="agentFilterSelect">…</select>`), keeping the search box, view toggle, and Add Agent button.
+
+- [ ] **Step 2: app.html — replace the flat grid (lines 740-742) with two category sections:**
+
+```html
+                <div id="agentsCategories">
+                    <section class="agents-category" data-category="builtin">
+                        <div class="agents-category-head">
+                            <h3 class="agents-category-title">Foundation Models</h3>
+                            <p class="agents-category-sub">A prompting game — give it money, an instruction, and a model, then backtest.</p>
+                        </div>
+                        <div id="agentsGridBuiltin" class="agents-grid"></div>
+                        <p id="agentsEmptyBuiltin" class="control-helper" hidden>No foundation agents yet. Click <strong>Add Agent</strong> to create one.</p>
+                    </section>
+                    <section class="agents-category" data-category="external">
+                        <div class="agents-category-head">
+                            <h3 class="agents-category-title">External Agents</h3>
+                            <p class="agents-category-sub">Bring your own agent and connect it with an API key.</p>
+                        </div>
+                        <div id="agentsGridExternal" class="agents-grid"></div>
+                    </section>
+                </div>
+                <p id="agentsErrorState" class="control-helper" hidden style="color:#f87171;">Couldn't reach the server to load agents. Check your connection and try again.</p>
+```
+
+(The old `agentsGrid` and `agentsEmptyState` ids disappear; the external row's empty state is the placeholder card rendered by JS.)
+
+- [ ] **Step 3: app.js — default-pointer helpers.** Insert after the `AGENT_CASH_OVERRIDE_PREFIX` constant (line ~135):
+
+```js
+const DEFAULT_AGENT_KEY_PREFIX = 'default-agent-id:';
+
+function defaultAgentKey() {
+  return `${DEFAULT_AGENT_KEY_PREFIX}${window.BROWSER_OWNER_ID || 'anon'}`;
+}
+
+function getDefaultAgentId() {
+  try {
+    return localStorage.getItem(defaultAgentKey());
+  } catch (e) {
+    return null;
+  }
+}
+
+function setDefaultAgentId(agentId) {
+  try {
+    localStorage.setItem(defaultAgentKey(), agentId);
+  } catch (e) {
+    /* storage unavailable — badge simply won't persist */
+  }
+}
+```
+
+- [ ] **Step 4: app.js — simplify `applyAgentFilters` (:632-657).** The type filter is gone; search stays and filters both rows:
+
+```js
+function applyAgentFilters() {
+  const query = (document.getElementById('agentSearchInput')?.value || '').trim().toLowerCase();
+
+  let list = allAgents.map(decorateAgent);
+  if (query) {
+    list = list.filter(
+      (a) =>
+        String(a.name || '').toLowerCase().includes(query) ||
+        String(a.model_name || '').toLowerCase().includes(query),
+    );
+  }
+
+  renderAgentCategories(list);
+}
+```
+
+- [ ] **Step 5: app.js — split `renderAgentsGrid` (:753-870) into `renderAgentCards(grid, agents)` + `renderAgentCategories(agents)`.** `renderAgentCards` is the old body parameterized by `grid`, minus the empty/error handling (which moves to the category level):
+
+```js
+function renderAgentCards(grid, agents) {
+  grid.innerHTML = '';
+
+  agents.forEach((agent) => {
+    const isBuiltin = agent.agent_type === 'builtin';
+    const statusBadge = resolveAgentStatusBadge(agent);
+    const card = document.createElement('div');
+    card.className = `section-card agent-card agent-card--status agent-card--${statusBadge.key}${isBuiltin ? ' agent-card-builtin' : ''}`;
+    const model = escapeHtml(agent.model_name || 'local-model');
+    const type = escapeHtml(agentTypeLabel(agent));
+
+    card.innerHTML = `
+      <div class="agent-card-top">
+        <div class="agent-card-identity">
+          ${agentRobotIcon()}
+          <div class="agent-card-identity-text">
+            <h3 class="agent-name">${escapeHtml(agent.name)}</h3>
+            <p class="agent-card-submeta">${model} · ${type}</p>
+          </div>
+        </div>
+        <span class="status-badge ${statusBadge.className}"><span class="status-badge-dot" aria-hidden="true"></span>${statusBadge.label}</span>
+      </div>
+      ${renderAgentCardBody(agent, statusBadge.key)}
+      ${renderAgentCardActions(agent, statusBadge.key)}
+    `;
+    grid.appendChild(card);
+  });
+
+  bindAgentCardMenus(grid);
+  // …every existing grid.querySelectorAll(...) binding block from the old
+  // renderAgentsGrid (:794-869) stays here VERBATIM: .agent-edit-btn,
+  // .agent-open-btn, .agent-view-runs-btn, .agent-run-backtest-btn,
+  // .agent-rotate-key-btn, .agent-delete-btn. They already operate on the
+  // `grid` element and the `agents` argument, so they work unchanged.
+}
+```
+
+Then add the category renderer and the placeholder card:
+
+```js
+function renderAgentCategories(agents) {
+  const builtinGrid = document.getElementById('agentsGridBuiltin');
+  const externalGrid = document.getElementById('agentsGridExternal');
+  const errorEl = document.getElementById('agentsErrorState');
+  if (!builtinGrid || !externalGrid) return;
+
+  if (errorEl) errorEl.hidden = true; // a successful render clears any prior error
+
+  const defaultId = getDefaultAgentId();
+  const pinDefaultFirst = (list) =>
+    [...list].sort((a, b) => (b.agent_id === defaultId) - (a.agent_id === defaultId));
+
+  const builtin = pinDefaultFirst(agents.filter((a) => a.agent_type === 'builtin'));
+  const external = pinDefaultFirst(agents.filter((a) => a.agent_type !== 'builtin'));
+
+  renderAgentCards(builtinGrid, builtin);
+  renderAgentCards(externalGrid, external);
+
+  const builtinEmpty = document.getElementById('agentsEmptyBuiltin');
+  if (builtinEmpty) builtinEmpty.hidden = builtin.length > 0;
+  if (!external.length) renderExternalPlaceholderCard(externalGrid);
+}
+
+// Reserved entry point for connect-your-own agents: the connection mechanism
+// is still an open team decision, so this opens the existing creation flow.
+function renderExternalPlaceholderCard(grid) {
+  const card = document.createElement('div');
+  card.className = 'section-card agent-card agent-card--placeholder';
+  card.innerHTML = `
+    <div class="agent-card-identity-text">
+      <h3 class="agent-name">Connect your own agent</h3>
+      <p class="agent-card-submeta">Run your own trading agent against our backtests via an API key.</p>
+    </div>
+    <button class="agent-card-cta agent-card-cta--outline" type="button">Connect agent</button>`;
+  card.querySelector('button')?.addEventListener('click', openCreateExternalAgentModal);
+  grid.appendChild(card);
+}
+```
+
+- [ ] **Step 6: app.js — fix the three references to the old single grid.**
+
+`setAgentViewMode` (:659-665):
+
+```js
+function setAgentViewMode(mode) {
+  agentViewMode = mode === 'list' ? 'list' : 'grid';
+  document.querySelectorAll('.agents-section .agents-grid').forEach((grid) => {
+    grid.classList.toggle('agents-grid--list', agentViewMode === 'list');
+  });
+  document.getElementById('agentViewGrid')?.classList.toggle('active', agentViewMode === 'grid');
+  document.getElementById('agentViewList')?.classList.toggle('active', agentViewMode === 'list');
+}
+```
+
+`renderAgentsError` (:707-714):
+
+```js
+function renderAgentsError() {
+  const errorEl = document.getElementById('agentsErrorState');
+  document.querySelectorAll('.agents-section .agents-grid').forEach((grid) => {
+    grid.innerHTML = '';
+  });
+  const builtinEmpty = document.getElementById('agentsEmptyBuiltin');
+  if (builtinEmpty) builtinEmpty.hidden = true;
+  if (errorEl) errorEl.hidden = false;
+}
+```
+
+Document click-closer (:872-880) — change both selectors from `#agentsGrid …` to `.agents-grid …`:
+
+```js
+document.addEventListener('click', (event) => {
+  if (event.target.closest?.('.agent-card-menu')) return;
+  document.querySelectorAll('.agents-grid .agent-menu-dropdown').forEach((el) => {
+    el.hidden = true;
+  });
+  document.querySelectorAll('.agents-grid .agent-menu-toggle').forEach((el) => {
+    el.setAttribute('aria-expanded', 'false');
+  });
+});
+```
+
+- [ ] **Step 7: app.js — remove the dead filter binding.** Delete line 3789 (`document.getElementById('agentFilterSelect')?.addEventListener('change', applyAgentFilters);`).
+
+- [ ] **Step 8: styles.css — append category + placeholder styles** (dark theme, existing var names):
+
+```css
+/* My Agents — category rows (Demo 1) */
+.agents-category { margin-top: 28px; }
+.agents-category:first-child { margin-top: 8px; }
+.agents-category-head { margin-bottom: 14px; }
+.agents-category-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 2px;
+}
+.agents-category-sub {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin: 0;
+}
+.agent-card--placeholder {
+    border-style: dashed;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    justify-content: center;
+    align-items: flex-start;
+}
+```
+
+- [ ] **Step 9: Verify by serving the app.**
+
+Run: `~/atl-venv/bin/python -m uvicorn dashboard.backend.app:app` then open `http://localhost:8000/app`, go to My Agents.
+Checks: two labelled rows render below the allocation charts; builtin agents in the top row, external below; the External row shows the "Connect your own agent" dashed card when no external agents exist and its button opens the external-agent modal; search filters both rows; grid/list toggle affects both rows; the type dropdown is gone; card ⋮ menus open and close.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add dashboard/frontend/app.html dashboard/frontend/app.js dashboard/frontend/styles.css
+git commit -m "feat: group My Agents into Foundation Models and External Agents rows"
+```
+
+---
+
+### Task 5: Frontend — Configure button, Default badge, Set as default
+
+**Files:**
+- Modify: `dashboard/frontend/app.js` — `renderAgentCardActions` (:583-611), card markup + bindings inside `renderAgentCards` (from Task 4)
+- Modify: `dashboard/frontend/styles.css` (append)
+
+**Interfaces:**
+- Consumes: `getDefaultAgentId()` / `setDefaultAgentId()` (Task 4), `window.AgentEditor.open(agent)`.
+- Produces: `.agent-configure-btn` (primary entry to the editor — replaces the ⋮ Edit item), `.agent-set-default-btn` menu item, `.agent-default-badge` on the default agent's card.
+
+- [ ] **Step 1: `renderAgentCardActions` — add Configure above the primary CTA, swap Edit for Set as default:**
+
+```js
+function renderAgentCardActions(agent, statusKey) {
+  const id = escapeHtml(agent.agent_id);
+  let primary = '';
+  if (statusKey === 'paper') {
+    primary = `<button class="agent-card-cta agent-open-btn" type="button" data-agent-id="${id}">Open Agent</button>`;
+  } else if (statusKey === 'backtested') {
+    primary = `<button class="agent-card-cta agent-card-cta--outline agent-view-runs-btn" type="button" data-agent-id="${id}">View All Runs</button>`;
+  } else {
+    primary = `<button class="agent-card-cta agent-run-backtest-btn" type="button" data-agent-id="${id}">Run Backtest</button>`;
+  }
+  const configure = `<button class="agent-card-cta agent-card-cta--configure agent-configure-btn" type="button" data-agent-id="${id}">Configure</button>`;
+  const rotate =
+    agent.agent_type === 'builtin'
+      ? ''
+      : `<button class="agent-menu-item agent-rotate-key-btn" type="button" data-agent-id="${id}">New API key</button>`;
+  return `
+    <div class="agent-card-actions agent-card-actions--status">
+      ${configure}
+      ${primary}
+      <div class="agent-card-menu">
+        <button class="agent-menu-toggle" type="button" aria-label="More actions" aria-expanded="false" data-agent-id="${id}">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="6" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="18" cy="12" r="1.6"/></svg>
+        </button>
+        <div class="agent-menu-dropdown" hidden>
+          <button class="agent-menu-item agent-set-default-btn" type="button" data-agent-id="${id}">Set as default</button>
+          ${rotate}
+          <button class="agent-menu-item agent-menu-item--danger agent-delete-btn" type="button" data-agent-id="${id}">Delete</button>
+        </div>
+      </div>
+    </div>`;
+}
+```
+
+- [ ] **Step 2: Default badge in the card markup.** In `renderAgentCards` (Task 4), compute the default id once per call (add `const defaultId = getDefaultAgentId();` before the `agents.forEach`), then change the name line to:
+
+```js
+            <h3 class="agent-name">${escapeHtml(agent.name)}${agent.agent_id === defaultId ? ' <span class="agent-default-badge">Default</span>' : ''}</h3>
+```
+
+- [ ] **Step 3: Bindings.** In `renderAgentCards`, replace the old `.agent-edit-btn` binding block with `.agent-configure-btn` (same handler body), and add `.agent-set-default-btn`:
+
+```js
+  grid.querySelectorAll('.agent-configure-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const agent = agents.find((a) => a.agent_id === btn.dataset.agentId);
+      if (!agent || !window.AgentEditor) return;
+      navigateToPage('playground', { playgroundTab: 'agents' });
+      showPlaygroundPanel('agents');
+      window.AgentEditor.open(agent);
+    });
+  });
+
+  grid.querySelectorAll('.agent-set-default-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      setDefaultAgentId(btn.dataset.agentId);
+      applyAgentFilters(); // re-render: badge + pin move to the new default
+    });
+  });
+```
+
+- [ ] **Step 4: styles.css — append:**
+
+```css
+/* Configure CTA + Default badge (Demo 1) */
+.agent-card-cta--configure {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+}
+.agent-card-cta--configure:hover { border-color: var(--text-secondary); }
+.agent-default-badge {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 8px;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    vertical-align: middle;
+    color: #10b981;
+    border: 1px solid rgba(16, 185, 129, 0.45);
+    background: rgba(16, 185, 129, 0.12);
+}
+```
+
+- [ ] **Step 5: Verify by serving the app.**
+
+Checks: every card shows Configure above the old primary button; Configure opens the fullscreen editor for that agent; ⋮ menu shows Set as default / (New API key for external) / Delete — no Edit; Set as default moves the badge and pins that card first in its row after re-render.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/frontend/app.js dashboard/frontend/styles.css
+git commit -m "feat: first-class Configure button and per-user default agent badge"
+```
+
+---
+
+### Task 6: Frontend — auto-provision the default Foundation agent
+
+**Files:**
+- Modify: `dashboard/frontend/app.js` — new constants near line ~135, new `ensureDefaultFoundationAgent()`, wire into `loadAgents` (:983-1049)
+
+**Interfaces:**
+- Consumes: `API.post` / `API.get` / `API.patch` (:1377-1438), `getDefaultAgentId`/`setDefaultAgentId` (Task 4), `isDemoMode()` (:696).
+- Produces: on first visit with zero builtin agents, one real "My Foundation Agent" (DeepSeek V4 Pro) with a seeded 1-step `simple_instruction` pipeline; guard key prevents re-provision after deletion. Task 7 reads the same `SIMPLE_INSTRUCTION_*` constants (they live in agent-editor.js too — the two copies must stay byte-identical; see Global Constraints).
+
+- [ ] **Step 1: Constants** — insert after the `DEFAULT_AGENT_KEY_PREFIX` block from Task 4:
+
+```js
+const DEFAULT_AGENT_PROVISION_GUARD_PREFIX = 'default-agent-provisioned:';
+const DEFAULT_FOUNDATION_MODEL = 'deepseek/deepseek-v4-pro';
+const SIMPLE_INSTRUCTION_PRESET_KEY = 'simple_instruction';
+const SIMPLE_INSTRUCTION_OUTPUT_FORMAT =
+  'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }';
+const DEFAULT_STARTER_INSTRUCTION =
+  'Spread the money across a few of the strongest available stocks. Buy on meaningful dips, take profits after strong run-ups, and never put everything into one stock.';
+```
+
+- [ ] **Step 2: Provisioning function** — add above `loadAgents`:
+
+```js
+// First-visit onboarding: a brand-new owner gets one real Foundation agent so
+// the row is never empty. The guard key means "we provisioned once for this
+// browser identity" — deleting the agent must NOT resurrect it.
+let defaultAgentProvisionInFlight = false;
+
+async function ensureDefaultFoundationAgent(agents) {
+  if (isDemoMode()) return false;
+  if (agents.some((a) => a.agent_type === 'builtin')) return false;
+  const guardKey = `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}${window.BROWSER_OWNER_ID || 'anon'}`;
+  try {
+    if (localStorage.getItem(guardKey)) return false;
+  } catch (e) {
+    return false; // no storage → cannot guard → do not provision
+  }
+  if (defaultAgentProvisionInFlight) return false;
+  defaultAgentProvisionInFlight = true;
+  try {
+    const data = await API.post(`${API_BASE}/api/v1/agents`, {
+      name: 'My Foundation Agent',
+      model_name: DEFAULT_FOUNDATION_MODEL,
+      agent_type: 'builtin',
+      description: 'Your starter agent — configure it and run a backtest.',
+      cash_allocation: DEFAULT_AGENT_CASH_ALLOCATION,
+    });
+    const agent = data?.agent;
+    if (!agent?.agent_id) return false;
+    localStorage.setItem(guardKey, agent.agent_id);
+    try {
+      await API.patch(`${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`, {
+        pipeline: [
+          {
+            id: `sub_starter_${agent.agent_id}`,
+            presetKey: SIMPLE_INSTRUCTION_PRESET_KEY,
+            label: 'Trading instruction',
+            prompt: DEFAULT_STARTER_INSTRUCTION,
+            outputFormat: SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
+          },
+        ],
+      });
+    } catch (seedError) {
+      // Non-fatal: the agent exists; the editor just opens with a blank instruction.
+      console.warn('Starter instruction seed failed:', seedError.message);
+    }
+    if (!getDefaultAgentId()) setDefaultAgentId(agent.agent_id);
+    return true;
+  } catch (error) {
+    // Non-fatal: the row falls back to its empty state with the Add Agent CTA.
+    console.warn('Default agent provisioning skipped:', error.message);
+    return false;
+  } finally {
+    defaultAgentProvisionInFlight = false;
+  }
+}
+```
+
+- [ ] **Step 3: Wire into `loadAgents`.** Immediately after the demo-mode seeding block (`if (!agents.length && isDemoMode()) { … }`, :1020-1022) and before `allAgents = agents;`, insert:
+
+```js
+    if (await ensureDefaultFoundationAgent(agents)) {
+      try {
+        const refreshed = await API.get(`${API_BASE}/api/v1/agents`);
+        agents = refreshed.agents || agents;
+      } catch (refreshError) {
+        console.warn('Refresh after default-agent provisioning failed:', refreshError.message);
+      }
+    }
+```
+
+- [ ] **Step 4: Verify by serving the app.**
+
+In a fresh browser profile (or after `localStorage.clear()` in devtools): open `/app` → My Agents shows "My Foundation Agent" (DeepSeek V4 Pro, $1,000, Default badge) in the Foundation row. Delete it → row shows the empty-state CTA and the agent does NOT come back on reload (guard). In devtools, `localStorage` has `default-agent-provisioned:<uuid>` and `default-agent-id:<uuid>`. With `?demo=1`, no provisioning happens.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/app.js
+git commit -m "feat: auto-provision a default Foundation agent on first visit"
+```
+
+---
+
+### Task 7: Frontend — Simple ⇄ Advanced Configure screen + editable model
+
+**Files:**
+- Modify: `dashboard/frontend/app.html:748-807` (editor view)
+- Modify: `dashboard/frontend/js/agent-editor.js` (mode state, detection, simple panel, model select, save path)
+- Modify: `dashboard/frontend/styles.css` (append)
+
+**Interfaces:**
+- Consumes: Task 2's PATCH `model_name`; the create modal's `#builtinAgentModel` options (cloned so the two lists never drift); `SIMPLE_INSTRUCTION_*` values (byte-identical local copies — agent-editor.js is an IIFE and cannot see app.js file-scoped consts).
+- Produces: editor opens in Simple for empty/1-step-simple pipelines, Advanced otherwise; Simple save writes the 1-step pipeline; both modes save `model_name`. `window.AgentEditor` API unchanged.
+
+- [ ] **Step 1: app.html — editor header: model select + mode toggle.** Inside `agent-editor-title-wrap`, after the `agentEditorMeta` line (:756), add:
+
+```html
+                <label class="agent-editor-model-field" for="agentEditorModelSelect">
+                    <span class="agent-editor-model-label">Model</span>
+                    <select id="agentEditorModelSelect" class="agent-editor-model-select" aria-label="Agent model"></select>
+                </label>
+```
+
+Inside `agent-editor-header-actions` (:763), before the dirty badge, add:
+
+```html
+                <div class="agent-editor-mode-toggle" role="group" aria-label="Editor mode">
+                    <button id="agentEditorModeSimple" class="agent-editor-mode-btn" type="button">Simple</button>
+                    <button id="agentEditorModeAdvanced" class="agent-editor-mode-btn" type="button">Advanced</button>
+                </div>
+```
+
+- [ ] **Step 2: app.html — Simple panel + Advanced wrapper.** Inside `agent-editor-main` (:771), insert the Simple panel as the first child, and wrap the three existing Advanced elements (the intro card :772-780, `#agentEditorPipeline` :781, and the add-row :782-791) in a new `<div id="agentEditorAdvancedPanel">`:
+
+```html
+                <div class="agent-editor-main">
+                    <div id="agentEditorSimplePanel" class="agent-editor-simple section-card compact" hidden>
+                        <h3 class="agent-editor-intro-title">Trading instruction</h3>
+                        <p class="agent-editor-intro-text">Tell the agent how to trade in plain language. Each market hour it sees prices and its portfolio, follows your instruction, and decides what to buy or sell.</p>
+                        <textarea id="agentEditorSimpleInstruction" rows="6" maxlength="8000" placeholder="e.g. Spread the money across a few of the strongest available stocks. Buy on meaningful dips and take profits after strong run-ups." aria-label="Trading instruction"></textarea>
+                        <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note" hidden>This agent currently uses a multi-step pipeline. Saving in Simple mode replaces the pipeline with this one instruction.</p>
+                    </div>
+                    <div id="agentEditorAdvancedPanel">
+                        <!-- existing intro card, #agentEditorPipeline, and add-row move in here UNCHANGED -->
+                    </div>
+                    <p id="agentEditorSaveStatus" class="agent-editor-save-status" hidden></p>
+                    <p class="agent-editor-hint">Tip: use ↑↓ to reorder steps. Press <kbd>Ctrl</kbd>+<kbd>S</kbd> to save.</p>
+                </div>
+```
+
+(`agentEditorSaveStatus` and the hint stay outside the wrapper so save feedback is visible in both modes.)
+
+- [ ] **Step 3: agent-editor.js — constants + mode state.** After `CASH_OVERRIDE_PREFIX` (:10), add:
+
+```js
+  const SIMPLE_PRESET_KEY = 'simple_instruction';
+  // Must stay byte-identical to SIMPLE_INSTRUCTION_OUTPUT_FORMAT in app.js.
+  const SIMPLE_OUTPUT_FORMAT =
+    'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }';
+```
+
+Next to the `let currentAgent = null;` state block (:79-83), add:
+
+```js
+  let editorMode = 'simple';
+```
+
+- [ ] **Step 4: agent-editor.js — detection + stored-pipeline loader.** Add after `resolvePipeline` (:142-147):
+
+```js
+  function isSimplePipeline(pipeline) {
+    return (
+      !Array.isArray(pipeline) ||
+      pipeline.length === 0 ||
+      (pipeline.length === 1 && pipeline[0].presetKey === SIMPLE_PRESET_KEY)
+    );
+  }
+
+  // The pipeline the agent ACTUALLY has (backend row, then local cache) — with
+  // NO default-5-step substitution, so a fresh agent opens in Simple mode.
+  // Demo agents keep resolvePipeline's default behavior.
+  function loadStoredPipeline(agent) {
+    if (Array.isArray(agent.pipeline) && agent.pipeline.length) {
+      return agent.pipeline.map(normalizeLoadedSubAgent);
+    }
+    try {
+      const raw = localStorage.getItem(storageKey(agent.agent_id));
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed.subAgents) && parsed.subAgents.length) {
+          return parsed.subAgents.map(normalizeLoadedSubAgent);
+        }
+      }
+    } catch {
+      /* fall through to empty */
+    }
+    return [];
+  }
+```
+
+- [ ] **Step 5: agent-editor.js — mode switching.** Add after `renderPipeline` (:415):
+
+```js
+  function updateSimpleReplaceNote() {
+    const note = document.getElementById('agentEditorSimpleReplaceNote');
+    if (note) note.hidden = !(editorMode === 'simple' && subAgents.length > 1);
+  }
+
+  function setEditorMode(mode) {
+    editorMode = mode === 'advanced' ? 'advanced' : 'simple';
+    const simplePanel = document.getElementById('agentEditorSimplePanel');
+    const advancedPanel = document.getElementById('agentEditorAdvancedPanel');
+    const resetBtn = document.getElementById('agentEditorResetBtn');
+    if (simplePanel) simplePanel.hidden = editorMode !== 'simple';
+    if (advancedPanel) advancedPanel.hidden = editorMode !== 'advanced';
+    if (resetBtn) resetBtn.hidden = editorMode !== 'advanced';
+    document.getElementById('agentEditorModeSimple')?.classList.toggle('active', editorMode === 'simple');
+    document.getElementById('agentEditorModeAdvanced')?.classList.toggle('active', editorMode === 'advanced');
+    if (editorMode === 'advanced' && subAgents.length === 0) {
+      // First look at Advanced on a fresh agent: start from the default chain.
+      subAgents = defaultPipeline();
+      renderPipeline();
+    }
+    updateSimpleReplaceNote();
+    markDirtyFromInput();
+  }
+```
+
+- [ ] **Step 6: agent-editor.js — model select.** Add after `fillHeader` (:432):
+
+```js
+  function populateModelSelect(agent) {
+    const select = document.getElementById('agentEditorModelSelect');
+    if (!select) return;
+    select.innerHTML = '';
+    const seen = new Set();
+    const source = document.getElementById('builtinAgentModel');
+    if (source) {
+      Array.from(source.options).forEach((opt) => {
+        const clone = document.createElement('option');
+        clone.value = opt.value;
+        clone.textContent = opt.textContent;
+        select.appendChild(clone);
+        seen.add(opt.value);
+      });
+    }
+    const current = agent.model_name || 'local-model';
+    if (!seen.has(current)) {
+      // External / legacy models aren't in the curated list — keep them selectable.
+      const opt = document.createElement('option');
+      opt.value = current;
+      opt.textContent = current;
+      select.insertBefore(opt, select.firstChild);
+    }
+    select.value = current;
+  }
+```
+
+And in `fillHeader` (:428-431), the meta line no longer duplicates the model (the select owns it now):
+
+```js
+    if (meta) {
+      meta.textContent = agent.agent_type === 'builtin' ? 'Built-in agent' : 'External agent';
+    }
+```
+
+- [ ] **Step 7: agent-editor.js — `getEditorState` collects mode + model + instruction.** Replace the `return` block (:187-192) with:
+
+```js
+    const modelSelect = document.getElementById('agentEditorModelSelect');
+    let subAgentsOut;
+    if (editorMode === 'simple') {
+      const instruction = (
+        document.getElementById('agentEditorSimpleInstruction')?.value || ''
+      ).trim();
+      if (instruction) {
+        const existing =
+          subAgents.length === 1 && subAgents[0].presetKey === SIMPLE_PRESET_KEY
+            ? subAgents[0]
+            : null;
+        subAgentsOut = [
+          {
+            id: existing ? existing.id : newSubAgentId(),
+            presetKey: SIMPLE_PRESET_KEY,
+            label: 'Trading instruction',
+            prompt: instruction,
+            outputFormat: SIMPLE_OUTPUT_FORMAT,
+          },
+        ];
+      } else {
+        // Empty instruction never destroys an existing pipeline.
+        subAgentsOut = subAgents;
+      }
+    } else {
+      subAgentsOut = collectPipelineFromDom();
+    }
+    return {
+      name: nameInput ? nameInput.value.trim() : '',
+      description: descInput ? descInput.value.trim() : '',
+      cash_allocation,
+      model_name: modelSelect ? modelSelect.value : '',
+      subAgents: subAgentsOut,
+    };
+```
+
+- [ ] **Step 8: agent-editor.js — `open()` detects mode and fills the instruction.** Replace the top of `open` (:597-604) with:
+
+```js
+  function open(agent) {
+    if (!agent || !agent.agent_id) return;
+
+    currentAgent = { ...agent };
+    if (isDemoAgent(agent.agent_id)) {
+      subAgents = resolvePipeline(agent); // demo agents keep the legacy default chain
+    } else {
+      subAgents = loadStoredPipeline(agent);
+    }
+    fillHeader(agent);
+    populateModelSelect(agent);
+    const instructionEl = document.getElementById('agentEditorSimpleInstruction');
+    if (instructionEl) {
+      const simpleStep =
+        subAgents.length === 1 && subAgents[0].presetKey === SIMPLE_PRESET_KEY
+          ? subAgents[0]
+          : null;
+      instructionEl.value = simpleStep ? simpleStep.prompt : '';
+    }
+    renderPipeline();
+    setEditorMode(isSimplePipeline(subAgents) ? 'simple' : 'advanced');
+    refreshRunHistory(currentAgent);
+```
+
+(The rest of `open` — showing the view, `captureSavedSnapshot()`, focus — stays as-is. `captureSavedSnapshot` must remain AFTER the lines above so the snapshot includes mode-dependent state.)
+
+- [ ] **Step 9: agent-editor.js — thread `model_name` through save.** In `patchAgent` (:444-450), add the parameter and payload field:
+
+```js
+  async function patchAgent(agent, name, description, pipeline, cash_allocation, model_name) {
+    const payload = {
+      name,
+      description: description || null,
+      pipeline: serializePipeline(pipeline),
+      cash_allocation,
+    };
+    if (model_name) payload.model_name = model_name;
+```
+
+In `save()` (:698-705), pass it:
+
+```js
+      const updated = await patchAgent(
+        currentAgent,
+        state.name,
+        state.description,
+        subAgents,
+        state.cash_allocation,
+        state.model_name
+      );
+```
+
+Also in `save()`, right after `subAgents = state.subAgents;` (:654), add:
+
+```js
+    updateSimpleReplaceNote();
+```
+
+(after a Simple save the pipeline is 1-step, so the replace-warning must clear).
+
+- [ ] **Step 10: agent-editor.js — bind the toggle.** In `bindEvents` (:787), add:
+
+```js
+    document.getElementById('agentEditorModeSimple')?.addEventListener('click', () => setEditorMode('simple'));
+    document.getElementById('agentEditorModeAdvanced')?.addEventListener('click', () => setEditorMode('advanced'));
+```
+
+Update the file header comment (:1-4) to mention the two modes:
+
+```js
+/**
+ * agent-editor.js — Fullscreen agent Configure screen.
+ * Simple mode: capital + one plain-language instruction (stored as a 1-step
+ * pipeline) + model. Advanced mode: the multi-step sub-agent chain.
+ * Agent fields: PATCH /api/v1/agents/{id}. Pipeline cache: localStorage.
+ */
+```
+
+- [ ] **Step 11: styles.css — append:**
+
+```css
+/* Agent editor — Simple/Advanced modes (Demo 1) */
+.agent-editor-mode-toggle {
+    display: inline-flex;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+}
+.agent-editor-mode-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 6px 14px;
+    cursor: pointer;
+}
+.agent-editor-mode-btn.active {
+    background: var(--border-color);
+    color: var(--text-primary);
+}
+.agent-editor-model-field {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+}
+.agent-editor-model-label {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+.agent-editor-model-select {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    padding: 4px 8px;
+}
+.agent-editor-simple textarea {
+    width: 100%;
+    resize: vertical;
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    padding: 10px 12px;
+    margin-top: 10px;
+}
+.agent-editor-simple-note {
+    margin: 10px 0 0;
+    font-size: 0.8rem;
+    color: #fbbf24;
+}
+```
+
+- [ ] **Step 12: Verify by serving the app.**
+
+Checks (each against `http://localhost:8000/app`):
+1. Configure on the provisioned default agent → opens in **Simple** with the starter instruction, model select showing DeepSeek V4 Pro, cash 1000.
+2. Change model to GPT-5.5 + edit instruction + Save → "Saved successfully"; reload; both persist (model via Task 2's PATCH, instruction via pipeline).
+3. Toggle Advanced → the one `Trading instruction` step renders in the pipeline UI (custom-preset fallback); toggle back → instruction intact.
+4. Create a second builtin agent via Add Agent, open Configure, toggle Advanced on the fresh (empty) agent → default 5-step chain appears; Save; reopen → opens in **Advanced** (multi-step detection); switch to Simple → replace-note visible; Save with a non-empty instruction → pipeline is now 1 step; reopen → opens in Simple.
+5. In Simple mode with the instruction cleared (empty textarea) on the multi-step agent → Save → pipeline unchanged (note still shown).
+6. Ctrl+S saves in both modes; Escape closes; dirty badge appears on edits in both modes.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add dashboard/frontend/app.html dashboard/frontend/js/agent-editor.js dashboard/frontend/styles.css
+git commit -m "feat: Simple/Advanced Configure screen with editable model"
+```
+
+---
+
+### Task 8: End-to-end verification (exit criterion) + suite
+
+**Files:** none (verification only; fix-forward anything found, as its own commits)
+
+- [ ] **Step 1: Full backend suite**
+
+Run: `~/atl-venv/bin/python -m pytest dashboard/backend/tests/ -q`
+Expected: all green, including the three route-freeze guards (`test_full_route_contract_unchanged`, `test_backtests_router_contract`, `test_agent_router_route_contract_unchanged`) — no route was added, so they must pass untouched. If `test_deleted_shim_is_not_importable` fails with "DID NOT RAISE", that's the stale-`__pycache__` phantom: `rm -rf dashboard/backend/engines dashboard/backend/services` and re-run.
+
+- [ ] **Step 2: The exit-criterion click-through** (fresh browser profile / cleared localStorage, real backend, real `dashboard/.env` keys):
+
+1. Open `http://localhost:8000/app` → My Agents.
+2. **See** a default agent in the Foundation row (Default badge) and the Connect-your-own placeholder in the External row — no action needed.
+3. Press **Configure** on the default agent → Simple screen: money, instruction, model.
+4. Set cash 2,000, tweak the instruction, keep DeepSeek → Save.
+5. Back → **Run Backtest** → a result renders (equity curve + metrics). The decision log should show the instruction-driven pipeline step (1-step pipeline reaches `run_pipeline_decision`; a parse failure degrades to hold, which is acceptable but should be rare).
+6. Confirm the whole path needed **zero** knowledge of pipelines, presets, or JSON.
+
+- [ ] **Step 3: Regression spot-checks**
+
+- `?demo=1` still shows mock agents, grouped into the two rows, no auto-provision.
+- An existing multi-step agent (create one via Advanced) still round-trips through Run Backtest.
+- External-agent creation flow still works from the placeholder card and Add Agent.
+- Delete / rotate-key / set-default all reachable from ⋮.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin feat/my-agents-configure-run
+```
+
+PR title: `feat: My Agents configure-and-run rebuild (Demo 1)`. Body: 3-5 lines — two category rows, default agent, Configure button, Simple/Advanced editor, `model_name` PATCH + cap raise; link the spec file. Keep it concise per repo convention.

--- a/docs/superpowers/specs/2026-07-22-my-agents-configure-run-design.md
+++ b/docs/superpowers/specs/2026-07-22-my-agents-configure-run-design.md
@@ -1,0 +1,196 @@
+# My Agents "Configure & run" rebuild — design
+
+**Date:** 2026-07-22
+**Status:** Approved (design reviewed in session; decisions 1, 2, 4 of the Two-Demo Plan resolved)
+**Upstream:** ATL Two-Demo Plan (2026-07), Demo 1 — "Configure and run"
+**Branch:** `feat/my-agents-configure-run`
+
+## Goal
+
+A first-time, non-technical user opens My Agents, sees a default agent in each
+category row, presses **Configure**, sets money + one plain-language
+instruction + a model, presses **Run Backtest**, and gets a result — with no
+help. ATL's audience is people with money who want to trade, not tech geeks;
+today's tab fails that test (flat grid, editor hidden behind ⋮ → Edit, editor
+is a multi-step sub-agent pipeline, model frozen at creation, cash capped at
+$3,000).
+
+## Resolved decisions
+
+1. **Simple Configure screen** (capital / instruction / model) is the default
+   editor; today's multi-step pipeline moves behind an **Advanced** toggle.
+2. **Default Foundation agent = DeepSeek V4 Pro** (`deepseek/deepseek-v4-pro`),
+   the only leaderboard entry that beat the passive baselines. External row
+   gets a reserved placeholder card (the real connection mechanism is an open
+   teammate decision).
+3. **Capital ceiling raised**: `MAX_AGENT_CASH_ALLOCATION` 3,000 → 1,000,000
+   (default stays 1,000).
+
+## Component 1 — Two category rows
+
+*Files: `dashboard/frontend/app.html`, `dashboard/frontend/app.js`*
+
+Replace the flat `#agentsGrid` (app.html ~:740) + type-filter dropdown
+(~:718) with two labelled sections below the Capital Allocation charts:
+
+- **Foundation Models** (`agent_type: 'builtin'`) — subtitle: *"A prompting
+  game — give it money, an instruction, and a model, then backtest."*
+- **External Agents** (`agent_type: 'external'`) — subtitle: *"Bring your own
+  agent and connect it with an API key."*
+
+`renderAgentCategories()` replaces `renderAgentsGrid()` (app.js ~:753):
+partition decorated agents by `agent_type`, default agent pinned first in its
+row. Search still filters both rows; Add Agent and the card/list view toggle
+stay; the now-redundant type dropdown is removed. Empty-row states: Foundation
+never renders empty for a signed-in user (see Component 2); External shows the
+placeholder card.
+
+## Component 2 — Default agent per user (client-driven)
+
+*Files: `dashboard/frontend/app.js`*
+
+- **Foundation:** when an authenticated user's agent list contains zero
+  built-in agents, auto-provision one real agent via the existing
+  `POST /api/v1/agents`: name **"My Foundation Agent"**, model
+  `deepseek/deepseek-v4-pro`, cash 1,000, and a seeded one-step starter
+  instruction (stored per Component 4's storage model) so it opens in Simple
+  mode and runs immediately. Starter instruction text: *"Spread the money
+  across a few of the strongest available stocks. Buy on meaningful dips,
+  take profits after strong run-ups, and never put everything into one
+  stock."* A localStorage guard
+  (`default-agent-provisioned:<user>`) is set after the first provision so a
+  user who deletes the agent doesn't get it re-created. Failure to provision
+  (network/auth) is non-fatal: the row falls back to its empty state with a
+  "Create agent" call-to-action.
+- **Default badge & pointer:** the default agent carries a "Default" badge and
+  is pinned first. The pointer is a **new** localStorage key
+  (`default-agent-id:<user>`), deliberately distinct from the session-scoped
+  `active-agent-id` (app.js :11): "default" is which agent greets you,
+  "active" is which one you're working with right now. A "Set as default"
+  card action repoints it. Durable per-account default is a flagged backend
+  follow-up, out of scope.
+- **External:** a reserved placeholder card ("Connect your own agent") — no
+  real agent row is created. Its button opens the existing external-agent
+  creation flow. This reserves the row and the Configure entry point without
+  pre-deciding the key-flow direction.
+
+## Component 3 — First-class Configure button
+
+*Files: `dashboard/frontend/app.js`*
+
+Every agent card gets a **Configure** button rendered above "Run Backtest"
+(`renderAgentCardActions`, app.js ~:583). It opens the agent's editor
+directly (Simple mode per Component 4's detection rule). The hidden
+"⋮ → Edit" item is removed (Configure supersedes it); the ⋮ menu keeps
+rotate-key / delete / set-as-default.
+
+## Component 4 — Simple ⇄ Advanced Configure screen
+
+*Files: `dashboard/frontend/js/agent-editor.js`, `app.html`, `styles.css`*
+
+A mode toggle in the editor header (`#agentEditorView`, app.html ~:748).
+
+**Simple (default)** — three fields:
+- **Capital** — "How much should it trade?" (respects the new 1,000,000 cap).
+- **Instruction** — one plain-language textarea.
+- **Model** — dropdown, now **editable**, options cloned from the create
+  modal's `#builtinAgentModel` list so the two never drift.
+
+**Advanced** — today's multi-step pipeline UI, unchanged.
+
+### Storage model — Simple is a one-step pipeline (no migration)
+
+The instruction is stored as the agent's `pipeline` with exactly one step:
+
+```json
+[{
+  "id": "sub_…",
+  "presetKey": "simple_instruction",
+  "label": "Trading instruction",
+  "prompt": "<the user's plain-language instruction>",
+  "outputFormat": "JSON: { \"orders\": [{ \"symbol\": \"...\", \"side\": \"buy|sell|hold\", \"qty\": number, \"order_type\": \"market|limit\", \"limit_price\": number|null, \"reason\": \"...\" }] }"
+}]
+```
+
+The `outputFormat` is fixed and hidden in Simple mode — verbatim the proven
+`signal_to_execution` preset contract (agent-editor.js :42-43), which
+`pipeline_output_to_decision` (pipeline_runner.py :145) already normalizes
+into `{"actions": [...]}`. The backend pipeline runner gives a single step
+both the market snapshot and the execution rules (`_build_step_prompt`,
+pipeline_runner.py :91-142), so one instruction + this contract is a
+complete, working backtest driver. `presetKey: "simple_instruction"` is inert
+on the backend (only `post_trade_analysis` is special-cased) and unknown keys
+already fall back to the custom preset in the Advanced renderer.
+
+### Mode detection & switching
+
+- Open in **Simple** when the pipeline is empty or is exactly one
+  `simple_instruction` step; otherwise open in **Advanced**.
+- Advanced → Simple on a multi-step agent shows the instruction field empty
+  with an explicit notice: *"Saving in Simple mode replaces the pipeline with
+  one instruction."* Nothing is destroyed until the user saves.
+- Simple → Advanced shows the one step in the pipeline UI (falls back to the
+  custom preset renderer).
+
+### Save path
+
+Simple save calls the existing PATCH `/api/v1/agents/{id}` with
+`{name, description, pipeline: <1 step>, cash_allocation, model_name}` —
+`model_name` is the one new field (Component 5). Advanced save is unchanged
+plus `model_name`.
+
+## Component 5 — Backend (two changes; no migration, no new route)
+
+1. **`model_name` becomes PATCH-editable.** The `external_agents.model_name`
+   column already exists (repository.py :100). Add the optional field through
+   the chain, following the `_UNSET` sentinel pattern already used there:
+   - `UpdateAgentBody` (api/routers/agents.py :58-66) — validate against
+     non-empty string, max length matching the create path;
+   - `AgentService.update_agent` (domain/agents/service.py :179-197);
+   - `update_agent` in both repos: SQLite (domain/agents/repository.py
+     :457-505) and the Postgres twin (repository_postgres.py :414-456).
+   No route is added, so the three route-contract freeze tests stay green.
+2. **Cash cap:** `MAX_AGENT_CASH_ALLOCATION` 3,000 → 1,000,000 in
+   `domain/backtesting/constants.py` (:24-31). `resolve_initial_capital`
+   and the create/patch validators pick the constant up. Frontend: the two
+   hardcoded `max="3000"` inputs (app.html ~:609 create modal, ~:760 editor)
+   and their "(max $3,000)" labels, plus the editor's JS clamp
+   (agent-editor.js `getEditorState` :170-193) move to 1,000,000.
+
+## Data flow (end-to-end)
+
+Configure (Simple) → PATCH persists `pipeline` (1 step) + `model_name` +
+`cash_allocation` → Run Backtest (`runBacktest`, app.js ~:3180) already sends
+`model: agent.model_name` and `pipeline: loadAgentPipelineForBacktest(agent)`
+to `POST /backtest/run` → engine runs the pipeline path
+(`make_trading_decision_with_llm` precedence: pipeline first,
+portfolio_manager.py :290-366) → decision → result. No new wiring needed at
+run time.
+
+## Error handling
+
+- Pipeline step parse failure at run time already degrades to
+  `{"actions": []}` (hold) — unchanged, acceptable.
+- PATCH `model_name` rejects empty/oversized strings with 422 (Pydantic).
+- Default-agent provisioning failure is silent-but-visible: empty-row CTA
+  instead of a broken card; no retry loop.
+- Cash validation stays server-side authoritative (0..1,000,000), client
+  clamps mirror it.
+
+## Testing & verification
+
+- **Backend (pytest):** PATCH `model_name` round-trip (SQLite; Postgres twin
+  covered by the existing `@pg_only` pattern where applicable), `model_name`
+  absent-vs-null semantics under `_UNSET`, cap boundary cases (1,000,000
+  accepted, above rejected), full suite + the three route-freeze guards.
+- **Frontend (manual, no build step):** run `uvicorn dashboard.backend.app:app`
+  and click the exit-criterion path end-to-end: open My Agents → default agent
+  visible in each row → Configure → set money + instruction + model → Run
+  Backtest → result renders. Also: mode detection on a multi-step agent,
+  Simplify-replaces-pipeline warning, search across both rows.
+
+## Out of scope
+
+Advanced pipeline internals (kept, not deleted) · paper trading · the real
+External-Agent connection mechanism (open teammate decision) · durable
+per-account default (client-side for the demo; backend follow-up flagged).


### PR DESCRIPTION
Demo 1 ("configure & run"): a non-technical user opens My Agents, sees a default agent, presses Configure, sets money + one plain-language instruction + a model, and runs a backtest — unaided.

**Frontend**
- My Agents grouped into **Foundation Models** / **External Agents** rows (type-filter dropdown removed); "Connect your own agent" placeholder reserves the External row.
- First visit auto-provisions a default Foundation agent (DeepSeek V4 Pro, seeded starter instruction, "Default" badge; localStorage-guarded so deletion doesn't resurrect it).
- First-class **Configure** button on every card (replaces ⋮ → Edit); ⋮ gains "Set as default".
- Editor now has **Simple** (capital + one instruction + editable model) ⇄ **Advanced** (legacy multi-step pipeline, unchanged). The instruction is stored as a 1-step `simple_instruction` pipeline reusing the proven `orders` output contract — no new run-time wiring.

**Backend** (no new routes — freeze guards green; no migration)
- `PATCH /api/v1/agents/{id}` accepts optional `model_name` (SQLite + Postgres twins).
- `MAX_AGENT_CASH_ALLOCATION` 3,000 → 1,000,000 (default stays 1,000); frontend mirrors updated.

**Verification**: backend suite 1109 passed / 24 skipped; Playwright end-to-end click-through of the exit-criterion path (provisioning, Simple save/reload persistence incl. model round-trip, mode toggles, replace-warning, backtest run, `?demo=1` regression).

Notes: auto-provisioning keys on browser identity (demo visitors aren't logged in) with a client-side guard — server-side cap is a candidate follow-up. The new PG `update_agent` parity test is `@pg_only` (skips without `TEST_POSTGRES_URL`); the SQL delta mirrors the SQLite twin verbatim.

Spec: `docs/superpowers/specs/2026-07-22-my-agents-configure-run-design.md` · Plan: `docs/superpowers/plans/2026-07-22-my-agents-configure-run.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya39uNCr9z5JMJ94eNbYgo