### PR TITLE
ci: add CodeQL security + quality scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+name: "ATL CodeQL config"
+
+# Query suite applied to every language in the matrix.
+#
+# `security-and-quality` is the broad suite: the security queries plus
+# maintainability/quality checks. It matches the "security and quality" intent
+# behind adding this scan, and is a superset of `security-extended`.
+#
+# Trade-off: on a repo that has never been scanned, the first run of this suite
+# can surface a large batch of *low-severity quality* findings (unused code,
+# style-ish issues) alongside the security ones. If that signal-to-noise is too
+# low, narrow this one line to `security-extended` (security only) or the
+# default suite — no other change needed.
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  # Built Vite bundle of the landing page: generated + minified, and its real
+  # source already lives in dashboard/landing/src. Scanning the bundle is pure
+  # noise and can crowd out findings on the hand-written frontend JS.
+  - dashboard/frontend/assets
+  # Vendored / generated JS is never our code to fix.
+  - "**/node_modules"
+  - "**/dist"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+name: CodeQL
+
+# Static security + quality analysis (GitHub CodeQL, advanced setup).
+#
+# This is intentionally a SEPARATE workflow from ci.yml and is NON-GATING:
+#   * The repo has no branch protection, so nothing blocks a merge on it.
+#   * The prod deploy in ci.yml gates only on `backend-tests`, not on this job.
+# Its purpose is to surface findings in the repo's Security > Code scanning tab
+# (the repo had no code scanning before this) — not to add a merge hurdle.
+#
+# Advanced setup (this file) is mutually exclusive with CodeQL "default setup"
+# in the Security tab UI: enabling default setup there would DISABLE this
+# workflow. Manage the scan here, in version control.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly re-scan (Mondays 06:31 UTC) so newly-published CodeQL queries
+    # run against existing code, not only against new commits.
+    - cron: "31 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF results to code scanning
+      packages: read # download the CodeQL query packs
+      actions: read # required on private repos; harmless on public
+      contents: read # checkout
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Python is the dominant surface (backend, orchestration, SDK).
+          - language: python
+            build-mode: none
+          # Hand-written frontend JS (some with XSS history) + the React/TS
+          # landing source. build-mode: none = analyze source directly.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,16 @@ on:
     # Weekly re-scan (Mondays 06:31 UTC) so newly-published CodeQL queries
     # run against existing code, not only against new commits.
     - cron: "31 6 * * 1"
+  # Manual re-run — e.g. after narrowing the query suite in codeql-config.yml —
+  # without having to push an empty commit.
+  workflow_dispatch:
+
+# Cancel a superseded run only on pull requests (github.ref = refs/pull/N/merge);
+# pushes to main keep every commit's scan, since code-scanning results are
+# tracked per-commit on the default branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:


### PR DESCRIPTION
Adds GitHub CodeQL (advanced setup) — the repo had **no code scanning** before, so security/quality issues never surfaced. Findings land in **Security → Code scanning**.

**Scope**
- Languages: `python` (backend / orchestration / SDK) + `javascript-typescript` (frontend JS + landing TS), both `build-mode: none`.
- Suite: `security-and-quality`. Excludes the built Vite bundle (`frontend/assets`) and vendored/generated JS.
- Triggers: push + PR to `main`, a weekly re-scan, plus manual `workflow_dispatch`.

**Non-gating by design:** separate workflow from `ci.yml`; prod deploy still gates only on `backend-tests`. This adds visibility, not a merge hurdle.

**Fork PRs:** GitHub gives fork-PR workflows a read-only token, so CodeQL results won't upload/post on PRs opened from forks — that code is covered by the push-to-`main` and weekly runs after merge. Expected GitHub behavior, non-gating.

Notes:
- First run of `security-and-quality` on a never-scanned repo may surface many low-severity *quality* findings alongside security ones. If too noisy, narrow one line in `.github/codeql/codeql-config.yml` to `security-extended`.
- Advanced setup here is mutually exclusive with UI "default setup".
- `concurrency` cancels superseded scans on PR pushes only; every `main` commit keeps its own scan.
