### PR TITLE
fix: escape exception text before rendering it as HTML

### DIFF
--- a/dashboard/backend/tests/test_frontend_xss_guards.py
+++ b/dashboard/backend/tests/test_frontend_xss_guards.py
@@ -1,0 +1,145 @@
+"""XSS guards for the vanilla-JS dashboard (CodeQL js/xss-through-exception #1098).
+
+``appendAlgoChatMessage`` renders into ``innerHTML`` so that ``**bold**`` markers
+survive, and every one of its callers feeds it text the server controls: an
+``err.message`` built from a backend ``detail`` / a backtest job's ``error``
+string (which embeds the subprocess stderr tail, and therefore the user's own
+team name), the raw LLM ``reply``, and the echoed ``team_name``. Unescaped, that
+is a script-injection sink.
+
+The frontend has no JS test harness, so these run the *real* functions lifted out
+of ``app.js`` under node — the extraction is brace-matched against the shipped
+source, so the tests break if the functions are renamed or deleted rather than
+silently passing against a stale copy. A source-level guard backs them up for the
+case where node is unavailable.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_JS = _FRONTEND / "app.js"
+_LEADERBOARD_JS = _FRONTEND / "js" / "leaderboard.js"
+
+# Payloads shaped like what actually reaches the chat bubble.
+_ATTACKS = [
+    "<img src=x onerror=alert(1)>",
+    "Error: <script>alert(document.cookie)</script>",
+    'Backtest failed (code 1): Traceback ... team "<svg onload=alert(1)>"',
+]
+
+
+def _extract_function(src: str, name: str) -> str:
+    """Return the source of ``function <name>(...) { ... }`` by brace matching."""
+    marker = f"function {name}("
+    start = src.index(marker)
+    depth = 0
+    i = src.index("{", start)
+    while True:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+
+
+def _run_renderer(inputs: list[str], entry: str = "renderAlgoChatHtml") -> list[str]:
+    """Execute the shipped escape+render functions in node against ``inputs``."""
+    src = _APP_JS.read_text(encoding="utf-8")
+    parts = [_extract_function(src, "escapeHtml")]
+    if entry != "escapeHtml":
+        parts.append(_extract_function(src, entry))
+    driver = "\n".join(
+        parts
+        + [
+            "const cases = JSON.parse(process.argv[1]);",
+            f"console.log(JSON.stringify(cases.map({entry})));",
+        ]
+    )
+    proc = subprocess.run(
+        ["node", "-e", driver, json.dumps(inputs)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+requires_node = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is required to execute app.js functions"
+)
+
+
+@requires_node
+def test_chat_bubble_neutralizes_injected_markup():
+    for attack, rendered in zip(_ATTACKS, _run_renderer(_ATTACKS)):
+        assert "<img" not in rendered, attack
+        assert "<script" not in rendered, attack
+        assert "<svg" not in rendered, attack
+        assert "&lt;" in rendered, attack
+
+
+@requires_node
+def test_chat_bubble_still_renders_bold_markers():
+    # The escaping must not cost the one bit of markup the bubble deliberately
+    # supports — otherwise the fix would be a regression the next dev reverts.
+    assert _run_renderer(["Strategy updated: **4 blocks**"]) == [
+        "Strategy updated: <strong>4 blocks</strong>"
+    ]
+
+
+@requires_node
+def test_chat_bubble_escapes_quotes_and_ampersands():
+    assert _run_renderer(['a & b "c"']) == ["a &amp; b &quot;c&quot;"]
+
+
+@requires_node
+def test_escape_html_neutralizes_markup():
+    """``escapeHtml`` is the shared primitive behind all three error sinks."""
+    assert _run_renderer(_ATTACKS, entry="escapeHtml") == [
+        "&lt;img src=x onerror=alert(1)&gt;",
+        "Error: &lt;script&gt;alert(document.cookie)&lt;/script&gt;",
+        "Backtest failed (code 1): Traceback ... team "
+        "&quot;&lt;svg onload=alert(1)&gt;&quot;",
+    ]
+
+
+def _inner_html_assignments(body: str) -> list[str]:
+    return [ln.strip() for ln in body.splitlines() if "innerHTML" in ln and "=" in ln]
+
+
+def test_paper_trading_error_escapes_the_exception_text():
+    """``displayPaperError`` is fed ``error.message`` — same sink class as #1098."""
+    body = _extract_function(_APP_JS.read_text(encoding="utf-8"), "displayPaperError")
+    assignments = _inner_html_assignments(body)
+    assert assignments
+    for line in assignments:
+        assert "escapeHtml(message)" in line, line
+
+
+def test_leaderboard_error_escapes_the_exception_text():
+    """``displayLeaderboardError`` is called with a bare ``error.message``."""
+    src = _LEADERBOARD_JS.read_text(encoding="utf-8")
+    body = _extract_function(src, "displayLeaderboardError")
+    assignments = _inner_html_assignments(body)
+    assert assignments
+    for line in assignments:
+        assert "escapeHtml(message)" in line, line
+
+
+def test_chat_bubble_never_assigns_unescaped_text_to_inner_html():
+    """Source guard: runs even where node is absent, so CI can never fail open."""
+    src = _APP_JS.read_text(encoding="utf-8")
+    body = _extract_function(src, "appendAlgoChatMessage")
+    for line in body.splitlines():
+        if "innerHTML" in line and "=" in line:
+            assert "renderAlgoChatHtml(" in line, line.strip()
+    # The pre-fix sink — raw text straight into innerHTML — must stay gone.
+    assert "innerHTML = text.replace(" not in " ".join(src.split())

--- a/dashboard/backend/tests/test_frontend_xss_guards.py
+++ b/dashboard/backend/tests/test_frontend_xss_guards.py
@@ -124,6 +124,19 @@ def test_paper_trading_error_escapes_the_exception_text():
         assert "escapeHtml(message)" in line, line
 
 
+def test_ticker_status_escapes_the_server_supplied_error():
+    """``showTickerStatus`` renders ``data.error`` from the market-quotes route.
+
+    Not exception text, so CodeQL stayed quiet — but it is the same
+    server-controlled-string-into-innerHTML sink.
+    """
+    body = _extract_function(_APP_JS.read_text(encoding="utf-8"), "showTickerStatus")
+    assignments = _inner_html_assignments(body)
+    assert assignments
+    for line in assignments:
+        assert "escapeHtml(message)" in line, line
+
+
 def test_leaderboard_error_escapes_the_exception_text():
     """``displayLeaderboardError`` is called with a bare ``error.message``."""
     src = _LEADERBOARD_JS.read_text(encoding="utf-8")

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1584,8 +1584,8 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=3"></script>
     <script src="js/agent-editor.js?v=8"></script>
-    <script src="app.js?v=28"></script>
-    <script src="js/leaderboard.js?v=13"></script>
+    <script src="app.js?v=29"></script>
+    <script src="js/leaderboard.js?v=14"></script>
     <script src="home-page.js?v=33"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -5249,7 +5249,7 @@ function displayPaperError(message) {
     
     const positionsList = document.getElementById('positionsList');
     if (positionsList) {
-        positionsList.innerHTML = `<div class="loading" style="color: var(--danger-color);">Error: ${message}</div>`;
+        positionsList.innerHTML = `<div class="loading" style="color: var(--danger-color);">Error: ${escapeHtml(message)}</div>`;
     }
 }
 
@@ -5301,6 +5301,19 @@ function highlightAlgoBlocks(updatedKeys) {
     }, 2500);
 }
 
+/**
+ * Render a chat bubble's text as HTML, supporting only `**bold**`.
+ *
+ * Escape first, then add the markup: every caller passes text the server
+ * controls (an `err.message` carrying a backend `detail` or a backtest job's
+ * stderr tail, the LLM's `reply`, the echoed `team_name`), so the raw string
+ * must never reach `innerHTML`. Escaping leaves `*` alone, so the bold markers
+ * still survive; the only live tags are the ones we generate here.
+ */
+function renderAlgoChatHtml(text) {
+    return escapeHtml(text).replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+}
+
 function appendAlgoChatMessage(text, role = 'bot') {
     const container = document.getElementById('algoChatMessages');
     if (!container) return;
@@ -5308,7 +5321,7 @@ function appendAlgoChatMessage(text, role = 'bot') {
     row.className = `algo-chat-msg ${role}`;
     const bubble = document.createElement('div');
     bubble.className = 'algo-chat-bubble';
-    bubble.innerHTML = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    bubble.innerHTML = renderAlgoChatHtml(text);
     row.appendChild(bubble);
     container.appendChild(row);
     container.scrollTop = container.scrollHeight;

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -2999,7 +2999,7 @@ function showTickerStatus(message) {
     stopTickerScroll();
     tickerTrack.dataset.tickerReady = '0';
     tickerTrack.style.transform = 'none';
-    tickerTrack.innerHTML = `<div class="ticker-placeholder">${message}</div>`;
+    tickerTrack.innerHTML = `<div class="ticker-placeholder">${escapeHtml(message)}</div>`;
 }
 
 /**

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -1015,7 +1015,9 @@ function transformLeaderboardChartData(curveValues, viewType, initialValue) {
 function displayLeaderboardError(message) {
   const tbody = document.getElementById('leaderboardTableBody');
   if (tbody) {
-    tbody.innerHTML = `<tr><td colspan="9" style="text-align: center; padding: 30px; color: var(--danger-color);">Error: ${message}</td></tr>`;
+    // `escapeHtml` is a global from app.js, which app.html loads first — the same
+    // contract js/leaderboard.js already relies on for API/API_BASE.
+    tbody.innerHTML = `<tr><td colspan="9" style="text-align: center; padding: 30px; color: var(--danger-color);">Error: ${escapeHtml(message)}</td></tr>`;
   }
 }
 


### PR DESCRIPTION
Closes CodeQL alert #1098 (`js/xss-through-exception`, medium).

`appendAlgoChatMessage` writes to `innerHTML` so `**bold**` renders, but every caller passes server-controlled text — `err.message` from a backend `detail` or the backtest job's `error` (which embeds the subprocess stderr tail, and therefore the user's own `--team-name`), the raw LLM `reply`, and the echoed `team_name`.

Fix: escape first, then apply the bold transform. Escaping leaves `*` alone, so the markers still work and the only live tags are ours.

Three sibling sinks had the same shape and CodeQL flagged none of them — fixed alongside rather than shipping a PR that hardens one line and leaves the copies next door:

- `displayPaperError` / `displayLeaderboardError` — bare `error.message` into `innerHTML`
- `showTickerStatus` — `data.error` from the market-quotes route (server-controlled, not exception text, so the query never fired)

Swept the remaining `innerHTML` interpolations too and left them alone with reasons: the universe chip is guarded by `/^[A-Z0-9]{1,5}$/`, the autocomplete reads the hardcoded `POPULAR_STOCKS` map, and every `clearTradingLog` caller passes a literal.

No JS harness here, so the tests brace-match the real functions out of `app.js` and execute them under node (present on `ubuntu-latest`), plus source guards that still run where node is absent. Escaping was mutation-verified: removing it fails the security assertions while the bold test keeps passing.

Suite: 1175 passed, 30 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3ZqUBXgzJ8RiCRKMEKGLV
