### PR TITLE
feat(dashboard): backtest run UX and home My Agents overview

### DIFF
--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=59">
+    <link rel="stylesheet" href="styles.css?v=63">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -146,7 +146,7 @@
                 <svg class="header-discord-btn__arrow" aria-hidden="true"><use href="#icon-chevron-right"/></svg>
             </a>
         </div>
-        <a class="header-brand" href="/?stay=1" aria-label="Agentic Trading Lab home">
+        <a class="header-brand" href="/" aria-label="Agentic Trading Lab home">
             <div class="logo-container">
                 <img src="images/atltransparent.png" alt="" class="logo-icon">
             </div>
@@ -176,6 +176,7 @@
                             <span id="accountMenuEmail" class="account-menu-email"></span>
                         </div>
                         <button id="accountMenuAccountBtn" class="account-menu-item" type="button">Account</button>
+                        <a id="accountMenuLandingLink" class="account-menu-item" href="/?stay=1">Visit Landing Page</a>
                         <button id="accountMenuLogoutBtn" class="account-menu-item account-menu-item--danger" type="button">Log out</button>
                     </div>
                 </div>
@@ -211,6 +212,124 @@
         </div>
     </div>
 
+    <div id="runBacktestModal" class="auth-modal run-backtest-modal" hidden>
+        <div class="auth-modal-backdrop" id="runBacktestModalBackdrop"></div>
+        <div class="auth-modal-panel run-backtest-modal-panel" role="dialog" aria-labelledby="runBacktestModalTitle">
+            <button id="runBacktestModalClose" class="auth-modal-close" type="button" aria-label="Close">×</button>
+            <h2 id="runBacktestModalTitle" class="auth-modal-title">Run Backtest</h2>
+            <p class="auth-modal-subtitle">Simulation settings for this agent. Does not change allocated capital.</p>
+
+            <div class="run-backtest-modal-body">
+                <div class="control-group">
+                    <label>Agent</label>
+                    <p id="runBacktestAgentName" class="run-backtest-readonly">—</p>
+                </div>
+
+                <div class="control-group" id="runBacktestPromptGroup" hidden>
+                    <label>Prompt</label>
+                    <pre id="runBacktestPromptPreview" class="run-backtest-prompt-preview"></pre>
+                </div>
+
+                <div class="control-group">
+                    <label>Period</label>
+                    <div class="date-range-inputs">
+                        <div class="date-input-wrapper">
+                            <input type="date" id="startDate" value="2026-04-15" class="date-input">
+                        </div>
+                        <span class="date-separator">→</span>
+                        <div class="date-input-wrapper">
+                            <input type="date" id="endDate" value="2026-04-23" class="date-input">
+                        </div>
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label>Asset Universe</label>
+                    <p class="control-helper">Choose the universe of assets your agent is allowed to trade.</p>
+                    <div class="universe-tabs">
+                        <button class="universe-tab active" data-tab="builtin" type="button">Built-in</button>
+                        <button class="universe-tab" data-tab="custom" type="button">Custom</button>
+                    </div>
+                    <div id="builtinTab" class="universe-content active">
+                        <div class="preset-cards">
+                            <div class="preset-card selected" id="djiaCard">
+                                <div class="preset-name">DJIA 30</div>
+                                <div class="preset-desc">30 blue-chip companies</div>
+                                <button class="preset-btn" type="button">Selected</button>
+                            </div>
+                            <div class="preset-card" id="mag7Card">
+                                <div class="preset-name">Magnificent 7</div>
+                                <div class="preset-desc">7 major tech companies</div>
+                                <button class="preset-btn" type="button">Select</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="customTab" class="universe-content">
+                        <div class="custom-universe">
+                            <div class="custom-header">Build custom universe</div>
+                            <div class="search-input-group">
+                                <input type="text" class="search-asset-input" id="assetSearchInput" placeholder="Search company or ticker">
+                                <button class="add-asset-btn" type="button">+</button>
+                            </div>
+                            <div class="selected-chips" id="selectedChips">
+                                <div class="chip" data-ticker="AAPL">AAPL <span class="chip-remove">×</span></div>
+                                <div class="chip" data-ticker="MSFT">MSFT <span class="chip-remove">×</span></div>
+                                <div class="chip" data-ticker="GOOGL">GOOGL <span class="chip-remove">×</span></div>
+                                <div class="chip" data-ticker="AMZN">AMZN <span class="chip-remove">×</span></div>
+                                <div class="chip" data-ticker="NVDA">NVDA <span class="chip-remove">×</span></div>
+                                <div class="chip" data-ticker="TSLA">TSLA <span class="chip-remove">×</span></div>
+                            </div>
+                            <div class="chips-helper">Add companies to create your custom universe.</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <label for="backtestInitialCapital">Initial Capital</label>
+                    <p class="control-helper">Simulation starting cash for this backtest only (max $10,000). Independent of portfolio allocation and paper trading.</p>
+                    <input
+                        class="control-select"
+                        id="backtestInitialCapital"
+                        type="number"
+                        min="1"
+                        max="10000"
+                        step="100"
+                        value="1000"
+                        aria-label="Backtest initial capital"
+                    >
+                    <p id="runBacktestCapitalHint" class="control-helper">Does not change Allocated Capital.</p>
+                </div>
+
+                <div class="control-group">
+                    <label for="modelSelect">Model</label>
+                    <p class="control-helper">Defaults to this agent’s model. Changing it here is temporary and is not saved to the agent.</p>
+                    <select class="control-select" id="modelSelect">
+                        <option value="claude-haiku-4.5">Claude Haiku 4.5</option>
+                        <option value="claude-sonnet-4.6">Claude Sonnet 4.6</option>
+                        <option value="claude-opus-4.7">Claude Opus 4.7</option>
+                        <option value="gpt-5.2">GPT-5.2</option>
+                        <option value="gpt-5-mini">GPT-5 mini</option>
+                        <option value="deepseek-v4-flash">DeepSeek V4 Flash</option>
+                        <option value="deepseek-v4-pro">DeepSeek V4 Pro</option>
+                        <option value="gemini-3.5-flash">Gemini 3.5 Flash</option>
+                        <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
+                    </select>
+                </div>
+
+                <!-- Hidden: keep market-data hooks working; default Alpaca -->
+                <select id="marketDataSourceSelect" hidden aria-hidden="true">
+                    <option value="alpaca" selected>Alpaca market data</option>
+                </select>
+                <select id="backtestAgentSelect" hidden aria-hidden="true">
+                    <option value="">Loading agents…</option>
+                </select>
+            </div>
+
+            <p id="runBacktestModalError" class="auth-error" hidden></p>
+            <button id="runBacktestModalSubmit" class="auth-submit" type="button">▶ Run Backtest</button>
+        </div>
+    </div>
+
     <!-- Live Ticker — auto-scrolls right to left -->
     <div class="ticker-bar">
         <div class="ticker-marquee" id="tickerMarquee">
@@ -239,7 +358,7 @@
                             </h1>
                             <div class="home-landing-ctas">
                                 <button id="homeGetStartedBtn" class="home-btn home-btn-primary home-landing-cta" type="button">Get Started</button>
-                                <a class="home-btn home-btn-secondary home-landing-cta" href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">Join Discord Community</a>
+                                <a class="home-btn home-btn-secondary home-landing-cta" href="https://discord.gg/9HnQ6XDG98" target="_blank" rel="noopener noreferrer">Join Discord</a>
                             </div>
                         </div>
                         <div class="home-landing-playground" aria-label="Agent playground preview">
@@ -392,14 +511,15 @@
                         <article class="home-module home-module--agent" id="homeModuleAgent">
                             <header class="home-module-head">
                                 <h3 class="home-module-title">My Agents</h3>
+                                <button class="hm-head-outline-btn" id="homeModuleViewAgentsBtn" type="button">Manage Agents</button>
                             </header>
                             <div class="home-module-body" id="homeAgentBody">
                                 <div class="hm-agent-empty" id="homeAgentEmpty">
-                                    <button class="hm-agent-empty-cta" id="homeModuleCreateAgentEmpty" type="button">Create your agent</button>
+                                    <p class="hm-agent-empty-copy">Create your first agent to start testing trading ideas.</p>
+                                    <button class="hm-agent-empty-cta" id="homeModuleCreateAgentEmpty" type="button">Create Agent</button>
                                 </div>
                                 <div class="hm-agent-filled" id="homeAgentFilled" hidden></div>
                             </div>
-                            <button class="hm-footer-btn" id="homeModuleViewAgentsBtn" type="button" hidden>Manage agents</button>
                         </article>
 
                         <article class="home-module home-module--ranking" id="homeModuleRanking">
@@ -473,7 +593,7 @@
                                 <li><span class="hm-act-dot"></span><span>QuantNova completed a backtest</span><time class="tabular-nums">18m ago</time></li>
                                 <li><span class="hm-act-dot"></span><span>Momentum Scout moved to #3</span><time class="tabular-nums">31m ago</time></li>
                             </ul>
-                            <button class="hm-footer-btn" id="homeModuleCommunityBtn" type="button">Join the Discord community</button>
+                            <button class="hm-footer-btn" id="homeModuleCommunityBtn" type="button">Join Discord</button>
                         </article>
                         </div>
                     </div>
@@ -600,7 +720,7 @@
                     <input id="externalAgentModel" type="text" maxlength="100" placeholder="gpt-4 / rule-based" autocomplete="off">
                 </label>
                 <label class="auth-field">
-                    <span>Initial cash (max $3,000)</span>
+                    <span>Allocated capital (max $3,000)</span>
                     <input id="externalAgentCashAllocation" type="number" min="0" max="3000" step="100" value="1000" required aria-describedby="externalAgentCashHint">
                 </label>
                 <p id="externalAgentCashHint" class="credential-hint">Starting capital budget for this agent's backtests and trading sessions.</p>
@@ -637,7 +757,7 @@
                     <input id="builtinAgentDescription" type="text" maxlength="280" placeholder="What is this agent's edge?" autocomplete="off">
                 </label>
                 <label class="auth-field">
-                    <span>Initial cash (max $3,000)</span>
+                    <span>Allocated capital (max $3,000)</span>
                     <input id="builtinAgentCashAllocation" type="number" min="0" max="3000" step="100" value="1000" required aria-describedby="builtinAgentCashHint">
                 </label>
                 <p id="builtinAgentCashHint" class="credential-hint">Starting capital budget for this agent's backtests and trading sessions.</p>
@@ -763,8 +883,8 @@
                 </label>
                 <textarea id="agentEditorDescription" class="agent-editor-description" rows="2" maxlength="280" placeholder="Optional description for this agent…" aria-label="Agent description"></textarea>
                 <label class="agent-editor-cash-field" for="agentEditorCashAllocation">
-                    <span class="agent-editor-cash-label">Initial cash (max $3,000)</span>
-                    <input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="3000" step="100" placeholder="0" aria-label="Initial cash">
+                    <span class="agent-editor-cash-label">Allocated capital (paper, max $3,000)</span>
+                    <input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="3000" step="100" placeholder="0" aria-label="Allocated capital for paper trading">
                 </label>
             </div>
             <div class="agent-editor-header-actions">
@@ -774,6 +894,7 @@
                 </div>
                 <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>
                 <button id="agentEditorResetBtn" class="home-btn home-btn-secondary agent-editor-reset-btn" type="button">Reset pipeline</button>
+                <button id="agentEditorRunBacktestBtn" class="home-btn home-btn-secondary" type="button">Run Backtest</button>
                 <button id="agentEditorSaveBtn" class="home-btn home-btn-primary" type="button">Save</button>
             </div>
         </header>
@@ -827,109 +948,45 @@
 
     <!-- Main Content: 3-Column Layout (Playground / Backtest) -->
     <div class="main-container playground-panel playground-backtest-panel" style="display: none;">
-        <!-- Left Panel: Setup -->
+        <!-- Left Panel: selected / running run config (read-only) -->
         <aside class="left-panel">
-            <!-- Backtest Setup Section -->
             <section class="control-section">
-                <h3 class="control-title">Backtest Setup</h3>
-                
-                <div class="control-group">
-                    <label>Period</label>
-                    <div class="date-range-inputs">
-                        <div class="date-input-wrapper">
-                            <input type="date" id="startDate" value="2026-04-15" class="date-input">
-                        </div>
-                        <span class="date-separator">→</span>
-                        <div class="date-input-wrapper">
-                            <input type="date" id="endDate" value="2026-04-23" class="date-input">
-                        </div>
+                <h3 class="control-title">Run config</h3>
+                <p id="backtestConfigEmpty" class="control-helper">No backtests yet. Run one from My Agents.</p>
+                <dl id="backtestConfigList" class="backtest-config-list" hidden>
+                    <div class="backtest-config-row">
+                        <dt>Agent</dt>
+                        <dd id="backtestConfigAgent">—</dd>
                     </div>
-                </div>
-
-                <div class="control-group">
-                    <label>Asset Universe</label>
-                    <p class="control-helper">Choose the universe of assets your agent is allowed to trade.</p>
-                    
-                    <!-- Tabs: Built-in / Custom -->
-                    <div class="universe-tabs">
-                        <button class="universe-tab active" data-tab="builtin">Built-in</button>
-                        <button class="universe-tab" data-tab="custom">Custom</button>
+                    <div class="backtest-config-row">
+                        <dt>Model</dt>
+                        <dd id="backtestConfigModel">—</dd>
                     </div>
-                    
-                    <!-- Built-in Tab -->
-                    <div id="builtinTab" class="universe-content active">
-                        <div class="preset-cards">
-                            <div class="preset-card selected" id="djiaCard">
-                                <div class="preset-name">DJIA</div>
-                                <div class="preset-desc">30 blue-chip companies</div>
-                                <button class="preset-btn">Selected</button>
-                            </div>
-                            <div class="preset-card" id="mag7Card">
-                                <div class="preset-name">Magnificent 7</div>
-                                <div class="preset-desc">7 major tech companies</div>
-                                <button class="preset-btn">Select</button>
-                            </div>
-                        </div>
-                        
-
+                    <div class="backtest-config-row" id="backtestConfigPromptRow" hidden>
+                        <dt>Prompt</dt>
+                        <dd id="backtestConfigPrompt" class="backtest-config-prompt">—</dd>
                     </div>
-                    
-                    <!-- Custom Tab -->
-                    <div id="customTab" class="universe-content">
-                        <div class="custom-universe">
-                            <div class="custom-header">Build custom universe</div>
-                            
-                            <div class="search-input-group">
-                                <input type="text" class="search-asset-input" id="assetSearchInput" placeholder="Search company or ticker">
-                                <button class="add-asset-btn">+</button>
-                            </div>
-                            
-                            <div class="selected-chips" id="selectedChips">
-                                <div class="chip" data-ticker="AAPL">AAPL <span class="chip-remove">×</span></div>
-                                <div class="chip" data-ticker="MSFT">MSFT <span class="chip-remove">×</span></div>
-                                <div class="chip" data-ticker="GOOGL">GOOGL <span class="chip-remove">×</span></div>
-                                <div class="chip" data-ticker="AMZN">AMZN <span class="chip-remove">×</span></div>
-                                <div class="chip" data-ticker="NVDA">NVDA <span class="chip-remove">×</span></div>
-                                <div class="chip" data-ticker="TSLA">TSLA <span class="chip-remove">×</span></div>
-                            </div>
-                            
-                            <div class="chips-helper">Add companies to create your custom universe.</div>
-                        </div>
+                    <div class="backtest-config-row">
+                        <dt>Started</dt>
+                        <dd id="backtestConfigStarted">—</dd>
                     </div>
-                </div>
-
-                <div class="control-group">
-                    <label for="backtestAgentSelect">Agent</label>
-                    <p class="control-helper">Choose which agent's pipeline and session this backtest should use.</p>
-                    <select class="control-select" id="backtestAgentSelect" aria-label="Select agent for backtest">
-                        <option value="">Loading agents…</option>
-                    </select>
-                </div>
-
-                <div class="control-group">
-                    <label for="marketDataSourceSelect">Market Data</label>
-                    <select class="control-select" id="marketDataSourceSelect" aria-label="Select market data source">
-                        <option value="alpaca">Alpaca market data</option>
-                    </select>
-                    <p id="vnpySimulationNotice" class="market-data-notice" hidden>
-                        vn.py simulated bars · deterministic · no LLM calls
-                    </p>
-                </div>
-
-                <div class="control-group universe-spacing">
-                    <label for="modelSelect">Model</label>
-                    <select class="control-select" id="modelSelect">
-                        <option value="claude-haiku-4.5">Claude Haiku 4.5</option>
-                        <option value="claude-sonnet-4.6">Claude Sonnet 4.6</option>
-                        <option value="claude-opus-4.7">Claude Opus 4.7</option>
-                        <option value="gpt-5.2">GPT-5.2</option>
-                        <option value="gpt-5-mini">GPT-5 mini</option>
-                        <option value="deepseek-v4-flash">DeepSeek V4 Flash</option>
-                        <option value="deepseek-v4-pro">DeepSeek V4 Pro</option>
-                        <option value="gemini-3.5-flash">Gemini 3.5 Flash</option>
-                        <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
-                    </select>
-                </div>
+                    <div class="backtest-config-row">
+                        <dt>Initial capital</dt>
+                        <dd id="backtestConfigCapital">—</dd>
+                    </div>
+                    <div class="backtest-config-row">
+                        <dt>Asset universe</dt>
+                        <dd id="backtestConfigUniverse">—</dd>
+                    </div>
+                    <div class="backtest-config-row">
+                        <dt>Time window</dt>
+                        <dd id="backtestConfigWindow">—</dd>
+                    </div>
+                    <div class="backtest-config-row">
+                        <dt>Status</dt>
+                        <dd id="backtestConfigStatus">—</dd>
+                    </div>
+                </dl>
 
                 <div id="backtestRunProgress" class="backtest-run-progress section-card compact" hidden>
                     <div class="backtest-run-progress-head">
@@ -943,91 +1000,6 @@
                     <p class="backtest-run-progress-hint">Multi-step agent pipelines can take several minutes (timeout: 10 min).</p>
                 </div>
             </section>
-
-            <!-- Advanced Settings Section (Collapsible) -->
-            <section class="control-section">
-                <button class="collapsible-header" id="advancedToggle">
-                    <span class="toggle-icon">▶</span>
-                    <h3 class="control-title" style="display: inline; margin: 0;">Advanced Settings</h3>
-                </button>
-                
-                <div class="collapsible-content" id="advancedContent" style="display: none;">
-                    <div class="control-group">
-                        <label>Agent Type</label>
-                        <select class="control-select">
-                            <option>Momentum Agent</option>
-                            <option>Mean Reversion</option>
-                            <option>Custom</option>
-                        </select>
-                    </div>
-
-                    <div class="control-group">
-                        <label>Initial Capital</label>
-                        <div style="padding: 8px 0; color: #e5e7eb; font-weight: 500;">$1,000</div>
-                    </div>
-
-                    <div class="control-group">
-                        <label>Risk Aversion</label>
-                        <div class="slider-container">
-                            <input type="range" min="0" max="100" value="60" class="slider">
-                            <div class="slider-labels">
-                                <span>Conservative</span>
-                                <span class="slider-value">0.60</span>
-                                <span>Aggressive</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="control-group">
-                        <label>Trades/Day</label>
-                        <div class="slider-container">
-                            <input type="range" min="0" max="10" value="3.2" step="0.1" class="slider">
-                            <div class="slider-labels">
-                                <span>0</span>
-                                <span class="slider-value">3.2</span>
-                                <span>10</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="control-group">
-                        <label>Slippage (%)</label>
-                        <div class="slider-container">
-                            <input type="range" min="0" max="1" value="0.1" step="0.01" class="slider">
-                            <div class="slider-labels">
-                                <span>0%</span>
-                                <span class="slider-value">0.10%</span>
-                                <span>1%</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="control-group">
-                        <label>Transaction Cost (%)</label>
-                        <div class="slider-container">
-                            <input type="range" min="0" max="1" value="0.1" step="0.01" class="slider">
-                            <div class="slider-labels">
-                                <span>0%</span>
-                                <span class="slider-value">0.10%</span>
-                                <span>1%</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="control-group">
-                        <label>Max Position per Asset (%)</label>
-                        <div class="slider-container">
-                            <input type="range" min="0" max="100" value="50" class="slider">
-                            <div class="slider-labels">
-                                <span>0%</span>
-                                <span class="slider-value">50%</span>
-                                <span>100%</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
         </aside>
 
         <!-- Center Panel: Charts & Decision Log -->
@@ -1043,7 +1015,6 @@
                         <select id="backtestRunSelect" class="filter-select backtest-run-select" aria-label="Select backtest run" hidden>
                             <option value="">Latest run</option>
                         </select>
-                        <button class="run-backtest-btn">▶ Run Backtest</button>
                         <button class="time-btn active">1D</button>
                         <button class="time-btn">1W</button>
                         <button class="time-btn">1M</button>
@@ -1544,11 +1515,11 @@
     <script src="market-events/marketEventRelativeTime.js"></script>
     <script src="market-events/MarketEventCard.js"></script>
     <script src="market-events/MarketEventFeed.js"></script>
-    <script src="js/portfolio.js?v=11"></script>
-    <script src="js/agent-editor.js?v=9"></script>
-    <script src="app.js?v=31"></script>
+    <script src="js/portfolio.js?v=12"></script>
+    <script src="js/agent-editor.js?v=11"></script>
+    <script src="app.js?v=41"></script>
     <script src="js/leaderboard.js?v=16"></script>
-    <script src="home-page.js?v=34"></script>
+    <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),
          both loaded above — not beside the market-events/* block, which loads

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -320,6 +320,9 @@
                 <select id="marketDataSourceSelect" hidden aria-hidden="true">
                     <option value="alpaca" selected>Alpaca market data</option>
                 </select>
+                <p id="vnpySimulationNotice" class="market-data-notice" hidden>
+                    vn.py simulated bars · deterministic · no LLM calls
+                </p>
                 <select id="backtestAgentSelect" hidden aria-hidden="true">
                     <option value="">Loading agents…</option>
                 </select>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -193,10 +193,10 @@ function parseAgentCashAllocationInput(raw) {
   }
   const value = Number(raw);
   if (!Number.isFinite(value) || value < 0) {
-    throw new Error(`Initial cash must be between $0 and $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
+    throw new Error(`Allocated capital must be between $0 and $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
   }
   if (value > MAX_AGENT_CASH_ALLOCATION) {
-    throw new Error(`Initial cash cannot exceed $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
+    throw new Error(`Allocated capital cannot exceed $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
   }
   return Math.round(value);
 }
@@ -393,21 +393,43 @@ function hashStringSeed(str) {
   return Math.abs(h) || 1;
 }
 
-function renderAgentSparkline(seed, positive = true) {
+/** Render card sparkline from real equity samples (or a 2-point start→end fallback). */
+function renderAgentSparklineFromValues(values, positive = true, seed = 'spark') {
+  const nums = (Array.isArray(values) ? values : [])
+    .map(Number)
+    .filter((v) => Number.isFinite(v));
   const color = positive ? '#4ade80' : '#ff6b6b';
   const fillId = `agSpark-${hashStringSeed(seed)}`;
-  const n = 8;
-  const pts = [];
-  let v = 0.35 + (hashStringSeed(seed) % 30) / 100;
-  for (let i = 0; i < n; i += 1) {
-    const wobble = ((hashStringSeed(`${seed}:${i}`) % 17) - 8) / 40;
-    v = Math.max(0.08, Math.min(0.92, v + wobble + (positive ? 0.04 : -0.03)));
-    pts.push([ (i / (n - 1)) * 80, 36 - v * 32 ]);
+  const w = 80;
+  const h = 36;
+  const top = 4;
+  const bottom = 4;
+  const plotH = h - top - bottom;
+
+  if (nums.length < 2) {
+    return `
+    <svg class="agent-card-sparkline agent-card-sparkline--empty" viewBox="0 0 ${w} ${h}" width="${w}" height="${h}" aria-hidden="true">
+      <path d="M4,${(h / 2).toFixed(1)} H${w - 4}" fill="none" stroke="rgba(148,163,184,0.35)" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="3 3"/>
+    </svg>`;
   }
+
+  const min = Math.min(...nums);
+  const max = Math.max(...nums);
+  // Keep tiny PnL readable without inventing fake volatility.
+  const span = max - min;
+  const pad = span > 0 ? span * 0.18 : Math.max(Math.abs(max) * 0.004, 1);
+  const lo = min - pad;
+  const hi = max + pad;
+  const range = hi - lo || 1;
+  const pts = nums.map((v, i) => {
+    const x = (i / (nums.length - 1)) * w;
+    const y = top + (1 - (v - lo) / range) * plotH;
+    return [x, y];
+  });
   const line = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' ');
-  const area = `${line} L80,36 L0,36 Z`;
+  const area = `${line} L${w},${h} L0,${h} Z`;
   return `
-    <svg class="agent-card-sparkline" viewBox="0 0 80 36" width="80" height="36" aria-hidden="true">
+    <svg class="agent-card-sparkline" viewBox="0 0 ${w} ${h}" width="${w}" height="${h}" aria-hidden="true">
       <defs>
         <linearGradient id="${fillId}" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stop-color="${color}" stop-opacity="0.35"/>
@@ -417,6 +439,25 @@ function renderAgentSparkline(seed, positive = true) {
       <path d="${area}" fill="url(#${fillId})"/>
       <path d="${line}" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>`;
+}
+
+function resolveAgentSparklineValues(agent, metrics = {}) {
+  const fromAgent = agent?.equity_sparkline;
+  if (Array.isArray(fromAgent) && fromAgent.length >= 2) return fromAgent;
+  const fromRun = agent?.latest_run?.equity_sparkline;
+  if (Array.isArray(fromRun) && fromRun.length >= 2) return fromRun;
+  const ending = Number(metrics.ending);
+  const pnl = Number(metrics.pnl);
+  if (Number.isFinite(ending) && Number.isFinite(pnl)) {
+    return [ending - pnl, ending];
+  }
+  return null;
+}
+
+function renderAgentSparkline(agent, positive = true, metrics = {}) {
+  const values = resolveAgentSparklineValues(agent, metrics);
+  const seed = agent?.agent_id || agent?.name || 'spark';
+  return renderAgentSparklineFromValues(values, positive, seed);
 }
 
 function agentTypeLabel(agent) {
@@ -565,7 +606,7 @@ function renderAgentCardBody(agent, statusKey) {
           <p class="agent-card-metric-value">${escapeHtml(formatAgentMoney(m.equity))}</p>
           ${changeHtml}
         </div>
-        ${renderAgentSparkline(agent.agent_id || agent.name, positive)}
+        ${renderAgentSparkline(agent, positive, { ending: m.equity, pnl: m.dayPnl ?? 0 })}
       </div>
       <div class="agent-card-divider"></div>
       <div class="agent-card-stats">
@@ -605,7 +646,7 @@ function renderAgentCardBody(agent, statusKey) {
           <p class="agent-card-metric-value">${escapeHtml(formatAgentMoney(m.ending))}</p>
           <p class="agent-card-change ${m.positive ? 'is-pos' : 'is-neg'}">${escapeHtml(formatSignedMoney(m.pnl))} during latest run</p>
         </div>
-        ${renderAgentSparkline(agent.agent_id || agent.name, m.positive)}
+        ${renderAgentSparkline(agent, m.positive, m)}
       </div>
       <p class="agent-card-period">${escapeHtml(m.period)}</p>
       <div class="agent-card-divider"></div>
@@ -646,8 +687,6 @@ function renderAgentCardActions(agent, statusKey) {
   let primary = '';
   if (statusKey === 'paper') {
     primary = `<button class="agent-card-cta agent-open-btn" type="button" data-agent-id="${id}">Open Agent</button>`;
-  } else if (statusKey === 'backtested') {
-    primary = `<button class="agent-card-cta agent-card-cta--outline agent-view-runs-btn" type="button" data-agent-id="${id}">View All Runs</button>`;
   } else {
     primary = `<button class="agent-card-cta agent-run-backtest-btn" type="button" data-agent-id="${id}">Run Backtest</button>`;
   }
@@ -894,7 +933,8 @@ function renderAgentCards(grid, agents) {
   grid.querySelectorAll('.agent-run-backtest-btn').forEach((btn) => {
     btn.addEventListener('click', async () => {
       const agent = agents.find((a) => a.agent_id === btn.dataset.agentId);
-      await openAgentInBacktest(agent);
+      if (!agent) return;
+      openRunBacktestModal(agent);
     });
   });
 
@@ -1969,6 +2009,18 @@ function closeAccountMenu() {
   toggleAccountMenu(false);
 }
 
+function syncHeaderBrand(signedIn) {
+  const brand = document.querySelector('.header-brand');
+  if (!brand) return;
+  if (signedIn) {
+    brand.setAttribute('href', '/app?view=home');
+    brand.setAttribute('aria-label', 'Agentic Trading Lab dashboard');
+  } else {
+    brand.setAttribute('href', '/');
+    brand.setAttribute('aria-label', 'Agentic Trading Lab home');
+  }
+}
+
 function updateAuthUI() {
   const user = getStoredAuthUser();
   const label = document.getElementById('authUserLabel');
@@ -1993,6 +2045,8 @@ function updateAuthUI() {
     menuWrap.hidden = true;
     closeAccountMenu();
   }
+
+  syncHeaderBrand(Boolean(user));
 
   updateAccountPage();
 
@@ -2216,9 +2270,17 @@ function initAuthUI() {
     closeAccountMenu();
     navigateToPage('account');
   });
+  document.getElementById('accountMenuLandingLink')?.addEventListener('click', () => {
+    closeAccountMenu();
+  });
   document.getElementById('accountMenuLogoutBtn')?.addEventListener('click', () => {
     closeAccountMenu();
     logoutUser();
+  });
+  document.querySelector('.header-brand')?.addEventListener('click', (event) => {
+    if (!getStoredAuthUser()) return;
+    event.preventDefault();
+    navigateToPage('home');
   });
   document.addEventListener('click', (event) => {
     const wrap = document.getElementById('accountMenuWrap');
@@ -2329,6 +2391,10 @@ window.DEFAULT_RUNS = {};
 
 let chartInstance = null;
 let liveBacktestChartActive = false;
+/** When set, Backtest view is pinned to this in-flight run (blocks history chart paint). */
+let liveBacktestRunId = null;
+/** Active status-poll timer id (so dropdown can re-attach to a running job). */
+let backtestPollTimer = null;
 let liveBacktestChartMeta = { timestamps: [] };
 let tradingLogCache = [];
 let tradingLogFilter = 'all';
@@ -2347,14 +2413,34 @@ document.addEventListener('DOMContentLoaded', async () => {
     initSession();
     initAuthUI();
     await restoreActiveAgentSession();
-    // Load agents before home modules render so the dashboard My Agents card
-    // is not empty on first paint (previously only loaded on My Agents tab).
-    try {
-        await loadAgents();
-    } catch (error) {
-        console.warn('Initial loadAgents failed:', error.message);
+    // Portfolio overview must not wait on the agents waterfall. Paint any
+    // sessionStorage snapshot immediately, kick GET /portfolio in parallel,
+    // then show the page while loadAgents continues in the background.
+    if (typeof window.paintPortfolioBoot === 'function') {
+        try {
+            window.paintPortfolioBoot(
+                Array.isArray(allAgents) ? allAgents.map(decorateAgent) : [],
+            );
+        } catch (error) {
+            console.warn('Portfolio boot paint failed:', error?.message || error);
+        }
     }
+    if (typeof window.prefetchPortfolio === 'function') {
+        Promise.resolve(
+            window.prefetchPortfolio(
+                Array.isArray(allAgents) ? allAgents.map(decorateAgent) : [],
+            ),
+        ).catch((error) => {
+            console.warn('Portfolio prefetch failed:', error?.message || error);
+        });
+    }
+    const agentsReady = loadAgents().catch((error) => {
+        console.warn('Initial loadAgents failed:', error.message);
+    });
     applyInitialNavigation();
+    // Home modules / agent cards catch up once the list lands; do not block
+    // first navigation on that wait.
+    await agentsReady;
     window.addEventListener('agent-editor-saved', async (event) => {
         const agent = event.detail?.agent;
         if (agent?.agent_id) {
@@ -2399,13 +2485,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     setupTickerResizeHandler();
     setupTickerScrollControls();
 
-    // Setup slider value displays
-    document.querySelectorAll('.slider').forEach(slider => {
-        slider.addEventListener('input', (e) => {
-            updateSliderValue(e.target);
-        });
-    });
-
     // Setup time period buttons
     document.querySelectorAll('.time-btn').forEach(btn => {
         btn.addEventListener('click', (e) => {
@@ -2413,20 +2492,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     });
 
-    // Setup quick scenario buttons
-    document.querySelectorAll('.scenario-btn').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-            handleScenario(e.currentTarget);
-        });
+    // Setup run backtest modal
+    document.getElementById('runBacktestModalClose')?.addEventListener('click', closeRunBacktestModal);
+    document.getElementById('runBacktestModalBackdrop')?.addEventListener('click', closeRunBacktestModal);
+    document.getElementById('runBacktestModalSubmit')?.addEventListener('click', () => {
+        runBacktest();
     });
-
-    // Setup run backtest button
-    const runBtn = document.querySelector('.run-backtest-btn');
-    if (runBtn) {
-        runBtn.addEventListener('click', () => {
-            runBacktest();
-        });
-    }
+    document.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape') return;
+        const modal = document.getElementById('runBacktestModal');
+        if (modal && !modal.hidden) closeRunBacktestModal();
+    });
 
     const backtestRunSelect = document.getElementById('backtestRunSelect');
     if (backtestRunSelect) {
@@ -2465,24 +2541,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         marketDataSourceSelect.addEventListener('change', syncMarketDataSourceUI);
     }
 
-    // Setup collapsible advanced settings
-    const advancedToggle = document.getElementById('advancedToggle');
-    const advancedContent = document.getElementById('advancedContent');
-    if (advancedToggle && advancedContent) {
-        advancedToggle.addEventListener('click', () => {
-            advancedToggle.classList.toggle('active');
-            advancedContent.style.display = advancedContent.style.display === 'none' ? 'block' : 'none';
-        });
-    }
-
     // Setup universe tabs
     document.querySelectorAll('.universe-tab').forEach(tab => {
         tab.addEventListener('click', (e) => handleUniverseTabSwitch(e.target));
     });
     
     // Setup preset cards
-    document.getElementById('djiaCard').addEventListener('click', () => selectPreset('djia'));
-    document.getElementById('mag7Card').addEventListener('click', () => selectPreset('mag7'));
+    document.getElementById('djiaCard')?.addEventListener('click', () => selectPreset('djia'));
+    document.getElementById('mag7Card')?.addEventListener('click', () => selectPreset('mag7'));
     
     // Setup custom universe builder
     setupAssetSearch();
@@ -2565,6 +2631,10 @@ window.isUsEquityMarketOpen = isUsEquityMarketOpen;
  */
 async function loadPerformanceMetrics() {
     try {
+        if (liveBacktestChartActive) {
+            displayNoMetrics();
+            return;
+        }
         // Mirror the chart: show metrics for the selected run. window.SELECTED_RUN
         // is set by loadData; resolve from session runs when called standalone.
         let metrics = window.SELECTED_RUN || null;
@@ -3007,57 +3077,12 @@ function showTickerStatus(message) {
 }
 
 /**
- * Update slider value display
- */
-function updateSliderValue(slider) {
-    const container = slider.closest('.slider-container');
-    const valueSpan = container.querySelector('.slider-value');
-    if (valueSpan) {
-        const value = slider.value;
-        const max = slider.max;
-        
-        if (max === '100') {
-            valueSpan.textContent = (value / 100).toFixed(2);
-        } else {
-            valueSpan.textContent = parseFloat(value).toFixed(2);
-        }
-    }
-}
-
-/**
  * Update time period selection
  */
 function updateTimePeriod(btn) {
     document.querySelectorAll('.time-btn').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
     console.log('Time period changed:', btn.textContent);
-}
-
-/**
- * Handle quick scenario buttons
- */
-function handleScenario(btn) {
-    const scenario = btn.querySelector('span:last-child').textContent;
-    console.log('Scenario selected:', scenario);
-    
-    const sliders = document.querySelectorAll('.slider');
-    
-    switch(scenario) {
-        case 'Low Cost':
-            sliders[3].value = 0.01;
-            sliders[4].value = 0.01;
-            break;
-        case 'High Momentum':
-            sliders[1].value = 80;
-            sliders[2].value = 6;
-            break;
-        case 'Conservative':
-            sliders[1].value = 20;
-            sliders[2].value = 1.5;
-            break;
-    }
-    
-    sliders.forEach(updateSliderValue);
 }
 
 
@@ -3068,7 +3093,7 @@ function handleScenario(btn) {
 // Asset universe definitions
 const ASSET_UNIVERSES = {
     djia: {
-        name: 'DJIA',
+        name: 'DJIA 30',
         // Canonical Dow-30 — must mirror backend validator.DJIA_30
         // (pinned by dashboard/backend/tests/test_djia30_universe.py).
         assets: ['AAPL', 'AMGN', 'AMZN', 'AXP', 'BA', 'CAT', 'CRM', 'CSCO', 'CVX', 'DIS',
@@ -3201,17 +3226,21 @@ function selectPreset(preset) {
 
     selectedUniverse = preset;
 
-    document.getElementById('djiaCard').classList.remove('selected');
-    document.getElementById('mag7Card').classList.remove('selected');
+    const djiaCard = document.getElementById('djiaCard');
+    const mag7Card = document.getElementById('mag7Card');
+    if (!djiaCard || !mag7Card) return;
+
+    djiaCard.classList.remove('selected');
+    mag7Card.classList.remove('selected');
 
     if (preset === 'djia') {
-        document.getElementById('djiaCard').classList.add('selected');
-        document.getElementById('djiaCard').querySelector('.preset-btn').textContent = 'Selected';
-        document.getElementById('mag7Card').querySelector('.preset-btn').textContent = 'Select';
+        djiaCard.classList.add('selected');
+        djiaCard.querySelector('.preset-btn').textContent = 'Selected';
+        mag7Card.querySelector('.preset-btn').textContent = 'Select';
     } else if (preset === 'mag7') {
-        document.getElementById('mag7Card').classList.add('selected');
-        document.getElementById('mag7Card').querySelector('.preset-btn').textContent = 'Selected';
-        document.getElementById('djiaCard').querySelector('.preset-btn').textContent = 'Select';
+        mag7Card.classList.add('selected');
+        mag7Card.querySelector('.preset-btn').textContent = 'Selected';
+        djiaCard.querySelector('.preset-btn').textContent = 'Select';
     }
 
     const universeData = ASSET_UNIVERSES[preset];
@@ -3331,7 +3360,7 @@ function setupAssetSearch() {
  */
 function getSelectedAssets() {
     const builtinTab = document.getElementById('builtinTab');
-    const isBuiltin = builtinTab.classList.contains('active');
+    const isBuiltin = builtinTab?.classList.contains('active');
     
     if (!isBuiltin) {
         // Get chips from custom universe
@@ -3402,19 +3431,23 @@ function showBacktestRunProgress(show, { isError = false } = {}) {
     panel.classList.toggle('is-error', !!isError);
 }
 
-function updateBacktestRunProgress({ elapsedSeconds = 0, message = '', maxSeconds = BACKTEST_POLL_MAX_SECONDS, stepPct = null }) {
+function updateBacktestRunProgress({ elapsedSeconds, message = '', maxSeconds = BACKTEST_POLL_MAX_SECONDS, stepPct = null } = {}) {
     const elapsedEl = document.getElementById('backtestRunElapsed');
     const messageEl = document.getElementById('backtestRunProgressMessage');
     const barEl = document.getElementById('backtestRunProgressBar');
-    const elapsed = Math.max(0, Number(elapsedSeconds) || 0);
 
-    if (elapsedEl) elapsedEl.textContent = formatBacktestElapsed(elapsed);
+    if (elapsedEl && elapsedSeconds !== undefined && elapsedSeconds !== null) {
+        const elapsed = Math.max(0, Number(elapsedSeconds) || 0);
+        elapsedEl.textContent = formatBacktestElapsed(elapsed);
+    }
     if (messageEl && message) messageEl.textContent = message;
     if (barEl) {
         const pct = Number.isFinite(stepPct)
             ? Math.min(99, Math.round(stepPct))
-            : Math.min(95, Math.round((elapsed / maxSeconds) * 100));
-        barEl.style.width = `${pct}%`;
+            : (elapsedSeconds !== undefined && elapsedSeconds !== null
+                ? Math.min(95, Math.round((Math.max(0, Number(elapsedSeconds) || 0) / maxSeconds) * 100))
+                : null);
+        if (pct != null) barEl.style.width = `${pct}%`;
     }
 }
 
@@ -3508,10 +3541,13 @@ function initLiveBacktestChart() {
 
     if (chartInstance) {
         chartInstance.destroy();
+        chartInstance = null;
     }
 
     liveBacktestChartMeta = { timestamps: [] };
     liveBacktestChartActive = true;
+    backtestChartData = null;
+    window.SELECTED_RUN = null;
     const ctx = perfCtx.getContext('2d');
     chartInstance = new Chart(ctx, {
         type: 'line',
@@ -3531,6 +3567,181 @@ function initLiveBacktestChart() {
         },
         options: getPerformanceChartOptions(liveBacktestChartMeta),
     });
+}
+
+/** Clear history chart/metrics/log and pin the view to a soon-to-start live run. */
+function prepareLiveBacktestView(launchConfig = null) {
+    liveBacktestChartActive = true;
+    liveBacktestRunId = null;
+    localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
+    const runSelect = document.getElementById('backtestRunSelect');
+    if (runSelect) runSelect.value = '';
+    displayNoMetrics();
+    clearTradingLog('Backtest running… trades will appear here.');
+    initLiveBacktestChart();
+    renderBacktestRunConfig(null, { running: true, launchConfig });
+    showBacktestRunProgress(true);
+}
+
+/** Switch the Backtest surface onto an in-flight run (chart + log + config). */
+function attachToLiveBacktest(runId, progress = null, launchConfig = null) {
+    if (!runId) return;
+    const alreadyLive =
+        liveBacktestChartActive &&
+        liveBacktestRunId === runId &&
+        chartInstance &&
+        chartInstance.data?.datasets?.[0]?.label === 'Agent (live)';
+
+    liveBacktestRunId = runId;
+    liveBacktestChartActive = true;
+    localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, runId);
+    const runSelect = document.getElementById('backtestRunSelect');
+    if (runSelect) {
+        // Ensure the Running option exists / is selected even if not in DB yet.
+        if (![...runSelect.options].some((opt) => opt.value === runId)) {
+            const cfg = launchConfig || getBacktestLaunchConfig(runId);
+            const label = `Running… · ${cfg?.agentName || 'Agent'}`;
+            const opt = document.createElement('option');
+            opt.value = runId;
+            opt.textContent = label;
+            runSelect.insertBefore(opt, runSelect.firstChild);
+        }
+        runSelect.value = runId;
+        runSelect.hidden = false;
+    }
+    displayNoMetrics();
+    if (!alreadyLive) {
+        initLiveBacktestChart();
+    }
+    renderBacktestRunConfig(
+        { run_id: runId },
+        { running: true, launchConfig: launchConfig || getBacktestLaunchConfig(runId) },
+    );
+    showBacktestRunProgress(true);
+    if (progress) {
+        updateLiveBacktestChart(progress);
+        updateLiveTradingLog(progress);
+        const step = Number(progress.step);
+        const total = Number(progress.total_steps);
+        const stepPct = Number.isFinite(step) && Number.isFinite(total) && total > 0
+            ? (100 * step / total)
+            : null;
+        updateBacktestRunProgress({
+            message: stepPct != null
+                ? `Backtest running… step ${step}/${total} (${Math.round(stepPct)}%)`
+                : 'Backtest is running…',
+            stepPct,
+        });
+    } else if (!alreadyLive) {
+        clearTradingLog('Backtest running… trades will appear here.');
+    }
+    ensureBacktestPolling();
+}
+
+function stopBacktestPolling() {
+    if (backtestPollTimer) {
+        clearInterval(backtestPollTimer);
+        backtestPollTimer = null;
+    }
+}
+
+function isViewingLiveBacktest(liveId = liveBacktestRunId) {
+    if (!liveId) return false;
+    return localStorage.getItem(SELECTED_BACKTEST_RUN_KEY) === liveId;
+}
+
+function ensureBacktestPolling() {
+    if (backtestPollTimer) return;
+    const maxAttempts = BACKTEST_POLL_MAX_SECONDS;
+    let attempts = 0;
+
+    backtestPollTimer = setInterval(async () => {
+        attempts += 1;
+        try {
+            const status = await API.get(`${API_BASE}/backtest/status`);
+            const liveId = status.live_run_id || liveBacktestRunId;
+            const serverElapsed = Number(status.elapsed_seconds);
+            const displayElapsed = Number.isFinite(serverElapsed) && serverElapsed > 0
+                ? serverElapsed
+                : attempts;
+            const viewingLive = isViewingLiveBacktest(liveId);
+
+            if (status.running) {
+                if (liveId) liveBacktestRunId = liveId;
+                const step = Number(status.progress?.step);
+                const total = Number(status.progress?.total_steps);
+                const stepPct = Number.isFinite(step) && Number.isFinite(total) && total > 0
+                    ? (100 * step / total)
+                    : null;
+
+                if (viewingLive) {
+                    liveBacktestChartActive = true;
+                    if (status.progress) {
+                        updateLiveBacktestChart(status.progress);
+                        updateLiveTradingLog(status.progress);
+                    }
+                    updateBacktestRunProgress({
+                        elapsedSeconds: displayElapsed,
+                        message: status.message || 'Backtest is running…',
+                        stepPct,
+                    });
+                    showBacktestRunProgress(true);
+                    renderBacktestRunConfig(
+                        { run_id: liveId },
+                        { running: true, launchConfig: getBacktestLaunchConfig(liveId) },
+                    );
+                }
+            } else {
+                stopBacktestPolling();
+                liveBacktestChartActive = false;
+                const finishedId = liveBacktestRunId;
+                liveBacktestRunId = null;
+
+                if (status.error) {
+                    if (viewingLive) {
+                        showBacktestRunProgress(true, { isError: true });
+                        updateBacktestRunProgress({
+                            elapsedSeconds: displayElapsed,
+                            message: status.error,
+                        });
+                    }
+                    return;
+                }
+
+                if (status.success && viewingLive) {
+                    updateBacktestRunProgress({
+                        elapsedSeconds: displayElapsed,
+                        message: `Completed in ${formatBacktestElapsed(displayElapsed)}.`,
+                    });
+                    if (finishedId) {
+                        localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, finishedId);
+                    } else {
+                        localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
+                    }
+                    await loadData();
+                    await loadPerformanceMetrics();
+                    setTimeout(() => showBacktestRunProgress(false), 2500);
+                } else if (!viewingLive) {
+                    showBacktestRunProgress(false);
+                }
+            }
+
+            if (attempts >= maxAttempts) {
+                stopBacktestPolling();
+                if (isViewingLiveBacktest(liveBacktestRunId)) {
+                    showBacktestRunProgress(true, { isError: true });
+                    updateBacktestRunProgress({
+                        elapsedSeconds: maxAttempts,
+                        message: 'Timed out after 10 minutes. The backtest may still be running in the background.',
+                    });
+                }
+                liveBacktestChartActive = false;
+                liveBacktestRunId = null;
+            }
+        } catch (error) {
+            console.error('Error polling backtest status:', error);
+        }
+    }, 1000);
 }
 
 function updateLiveBacktestChart(progress) {
@@ -3638,6 +3849,197 @@ async function loadTradingLogForRun(runId) {
     }
 }
 
+const BACKTEST_LAUNCH_CONFIG_KEY = 'backtest-launch-configs';
+/** @type {null | object} */
+let runBacktestModalAgent = null;
+
+function readBacktestLaunchConfigMap() {
+    try {
+        const raw = localStorage.getItem(BACKTEST_LAUNCH_CONFIG_KEY);
+        const parsed = raw ? JSON.parse(raw) : {};
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (_error) {
+        return {};
+    }
+}
+
+function stashBacktestLaunchConfig(runId, config) {
+    if (!runId || !config) return;
+    const map = readBacktestLaunchConfigMap();
+    map[runId] = { ...config, savedAt: new Date().toISOString() };
+    const keys = Object.keys(map).sort(
+        (a, b) => String(map[a].savedAt || '').localeCompare(String(map[b].savedAt || '')),
+    );
+    while (keys.length > 40) {
+        delete map[keys.shift()];
+    }
+    try {
+        localStorage.setItem(BACKTEST_LAUNCH_CONFIG_KEY, JSON.stringify(map));
+    } catch (_error) {
+        /* ignore quota */
+    }
+}
+
+function getBacktestLaunchConfig(runId) {
+    if (!runId) return null;
+    return readBacktestLaunchConfigMap()[runId] || null;
+}
+
+function formatPromptFromPipeline(pipeline) {
+    if (!Array.isArray(pipeline) || !pipeline.length) return null;
+    if (pipeline.length === 1) {
+        const prompt = String(pipeline[0]?.prompt || '').trim();
+        return prompt || null;
+    }
+    return pipeline
+        .map((step, index) => {
+            const label = step.label || step.presetKey || `Step ${index + 1}`;
+            const prompt = String(step.prompt || '').trim();
+            return prompt ? `• ${label}: ${prompt}` : `• ${label}`;
+        })
+        .join('\n');
+}
+
+function describeUniverseFromAssets(assets) {
+    if (!Array.isArray(assets) || !assets.length) return null;
+    const sorted = [...assets].map(String).sort().join(',');
+    for (const uni of Object.values(ASSET_UNIVERSES)) {
+        if ([...uni.assets].map(String).sort().join(',') === sorted) {
+            return uni.name;
+        }
+    }
+    if (assets.length <= 8) return assets.join(', ');
+    return `${assets.slice(0, 6).join(', ')} +${assets.length - 6} more`;
+}
+
+function setBacktestConfigText(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+}
+
+function renderBacktestRunConfig(run, { running = false, launchConfig = null } = {}) {
+    const empty = document.getElementById('backtestConfigEmpty');
+    const list = document.getElementById('backtestConfigList');
+    const cfg = launchConfig || (run?.run_id ? getBacktestLaunchConfig(run.run_id) : null);
+
+    if (!run && !cfg) {
+        if (empty) empty.hidden = false;
+        if (list) list.hidden = true;
+        if (!running) showBacktestRunProgress(false);
+        return;
+    }
+
+    if (empty) empty.hidden = true;
+    if (list) list.hidden = false;
+
+    const agentName = cfg?.agentName || run?.agent_name || '—';
+    const model = cfg?.model || run?.llm_model || '—';
+    const capital = cfg?.initialCapital ?? run?.initial_equity;
+    const start = cfg?.startDate || run?.start_date;
+    const end = cfg?.endDate || run?.end_date;
+    const universe = cfg?.universeLabel || describeUniverseFromAssets(cfg?.assets) || '—';
+    const started = run?.created_at
+        ? new Date(String(run.created_at).replace(' ', 'T')).toLocaleString()
+        : (cfg?.startedAt
+            ? new Date(cfg.startedAt).toLocaleString()
+            : (running ? 'Just now' : '—'));
+    const prompt = cfg?.prompt || null;
+
+    setBacktestConfigText('backtestConfigAgent', agentName);
+    setBacktestConfigText('backtestConfigModel', model || '—');
+    setBacktestConfigText('backtestConfigStarted', started);
+    setBacktestConfigText(
+        'backtestConfigCapital',
+        Number.isFinite(Number(capital)) ? `$${Number(capital).toLocaleString()}` : '—',
+    );
+    setBacktestConfigText('backtestConfigUniverse', universe);
+    setBacktestConfigText(
+        'backtestConfigWindow',
+        start && end ? `${start} → ${end}` : '—',
+    );
+    setBacktestConfigText('backtestConfigStatus', running ? 'Running' : 'Completed');
+
+    const promptRow = document.getElementById('backtestConfigPromptRow');
+    const promptEl = document.getElementById('backtestConfigPrompt');
+    if (prompt) {
+        if (promptRow) promptRow.hidden = false;
+        if (promptEl) promptEl.textContent = prompt;
+    } else if (promptRow) {
+        promptRow.hidden = true;
+    }
+}
+
+function closeRunBacktestModal() {
+    const modal = document.getElementById('runBacktestModal');
+    if (modal) modal.hidden = true;
+    runBacktestModalAgent = null;
+    const err = document.getElementById('runBacktestModalError');
+    if (err) {
+        err.hidden = true;
+        err.textContent = '';
+    }
+}
+
+function openRunBacktestModal(agent) {
+    if (!agent?.agent_id) {
+        alert('Please create or select an agent first.');
+        return;
+    }
+    if (isDemoAgent(agent.agent_id)) {
+        alert('Demo agents cannot run backtests. Create your own agent first.');
+        return;
+    }
+
+    runBacktestModalAgent = agent;
+    populateBacktestAgentSelect();
+    const select = document.getElementById('backtestAgentSelect');
+    if (select) select.value = agent.agent_id;
+
+    const nameEl = document.getElementById('runBacktestAgentName');
+    if (nameEl) nameEl.textContent = agent.name || agent.agent_id;
+
+    const sleeve = Number(agent.cash_allocation);
+    const hint = document.getElementById('runBacktestCapitalHint');
+    if (hint) {
+        hint.textContent = Number.isFinite(sleeve)
+            ? `Does not change Allocated Capital ($${sleeve.toLocaleString()}).`
+            : 'Does not change Allocated Capital.';
+    }
+
+    syncModelSelectFromAgent(agent);
+    selectPreset('djia');
+    const builtinTabBtn = document.querySelector('#runBacktestModal .universe-tab[data-tab="builtin"]');
+    if (builtinTabBtn) handleUniverseTabSwitch(builtinTabBtn);
+
+    const pipeline = loadAgentPipelineForBacktest(agent);
+    const prompt = formatPromptFromPipeline(pipeline);
+    const promptGroup = document.getElementById('runBacktestPromptGroup');
+    const promptPreview = document.getElementById('runBacktestPromptPreview');
+    if (prompt) {
+        if (promptGroup) promptGroup.hidden = false;
+        if (promptPreview) promptPreview.textContent = prompt;
+    } else if (promptGroup) {
+        promptGroup.hidden = true;
+    }
+
+    const err = document.getElementById('runBacktestModalError');
+    if (err) {
+        err.hidden = true;
+        err.textContent = '';
+    }
+    const submit = document.getElementById('runBacktestModalSubmit');
+    if (submit) {
+        submit.disabled = false;
+        submit.textContent = '▶ Run Backtest';
+    }
+
+    const modal = document.getElementById('runBacktestModal');
+    if (modal) modal.hidden = false;
+}
+
+window.openRunBacktestModal = openRunBacktestModal;
+window.closeRunBacktestModal = closeRunBacktestModal;
+
 async function runBacktest() {
     // Get dates from form
     const startDateInput = document.getElementById('startDate');
@@ -3652,7 +4054,14 @@ async function runBacktest() {
     const endDate = endDateInput.value;
     
     if (!startDate || !endDate) {
-        console.warn('⚠️ Please select both start and end dates');
+        const msg = 'Please select both start and end dates.';
+        const err = document.getElementById('runBacktestModalError');
+        if (err && !document.getElementById('runBacktestModal')?.hidden) {
+            err.textContent = msg;
+            err.hidden = false;
+        } else {
+            console.warn(msg);
+        }
         return;
     }
 
@@ -3661,22 +4070,44 @@ async function runBacktest() {
     const marketDataSourceSelect = document.getElementById('marketDataSourceSelect');
     const dataSource = marketDataSourceSelect?.value || 'alpaca';
     const isSimulation = dataSource === 'vnpy_simulation';
-    const activeAgent = getSelectedBacktestAgent();
+    const activeAgent = runBacktestModalAgent || getSelectedBacktestAgent();
     if (!activeAgent) {
         alert('Please create or select an agent first.');
         return;
     }
 
     await activateAgent(activeAgent);
-    syncModelSelectFromAgent(activeAgent);
     const pipeline = loadAgentPipelineForBacktest(activeAgent);
     const model = isSimulation
         ? null
-        : activeAgent?.model_name || (modelSelect ? modelSelect.value : 'claude-haiku-4.5');
+        : (modelSelect?.value || activeAgent?.model_name || 'claude-haiku-4.5');
+
+    const capitalInput = document.getElementById('backtestInitialCapital');
+    let initialCapital = 1000;
+    if (capitalInput && capitalInput.value !== '') {
+        const parsed = Number(capitalInput.value);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+            alert('Initial capital must be greater than 0.');
+            return;
+        }
+        if (parsed > 10000) {
+            alert('Initial capital cannot exceed $10,000.');
+            return;
+        }
+        initialCapital = Math.round(parsed);
+        capitalInput.value = String(initialCapital);
+    }
+
+    const promptSummary = formatPromptFromPipeline(pipeline);
+    const universeLabel =
+        document.getElementById('builtinTab')?.classList.contains('active')
+            ? (ASSET_UNIVERSES[selectedUniverse]?.name || selectedUniverse)
+            : describeUniverseFromAssets(assets);
     
     console.log(`Running backtest: ${startDate} to ${endDate}`);
     console.log(`Assets: ${assets.join(', ')}`);
     console.log(`Market data: ${dataSource}`);
+    console.log(`Initial capital (simulation): $${initialCapital}`);
     console.log(`Model: ${model || 'disabled for simulation'}`);
     if (activeAgent?.agent_id) {
         console.log(`Agent: ${activeAgent.name} (${activeAgent.agent_id})`);
@@ -3685,12 +4116,32 @@ async function runBacktest() {
         console.log(`Sub-agent pipeline: ${pipeline.length} step(s)`);
     }
     
-    const btn = document.querySelector('.run-backtest-btn');
-    btn.textContent = '⏳ Running...';
-    btn.disabled = true;
-    showBacktestRunProgress(true);
-    initLiveBacktestChart();
-    clearTradingLog('Backtest running… trades will appear here.');
+    const btn = document.getElementById('runBacktestModalSubmit');
+    if (btn) {
+        btn.textContent = '⏳ Running...';
+        btn.disabled = true;
+    }
+
+    const launchConfigBase = {
+        agentId: activeAgent.agent_id,
+        agentName: activeAgent.name,
+        model: model || null,
+        prompt: promptSummary,
+        initialCapital,
+        startDate,
+        endDate,
+        assets: [...assets],
+        universeLabel,
+        dataSource,
+        startedAt: new Date().toISOString(),
+    };
+
+    // Pin live view BEFORE navigateToPage → showPlaygroundPanel → loadData(),
+    // otherwise the async history load paints the previous run over the chart.
+    closeRunBacktestModal();
+    prepareLiveBacktestView(launchConfigBase);
+    navigateToPage('playground', { playgroundTab: 'backtest' });
+    currentMode = 'backtest';
     updateBacktestRunProgress({
         elapsedSeconds: 0,
         message: pipeline?.length
@@ -3710,6 +4161,9 @@ async function runBacktest() {
             start_date: startDate,
             end_date: endDate,
             data_source: dataSource,
+            initial_capital: initialCapital,
+            // Body is authoritative; query `assets` kept for older callers/logs.
+            assets: [...assets],
         };
         if (model) {
             params.set('model', model);
@@ -3725,38 +4179,36 @@ async function runBacktest() {
         
         if (!data.success) {
             console.error('❌ Backtest failed:', data.error || 'Unknown error');
+            liveBacktestChartActive = false;
+            liveBacktestRunId = null;
             showBacktestRunProgress(true, { isError: true });
             updateBacktestRunProgress({
                 elapsedSeconds: 0,
                 message: data.error || 'Failed to start backtest.',
             });
-            btn.textContent = '❌ Error - Try Again';
-            btn.disabled = false;
-            setTimeout(() => {
-                btn.textContent = '▶ Run Backtest';
-                showBacktestRunProgress(false);
-            }, 5000);
+            setTimeout(() => showBacktestRunProgress(false), 5000);
             return;
+        }
+
+        const liveRunId = data.live_run_id || data.run_id;
+        if (liveRunId) {
+            stashBacktestLaunchConfig(liveRunId, launchConfigBase);
+            attachToLiveBacktest(liveRunId, null, launchConfigBase);
         }
         
         console.log('✅ Backtest started:', data.message);
-        
-        // Poll for status (now session-aware)
-        await pollBacktestStatus(btn);
+        await pollBacktestStatus(null);
         
     } catch (error) {
         console.error('❌ Error starting backtest:', error.message);
+        liveBacktestChartActive = false;
+        liveBacktestRunId = null;
         showBacktestRunProgress(true, { isError: true });
         updateBacktestRunProgress({
             elapsedSeconds: 0,
             message: error.message || 'Failed to start backtest.',
         });
-        btn.textContent = '❌ Error - Try Again';
-        btn.disabled = false;
-        setTimeout(() => {
-            btn.textContent = '▶ Run Backtest';
-            showBacktestRunProgress(false);
-        }, 5000);
+        setTimeout(() => showBacktestRunProgress(false), 5000);
     }
 }
 
@@ -3764,108 +4216,24 @@ async function runBacktest() {
  * Poll backtest status until complete
  */
 async function pollBacktestStatus(btn) {
+    ensureBacktestPolling();
+    // Legacy callers awaited this; keep a lightweight wait until the poller stops
+    // or the run leaves "running" (max ~10 min).
     const maxAttempts = BACKTEST_POLL_MAX_SECONDS;
-    let attempts = 0;
-    let isComplete = false;
-    
-    return new Promise((resolve) => {
-        const interval = setInterval(async () => {
-            if (isComplete) return; // Prevent re-entry
-            
-            attempts++;
-            const elapsedSeconds = attempts;
-            
-            try {
-                const status = await API.get(`${API_BASE}/backtest/status`);
-                const serverElapsed = Number(status.elapsed_seconds);
-                const displayElapsed = Number.isFinite(serverElapsed) && serverElapsed > 0
-                    ? serverElapsed
-                    : elapsedSeconds;
-
-                if (status.running) {
-                    if (status.progress) {
-                        updateLiveBacktestChart(status.progress);
-                        updateLiveTradingLog(status.progress);
-                    }
-                    const step = Number(status.progress?.step);
-                    const total = Number(status.progress?.total_steps);
-                    const stepPct = Number.isFinite(step) && Number.isFinite(total) && total > 0
-                        ? (100 * step / total)
-                        : null;
-                    updateBacktestRunProgress({
-                        elapsedSeconds: displayElapsed,
-                        message: status.message || 'Backtest is running…',
-                        stepPct,
-                    });
-                    if (btn) {
-                        btn.textContent = `⏳ Running… ${formatBacktestElapsed(displayElapsed)}`;
-                    }
-                }
-                
-                if (!status.running) {
-                    isComplete = true;
-                    clearInterval(interval);
-                    liveBacktestChartActive = false;
-                    
-                    if (status.error) {
-                        console.error('❌ Backtest error:', status.error);
-                        showBacktestRunProgress(true, { isError: true });
-                        updateBacktestRunProgress({
-                            elapsedSeconds: displayElapsed,
-                            message: status.error,
-                        });
-                    } else if (status.success) {
-                        console.log('✅ Backtest completed:', status.message);
-                        console.log(`   Found ${status.runs_count} runs`);
-                        updateBacktestRunProgress({
-                            elapsedSeconds: displayElapsed,
-                            message: `Completed in ${formatBacktestElapsed(displayElapsed)}.`,
-                        });
-                        
-                        console.log('→ Reloading backtest data...');
-                        localStorage.removeItem(SELECTED_BACKTEST_RUN_KEY);
-                        const runSelect = document.getElementById('backtestRunSelect');
-                        if (runSelect) runSelect.value = '';
-                        window.SELECTED_RUN = null;
-                        await loadData();
-                        
-                        console.log('→ Refreshing performance metrics...');
-                        await loadPerformanceMetrics();
-                        
-                        console.log('✅ Dashboard updated with latest backtest results');
-                        setTimeout(() => showBacktestRunProgress(false), 2500);
-                    } else {
-                        showBacktestRunProgress(false);
-                    }
-                    
-                    if (btn) {
-                        btn.textContent = '▶ Run Backtest';
-                        btn.disabled = false;
-                    }
-                    resolve();
-                    return;
-                }
-                
-                if (attempts >= maxAttempts) {
-                    isComplete = true;
-                    clearInterval(interval);
-                    console.warn('⚠️ Backtest timeout - still running after 10 minutes');
-                    showBacktestRunProgress(true, { isError: true });
-                    updateBacktestRunProgress({
-                        elapsedSeconds: maxAttempts,
-                        message: 'Timed out after 10 minutes. The backtest may still be running in the background.',
-                    });
-                    if (btn) {
-                        btn.textContent = '▶ Run Backtest';
-                        btn.disabled = false;
-                    }
-                    resolve();
-                }
-            } catch (error) {
-                console.error('Error polling backtest status:', error);
+    for (let i = 0; i < maxAttempts; i += 1) {
+        if (!backtestPollTimer) {
+            if (btn) {
+                btn.disabled = false;
+                btn.textContent = '▶ Run Backtest';
             }
-        }, 1000);
-    });
+            return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    if (btn) {
+        btn.disabled = false;
+        btn.textContent = '▶ Run Backtest';
+    }
 }
 
 /**
@@ -4513,13 +4881,23 @@ function resolveSelectedExternalRun(externalRuns) {
     return latestRun([...externalRuns]);
 }
 
-function populateBacktestRunSelector(externalRuns) {
+function populateBacktestRunSelector(externalRuns, { runningId = null } = {}) {
     const select = document.getElementById('backtestRunSelect');
     if (!select) return;
 
     const sorted = [...externalRuns].sort(
         (a, b) => (b.created_at || '').localeCompare(a.created_at || ''),
     );
+
+    if (runningId && !sorted.some((run) => run.run_id === runningId)) {
+        const cfg = getBacktestLaunchConfig(runningId);
+        sorted.unshift({
+            run_id: runningId,
+            agent_name: cfg?.agentName || 'Agent',
+            created_at: cfg?.startedAt || '',
+            _running: true,
+        });
+    }
 
     if (!sorted.length) {
         select.innerHTML = '';
@@ -4530,16 +4908,21 @@ function populateBacktestRunSelector(externalRuns) {
     select.hidden = false;
     const previous = select.value || localStorage.getItem(SELECTED_BACKTEST_RUN_KEY);
     select.innerHTML = sorted
-        .map(
-            (run) =>
-                `<option value="${escapeHtml(run.run_id)}">${escapeHtml(formatBacktestRunLabel(run))}</option>`,
-        )
+        .map((run) => {
+            const isRunning = run._running || run.run_id === runningId;
+            const label = isRunning
+                ? `Running… · ${formatBacktestRunPrimary(run)}`
+                : formatBacktestRunLabel(run);
+            return `<option value="${escapeHtml(run.run_id)}">${escapeHtml(label)}</option>`;
+        })
         .join('');
 
     const selectedId =
-        previous && sorted.some((r) => r.run_id === previous)
-            ? previous
-            : sorted[0].run_id;
+        (runningId && sorted.some((r) => r.run_id === runningId) && (!previous || previous === runningId))
+            ? runningId
+            : (previous && sorted.some((r) => r.run_id === previous)
+                ? previous
+                : sorted[0].run_id);
     select.value = selectedId;
     localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, selectedId);
 }
@@ -4654,11 +5037,42 @@ async function loadData() {
                 console.warn('Session runs unavailable:', e.message);
             }
 
-            // Selectable runs are the agent's own runs; baselines are plotted
-            // for comparison but never listed/selected. Built-in and external
-            // agents share this path: the selected run_id drives everything.
+            let runningId = liveBacktestRunId || null;
+            let statusProgress = null;
+            try {
+                const status = await API.get(`${API_BASE}/backtest/status`);
+                if (status?.running && status.live_run_id) {
+                    runningId = status.live_run_id;
+                    liveBacktestRunId = runningId;
+                    statusProgress = status.progress || null;
+                    ensureBacktestPolling();
+                } else if (!status?.running) {
+                    liveBacktestRunId = null;
+                }
+            } catch (_statusError) {
+                /* status optional while browsing history */
+            }
+
             const selectableRuns = sessionRuns.filter(r => !isBaselineRun(r));
-            populateBacktestRunSelector(selectableRuns);
+            populateBacktestRunSelector(selectableRuns, { runningId });
+
+            const selectedId = localStorage.getItem(SELECTED_BACKTEST_RUN_KEY);
+
+            // Dropdown (or deep-link) onto the in-flight run — always attach live
+            // surface even if the run is not in DB yet (synthetic selector option).
+            if (runningId && selectedId === runningId) {
+                attachToLiveBacktest(
+                    runningId,
+                    statusProgress,
+                    getBacktestLaunchConfig(runningId),
+                );
+                return;
+            }
+
+            // Viewing a finished run while another job may still be running.
+            liveBacktestChartActive = false;
+            showBacktestRunProgress(false);
+
             const selectedRun = resolveSelectedRun(sessionRuns);
 
             window.SELECTED_RUN = selectedRun;
@@ -4671,14 +5085,34 @@ async function loadData() {
                 comparisonData = null;
                 backtestChartData = null;
                 displayNoMetrics();
-                clearTradingLog('Run a backtest to see trades here.');
+                clearTradingLog(
+                    runningId
+                        ? 'Select the Running run to watch live progress.'
+                        : 'No backtests yet. Run one from My Agents.',
+                );
+                if (runningId) {
+                    renderBacktestRunConfig(
+                        { run_id: runningId },
+                        { running: true, launchConfig: getBacktestLaunchConfig(runningId) },
+                    );
+                } else {
+                    renderBacktestRunConfig(null);
+                }
                 return;
             }
 
             localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, selectedRun.run_id);
+            renderBacktestRunConfig(selectedRun, {
+                running: false,
+                launchConfig: getBacktestLaunchConfig(selectedRun.run_id),
+            });
 
             const chartUrl = `${API_BASE}/api/backtest/${encodeURIComponent(selectedRun.run_id)}/chart-data?t=${Date.now()}`;
             backtestChartData = await API.get(chartUrl);
+            // Another click may have switched to the live run while we awaited.
+            if (liveBacktestChartActive || isViewingLiveBacktest(runningId)) {
+                return;
+            }
             console.log('Loaded backtest chart data:', backtestChartData);
 
             initializeCharts();
@@ -4696,6 +5130,10 @@ async function loadData() {
  * Agent vs DJIA index + Nasdaq-100 (same baselines as Discord plot.png).
  */
 function initializeCharts() {
+    if (liveBacktestChartActive) {
+        console.log('Skipping historical chart paint — live backtest view is active');
+        return;
+    }
     if (!backtestChartData || !backtestChartData.series || !backtestChartData.series.length) {
         console.warn('No backtest chart data available');
         return;

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -1168,107 +1168,244 @@ async function updateHomePortfolioModule() {
     renderHomePortfolioChart(equity, dayPnl, homePortRange);
 }
 
-function renderHomeAgentStatusCard(agent) {
-    const status = (typeof resolveAgentStatusBadge === 'function')
-        ? resolveAgentStatusBadge(agent)
-        : { key: 'draft', label: 'DRAFT', className: 'draft' };
+function homeListUserAgents() {
+    if (typeof allAgents === 'undefined' || !Array.isArray(allAgents)) return [];
+    return allAgents.filter(
+        (a) => a?.agent_id && !(typeof isDemoAgent === 'function' && isDemoAgent(a.agent_id)),
+    );
+}
+
+function homeAgentIsPaperTrading(agent) {
+    if (typeof resolveAgentStatusBadge === 'function') {
+        return resolveAgentStatusBadge(agent).key === 'paper';
+    }
+    const deployment = String(agent?.deployment_status || '').toLowerCase();
+    return agent?.is_live === true || deployment === 'live' || deployment === 'paper';
+}
+
+function homeParseActivityTime(raw) {
+    if (!raw) return NaN;
+    const t = new Date(String(raw).replace(' ', 'T')).getTime();
+    return Number.isFinite(t) ? t : NaN;
+}
+
+function homeActivityRelTime(iso) {
+    const t = homeParseActivityTime(iso);
+    if (!Number.isFinite(t)) return '';
+    const mins = Math.round((Date.now() - t) / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins} min ago`;
+    const hours = Math.round(mins / 60);
+    if (hours < 24) return `${hours} hr ago`;
+    const startToday = new Date();
+    startToday.setHours(0, 0, 0, 0);
+    const startYesterday = new Date(startToday);
+    startYesterday.setDate(startYesterday.getDate() - 1);
+    if (t >= startYesterday.getTime() && t < startToday.getTime()) return 'Yesterday';
+    if (typeof formatRelativeTime === 'function') return formatRelativeTime(iso);
+    return `${Math.round(hours / 24)}d ago`;
+}
+
+function homeFormatReturnBadge(run) {
+    const retRaw = Number(run?.total_return);
+    let frac = null;
+    if (Number.isFinite(retRaw)) {
+        frac = Math.abs(retRaw) <= 1 ? retRaw : retRaw / 100;
+    } else {
+        const initial = Number(run?.initial_equity);
+        const final = Number(run?.final_equity);
+        if (Number.isFinite(initial) && initial > 0 && Number.isFinite(final)) {
+            frac = (final - initial) / initial;
+        }
+    }
+    if (frac == null || !Number.isFinite(frac)) return null;
+    const pct = frac * 100;
+    const sign = pct > 0 ? '+' : '';
+    return {
+        text: `${sign}${pct.toFixed(1)}%`,
+        tone: pct >= 0 ? 'pos' : 'neg',
+    };
+}
+
+/** Build up to 3 recent real activities from agent records (no demo filler). */
+function collectHomeAgentActivities(agents) {
+    const events = [];
+    for (const agent of agents) {
+        const agentId = agent.agent_id;
+        const agentName = agent.name || 'Untitled agent';
+
+        if (agent.created_at) {
+            events.push({
+                at: agent.created_at,
+                agentId,
+                agentName,
+                kind: 'created',
+                description: 'was created',
+                badge: null,
+                tone: 'neutral',
+                target: 'configure',
+                runId: null,
+            });
+        }
+
+        const runs = Array.isArray(agent.runs) && agent.runs.length
+            ? agent.runs
+            : (agent.latest_run && (agent.latest_run.run_id || agent.latest_run.created_at)
+                ? [agent.latest_run]
+                : []);
+        const seenRuns = new Set();
+        for (const run of runs) {
+            const runId = run?.run_id || null;
+            const dedupe = runId || `${agentId}:${run?.created_at || ''}`;
+            if (seenRuns.has(dedupe)) continue;
+            seenRuns.add(dedupe);
+            if (!run?.created_at && !runId) continue;
+            const badge = homeFormatReturnBadge(run);
+            events.push({
+                at: run.created_at || agent.created_at,
+                agentId,
+                agentName,
+                kind: 'backtest',
+                description: 'completed a backtest',
+                badge: badge?.text || null,
+                tone: badge?.tone || 'neutral',
+                target: 'backtest',
+                runId,
+            });
+        }
+
+        if (homeAgentIsPaperTrading(agent)) {
+            const paperAt = agent.paper_updated_at || agent.last_used_at || agent.created_at;
+            if (paperAt) {
+                events.push({
+                    at: paperAt,
+                    agentId,
+                    agentName,
+                    kind: 'paper',
+                    description: 'started paper trading',
+                    badge: null,
+                    tone: 'cyan',
+                    target: 'paper',
+                    runId: null,
+                });
+            }
+        }
+    }
+
+    return events
+        .filter((e) => Number.isFinite(homeParseActivityTime(e.at)))
+        .sort((a, b) => homeParseActivityTime(b.at) - homeParseActivityTime(a.at))
+        .slice(0, 3);
+}
+
+function renderHomeAgentOverview(agents) {
     const esc = (typeof escapeHtml === 'function') ? escapeHtml : (v) => String(v ?? '');
-    const modelLabel = (typeof formatAgentModelLabel === 'function')
-        ? formatAgentModelLabel(agent.model_name)
-        : (agent.model_name || 'local-model');
-    const type = (typeof agentTypeLabel === 'function')
-        ? agentTypeLabel(agent)
-        : (agent.agent_type === 'builtin' ? 'Built-in' : 'External');
-    const icon = (typeof agentRobotIcon === 'function')
-        ? agentRobotIcon()
-        : '';
-    const body = (typeof renderAgentCardBody === 'function')
-        ? renderAgentCardBody(agent, status.key)
-        : '';
-    const actions = (typeof renderAgentCardActions === 'function')
-        ? renderAgentCardActions(agent, status.key)
-        : '';
+    const total = agents.length;
+    const paper = agents.filter(homeAgentIsPaperTrading).length;
+    const notTrading = Math.max(0, total - paper);
+    const activities = collectHomeAgentActivities(agents);
+
+    const activityHtml = activities.length
+        ? `<ul class="hm-agent-activity-list" role="list">
+            ${activities.map((ev) => {
+                const badge = ev.badge
+                    ? `<span class="hm-agent-activity-badge is-${esc(ev.tone)}">${esc(ev.badge)}</span>`
+                    : '';
+                return `<li>
+                  <button type="button" class="hm-agent-activity-row"
+                    data-agent-id="${esc(ev.agentId)}"
+                    data-target="${esc(ev.target)}"
+                    data-run-id="${esc(ev.runId || '')}"
+                    data-kind="${esc(ev.kind)}">
+                    <span class="hm-agent-activity-dot is-${esc(ev.tone || ev.kind)}" aria-hidden="true"></span>
+                    <span class="hm-agent-activity-main">
+                      <span class="hm-agent-activity-name">${esc(ev.agentName)}</span>
+                      <span class="hm-agent-activity-desc">${esc(ev.description)}</span>
+                      ${badge}
+                    </span>
+                    <time class="hm-agent-activity-time tabular-nums" datetime="${esc(ev.at)}">${esc(homeActivityRelTime(ev.at))}</time>
+                  </button>
+                </li>`;
+            }).join('')}
+          </ul>`
+        : `<p class="hm-agent-activity-empty">No recent agent activity.</p>`;
 
     return `
-      <div class="agent-card agent-card--status agent-card--home agent-card--${status.key}">
-        <div class="agent-card-top">
-          <div class="agent-card-identity">
-            ${icon}
-            <div class="agent-card-identity-text">
-              <h3 class="agent-name">${esc(agent.name || 'Untitled agent')}</h3>
-              <p class="agent-card-submeta">${esc(modelLabel)} · ${esc(type)}</p>
-            </div>
+      <div class="hm-agent-overview" aria-label="Agent team overview">
+        <div class="hm-agent-stats" role="group" aria-label="Agent status overview">
+          <div class="hm-agent-stat">
+            <span class="hm-agent-stat-value tabular-nums">${esc(String(total))}</span>
+            <span class="hm-agent-stat-label">Total Agents</span>
           </div>
-          <span class="status-badge ${status.className}"><span class="status-badge-dot" aria-hidden="true"></span>${status.label}</span>
+          <div class="hm-agent-stat hm-agent-stat--paper">
+            <span class="hm-agent-stat-value tabular-nums">${esc(String(paper))}</span>
+            <span class="hm-agent-stat-label">Paper Trading</span>
+          </div>
+          <div class="hm-agent-stat hm-agent-stat--idle">
+            <span class="hm-agent-stat-value tabular-nums">${esc(String(notTrading))}</span>
+            <span class="hm-agent-stat-label">Not Trading</span>
+          </div>
         </div>
-        ${body}
-        ${actions}
+        <div class="hm-agent-activity">
+          <p class="hm-agent-activity-label">Agent Activity</p>
+          ${activityHtml}
+        </div>
       </div>`;
+}
+
+async function openHomeAgentActivity(event) {
+    const row = event.currentTarget;
+    const agentId = row?.dataset?.agentId;
+    if (!agentId) return;
+    const agents = homeListUserAgents();
+    const agent = agents.find((a) => a.agent_id === agentId);
+    if (!agent) return;
+
+    const target = row.dataset.target || 'configure';
+    const runId = row.dataset.runId || null;
+
+    if (target === 'backtest' && typeof openAgentInBacktest === 'function') {
+        await openAgentInBacktest(agent, runId || undefined);
+        return;
+    }
+    if (target === 'paper' && typeof openAgentInPaper === 'function') {
+        await openAgentInPaper(agent);
+        return;
+    }
+    if (typeof navigateToPage === 'function') {
+        navigateToPage('playground', { playgroundTab: 'agents' });
+    }
+    if (typeof showPlaygroundPanel === 'function') {
+        showPlaygroundPanel('agents');
+    }
+    if (window.AgentEditor?.open) {
+        window.AgentEditor.open(agent);
+    }
 }
 
 function updateHomeAgentModule() {
     const empty = document.getElementById('homeAgentEmpty');
     const filled = document.getElementById('homeAgentFilled');
-    const viewBtn = document.getElementById('homeModuleViewAgentsBtn');
+    const agents = homeListUserAgents();
 
-    const agents = (typeof allAgents !== 'undefined' && Array.isArray(allAgents))
-        ? allAgents.filter((a) => a?.agent_id && !(typeof isDemoAgent === 'function' && isDemoAgent(a.agent_id)))
-        : [];
-    const activeId = localStorage.getItem('active-agent-id');
-    const agent = agents.find((a) => a.agent_id === activeId) || agents[0] || null;
-
-    if (!agent) {
+    if (!agents.length) {
         if (empty) empty.hidden = false;
         if (filled) {
             filled.hidden = true;
             filled.innerHTML = '';
         }
-        if (viewBtn) viewBtn.hidden = true;
         return;
     }
 
     if (empty) empty.hidden = true;
-    if (viewBtn) viewBtn.hidden = false;
     if (!filled) return;
     filled.hidden = false;
-    filled.innerHTML = renderHomeAgentStatusCard(agent);
+    filled.innerHTML = renderHomeAgentOverview(agents);
 
-    filled.querySelectorAll('.agent-view-runs-btn').forEach((btn) => {
-        btn.addEventListener('click', async (event) => {
+    filled.querySelectorAll('.hm-agent-activity-row').forEach((btn) => {
+        btn.addEventListener('click', (event) => {
             event.preventDefault();
-            event.stopPropagation();
-            if (typeof openAgentInBacktest !== 'function') {
-                if (typeof navigateToPage === 'function') {
-                    navigateToPage('playground', { playgroundTab: 'backtest' });
-                }
-                return;
-            }
-            const runId = typeof resolveLatestAgentRunId === 'function'
-                ? resolveLatestAgentRunId(agent)
-                : (typeof resolveBacktestCardMetrics === 'function'
-                    ? resolveBacktestCardMetrics(agent).runId
-                    : null);
-            await openAgentInBacktest(agent, runId);
-        });
-    });
-
-    filled.querySelectorAll('.agent-run-backtest-btn').forEach((btn) => {
-        btn.addEventListener('click', async (event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (typeof openAgentInBacktest === 'function') {
-                await openAgentInBacktest(agent);
-            }
-        });
-    });
-
-    filled.querySelectorAll('.agent-open-btn').forEach((btn) => {
-        btn.addEventListener('click', async (event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            if (typeof openAgentInPaper === 'function') {
-                await openAgentInPaper(agent);
-            }
+            openHomeAgentActivity(event);
         });
     });
 }

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -224,10 +224,10 @@
     if (cashInput && cashInput.value !== '') {
       const value = Number(cashInput.value);
       if (!Number.isFinite(value) || value < 0) {
-        throw new Error('Initial cash must be zero or greater.');
+        throw new Error('Allocated capital must be zero or greater.');
       }
       if (value > 3000) {
-        throw new Error('Initial cash cannot exceed $3,000.');
+        throw new Error('Allocated capital cannot exceed $3,000.');
       }
       cash_allocation = Math.round(value);
     } else {
@@ -670,7 +670,7 @@
     }
 
     if (!sorted.length) {
-      container.innerHTML = '<p class="agent-editor-run-empty">No backtest runs yet. Run a backtest from Playground to see history here.</p>';
+      container.innerHTML = '<p class="agent-editor-run-empty">No backtest runs yet. Run a backtest from this agent to see history here.</p>';
       return;
     }
 
@@ -947,6 +947,12 @@
     document.getElementById('agentEditorResetBtn')?.addEventListener('click', resetPipeline);
     document.getElementById('agentEditorModeSimple')?.addEventListener('click', () => setEditorMode('simple'));
     document.getElementById('agentEditorModeAdvanced')?.addEventListener('click', () => setEditorMode('advanced'));
+    document.getElementById('agentEditorRunBacktestBtn')?.addEventListener('click', () => {
+      if (!currentAgent) return;
+      if (typeof window.openRunBacktestModal === 'function') {
+        window.openRunBacktestModal(currentAgent);
+      }
+    });
 
     document.getElementById('agentEditorAddSelect')?.addEventListener('change', (e) => {
       const customName = document.getElementById('agentEditorCustomName');

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -1300,107 +1300,6 @@ a.header-brand:hover .title-section h1 {
     color: var(--info-color);
 }
 
-/* Collapsible Advanced Settings */
-.collapsible-header {
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    width: 100%;
-    text-align: left;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 12px;
-    transition: all 0.15s;
-}
-
-.collapsible-header:hover {
-    opacity: 0.8;
-}
-
-.toggle-icon {
-    display: inline-block;
-    transition: transform 0.2s;
-    font-size: 10px;
-    color: var(--text-secondary);
-}
-
-.collapsible-header.active .toggle-icon {
-    transform: rotate(90deg);
-}
-
-.collapsible-content {
-    max-height: 1000px;
-    overflow: hidden;
-    transition: max-height 0.3s ease-in-out;
-}
-
-.collapsible-content.hidden {
-    max-height: 0;
-    display: none;
-}
-
-.slider-container {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.slider {
-    width: 100%;
-    height: 2px;
-    border-radius: 1px;
-    background-color: var(--border-color);
-    outline: none;
-    -webkit-appearance: none;
-    appearance: none;
-}
-
-.slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 11px;
-    height: 11px;
-    border-radius: 50%;
-    background-color: var(--info-color);
-    cursor: pointer;
-    transition: all 0.15s;
-}
-
-.slider::-webkit-slider-thumb:hover {
-    background-color: #5ba3f5;
-}
-
-.slider::-moz-range-thumb {
-    width: 11px;
-    height: 11px;
-    border-radius: 50%;
-    background-color: var(--info-color);
-    border: none;
-    cursor: pointer;
-    transition: all 0.15s;
-}
-
-.slider::-moz-range-thumb:hover {
-    background-color: #5ba3f5;
-}
-
-.slider-labels {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: 11px;
-    color: var(--text-secondary);
-}
-
-.slider-value {
-    color: var(--text-primary);
-    font-weight: 700;
-    font-family: var(--font-mono);
-    flex: 0 0 auto;
-}
-
 .reset-defaults-btn {
     width: 100%;
     padding: 5px;
@@ -4368,6 +4267,94 @@ a.header-brand:hover .title-section h1 {
     background: rgba(34, 211, 238, 0.06);
 }
 
+.backtest-config-list {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.backtest-config-row {
+    display: grid;
+    gap: 4px;
+}
+
+.backtest-config-row dt {
+    margin: 0;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.backtest-config-row dd {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    word-break: break-word;
+}
+
+.backtest-config-prompt {
+    white-space: pre-wrap;
+    font-weight: 500;
+    line-height: 1.45;
+    max-height: 140px;
+    overflow: auto;
+    padding: 8px 10px;
+    border-radius: 8px;
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--border-color);
+}
+
+.run-backtest-modal {
+    z-index: 1300;
+}
+
+.run-backtest-modal-panel {
+    width: min(560px, calc(100vw - 32px));
+    max-height: calc(100vh - 48px);
+    overflow: auto;
+}
+
+.run-backtest-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin-bottom: 16px;
+}
+
+.run-backtest-readonly {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.run-backtest-prompt-preview {
+    margin: 0;
+    max-height: 120px;
+    overflow: auto;
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    color: var(--text-primary);
+}
+
+.run-backtest-modal .universe-tabs {
+    margin-top: 8px;
+}
+
+.run-backtest-modal .preset-cards {
+    margin-top: 10px;
+}
+
 .backtest-run-progress-head {
     display: flex;
     align-items: center;
@@ -5248,7 +5235,27 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 }
 .hm-buying-power strong { color: var(--home-accent-cyan); }
 
-/* Agent */
+/* Agent — team overview (not a single-agent detail card) */
+.hm-head-outline-btn {
+    appearance: none;
+    flex-shrink: 0;
+    margin: 0;
+    padding: 5px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    background: transparent;
+    color: rgba(226, 232, 240, 0.88);
+    font-size: 12px;
+    font-weight: 650;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.hm-head-outline-btn:hover {
+    border-color: rgba(34, 211, 238, 0.4);
+    color: var(--home-accent-cyan, #22d3ee);
+    background: rgba(34, 211, 238, 0.06);
+}
 .hm-agent-empty {
     display: flex;
     flex-direction: column;
@@ -5256,30 +5263,38 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     justify-content: center;
     align-items: center;
     text-align: center;
+    gap: 12px;
     min-height: 0;
-    padding: 24px 12px;
+    padding: 20px 12px;
+}
+.hm-agent-empty-copy {
+    margin: 0;
+    max-width: 22em;
+    font-size: 13.5px;
+    line-height: 1.45;
+    color: var(--text-muted);
 }
 .hm-agent-empty-cta {
     appearance: none;
-    border: none;
-    background: transparent;
+    border: 1px solid rgba(34, 211, 238, 0.35);
+    background: rgba(34, 211, 238, 0.08);
     color: var(--home-accent-cyan, #22d3ee);
-    font-size: 15px;
+    font-size: 13.5px;
     font-weight: 650;
     letter-spacing: 0.01em;
     cursor: pointer;
-    padding: 8px 12px;
-    border-radius: 8px;
-    transition: background 0.15s, color 0.15s;
+    padding: 8px 14px;
+    border-radius: 999px;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 .hm-agent-empty-cta:hover {
-    background: rgba(34, 211, 238, 0.1);
+    background: rgba(34, 211, 238, 0.14);
+    border-color: rgba(34, 211, 238, 0.5);
     color: #67e8f9;
 }
 .hm-agent-filled {
     display: flex;
     flex-direction: column;
-    gap: 10px;
     min-height: 0;
     flex: 1;
 }
@@ -5288,81 +5303,185 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     display: none !important;
 }
 .home-module--agent .home-module-head {
-    margin-bottom: 12px;
+    margin-bottom: 10px;
 }
-.home-module--agent .agent-card--home {
-    flex: 1;
-    gap: 14px;
-    padding: 0;
-    min-height: 0;
-    border: none;
-    background: transparent;
-    border-radius: 0;
-    justify-content: flex-start;
-}
-.home-module--agent .agent-card-identity {
+.hm-agent-overview {
+    display: flex;
+    flex-direction: column;
     gap: 12px;
+    min-height: 0;
+    flex: 1;
 }
-.home-module--agent .agent-card-metric-value {
-    font-size: 26px;
-    line-height: 1.15;
+.hm-agent-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px 10px;
+    flex-shrink: 0;
+    padding: 2px 0 10px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
 }
-.home-module--agent .agent-card-metric-head {
-    margin-bottom: 4px;
+.hm-agent-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
 }
-.home-module--agent .agent-card-icon {
-    width: 40px;
-    height: 40px;
+.hm-agent-stat-value {
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    color: rgba(248, 250, 252, 0.96);
+    line-height: 1;
 }
-.home-module--agent .agent-card-icon svg {
-    width: 20px;
-    height: 20px;
+.hm-agent-stat--paper .hm-agent-stat-value {
+    color: var(--home-accent-cyan, #22d3ee);
 }
-.home-module--agent .agent-name {
-    font-size: 16px;
-    line-height: 1.25;
+.hm-agent-stat--idle .hm-agent-stat-value {
+    color: rgba(148, 163, 184, 0.95);
 }
-.home-module--agent .agent-card-submeta {
+.hm-agent-stat-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.hm-agent-activity {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 0;
+    flex: 1 1 auto;
+}
+.hm-agent-activity-label {
+    margin: 0;
+    font-size: 12.5px;
+    font-weight: 650;
+    letter-spacing: 0.01em;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+.hm-agent-activity-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-height: 0;
+    overflow: auto;
+}
+.hm-agent-activity-list li { margin: 0; padding: 0; }
+.hm-agent-activity-row {
+    appearance: none;
+    width: 100%;
+    display: grid;
+    grid-template-columns: 8px minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: start;
+    text-align: left;
+    margin: 0;
+    padding: 7px 6px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.hm-agent-activity-row:hover {
+    background: rgba(34, 211, 238, 0.06);
+}
+.hm-agent-activity-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    margin-top: 5px;
+    background: rgba(148, 163, 184, 0.65);
+    box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.1);
+}
+.hm-agent-activity-dot.is-cyan,
+.hm-agent-activity-dot.is-paper {
+    background: var(--home-accent-cyan, #22d3ee);
+    box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.14);
+}
+.hm-agent-activity-dot.is-pos,
+.hm-agent-activity-dot.is-backtest {
+    background: #4ade80;
+    box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.12);
+}
+.hm-agent-activity-dot.is-neg {
+    background: #f87171;
+    box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.12);
+}
+.hm-agent-activity-main {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 6px;
+    min-width: 0;
+    font-size: 12.5px;
+    line-height: 1.35;
+    color: var(--text-secondary);
+}
+.hm-agent-activity-name {
+    font-weight: 700;
+    color: rgba(226, 232, 240, 0.94);
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.hm-agent-activity-desc {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.hm-agent-activity-badge {
+    flex-shrink: 0;
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    border: 1px solid transparent;
+}
+.hm-agent-activity-badge.is-pos {
+    color: #86efac;
+    background: rgba(34, 197, 94, 0.1);
+    border-color: rgba(34, 197, 94, 0.22);
+}
+.hm-agent-activity-badge.is-neg {
+    color: #fca5a5;
+    background: rgba(248, 113, 113, 0.1);
+    border-color: rgba(248, 113, 113, 0.22);
+}
+.hm-agent-activity-time {
+    color: var(--text-muted);
+    white-space: nowrap;
+    font-size: 11px;
+    margin-top: 2px;
+}
+.hm-agent-activity-empty {
+    margin: 0;
+    padding: 8px 2px 0;
     font-size: 12.5px;
     color: var(--text-muted);
-    line-height: 1.3;
 }
-.home-module--agent .agent-card-sparkline {
-    width: 96px;
-    height: 42px;
-}
-.home-module--agent .agent-card-hero {
-    align-items: flex-start;
-    gap: 12px;
-}
-.home-module--agent .agent-card-change {
-    margin-top: 6px;
-}
-.home-module--agent .agent-card-period {
-    margin: -4px 0 0;
-}
-.home-module--agent .agent-card-period,
-.home-module--agent .agent-card-activity-text,
-.home-module--agent .agent-card-change {
-    font-size: 12px;
-}
-.home-module--agent .agent-card-actions {
-    display: none !important;
-}
-.home-module--agent .agent-card-runs-link {
-    display: flex !important;
-    margin: 0;
-    padding: 8px 0;
-    font-size: 12.5px;
-}
-.home-module--agent .agent-card-activity {
-    padding: 0;
-}
-.home-module--agent .agent-card-empty {
-    padding: 16px 12px;
-}
-.home-module--agent .hm-footer-btn {
-    margin-top: auto;
+@media (max-width: 820px) {
+    .hm-agent-stats {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+    .hm-agent-stat {
+        flex-direction: row;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 10px;
+    }
+    .hm-agent-stat-value { font-size: 18px; }
 }
 
 /* Leaderboard */
@@ -8671,6 +8790,8 @@ body.agent-editor-open {
     font-weight: 600;
     text-align: left;
     cursor: pointer;
+    text-decoration: none;
+    box-sizing: border-box;
 }
 
 .account-menu-item:hover {


### PR DESCRIPTION
## Summary
- Run Backtest modal (period, universe labeled DJIA 30, capital, model override) from agent cards / editor; Backtest tab shows read-only run config.
- Agent cards render sparklines from `equity_sparkline` (falls back to start→end).
- Home **My Agents** module is a team overview (Total / Paper Trading / Not Trading + recent activity), not a single-agent portfolio card.

## Depends on
Best merged **after** `feat/backtest-capital-and-universe` so selected assets, independent capital, and sparkline samples are honored end-to-end. Frontend still degrades safely if that PR is not in yet.

## Test plan
- [ ] Hard refresh `/app`: Home My Agents shows counts from real agents; empty state copy + Create Agent when none
- [ ] Activity rows open configure / backtest / paper targets
- [ ] Run Backtest from agent card → modal → Backtest tab config + live progress
- [ ] Select DJIA 30 vs Mag7; request body includes `assets` and `initial_capital`
- [ ] Portfolio / Leaderboard home modules unchanged visually


Made with [Cursor](https://cursor.com)