### PR TITLE
perf(portfolio): cache and dedupe live portfolio fetches

### DIFF
--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -246,12 +246,22 @@ class AgentService:
         owner_browser_session: Optional[str],
         trading_session_id: Optional[str],
     ) -> List[Dict[str, Any]]:
+        """List owned agents enriched with run stats (batched, no N+1).
+
+        Same prefetch pattern as ``list_builtin_agents_with_stats``: one
+        ``get_runs_by_sessions`` query for the whole listing, then per-agent
+        enrichment from the prefetched map.
+        """
         agents = self.agents.list_agents(
             owner_user_id=owner_user_id,
             owner_browser_session=owner_browser_session,
             trading_session_id=trading_session_id,
         )
-        return [self.agent_with_stats(a) for a in agents]
+        runs_by_session = self.db.get_runs_by_sessions([a["session_id"] for a in agents])
+        return [
+            self.agent_with_stats(a, session_runs=runs_by_session.get(a["session_id"], []))
+            for a in agents
+        ]
 
     def claim_account_agents(
         self,

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -383,6 +383,43 @@ def test_builtin_listing_batches_run_stats_queries(client, monkeypatch):
     assert calls["batch"] == 1, "listing must fetch all stats in one query"
 
 
+def test_owner_listing_batches_run_stats_queries(client, monkeypatch):
+    """Owned /agents listing must batch run-stats the same way as /agents/builtin."""
+    browser_session = str(uuid.uuid4())
+    headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}
+    for i in range(3):
+        resp = client.post(
+            "/api/v1/agents",
+            json={"name": f"owned-{i}", "agent_type": "external"},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+
+    import dashboard.backend.api.routers.agents as agents_api
+
+    svc_db = agents_api.agent_service.db
+    calls = {"per_session": 0, "batch": 0}
+    orig_single = svc_db.get_runs_by_session
+    orig_batch = svc_db.get_runs_by_sessions
+
+    def counting_single(session_id):
+        calls["per_session"] += 1
+        return orig_single(session_id)
+
+    def counting_batch(session_ids):
+        calls["batch"] += 1
+        return orig_batch(session_ids)
+
+    monkeypatch.setattr(svc_db, "get_runs_by_session", counting_single)
+    monkeypatch.setattr(svc_db, "get_runs_by_sessions", counting_batch)
+
+    listing = client.get("/api/v1/agents", headers=headers)
+    assert listing.status_code == 200
+    assert len(listing.json()["agents"]) == 3
+    assert calls["per_session"] == 0, "owner listing still queries per agent (N+1)"
+    assert calls["batch"] == 1, "owner listing must fetch all stats in one query"
+
+
 def test_cash_allocation_cap_is_three_thousand(client):
     """Per-agent sleeve max is $3,000."""
     from dashboard.backend.domain.backtesting.constants import (

--- a/dashboard/backend/tests/test_frontend_portfolio_panel.py
+++ b/dashboard/backend/tests/test_frontend_portfolio_panel.py
@@ -121,20 +121,24 @@ def test_a_slow_earlier_render_cannot_repaint_over_a_newer_one():
     script = "\n".join(
         [
             "let portfolioRenderSeq = 0;",
+            "let livePortfolio = null;",
             "const painted = [];",
+            "const API = {};",
             "const API_BASE = '';",
             "const isPortfolioSignedIn = () => true;",
             "const renderPortfolioFromMock = () => painted.push('mock');",
             "const renderPortfolioFromLive = (p) => painted.push(p.tag);",
-            # First call hangs for 50ms, second returns immediately.
+            "const readCachedPortfolio = () => null;",
+            # Independent fetches (bypass coalescing) so out-of-order completion
+            # can be observed; coalescing is covered separately.
             "let call = 0;",
-            "const API = { get: () => {",
+            "const fetchLivePortfolio = () => {",
             "  call += 1;",
             "  const tag = call === 1 ? 'stale' : 'fresh';",
             "  const delay = call === 1 ? 50 : 0;",
             "  return new Promise((r) => setTimeout(",
-            "    () => r({ portfolio: { tag } }), delay));",
-            "} };",
+            "    () => r({ tag }), delay));",
+            "};",
             _extract_function(src, "renderPortfolio"),
             "(async () => {",
             "  const first = renderPortfolio([]);",
@@ -147,3 +151,114 @@ def test_a_slow_earlier_render_cannot_repaint_over_a_newer_one():
     painted = _run_node(script)
 
     assert painted == ["fresh"], painted
+
+
+def test_concurrent_renders_coalesce_to_one_portfolio_get():
+    """Boot prefetch + loadAgents must share a single in-flight GET."""
+    src = _PORTFOLIO_JS.read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            "let portfolioRenderSeq = 0;",
+            "let livePortfolio = null;",
+            "let portfolioFetchPromise = null;",
+            "const painted = [];",
+            "const API_BASE = '';",
+            "const isPortfolioSignedIn = () => true;",
+            "const renderPortfolioFromMock = () => painted.push('mock');",
+            "const renderPortfolioFromLive = (p) => painted.push('live');",
+            "const readCachedPortfolio = () => null;",
+            "let gets = 0;",
+            "const API = { get: () => {",
+            "  gets += 1;",
+            "  return Promise.resolve({ portfolio: { equity: 1, cash_available: 1, allocated: 0 } });",
+            "} };",
+            _extract_function(src, "fetchLivePortfolio"),
+            _extract_function(src, "renderPortfolio"),
+            "(async () => {",
+            "  await Promise.all([renderPortfolio([]), renderPortfolio([])]);",
+            "  console.log(JSON.stringify({ gets, painted }));",
+            "})();",
+        ]
+    )
+    result = _run_node(script)
+    assert result["gets"] == 1, result
+    assert result["painted"] == ["live"], result
+
+
+def test_session_cache_paints_before_network_returns():
+    """A hard-refresh cache hit must paint overview figures before GET resolves."""
+    src = _PORTFOLIO_JS.read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            "let portfolioRenderSeq = 0;",
+            "let livePortfolio = null;",
+            "let portfolioFetchPromise = null;",
+            "const painted = [];",
+            "const API_BASE = '';",
+            "const PORTFOLIO_CACHE_KEY = 'portfolio-live-cache';",
+            "const sessionStorage = { _d: {}, getItem(k){ return this._d[k] ?? null; },",
+            "  setItem(k,v){ this._d[k] = String(v); }, removeItem(k){ delete this._d[k]; } };",
+            "sessionStorage.setItem(PORTFOLIO_CACHE_KEY, JSON.stringify({",
+            "  equity: 10000, cash_available: 7000, allocated: 3000 }));",
+            "const isPortfolioSignedIn = () => true;",
+            "const renderPortfolioFromMock = () => painted.push('mock');",
+            "const renderPortfolioFromLive = (p, agents) => {",
+            "  painted.push({",
+            "    equity: Number(p.equity),",
+            "    cash_available: Number(p.cash_available),",
+            "    allocated: Number(p.allocated),",
+            "    agents: (agents || []).length,",
+            "  });",
+            "};",
+            _extract_function(src, "readCachedPortfolio"),
+            _extract_function(src, "writeCachedPortfolio"),
+            _extract_function(src, "clearCachedPortfolio"),
+            "let resolveNet;",
+            "const API = { get: () => new Promise((r) => { resolveNet = r; }) };",
+            _extract_function(src, "fetchLivePortfolio"),
+            _extract_function(src, "renderPortfolio"),
+            "(async () => {",
+            "  const pending = renderPortfolio([{ name: 'A' }]);",
+            "  // Cache paint happens synchronously before the awaited GET.",
+            "  const afterCache = painted.slice();",
+            "  resolveNet({ portfolio: { equity: 10000, cash_available: 7000, allocated: 3000 } });",
+            "  await pending;",
+            "  console.log(JSON.stringify({ afterCache, final: painted }));",
+            "})();",
+        ]
+    )
+    result = _run_node(script)
+
+    assert result["afterCache"] == [
+        {"equity": 10000, "cash_available": 7000, "allocated": 3000, "agents": 1}
+    ], result
+    assert result["final"][-1]["equity"] == 10000
+    assert "mock" not in result["final"]
+
+
+def test_repaint_from_session_cache_needs_no_network():
+    src = _PORTFOLIO_JS.read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            "let livePortfolio = null;",
+            "const painted = [];",
+            "const PORTFOLIO_CACHE_KEY = 'portfolio-live-cache';",
+            "const sessionStorage = { _d: {}, getItem(k){ return this._d[k] ?? null; },",
+            "  setItem(k,v){ this._d[k] = String(v); }, removeItem(k){ delete this._d[k]; } };",
+            "sessionStorage.setItem(PORTFOLIO_CACHE_KEY, JSON.stringify({",
+            "  equity: 10000, cash_available: 7000, allocated: 3000 }));",
+            "const isPortfolioSignedIn = () => true;",
+            "const renderPortfolioFromMock = () => painted.push('mock');",
+            "const renderPortfolioFromLive = (p) => painted.push(Number(p.equity));",
+            "const updateAgentAllocationFromAgents = () => {};",
+            _extract_function(src, "readCachedPortfolio"),
+            _extract_function(src, "writeCachedPortfolio"),
+            _extract_function(src, "clearCachedPortfolio"),
+            # renderPortfolioFromLive is stubbed above; repaint calls it.
+            _extract_function(src, "repaintPortfolioFromCache"),
+            "repaintPortfolioFromCache([]);",
+            "console.log(JSON.stringify(painted));",
+        ]
+    )
+    painted = _run_node(script)
+    assert painted == [10000], painted

--- a/dashboard/frontend/js/portfolio.js
+++ b/dashboard/frontend/js/portfolio.js
@@ -16,6 +16,9 @@ const PORTFOLIO_MOCK = {
 /** @type {null | { equity: number, cash_available: number, allocated: number }} */
 let livePortfolio = null;
 let portfolioRenderSeq = 0;
+/** In-flight GET /portfolio — shared so boot prefetch + loadAgents don't double-fetch. */
+let portfolioFetchPromise = null;
+const PORTFOLIO_CACHE_KEY = 'portfolio-live-cache';
 
 const PF_WALLET_ICON =
     '<path d="M19 7V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2"/><path d="M16 12h5v4h-5a2 2 0 0 1 0-4Z"/>';
@@ -328,8 +331,48 @@ function updateAgentAllocationFromAgents(agents) {
     renderAllocationChart('agent', buildAgentAllocationData(agents, getTotalPortfolioValue()));
 }
 
+function readCachedPortfolio() {
+    try {
+        const raw = sessionStorage.getItem(PORTFOLIO_CACHE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return null;
+        return {
+            equity: Number(parsed.equity) || 0,
+            cash_available: Number(parsed.cash_available) || 0,
+            allocated: Number(parsed.allocated) || 0,
+        };
+    } catch (_) {
+        return null;
+    }
+}
+
+function writeCachedPortfolio(portfolio) {
+    try {
+        sessionStorage.setItem(
+            PORTFOLIO_CACHE_KEY,
+            JSON.stringify({
+                equity: Number(portfolio.equity) || 0,
+                cash_available: Number(portfolio.cash_available) || 0,
+                allocated: Number(portfolio.allocated) || 0,
+            }),
+        );
+    } catch (_) {
+        /* sessionStorage unavailable — ignore */
+    }
+}
+
+function clearCachedPortfolio() {
+    try {
+        sessionStorage.removeItem(PORTFOLIO_CACHE_KEY);
+    } catch (_) {
+        /* ignore */
+    }
+}
+
 function renderPortfolioFromMock(agents) {
     livePortfolio = null;
+    clearCachedPortfolio();
     setPortfolioSampleBadgeVisible(true);
     renderPortfolioOverview(PORTFOLIO_MOCK.summary);
     renderAllocationChart('agent', buildAgentAllocationData(agents, getTotalPortfolioValue()));
@@ -341,18 +384,31 @@ function renderPortfolioFromLive(portfolio, agents) {
         cash_available: Number(portfolio.cash_available) || 0,
         allocated: Number(portfolio.allocated) || 0,
     };
+    writeCachedPortfolio(livePortfolio);
     setPortfolioSampleBadgeVisible(false);
     renderPortfolioOverview(summaryFromLivePortfolio(livePortfolio));
     updateAgentAllocationFromAgents(agents);
 }
 
+function fetchLivePortfolio() {
+    if (portfolioFetchPromise) return portfolioFetchPromise;
+    portfolioFetchPromise = (async () => {
+        try {
+            const data = await API.get(`${API_BASE}/api/v1/portfolio`);
+            return data && data.portfolio ? data.portfolio : null;
+        } finally {
+            portfolioFetchPromise = null;
+        }
+    })();
+    return portfolioFetchPromise;
+}
+
 // ---------------------------------------------------------------------------
-// Public entry point — called when the My Agents tab becomes visible.
+// Public entry points — My Agents tab + boot prefetch.
 // ---------------------------------------------------------------------------
 
 // Renders are async and callers do not await them, so two can be in flight at
-// once (switching to My Agents starts one, and the loadAgents() that follows
-// starts another with a fresher agent list). Responses are not guaranteed to
+// once (boot prefetch, then loadAgents). Responses are not guaranteed to
 // arrive in request order, so without this sequence guard a slower earlier
 // request can repaint the panel with stale agents after the newer one landed.
 async function renderPortfolio(agents) {
@@ -363,40 +419,64 @@ async function renderPortfolio(agents) {
         renderPortfolioFromMock(list);
         return;
     }
+    // Instant paint from memory / sessionStorage before the network round-trip.
+    const cached = livePortfolio || readCachedPortfolio();
+    if (cached) {
+        renderPortfolioFromLive(cached, list);
+    }
     try {
-        const data = await API.get(`${API_BASE}/api/v1/portfolio`);
+        const portfolio = await fetchLivePortfolio();
         if (seq !== portfolioRenderSeq) return;
-        const portfolio = data && data.portfolio;
         if (!portfolio) {
-            renderPortfolioFromMock(list);
+            if (!livePortfolio) renderPortfolioFromMock(list);
             return;
         }
         renderPortfolioFromLive(portfolio, list);
     } catch (error) {
         if (seq !== portfolioRenderSeq) return;
         console.warn('Portfolio API unavailable; showing sample data:', error?.message || error);
-        renderPortfolioFromMock(list);
+        // Keep last-known figures if we already painted them; only fall back to
+        // SAMPLE DATA when the panel would otherwise stay blank.
+        if (!livePortfolio) renderPortfolioFromMock(list);
     }
 }
 
 /**
- * Repaint the panel from whatever is already cached — no network.
+ * Repaint the panel from memory or sessionStorage — no network.
  *
- * Lets the My Agents tab paint instantly on a revisit while the authoritative
- * refresh rides along with loadAgents(), instead of both firing their own
- * GET /api/v1/portfolio on every tab switch.
+ * Lets hard refresh and My Agents tab revisit paint instantly while the
+ * authoritative refresh rides along with prefetchPortfolio / loadAgents.
  */
 function repaintPortfolioFromCache(agents) {
     const list = agents || [];
     if (livePortfolio) {
         renderPortfolioFromLive(livePortfolio, list);
-    } else if (!isPortfolioSignedIn()) {
-        renderPortfolioFromMock(list);
+        return;
     }
-    // Signed in but nothing cached yet: leave it be — the render that
-    // loadAgents() kicks off is about to paint the real figures.
+    if (!isPortfolioSignedIn()) {
+        renderPortfolioFromMock(list);
+        return;
+    }
+    const cached = readCachedPortfolio();
+    if (cached) {
+        renderPortfolioFromLive(cached, list);
+    }
+    // Signed in but nothing cached yet: leave it be — prefetch / loadAgents
+    // is about to paint the real figures.
+}
+
+/** Boot helper: paint from cache immediately (no network). */
+function paintPortfolioBoot(agents) {
+    repaintPortfolioFromCache(agents);
+}
+
+/** Boot helper: cache paint + start GET /portfolio without waiting on agents. */
+async function prefetchPortfolio(agents) {
+    return renderPortfolio(agents || []);
 }
 
 window.renderPortfolio = renderPortfolio;
 window.repaintPortfolioFromCache = repaintPortfolioFromCache;
+window.paintPortfolioBoot = paintPortfolioBoot;
+window.prefetchPortfolio = prefetchPortfolio;
 window.updateAgentAllocationFromAgents = updateAgentAllocationFromAgents;


### PR DESCRIPTION
## Summary
- Deduplicate concurrent `GET /api/v1/portfolio` calls and paint My Portfolio from sessionStorage for instant refresh.
- Add a regression test that owned `/api/v1/agents` listings batch run stats (no N+1).

## Test plan
- [ ] Hard-refresh My Agents: portfolio numbers paint quickly from cache, then refresh from network
- [ ] Switching to My Agents does not fire duplicate portfolio requests (Network tab)
- [ ] `pytest dashboard/backend/tests/test_frontend_portfolio_panel.py dashboard/backend/tests/test_agents_api.py -k 'portfolio or owner_listing' -q`


Made with [Cursor](https://cursor.com)