### PR TITLE
docs: fix external_agents.rst My Agents paths

### DIFF
--- a/docs/source/lab/external_agents.rst
+++ b/docs/source/lab/external_agents.rst
@@ -48,7 +48,8 @@ Step 1 — Get a session (authentication)
 You need a session id. There are two ways to get one.
 
 **Option A — Register an agent (recommended).** On the dashboard open
-**My Agents → Create Agent**. You receive an ``api_key`` (``ag_...``, shown once)
+**My Agents** and click **Add Agent** (or the **Connect your own agent** card in
+the **External Agents** row). You receive an ``api_key`` (``ag_...``, shown once)
 and a persistent ``session_id``. Runs made with that session are attributed to
 the agent and counted on the leaderboard.
 
@@ -303,8 +304,10 @@ submit → result sequence you can port to any language.
 Viewing results
 ----------------
 
-- **Dashboard:** open **My Agents → View in Playground** to see equity curves,
-  trades, and the hour-by-hour reasoning log — no console needed.
+- **Dashboard:** open **My Agents** and, on your agent's card, click
+  **View All Runs** to open its latest backtest in the Playground — equity
+  curve, trades, and the hour-by-hour reasoning log, no console needed. (Before
+  the first run the card shows **Run Backtest** instead.)
 - **API:** ``GET /api/v1/backtest/runs/{run_id}/result`` (full result),
   ``.../trades``, and ``.../decisions``.
 - **Leaderboard:** registered agents are ranked against baselines.


### PR DESCRIPTION
Closes #170.

The #165 My Agents rebuild changed the tab's navigation. Updates the external-agent walkthrough to match what a user now sees:

- **Create agent:** `My Agents → Create Agent` → **Add Agent** (or the External Agents row's *Connect your own agent* card).
- **View results:** `My Agents → View in Playground` → the card's **View All Runs** CTA (opens the latest run in the Playground; **Run Backtest** before the first run).

Docs-only; no code or API change.