### PR TITLE
fix: address CodeQL baseline findings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -22,3 +22,9 @@ paths-ignore:
   # Vendored / generated JS is never our code to fix.
   - "**/node_modules"
   - "**/dist"
+  # Imported research code (NeurIPS 2025 FinAgent framework) — per CLAUDE.md a
+  # separate project, not wired into the shipping dashboard or deployed. Its
+  # first scan contributed 771 of 1079 alerts (including files that don't
+  # parse); scanning it buries the dashboard findings we act on. Excluding a
+  # path auto-closes its existing alerts on the next default-branch scan.
+  - orchestration

--- a/dashboard/backend/api/routers/market.py
+++ b/dashboard/backend/api/routers/market.py
@@ -38,8 +38,9 @@ async def get_ticker(symbols: str = "AAPL,NVDA,MSFT,BTC"):
             "timestamp": datetime.now().isoformat()
         }
     except Exception as e:
+        print(f"/ticker quote fetch failed: {e!r}")
         return {
             "success": False,
-            "error": str(e),
+            "error": "Failed to fetch market quotes",
             "quotes": []
         }

--- a/dashboard/backend/api/routers/paper_trading.py
+++ b/dashboard/backend/api/routers/paper_trading.py
@@ -61,9 +61,10 @@ async def get_paper_account():
                 "timestamp": datetime.now().isoformat()
             }
     except Exception as e:
+        print(f"/paper/account fetch failed: {e!r}")
         return {
             "success": False,
-            "error": str(e),
+            "error": "Failed to fetch account",
             "timestamp": datetime.now().isoformat()
         }
 
@@ -117,9 +118,10 @@ async def get_paper_positions():
             "cached": False
         }
     except Exception as e:
+        print(f"/paper/positions fetch failed: {e!r}")
         return {
             "success": False,
-            "error": str(e),
+            "error": "Failed to fetch positions",
             "positions": [],
             "timestamp": datetime.now().isoformat()
         }
@@ -175,9 +177,10 @@ async def get_paper_trades(limit: int = 50):
             "cached": False
         }
     except Exception as e:
+        print(f"/paper/trades fetch failed: {e!r}")
         return {
             "success": False,
-            "error": str(e),
+            "error": "Failed to fetch trades",
             "trades": [],
             "timestamp": datetime.now().isoformat()
         }
@@ -240,9 +243,10 @@ async def get_paper_portfolio_history(timeframe: str = "1D"):
                 "timestamp": datetime.now().isoformat()
             }
     except Exception as e:
+        print(f"/paper/portfolio-history fetch failed: {e!r}")
         return {
             "success": False,
-            "error": str(e),
+            "error": "Failed to fetch portfolio history",
             "equity_curve": [],
             "timestamp": datetime.now().isoformat()
         }
@@ -269,9 +273,11 @@ async def start_paper_session(agent_name: str = "Agent"):
         if account:
             initial_equity = account.get("equity", 100000)
             
-            # Create run record in database
+            # Create run record in database. The paper flow has no separate
+            # protocol session, so the run doubles as its own session.
             db.insert_run(
                 run_id=run_id,
+                session_id=run_id,
                 agent_name=agent_name,
                 mode="paper",
                 start_date=datetime.now().isoformat(),
@@ -293,9 +299,10 @@ async def start_paper_session(agent_name: str = "Agent"):
                 "timestamp": datetime.now().isoformat()
             }
     except Exception as e:
+        print(f"/paper/start-session failed: {e!r}")
         return {
             "success": False,
-            "error": str(e),
+            "error": "Failed to start paper trading session",
             "timestamp": datetime.now().isoformat()
         }
 
@@ -352,9 +359,10 @@ async def get_paper_baselines(days: int = 31):
                 "timestamp": datetime.now().isoformat()
             }
     except Exception as e:
+        print(f"/paper/baselines fetch failed: {e!r}")
         return {
             "success": False,
-            "error": str(e),
+            "error": "Failed to fetch baselines",
             "baselines": {},
             "timestamp": datetime.now().isoformat()
         }

--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -328,10 +328,14 @@ async def serve_market_events_js(file_name: str):
 @app.get("/images/{file_name}", include_in_schema=False)
 async def serve_image(file_name: str):
     """Serve image files from the images directory."""
-    image_path = frontend_path / "images" / file_name
-    if not image_path.exists():
+    if "/" in file_name or "\\" in file_name:
         raise HTTPException(status_code=404, detail="Image not found")
-    
+
+    image_path = (frontend_path / "images" / file_name).resolve()
+    images_dir = (frontend_path / "images").resolve()
+    if not image_path.is_file() or images_dir not in image_path.parents:
+        raise HTTPException(status_code=404, detail="Image not found")
+
     # Determine media type based on file extension
     ext = image_path.suffix.lower()
     media_types = {

--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -333,7 +333,7 @@ async def serve_image(file_name: str):
 
     image_path = (frontend_path / "images" / file_name).resolve()
     images_dir = (frontend_path / "images").resolve()
-    if not image_path.is_file() or images_dir not in image_path.parents:
+    if not image_path.is_file() or not image_path.is_relative_to(images_dir):
         raise HTTPException(status_code=404, detail="Image not found")
 
     # Determine media type based on file extension

--- a/dashboard/backend/baselines_endpoint.py
+++ b/dashboard/backend/baselines_endpoint.py
@@ -52,8 +52,9 @@ def get_baselines_from_db() -> Dict:
             }
     
     except Exception as e:
+        print(f"Paper baselines fetch failed: {e!r}")
         return {
             "success": False,
-            "error": str(e),
+            "error": "Failed to fetch baselines",
             "baselines": {}
         }

--- a/dashboard/backend/domain/backtesting/algo_service.py
+++ b/dashboard/backend/domain/backtesting/algo_service.py
@@ -191,9 +191,9 @@ JSON schema:
             "updated_blocks": updated,
         }
     except Exception as exc:
-        print(f"LLM chat error: {exc}")
+        print(f"LLM chat error: {exc!r}")
         fallback = _process_chat_fallback(message, current)
-        fallback["reply"] += f"\n\n(LLM unavailable: {exc}. Used rule-based fallback.)"
+        fallback["reply"] += "\n\n(LLM unavailable — used rule-based fallback.)"
         return fallback
 
 

--- a/dashboard/backend/infrastructure/market_data/quotes.py
+++ b/dashboard/backend/infrastructure/market_data/quotes.py
@@ -10,6 +10,7 @@ logging are unchanged; only the module location moved.
 
 import json
 import os
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
@@ -22,6 +23,15 @@ from dashboard.backend.paths import CREDENTIALS_DIR
 
 TICKER_CACHE_TTL_SECONDS = 30
 _ticker_cache: Dict[str, Tuple[float, List[Dict]]] = {}
+
+# Symbols are interpolated into Alpaca URL paths, so anything outside a real
+# ticker's alphabet (letters, digits, "." and "-", e.g. BRK.B / BF-B) could
+# steer the request to a different endpoint under the server's API key.
+_SYMBOL_RE = re.compile(r"^[A-Za-z0-9.\-]{1,12}$")
+
+
+def _is_valid_symbol(symbol: str) -> bool:
+    return bool(_SYMBOL_RE.match(symbol or ""))
 
 
 def _extract_price_from_quote(quote: dict) -> Optional[float]:
@@ -125,6 +135,9 @@ class AlpacaMarketData:
             Dict with keys: symbol, price, changePercent, timestamp
             changePercent is percentage change vs previous day's close
         """
+        if not _is_valid_symbol(symbol):
+            print(f"❌ Rejected invalid symbol for quote fetch: {symbol!r}")
+            return None
         try:
             # Use Alpaca Data API endpoint
             url = f"{self.data_api_url}/v2/stocks/{symbol}/quotes/latest"
@@ -225,6 +238,9 @@ class AlpacaMarketData:
         2. If IEX fails, try SIP with delayed end time (15+ mins ago)
         3. If both fail, return None
         """
+        if not _is_valid_symbol(symbol):
+            print(f"❌ Rejected invalid symbol for previous-close fetch: {symbol!r}")
+            return None
         try:
             from datetime import datetime, timedelta
             

--- a/dashboard/backend/tests/infrastructure/market_data/test_quotes.py
+++ b/dashboard/backend/tests/infrastructure/market_data/test_quotes.py
@@ -337,3 +337,31 @@ def test_quotes_module_has_no_api_or_scripts_imports():
     for m in mods:
         assert not m.startswith("dashboard.backend.api"), m
         assert not m.startswith("dashboard.scripts"), m
+
+
+# ---------------------------------------------------------------------------
+# Symbol validation (CodeQL py/partial-ssrf #48–#50). ``symbol`` arrives from
+# ``/ticker?symbols=`` and is interpolated into the Alpaca URL path, so a
+# crafted "symbol" could steer the request to a different endpoint under the
+# server's API key. URL-breaking symbols must be rejected before any request.
+# ---------------------------------------------------------------------------
+
+
+def test_get_quote_rejects_url_breaking_symbols(md, fake_requests):
+    assert md.get_quote("../../v1/account") is None
+    assert md.get_quote("AAPL?feed=sip") is None
+    assert md.get_quote("AAPL#frag") is None
+    assert md.get_quote("") is None
+    assert fake_requests.calls == []
+
+
+def test_prev_close_rejects_url_breaking_symbols(md, fake_requests):
+    assert md._get_previous_close("../../v1/account") is None
+    assert fake_requests.calls == []
+
+
+def test_get_quote_still_requests_dotted_and_hyphenated_tickers(md, fake_requests):
+    # Real ticker classes the allowlist must not break (BRK.B, BF-B style).
+    md.get_quote("BRK.B")
+    md.get_quote("BF-B")
+    assert len(fake_requests.calls) >= 2

--- a/dashboard/backend/tests/test_error_detail_sanitization.py
+++ b/dashboard/backend/tests/test_error_detail_sanitization.py
@@ -1,0 +1,81 @@
+"""Exception text must not reach API response bodies (CodeQL py/stack-trace-exposure).
+
+The ``{"error": str(e)}`` envelope in the paper-trading/market routers hands raw
+exception text (filesystem paths, library internals, credential fragments) to
+any unauthenticated caller — and #1098 already demonstrated those strings feed
+frontend ``innerHTML`` sinks. Convention: ``print()`` the detail server-side
+(the repo's real logging channel — ``logger.*`` is invisible under the deployed
+config) and return a generic, route-specific message.
+"""
+
+import re
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+from dashboard.backend.api.routers import market as market_mod
+from dashboard.backend.api.routers import paper_trading as paper_mod
+from dashboard.backend.domain.backtesting import algo_service
+
+client = TestClient(app)
+
+_MARKER = "TRACE-MARKER /opt/render/project/secret_config.py line 42"
+
+
+class _ExplodingClient:
+    def __init__(self):
+        raise RuntimeError(_MARKER)
+
+
+def test_ticker_error_body_hides_exception_detail(monkeypatch):
+    def boom(symbols):
+        raise RuntimeError(_MARKER)
+
+    monkeypatch.setattr(market_mod, "get_market_quotes", boom)
+    data = client.get("/ticker?symbols=AAPL").json()
+    assert data["success"] is False
+    assert "TRACE-MARKER" not in str(data)
+    assert data["error"]  # still tells the client *something* went wrong
+
+
+def test_paper_account_error_body_hides_exception_detail(monkeypatch):
+    monkeypatch.setattr(paper_mod, "AlpacaPaperTradingClient", _ExplodingClient)
+    data = client.get("/paper/account").json()
+    assert data["success"] is False
+    assert "TRACE-MARKER" not in str(data)
+
+
+def test_paper_start_session_error_body_hides_exception_detail(monkeypatch):
+    monkeypatch.setattr(paper_mod, "AlpacaPaperTradingClient", _ExplodingClient)
+    data = client.post("/paper/start-session").json()
+    assert data["success"] is False
+    assert "TRACE-MARKER" not in str(data)
+
+
+def test_llm_chat_fallback_reply_hides_exception_detail(monkeypatch):
+    """``process_chat`` appended ``str(exc)`` to the user-visible reply."""
+
+    class _Messages:
+        def create(self, **kwargs):
+            raise RuntimeError(_MARKER)
+
+    class _Client:
+        messages = _Messages()
+
+    monkeypatch.setattr(algo_service, "_get_anthropic_client", lambda: _Client())
+    result = algo_service.process_chat("use momentum", None)
+    assert "TRACE-MARKER" not in result["reply"]
+    # The degraded mode must still be communicated, just without internals.
+    assert "fallback" in result["reply"].lower()
+
+
+def test_routers_never_return_raw_exception_text():
+    """Source guard: the ``"error": str(e)`` envelope pattern must stay gone."""
+    routers = Path(market_mod.__file__).resolve().parent
+    offenders = []
+    for path in sorted(routers.glob("*.py")):
+        src = path.read_text(encoding="utf-8")
+        if re.search(r'"error":\s*str\(', src):
+            offenders.append(path.name)
+    assert offenders == []

--- a/dashboard/backend/tests/test_frontend_xss_guards.py
+++ b/dashboard/backend/tests/test_frontend_xss_guards.py
@@ -156,3 +156,98 @@ def test_chat_bubble_never_assigns_unescaped_text_to_inner_html():
             assert "renderAlgoChatHtml(" in line, line.strip()
     # The pre-fix sink — raw text straight into innerHTML — must stay gone.
     assert "innerHTML = text.replace(" not in " ".join(src.split())
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard table & detail panel (CodeQL js/incomplete-sanitization #4).
+# ``entry.model`` / ``entry.team_name`` come from the leaderboard API — agent
+# names are user-registered, so the table is a stored-XSS surface. The row and
+# detail templates must escape every string field, and the inline onclick id
+# needs JS-string escaping *before* HTML-attribute escaping (backslash first,
+# or a trailing "\" un-escapes the closing quote).
+# ---------------------------------------------------------------------------
+
+_HOSTILE_ENTRY = {
+    "entry_id": "x'); globalThis.pwned = 1; ('",
+    "team_name": "<img src=x onerror=alert(1)>",
+    "model": '<svg onload=alert(2)> "quoted" & more',
+    "team_badge": "<script>alert(3)</script>",
+    "cumulative_return": 0.1,
+    "portfolio_value": 100000,
+    "sharpe_ratio": 1.5,
+    "max_drawdown": -0.2,
+    "rank": 1,
+}
+
+
+def _run_leaderboard_driver(js_body: str) -> dict:
+    app_src = _APP_JS.read_text(encoding="utf-8")
+    src = _LEADERBOARD_JS.read_text(encoding="utf-8")
+    driver = "\n".join(
+        [
+            _extract_function(app_src, "escapeHtml"),
+            _extract_function(src, "formatEntryBadge"),
+            _extract_function(src, "formatLeaderboardNumber"),
+            _extract_function(src, "renderLeaderboardRowHtml"),
+            _extract_function(src, "renderLeaderboardDetailHtml"),
+            "const entry = JSON.parse(process.argv[1]);",
+            js_body,
+        ]
+    )
+    proc = subprocess.run(
+        ["node", "-e", driver, json.dumps(_HOSTILE_ENTRY)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+@requires_node
+def test_leaderboard_row_escapes_every_string_field():
+    out = _run_leaderboard_driver(
+        "console.log(JSON.stringify({html: renderLeaderboardRowHtml(entry)}));"
+    )
+    html = out["html"]
+    for raw in ("<img", "<svg", "<script"):
+        assert raw not in html, html
+    assert "&lt;svg" in html  # the label rendered, escaped, not dropped
+
+
+@requires_node
+def test_leaderboard_row_onclick_round_trips_hostile_ids():
+    # Decode the onclick attribute exactly as a browser would, execute it with
+    # a recording stub, and prove the hostile id arrives intact as a *string*
+    # argument instead of executing.
+    out = _run_leaderboard_driver(
+        """
+const html = renderLeaderboardRowHtml(entry);
+const attr = /onclick="([^"]*)"/.exec(html)[1];
+const decoded = attr
+  .replace(/&quot;/g, '"').replace(/&#0?39;/g, "'")
+  .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+let captured = null;
+new Function('selectLeaderboardTeam', decoded)((id) => { captured = id; });
+console.log(JSON.stringify({captured, pwned: globalThis.pwned ?? null}));
+"""
+    )
+    assert out["pwned"] is None
+    assert out["captured"] == _HOSTILE_ENTRY["entry_id"]
+
+
+@requires_node
+def test_leaderboard_detail_panel_escapes_string_fields():
+    out = _run_leaderboard_driver(
+        "console.log(JSON.stringify({html: renderLeaderboardDetailHtml(entry, 12)}));"
+    )
+    html = out["html"]
+    for raw in ("<img", "<svg", "<script"):
+        assert raw not in html, html
+
+
+def test_leaderboard_table_and_detail_use_the_renderers():
+    """Source guard (node-free): the templates must stay in the pure renderers."""
+    src = _LEADERBOARD_JS.read_text(encoding="utf-8")
+    assert "renderLeaderboardRowHtml" in _extract_function(src, "populateLeaderboardTable")
+    assert "renderLeaderboardDetailHtml(" in _extract_function(src, "selectLeaderboardTeam")

--- a/dashboard/backend/tests/test_paper_start_session.py
+++ b/dashboard/backend/tests/test_paper_start_session.py
@@ -1,0 +1,34 @@
+"""POST /paper/start-session must actually record the run (CodeQL py/call/wrong-arguments #67).
+
+``BacktestDatabase.insert_run`` requires ``session_id``; the route omitted it,
+so every credentialed start-session raised ``TypeError`` — swallowed by the
+``except Exception`` envelope into ``{"success": False}``. The endpoint could
+never have succeeded; it only ever ran with live Alpaca credentials, which is
+why nothing caught it.
+"""
+
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+from dashboard.backend.api.routers import paper_trading as paper_mod
+from dashboard.backend.database import db
+
+client = TestClient(app)
+
+
+class _FakeAlpacaClient:
+    def get_account(self):
+        return {"equity": 55555.0, "cash": 55555.0}
+
+
+def test_start_session_succeeds_and_records_run(monkeypatch):
+    monkeypatch.setattr(paper_mod, "AlpacaPaperTradingClient", _FakeAlpacaClient)
+    data = client.post(
+        "/paper/start-session", params={"agent_name": "guard-test"}
+    ).json()
+    assert data["success"] is True, data
+    assert data["initial_equity"] == 55555.0
+    run = db.get_run(data["run_id"])
+    assert run is not None
+    assert run["mode"] == "paper"
+    assert run["agent_name"] == "guard-test"

--- a/dashboard/backend/tests/test_static_file_guards.py
+++ b/dashboard/backend/tests/test_static_file_guards.py
@@ -1,0 +1,35 @@
+"""``/images/{file_name}`` must reject path-separator names like its siblings.
+
+Every other static route in ``app.py`` refuses names containing "/" or "\\"
+and containment-checks the resolved path; ``/images`` did neither (CodeQL
+py/path-injection #46/#47). Starlette path params never match a decoded "/",
+and on POSIX a backslash is an ordinary filename character — so the practical
+gap is Windows checkouts — but the guard must be uniform, not platform-lucky.
+"""
+
+from fastapi.testclient import TestClient
+
+from dashboard.backend import app as app_mod
+
+
+def _client_with_frontend(tmp_path, monkeypatch):
+    images = tmp_path / "images"
+    images.mkdir()
+    (images / "ok.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    # A literal backslash is a valid POSIX filename character, which lets this
+    # test observe the guard's behavior without Windows path semantics.
+    (images / "..\\..\\evil.png").write_bytes(b"not-an-image")
+    monkeypatch.setattr(app_mod, "frontend_path", tmp_path)
+    return TestClient(app_mod.app)
+
+
+def test_images_serves_plain_names(tmp_path, monkeypatch):
+    client = _client_with_frontend(tmp_path, monkeypatch)
+    resp = client.get("/images/ok.png")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+
+
+def test_images_rejects_separator_names_even_when_a_file_matches(tmp_path, monkeypatch):
+    client = _client_with_frontend(tmp_path, monkeypatch)
+    assert client.get("/images/..%5C..%5Cevil.png").status_code == 404

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1585,7 +1585,7 @@
     <script src="js/portfolio.js?v=3"></script>
     <script src="js/agent-editor.js?v=8"></script>
     <script src="app.js?v=29"></script>
-    <script src="js/leaderboard.js?v=14"></script>
+    <script src="js/leaderboard.js?v=15"></script>
     <script src="home-page.js?v=33"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -576,31 +576,28 @@ function getFilteredLeaderboardEntries() {
   return entries;
 }
 
-function populateLeaderboardTable() {
-  const tbody = document.getElementById('leaderboardTableBody');
-  if (!tbody) return;
+// `entry.model` / `entry.team_name` are user-registered agent names, so every
+// string field must go through `escapeHtml` (a global from app.js, loaded
+// first). The onclick id additionally needs JS-string escaping — backslash
+// before quote, or a trailing "\" would un-escape the closing quote — and the
+// JS-escaped result is then HTML-escaped for the attribute context.
+function renderLeaderboardRowHtml(entry) {
+  const safeId = escapeHtml(
+    String(entry.entry_id || entry.team_name).replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+  );
+  const entryLabel = escapeHtml(entry.model || entry.team_name || '—');
+  const ret = Number(entry.cumulative_return || 0);
+  const retClass = ret >= 0 ? 'return-positive' : 'return-negative';
+  const ddRaw = Number(entry.max_drawdown || 0);
+  const dd = (Math.abs(ddRaw) * 100).toFixed(2);
 
-  const filtered = getFilteredLeaderboardEntries();
-  if (!filtered.length) {
-    tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;padding:24px;color:var(--text-secondary);">No leaderboard entries yet. Baselines compute on first load (requires market data).</td></tr>';
-    return;
-  }
-
-  tbody.innerHTML = filtered.map((entry) => {
-    const safeId = String(entry.entry_id || entry.team_name).replace(/'/g, "\\'");
-    const entryLabel = entry.model || entry.team_name || '—';
-    const ret = Number(entry.cumulative_return || 0);
-    const retClass = ret >= 0 ? 'return-positive' : 'return-negative';
-    const ddRaw = Number(entry.max_drawdown || 0);
-    const dd = (Math.abs(ddRaw) * 100).toFixed(2);
-
-    return `
+  return `
       <tr onclick="selectLeaderboardTeam('${safeId}')">
-        <td class="rank-cell">${entry.rank}</td>
+        <td class="rank-cell">${escapeHtml(entry.rank)}</td>
         <td>
           <div class="team-name-badge">
             <span>${entryLabel}</span>
-            <span class="team-badge">${formatEntryBadge(entry.team_badge)}</span>
+            <span class="team-badge">${escapeHtml(formatEntryBadge(entry.team_badge))}</span>
           </div>
         </td>
         <td style="text-align: right; font-family: var(--font-mono);">$${formatLeaderboardNumber(entry.portfolio_value)}</td>
@@ -611,30 +608,33 @@ function populateLeaderboardTable() {
         <td style="text-align: right; font-family: var(--font-mono);">${dd}%</td>
       </tr>
     `;
-  }).join('');
 }
 
-function selectLeaderboardTeam(entryId) {
-  const entries = leaderboardPayload?.entries || [];
-  selectedLeaderboardEntry =
-    entries.find((e) => String(e.entry_id) === String(entryId)) ||
-    entries.find((e) => e.team_name === entryId);
-  if (!selectedLeaderboardEntry) return;
+function populateLeaderboardTable() {
+  const tbody = document.getElementById('leaderboardTableBody');
+  if (!tbody) return;
 
-  const entry = selectedLeaderboardEntry;
-  const detailPanel = document.getElementById('selectedTeamDetail');
-  if (detailPanel) {
-    const ret = Number(entry.cumulative_return || 0);
-    const retColor = ret >= 0 ? 'var(--success-color)' : 'var(--danger-color)';
-    const entryLabel = entry.model || entry.team_name || '—';
-    detailPanel.innerHTML = `
+  const filtered = getFilteredLeaderboardEntries();
+  if (!filtered.length) {
+    tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;padding:24px;color:var(--text-secondary);">No leaderboard entries yet. Baselines compute on first load (requires market data).</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = filtered.map(renderLeaderboardRowHtml).join('');
+}
+
+function renderLeaderboardDetailHtml(entry, totalEntries) {
+  const ret = Number(entry.cumulative_return || 0);
+  const retColor = ret >= 0 ? 'var(--success-color)' : 'var(--danger-color)';
+  const entryLabel = escapeHtml(entry.model || entry.team_name || '—');
+  return `
       <div class="team-detail-row">
         <span class="team-detail-label">Entry</span>
         <span class="team-detail-value">${entryLabel}</span>
       </div>
       <div class="team-detail-row">
         <span class="team-detail-label">Type</span>
-        <span class="team-detail-value">${formatEntryBadge(entry.team_badge || (entry.entry_type === 'baseline' ? 'Baseline Strategy' : 'Agent'))}</span>
+        <span class="team-detail-value">${escapeHtml(formatEntryBadge(entry.team_badge || (entry.entry_type === 'baseline' ? 'Baseline Strategy' : 'Agent')))}</span>
       </div>
       <div class="team-detail-row">
         <span class="team-detail-label">Value</span>
@@ -654,9 +654,22 @@ function selectLeaderboardTeam(entryId) {
       </div>
       <div class="team-detail-row">
         <span class="team-detail-label">Rank</span>
-        <span class="team-detail-value">${entry.rank} / ${leaderboardPayload?.total_entries || '—'}</span>
+        <span class="team-detail-value">${escapeHtml(entry.rank)} / ${escapeHtml(totalEntries || '—')}</span>
       </div>
     `;
+}
+
+function selectLeaderboardTeam(entryId) {
+  const entries = leaderboardPayload?.entries || [];
+  selectedLeaderboardEntry =
+    entries.find((e) => String(e.entry_id) === String(entryId)) ||
+    entries.find((e) => e.team_name === entryId);
+  if (!selectedLeaderboardEntry) return;
+
+  const entry = selectedLeaderboardEntry;
+  const detailPanel = document.getElementById('selectedTeamDetail');
+  if (detailPanel) {
+    detailPanel.innerHTML = renderLeaderboardDetailHtml(entry, leaderboardPayload?.total_entries);
   }
 
   // Selecting an entry also forces it visible and re-emphasizes it on the chart.


### PR DESCRIPTION
Response to the first full CodeQL scan (1079 alerts). Two commits:

**`ci:`** exclude `orchestration/` from the scan — imported research code, 771 of the 1079 alerts; its alerts auto-close on the next `main` scan.

**`fix:`** the findings that were real:
- **Dead endpoint** (#67): `POST /paper/start-session` omitted `insert_run`'s required `session_id` → every credentialed call failed with a swallowed `TypeError`.
- **SSRF** (#48–50): ticker symbols were interpolated raw into Alpaca URL paths; now allowlist-validated (`BRK.B`/`BF-B` style still accepted).
- **Leaderboard stored XSS** (#4, under-flagged): `entry.model`/`team_name` (user-registered names) rendered unescaped into `innerHTML`; templates extracted into pure renderers with full escaping, proven by node-executed round-trip tests.
- **Exception text in responses** (#12–21): `{"error": str(e)}` envelopes now `print()` server-side and return generic messages; source guard keeps the pattern out of `api/routers`.
- **`/images` traversal guard** (#46–47): only static route without the separator/containment check its siblings have.

Suite: 1190 passed / 30 skipped (baseline 1175/30; 15 new tests, all verified red first). The ~23 false-positive alerts are being dismissed via the API with per-alert reasons, not code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)