### PR TITLE
feat(agents): keep allocated capital first on backtested cards

### DIFF
--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1520,7 +1520,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=12"></script>
     <script src="js/agent-editor.js?v=11"></script>
-    <script src="app.js?v=41"></script>
+    <script src="app.js?v=42"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -563,15 +563,45 @@ function resolveBacktestCardMetrics(agent) {
   if (ending == null && retFrac != null) ending = startEquity * (1 + retFrac);
   if (ending == null) ending = startEquity;
   const pnl = ending - startEquity;
+  const returnPct = retFrac != null
+    ? retFrac
+    : (startEquity ? pnl / startEquity : 0);
   return {
     ending,
     pnl,
+    returnPct,
     positive: pnl >= 0,
     period: formatShortDateRange(run?.start_date, run?.end_date),
     universe: run?.universe || run?.index || 'DJIA',
     createdAt: run?.created_at || null,
     runId: run?.run_id || null,
   };
+}
+
+function formatSignedReturnPct(frac) {
+  const n = Number(frac);
+  if (!Number.isFinite(n)) return '—';
+  const pct = n * 100;
+  const body = `${Math.abs(pct).toFixed(1)}%`;
+  if (pct > 0) return `+${body}`;
+  if (pct < 0) return `−${body}`;
+  return body;
+}
+
+/** Shared top block: portfolio sleeve always leads (draft + backtested cards). */
+function renderAgentAllocatedCapitalHero(agent) {
+  const capital =
+    agent.cash_allocation != null
+      ? formatAgentCashAllocation(agent.cash_allocation)
+      : '$1,000';
+  return `
+    <div class="agent-card-hero agent-card-hero--draft">
+      <div class="agent-card-hero-text">
+        <span class="agent-card-metric-label">Allocated Capital</span>
+        <p class="agent-card-metric-value">${escapeHtml(capital)}</p>
+        <p class="agent-card-capital-note">From My Portfolio</p>
+      </div>
+    </div>`;
 }
 
 function renderAgentCardBody(agent, statusKey) {
@@ -634,51 +664,35 @@ function renderAgentCardBody(agent, statusKey) {
 
   if (statusKey === 'backtested') {
     const m = resolveBacktestCardMetrics(agent);
-    const runCount = agentRunCount(agent);
-    const runLabel = runCount > 0 ? `Completed backtest #${runCount}` : 'Completed a backtest';
+    const endingLabel = formatAgentMoney(m.ending, { cents: false });
+    const metaParts = [`Ending Value ${endingLabel}`];
+    if (m.period && m.period !== '—') metaParts.push(m.period);
     return `
-      <div class="agent-card-hero">
-        <div class="agent-card-hero-text">
-          <div class="agent-card-metric-head">
-            <span class="agent-card-mode-chip agent-card-mode-chip--backtest">BACKTEST</span>
-            <span class="agent-card-metric-label">Ending Value</span>
-          </div>
-          <p class="agent-card-metric-value">${escapeHtml(formatAgentMoney(m.ending))}</p>
-          <p class="agent-card-change ${m.positive ? 'is-pos' : 'is-neg'}">${escapeHtml(formatSignedMoney(m.pnl))} during latest run</p>
-        </div>
-        ${renderAgentSparkline(agent, m.positive, m)}
-      </div>
-      <p class="agent-card-period">${escapeHtml(m.period)}</p>
+      ${renderAgentAllocatedCapitalHero(agent)}
       <div class="agent-card-divider"></div>
-      ${renderAgentRunsLink(agent)}
-      <div class="agent-card-divider"></div>
-      <div class="agent-card-activity">
-        <span class="agent-card-activity-icon agent-card-activity-icon--done" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="m8.5 12.5 2.5 2.5 4.5-5"/></svg>
-        </span>
-        <div class="agent-card-activity-text">
-          <span>${escapeHtml(runLabel)}</span>
+      <div class="agent-card-latest">
+        <div class="agent-card-latest-head">
+          <span class="agent-card-metric-label">Latest Backtest</span>
+          <span class="agent-card-mode-chip agent-card-mode-chip--simulation">Simulation</span>
         </div>
+        <div class="agent-card-latest-row">
+          <p class="agent-card-latest-return ${m.positive ? 'is-pos' : 'is-neg'}">${escapeHtml(formatSignedReturnPct(m.returnPct))}</p>
+          ${renderAgentSparkline(agent, m.positive, m)}
+        </div>
+        <p class="agent-card-latest-meta">${escapeHtml(metaParts.join(' · '))}</p>
+        <p class="agent-card-latest-note">Separate from allocated capital.</p>
+        ${renderAgentRunsLink(agent)}
       </div>`;
   }
 
-  const capital =
-    agent.cash_allocation != null
-      ? formatAgentCashAllocation(agent.cash_allocation)
-      : '$1,000';
   return `
-    <div class="agent-card-hero agent-card-hero--draft">
-      <div class="agent-card-hero-text">
-        <span class="agent-card-metric-label">Allocated Capital</span>
-        <p class="agent-card-metric-value">${escapeHtml(capital)}</p>
-      </div>
-    </div>
+    ${renderAgentAllocatedCapitalHero(agent)}
     <div class="agent-card-empty">
       <span class="agent-card-empty-icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M4 16l4-4 3 3 5-6 4 4"/><path d="M4 20h16"/></svg>
       </span>
-      <strong>No backtest runs yet</strong>
-      <span>Run a backtest to evaluate this agent.</span>
+      <strong>No backtests yet</strong>
+      <span>Test this agent on historical market data.</span>
     </div>`;
 }
 

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -7467,6 +7467,12 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     border-color: rgba(34, 211, 238, 0.28);
 }
 
+.agent-card-mode-chip--simulation {
+    color: #a5b4fc;
+    background: rgba(99, 102, 241, 0.12);
+    border-color: rgba(129, 140, 248, 0.3);
+}
+
 .agent-card-metric-label {
     display: inline;
     font-size: 11px;
@@ -7482,6 +7488,62 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     letter-spacing: -0.02em;
     line-height: 1.15;
     color: var(--text-primary);
+}
+
+.agent-card-capital-note {
+    margin: 4px 0 0;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+}
+
+.agent-card-latest {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.agent-card-latest-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.agent-card-latest-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.agent-card-latest-return {
+    margin: 0;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+}
+
+.agent-card-latest-return.is-pos { color: #4ade80; }
+.agent-card-latest-return.is-neg { color: var(--danger-color); }
+
+.agent-card-latest-meta {
+    margin: 0;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.agent-card-latest-note {
+    margin: 0;
+    font-size: 11.5px;
+    color: var(--text-muted);
+}
+
+.agent-card-latest .agent-card-runs-link {
+    padding-top: 4px;
+    padding-bottom: 0;
 }
 
 .agent-card-change {


### PR DESCRIPTION
## Summary
- Backtested agent cards now keep **Allocated Capital** (from My Portfolio) as the large white hero — same hierarchy as draft cards.
- Latest run summary moves to the lower half: return %, sparkline, ending value + date range, and the existing **N backtests** shortcut into the backtest page.
- Clarifies that simulation results are separate from allocated capital.

## Test plan
- [ ] Draft agent: Allocated Capital on top + empty “No backtests yet” block.
- [ ] After a backtest: same Allocated Capital hero; below divider shows Latest Backtest (+return / sparkline / ending · dates) and the runs link still opens the backtest tab for that agent.
- [ ] Paper-trading cards unchanged (Portfolio Value hero).
- [ ] Hard-refresh `/app?view=agents` (cache bust `app.js?v=42`).


Made with [Cursor](https://cursor.com)