### PR TITLE
fix(dashboard): portfolio load flash and cash ±100 steps

### DIFF
--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -578,8 +578,8 @@
                             </header>
                             <div class="hm-community-stats">
                                 <div class="hm-community-stat">
-                                    <span id="homeMetricAgents" class="hm-community-value tabular-nums">28</span>
-                                    <span class="hm-community-label">Active agents</span>
+                                    <span id="homeMetricAgents" class="hm-community-value tabular-nums">—</span>
+                                    <span class="hm-community-label">Your agents</span>
                                 </div>
                                 <div class="hm-community-stat">
                                     <span id="homeMetricUsers" class="hm-community-value tabular-nums">126</span>
@@ -1518,7 +1518,7 @@
     <script src="market-events/marketEventRelativeTime.js"></script>
     <script src="market-events/MarketEventCard.js"></script>
     <script src="market-events/MarketEventFeed.js"></script>
-    <script src="js/portfolio.js?v=12"></script>
+    <script src="js/portfolio.js?v=13"></script>
     <script src="js/agent-editor.js?v=11"></script>
     <script src="app.js?v=41"></script>
     <script src="js/leaderboard.js?v=16"></script>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -578,8 +578,8 @@
                             </header>
                             <div class="hm-community-stats">
                                 <div class="hm-community-stat">
-                                    <span id="homeMetricAgents" class="hm-community-value tabular-nums">—</span>
-                                    <span class="hm-community-label">Your agents</span>
+                                    <span id="homeMetricAgents" class="hm-community-value tabular-nums">28</span>
+                                    <span class="hm-community-label">Active agents</span>
                                 </div>
                                 <div class="hm-community-stat">
                                     <span id="homeMetricUsers" class="hm-community-value tabular-nums">126</span>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -201,6 +201,97 @@ function parseAgentCashAllocationInput(raw) {
   return Math.round(value);
 }
 
+/**
+ * Native number spinners sometimes step by 1 on the first click even when
+ * step="100" (leaving values like 1101). Intercept arrows and snap ±1 glitches
+ * so capital inputs always move in $100 increments.
+ */
+const CASH_STEP_INPUT_IDS = [
+  'externalAgentCashAllocation',
+  'builtinAgentCashAllocation',
+  'agentEditorCashAllocation',
+  'backtestInitialCapital',
+];
+
+function cashStepMeta(input) {
+  const step = Math.max(1, Number(input.step) || 100);
+  const min = Number(input.min);
+  const max = Number(input.max);
+  return {
+    step,
+    min: Number.isFinite(min) ? min : 0,
+    max: Number.isFinite(max) ? max : Number.POSITIVE_INFINITY,
+  };
+}
+
+function snapCashStepValue(input, raw) {
+  const { step, min, max } = cashStepMeta(input);
+  let value = Number(raw);
+  if (!Number.isFinite(value)) value = min;
+  value = Math.round(value / step) * step;
+  return Math.min(max, Math.max(min, value));
+}
+
+function nudgeCashStepInput(input, direction) {
+  const { step, min, max } = cashStepMeta(input);
+  const current = snapCashStepValue(input, input.value === '' ? min : input.value);
+  const next = Math.min(max, Math.max(min, current + direction * step));
+  input.value = String(next);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function bindCashStepInput(input) {
+  if (!input || input.dataset.cashStepBound === '1') return;
+  input.dataset.cashStepBound = '1';
+  if (!input.step || input.step === 'any') input.step = '100';
+
+  let lastValue = snapCashStepValue(input, input.value === '' ? 0 : input.value);
+
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      nudgeCashStepInput(input, 1);
+      lastValue = Number(input.value);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      nudgeCashStepInput(input, -1);
+      lastValue = Number(input.value);
+    }
+  });
+
+  input.addEventListener('input', () => {
+    const value = Number(input.value);
+    if (!Number.isFinite(value)) return;
+    const diff = value - lastValue;
+    // Spinner glitch: first click often lands on ±1 instead of ±step.
+    if (Math.abs(diff) === 1) {
+      const step = Number(input.step) || 100;
+      const corrected = snapCashStepValue(
+        input,
+        lastValue + (diff > 0 ? step : -step),
+      );
+      input.value = String(corrected);
+      lastValue = corrected;
+      return;
+    }
+    lastValue = value;
+  });
+
+  input.addEventListener('change', () => {
+    if (input.value === '') return;
+    const snapped = snapCashStepValue(input, input.value);
+    if (String(snapped) !== input.value) input.value = String(snapped);
+    lastValue = snapped;
+  });
+}
+
+function bindCashStepInputs() {
+  CASH_STEP_INPUT_IDS.forEach((id) => {
+    bindCashStepInput(document.getElementById(id));
+  });
+}
+
 function applyAgentCashAllocationOverride(agent) {
   if (!agent?.agent_id) return agent;
   if (agent.cash_allocation != null) return agent;
@@ -2412,6 +2503,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Initialize session FIRST (before any API calls)
     initSession();
     initAuthUI();
+    bindCashStepInputs();
     await restoreActiveAgentSession();
     // Portfolio overview must not wait on the agents waterfall. Paint any
     // sessionStorage snapshot immediately, kick GET /portfolio in parallel,

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -151,7 +151,9 @@ let homeMockIndex = 0;
 let homeToastTimer = null;
 let homeActivePulseTab = 'traded';
 let homeFeedHovered = false;
-let homeMetricValues = { agents: 28, decisions: 147, trades: 37, backtests: 126 };
+let homeMetricValues = { agents: 0, decisions: 147, trades: 37, backtests: 126 };
+/** When true, Community "Active agents" is driven by the user's held agents — mock pulses must not overwrite it. */
+let homeAgentsMetricIsLive = false;
 let homeEvents = [];
 let homeLatestEvent = null;
 
@@ -345,6 +347,7 @@ function prependActivity(item) {
 }
 
 function flashMetric(key, delta) {
+    if (key === 'agents' && homeAgentsMetricIsLive) return;
     if (homeMetricValues[key] === undefined) return;
     homeMetricValues[key] = Math.max(0, homeMetricValues[key] + delta);
     const map = {
@@ -1175,6 +1178,16 @@ function homeListUserAgents() {
     );
 }
 
+/** Community card: count of the user's agents that currently hold allocated capital. */
+function updateHomeCommunityAgentCount() {
+    const agents = homeListUserAgents();
+    const held = agents.filter((agent) => Number(agent.cash_allocation) > 0).length;
+    homeAgentsMetricIsLive = true;
+    homeMetricValues.agents = held;
+    const el = document.getElementById('homeMetricAgents');
+    if (el) el.textContent = String(held);
+}
+
 function homeAgentIsPaperTrading(agent) {
     if (typeof resolveAgentStatusBadge === 'function') {
         return resolveAgentStatusBadge(agent).key === 'paper';
@@ -1700,6 +1713,7 @@ function refreshHomeModules() {
         console.warn('Home portfolio refresh failed:', error?.message || error);
     });
     updateHomeAgentModule();
+    updateHomeCommunityAgentCount();
     loadHomeLeaderboardModule();
     loadHomeMarketNewsModule();
 }

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -151,9 +151,7 @@ let homeMockIndex = 0;
 let homeToastTimer = null;
 let homeActivePulseTab = 'traded';
 let homeFeedHovered = false;
-let homeMetricValues = { agents: 0, decisions: 147, trades: 37, backtests: 126 };
-/** When true, Community "Active agents" is driven by the user's held agents — mock pulses must not overwrite it. */
-let homeAgentsMetricIsLive = false;
+let homeMetricValues = { agents: 28, decisions: 147, trades: 37, backtests: 126 };
 let homeEvents = [];
 let homeLatestEvent = null;
 
@@ -347,7 +345,6 @@ function prependActivity(item) {
 }
 
 function flashMetric(key, delta) {
-    if (key === 'agents' && homeAgentsMetricIsLive) return;
     if (homeMetricValues[key] === undefined) return;
     homeMetricValues[key] = Math.max(0, homeMetricValues[key] + delta);
     const map = {
@@ -1178,16 +1175,6 @@ function homeListUserAgents() {
     );
 }
 
-/** Community card: count of the user's agents that currently hold allocated capital. */
-function updateHomeCommunityAgentCount() {
-    const agents = homeListUserAgents();
-    const held = agents.filter((agent) => Number(agent.cash_allocation) > 0).length;
-    homeAgentsMetricIsLive = true;
-    homeMetricValues.agents = held;
-    const el = document.getElementById('homeMetricAgents');
-    if (el) el.textContent = String(held);
-}
-
 function homeAgentIsPaperTrading(agent) {
     if (typeof resolveAgentStatusBadge === 'function') {
         return resolveAgentStatusBadge(agent).key === 'paper';
@@ -1713,7 +1700,6 @@ function refreshHomeModules() {
         console.warn('Home portfolio refresh failed:', error?.message || error);
     });
     updateHomeAgentModule();
-    updateHomeCommunityAgentCount();
     loadHomeLeaderboardModule();
     loadHomeMarketNewsModule();
 }

--- a/dashboard/frontend/js/portfolio.js
+++ b/dashboard/frontend/js/portfolio.js
@@ -331,6 +331,25 @@ function updateAgentAllocationFromAgents(agents) {
     renderAllocationChart('agent', buildAgentAllocationData(agents, getTotalPortfolioValue()));
 }
 
+/** Placeholder pie while agents are still loading — avoids a false "all Unallocated" flash. */
+function renderAllocationLoading() {
+    const legendEl = document.getElementById('agentAllocationLegend');
+    if (legendEl) {
+        legendEl.innerHTML =
+            '<li class="allocation-legend-item allocation-legend-item--loading">' +
+            '<span class="allocation-legend-label">Loading agents…</span></li>';
+    }
+    renderAllocationChart('agent', {
+        total: getTotalPortfolioValue(),
+        slices: [{
+            label: 'Loading',
+            value: Math.max(getTotalPortfolioValue(), 1),
+            pct: 100,
+            color: AVAILABLE_SLICE_COLOR,
+        }],
+    });
+}
+
 function readCachedPortfolio() {
     try {
         const raw = sessionStorage.getItem(PORTFOLIO_CACHE_KEY);
@@ -370,15 +389,21 @@ function clearCachedPortfolio() {
     }
 }
 
-function renderPortfolioFromMock(agents) {
+function renderPortfolioFromMock(agents, options) {
+    options = options || {};
     livePortfolio = null;
     clearCachedPortfolio();
     setPortfolioSampleBadgeVisible(true);
     renderPortfolioOverview(PORTFOLIO_MOCK.summary);
+    if (options.deferAllocation) {
+        renderAllocationLoading();
+        return;
+    }
     renderAllocationChart('agent', buildAgentAllocationData(agents, getTotalPortfolioValue()));
 }
 
-function renderPortfolioFromLive(portfolio, agents) {
+function renderPortfolioFromLive(portfolio, agents, options) {
+    options = options || {};
     livePortfolio = {
         equity: Number(portfolio.equity) || 0,
         cash_available: Number(portfolio.cash_available) || 0,
@@ -387,6 +412,10 @@ function renderPortfolioFromLive(portfolio, agents) {
     writeCachedPortfolio(livePortfolio);
     setPortfolioSampleBadgeVisible(false);
     renderPortfolioOverview(summaryFromLivePortfolio(livePortfolio));
+    if (options.deferAllocation) {
+        renderAllocationLoading();
+        return;
+    }
     updateAgentAllocationFromAgents(agents);
 }
 
@@ -411,33 +440,37 @@ function fetchLivePortfolio() {
 // once (boot prefetch, then loadAgents). Responses are not guaranteed to
 // arrive in request order, so without this sequence guard a slower earlier
 // request can repaint the panel with stale agents after the newer one landed.
-async function renderPortfolio(agents) {
+async function renderPortfolio(agents, options) {
+    options = options || {};
     const list = agents || [];
+    const deferAllocation = !!options.deferAllocation;
     const seq = ++portfolioRenderSeq;
     if (!isPortfolioSignedIn() || typeof API === 'undefined' || typeof API_BASE === 'undefined') {
         if (seq !== portfolioRenderSeq) return;
-        renderPortfolioFromMock(list);
+        renderPortfolioFromMock(list, { deferAllocation: deferAllocation });
         return;
     }
     // Instant paint from memory / sessionStorage before the network round-trip.
     const cached = livePortfolio || readCachedPortfolio();
     if (cached) {
-        renderPortfolioFromLive(cached, list);
+        renderPortfolioFromLive(cached, list, { deferAllocation: deferAllocation });
+    } else if (deferAllocation) {
+        renderAllocationLoading();
     }
     try {
         const portfolio = await fetchLivePortfolio();
         if (seq !== portfolioRenderSeq) return;
         if (!portfolio) {
-            if (!livePortfolio) renderPortfolioFromMock(list);
+            if (!livePortfolio) renderPortfolioFromMock(list, { deferAllocation: deferAllocation });
             return;
         }
-        renderPortfolioFromLive(portfolio, list);
+        renderPortfolioFromLive(portfolio, list, { deferAllocation: deferAllocation });
     } catch (error) {
         if (seq !== portfolioRenderSeq) return;
         console.warn('Portfolio API unavailable; showing sample data:', error?.message || error);
         // Keep last-known figures if we already painted them; only fall back to
         // SAMPLE DATA when the panel would otherwise stay blank.
-        if (!livePortfolio) renderPortfolioFromMock(list);
+        if (!livePortfolio) renderPortfolioFromMock(list, { deferAllocation: deferAllocation });
     }
 }
 
@@ -447,32 +480,38 @@ async function renderPortfolio(agents) {
  * Lets hard refresh and My Agents tab revisit paint instantly while the
  * authoritative refresh rides along with prefetchPortfolio / loadAgents.
  */
-function repaintPortfolioFromCache(agents) {
+function repaintPortfolioFromCache(agents, options) {
+    options = options || {};
     const list = agents || [];
+    const deferAllocation = !!options.deferAllocation;
     if (livePortfolio) {
-        renderPortfolioFromLive(livePortfolio, list);
+        renderPortfolioFromLive(livePortfolio, list, { deferAllocation: deferAllocation });
         return;
     }
     if (!isPortfolioSignedIn()) {
-        renderPortfolioFromMock(list);
+        renderPortfolioFromMock(list, { deferAllocation: deferAllocation });
         return;
     }
     const cached = readCachedPortfolio();
     if (cached) {
-        renderPortfolioFromLive(cached, list);
+        renderPortfolioFromLive(cached, list, { deferAllocation: deferAllocation });
+        return;
+    }
+    if (deferAllocation) {
+        renderAllocationLoading();
     }
     // Signed in but nothing cached yet: leave it be — prefetch / loadAgents
     // is about to paint the real figures.
 }
 
-/** Boot helper: paint from cache immediately (no network). */
+/** Boot helper: overview from cache; defer pie until loadAgents has the list. */
 function paintPortfolioBoot(agents) {
-    repaintPortfolioFromCache(agents);
+    repaintPortfolioFromCache(agents, { deferAllocation: true });
 }
 
-/** Boot helper: cache paint + start GET /portfolio without waiting on agents. */
+/** Boot helper: fetch portfolio totals without painting a false empty-agent pie. */
 async function prefetchPortfolio(agents) {
-    return renderPortfolio(agents || []);
+    return renderPortfolio(agents || [], { deferAllocation: true });
 }
 
 window.renderPortfolio = renderPortfolio;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -7211,6 +7211,12 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     gap: 6px;
 }
 
+.allocation-legend-item--loading .allocation-legend-label {
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-style: italic;
+}
+
 .section-card.pf-allocation-card .allocation-legend-row {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto auto;


### PR DESCRIPTION
## Summary
- **My Agents portfolio flash:** boot still prefetches `/portfolio` for totals, but Capital Allocation shows a loading state until `loadAgents` lands — no more empty-agent “all Unallocated” pie that then jumps.
- **Cash steppers:** allocated-capital / backtest-capital number inputs always move in **$100** steps (intercept ArrowUp/Down + correct the native spinner’s first-click ±1 glitch that produced 1101/1201).

Community Overview demo metrics are unchanged (still demo until a platform stats API exists).

## Test plan
- [ ] Hard-refresh `/app?view=agents` while signed in: overview totals may appear early; pie shows “Loading agents…” then real slices (no Unallocated→agents flash).
- [ ] Allocated capital inputs (create agent / editor): spinner and arrow keys go 1000→1100→1200 (never 1001/1101).
- [ ] Home Community still shows demo Active agents (28).
- [ ] `pytest dashboard/backend/tests/test_frontend_portfolio_panel.py -q`