### PR TITLE
fix(deps): bump mcp to 1.28.1 (3 HIGH Dependabot CVEs)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ jsonschema==4.25.1
 jsonschema-specifications==2025.4.1
 llvmlite==0.44.0
 matplotlib==3.11.0
-mcp==1.23.0
+mcp==1.28.1
 msgpack==1.2.1
 multidict==6.7.1
 networkx==3.5


### PR DESCRIPTION
Bumps `mcp==1.23.0` → `mcp==1.28.1` in `requirements.txt` to clear the 3 open **HIGH Dependabot alerts** (they auto-resolve on merge to the default branch).

| Dependabot alert | CVE | Fixed in |
|---|---|---|
| [74](https://github.com/Open-Finance-Lab/AgenticTrading/security/dependabot/74) | CVE-2026-59950 — MCP WebSocket transport lacks Host/Origin validation | 1.28.1 |
| [73](https://github.com/Open-Finance-Lab/AgenticTrading/security/dependabot/73) | CVE-2026-52869 — HTTP transports serve sessions without verifying principal | 1.27.2 |
| [72](https://github.com/Open-Finance-Lab/AgenticTrading/security/dependabot/72) | CVE-2026-52870 — experimental task handlers allow cross-client task access | 1.27.2 |

`1.28.1` is the first release patched for all three, and predates the breaking 2026-07-28 MCP spec (stays on the current pre-spec line).

**Why risk is low:** all three CVEs are MCP-*server* transport / task-handler issues. The shipping dashboard runs no MCP server and imports no `mcp` — only the separate `orchestration/` subsystem does, via its own `pyproject.toml`. Real exposure was already nil; the declared pin still had to move to clear the alerts.

**Verified:** pip resolver keeps every other pin unchanged (no transitive conflict); backend suite `1118 passed, 24 skipped`.

No CodeQL/code-scanning analysis is configured on the repo, so these Dependabot alerts are the only security/quality alerts to address.