### PR TITLE
feat: shared market-data store for backtest runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,10 @@ PUBLIC_APP_URL=https://agentic-trading-lab.vercel.app
 # Database
 DATABASE_PATH=dashboard/storage/data/backtest.db
 
+# Shared market-data cache: max distinct (symbols, start, end) datasets held
+# in memory for reuse across backtest runs (LRU beyond this). Default 4.
+# MARKET_DATA_CACHE_MAX_ENTRIES=4
+
 # User accounts (optional). When set, signup/login/session data is stored in
 # this Postgres database instead of the local SQLite file above -- required
 # on hosts with an ephemeral/disk-less filesystem (e.g. Render free tier),

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -780,20 +780,29 @@ def start_backtest(
     with _lock:
         _sessions[backtest_id] = session
 
-    def _load_in_background() -> None:
-        # load_market_data() constructs AlpacaDataLoader; missing credentials
-        # now raise MarketDataUnavailableError (a plain Exception, B0 deep
-        # fix). The SystemExit catch stays as defense-in-depth: on this daemon
-        # thread the default threading.excepthook silently swallows
-        # SystemExit, so a regression back to sys.exit() would strand the run
-        # in "loading" forever. (Mirrors the _finalize() catch above.)
-        try:
-            session.load_market_data()
-        except (Exception, SystemExit) as exc:
-            session.status = "failed"
-            session.error = str(exc)
+    # Fast path: creation runs under the caller's _create_lock, where blocking
+    # is forbidden — peek() is non-blocking. A resident dataset means no loader
+    # thread at all: attach it and open step 0 synchronously. Miss or
+    # build-in-flight falls through to the loader thread exactly as before
+    # (get_dataset inside the thread blocks/dedupes there).
+    dataset = market_data_store.peek(DJIA_30, start_date, end_date)
+    if dataset is not None:
+        session.adopt_dataset(dataset)
+    else:
+        def _load_in_background() -> None:
+            # load_market_data() constructs AlpacaDataLoader; missing credentials
+            # now raise MarketDataUnavailableError (a plain Exception, B0 deep
+            # fix). The SystemExit catch stays as defense-in-depth: on this daemon
+            # thread the default threading.excepthook silently swallows
+            # SystemExit, so a regression back to sys.exit() would strand the run
+            # in "loading" forever. (Mirrors the _finalize() catch above.)
+            try:
+                session.load_market_data()
+            except (Exception, SystemExit) as exc:
+                session.status = "failed"
+                session.error = str(exc)
 
-    threading.Thread(target=_load_in_background, daemon=True).start()
+        threading.Thread(target=_load_in_background, daemon=True).start()
 
     return {
         "backtest_id": backtest_id,

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -21,7 +21,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
-import pytz
 
 import dashboard.backend.infrastructure.llm.token_cost as token_cost
 from dashboard.backend.domain.agents.repository import agent_store
@@ -42,9 +41,9 @@ from dashboard.backend.domain.backtesting.portfolio_manager import PortfolioMana
 from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
 
 from dashboard.backend.domain.backtesting.engine import HourlyBacktester
+from dashboard.backend.domain.backtesting import market_data_store
 
 DECISION_TIMEOUT_SECONDS = int(os.getenv("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", "30"))
-ET_TZ = pytz.timezone("US/Eastern")
 
 _sessions: Dict[str, "ExternalBacktestSession"] = {}
 _lock = threading.Lock()
@@ -177,71 +176,35 @@ class ExternalBacktestSession:
     # ------------------------------------------------------------------
 
     def load_market_data(self) -> None:
-        loader = AlpacaDataLoader()
-        self.all_data = loader.fetch_bars(DJIA_30, self.start_date, self.end_date)
-        if not self.all_data:
-            raise RuntimeError("No market data returned from Alpaca")
+        # loader_factory resolves the module-global name at call time, so every
+        # existing monkeypatch of ebs.AlpacaDataLoader still controls the fetch.
+        dataset = market_data_store.get_dataset(
+            DJIA_30, self.start_date, self.end_date,
+            loader_factory=AlpacaDataLoader,
+        )
+        self.adopt_dataset(dataset)
 
-        for symbol, df in self.all_data.items():
-            self.all_data[symbol] = TechnicalIndicators.calculate_indicators(df)
+    def adopt_dataset(self, dataset: "market_data_store.MarketDataset") -> None:
+        """Attach a built shared dataset and open step 0.
 
-        self.timestamps = self._build_trading_timestamps()
-        self.total_steps = len(self.timestamps)
-        self.price_cache = self._build_price_cache()
+        SHARED + READ-ONLY: all_data/timestamps/price_cache belong to the
+        store and other sessions — never mutate them (see the store docstring).
 
-        if self.total_steps == 0:
-            raise RuntimeError("No trading hours in the selected date range")
+        Publish the loaded state under the step lock, and only if a concurrent
+        cancel() hasn't already moved the run to a terminal state (cancel()
+        writes "closed" under this same lock; an unlocked write here used to
+        resurrect a cancelled run back to waiting_decision).
+        """
+        self.all_data = dataset.all_data
+        self.timestamps = dataset.timestamps
+        self.price_cache = dataset.price_cache
+        self.total_steps = dataset.total_steps
 
-        # Publish the loaded state under the step lock, and only if a concurrent
-        # cancel() hasn't already moved the run to a terminal state. cancel()
-        # writes "closed" under this same lock; this write used to be unlocked
-        # and would resurrect a cancelled run back to waiting_decision (freeing
-        # its cap slot while it kept running). _open_current_step takes no lock.
         with self._step_lock:
             if self.status in TERMINAL_STATUSES:
                 return
             self.status = "waiting_decision"
             self._open_current_step()
-
-    def _build_trading_timestamps(self) -> List[Any]:
-        all_timestamps: set = set()
-        for df in self.all_data.values():
-            all_timestamps.update(df.index)
-        ordered = sorted(all_timestamps)
-
-        min_required = int(len(self.all_data) * 0.8)
-        filtered = []
-        for ts in ordered:
-            real_count = sum(1 for df in self.all_data.values() if ts in df.index)
-            if real_count >= min_required:
-                filtered.append(ts)
-        ordered = filtered if filtered else ordered
-
-        market_hours = []
-        for ts in ordered:
-            ts_et = ts.astimezone(ET_TZ)
-            hour, minute = ts_et.hour, ts_et.minute
-            is_market = (
-                (hour > 9 and hour < 16)
-                or (hour == 9 and minute >= 30)
-                or (hour == 16 and minute == 0)
-            )
-            if is_market:
-                market_hours.append(ts)
-        return market_hours
-
-    def _build_price_cache(self) -> Dict[str, Dict[Any, float]]:
-        cache: Dict[str, Dict[Any, float]] = {}
-        for symbol, df in self.all_data.items():
-            cache[symbol] = {}
-            last_price = None
-            for timestamp in self.timestamps:
-                if timestamp in df.index:
-                    last_price = df.loc[timestamp, "close"]
-                    cache[symbol][timestamp] = float(last_price)
-                elif last_price is not None:
-                    cache[symbol][timestamp] = float(last_price)
-        return cache
 
     def _market_data_at(self, timestamp) -> Dict[str, pd.Series]:
         market_data = {}

--- a/dashboard/backend/domain/backtesting/market_data_store.py
+++ b/dashboard/backend/domain/backtesting/market_data_store.py
@@ -117,6 +117,16 @@ def get_dataset(symbols, start_date, end_date,
                 raise
             with _cache_lock:
                 entry.dataset = dataset
+                # Mark the just-built entry most-recently-used BEFORE evicting.
+                # Every other access path (waiter, peek, non-leader) refreshes
+                # recency; a leader's entry otherwise keeps its stale
+                # insertion-time position, so after a slow build it can be the
+                # LRU victim and get evicted here — before event.set() below.
+                # That both drops the hottest dataset and lets a same-key
+                # request racing into the pre-signal window become a second
+                # leader (redundant build == single-flight violation). Refreshing
+                # keeps the fresh entry at the back, safe for any cap >= 1.
+                _cache.move_to_end(key)
                 _evict_lru_locked()
             entry.event.set()
             return dataset

--- a/dashboard/backend/domain/backtesting/market_data_store.py
+++ b/dashboard/backend/domain/backtesting/market_data_store.py
@@ -1,0 +1,212 @@
+"""Shared, immutable market-data datasets for backtest sessions (T1).
+
+One dataset (indicator-enriched bars + trading timestamps + price cache) per
+``(symbols, start_date, end_date)`` key, shared by every session with that
+config. READ-ONLY CONTRACT: every consumer treats ``all_data`` frames,
+``timestamps`` and ``price_cache`` as immutable — verified convention across
+the engine, baselines, and PortfolioManager. Never mutate a dataset.
+
+Concurrency model (deliberately NOT cache.py's coordinator, whose followers
+never block): the first requester for a key builds; concurrent requesters
+block on a ``threading.Event`` and receive the same object. A build failure
+propagates to every waiter and is negative-cached for ``NEGATIVE_TTL_SECONDS``
+so a dead upstream doesn't trigger a retry stampede.
+
+LOCK RULE: ``get_dataset`` may block for a full Alpaca fetch — it must only be
+called from loader threads, NEVER while holding the run-creation lock.
+``peek`` is non-blocking and is the only entry point allowed under that lock.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import pandas as pd
+import pytz
+
+from dashboard.backend.domain.backtesting.features import TechnicalIndicators
+from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
+
+# Read once at import (tests monkeypatch the module constant). Entry count, not
+# bytes: a month-long dataset is ~50 MB, so 4 entries caps the worst case at
+# ~200 MB against the 512 MB free tier. Byte-aware accounting is a 1000-tier
+# refinement; the per-build size print below keeps a pathological mix visible.
+MARKET_DATA_CACHE_MAX_ENTRIES = int(os.getenv("MARKET_DATA_CACHE_MAX_ENTRIES", "4"))
+NEGATIVE_TTL_SECONDS = 30.0
+
+_ET_TZ = pytz.timezone("US/Eastern")
+
+_now = time.monotonic  # indirection so tests can advance the clock
+
+
+class MarketDataset:
+    """Immutable bundle of everything a session needs from market data."""
+
+    __slots__ = ("key", "all_data", "timestamps", "price_cache", "total_steps")
+
+    def __init__(self, key: Tuple, all_data: Dict[str, pd.DataFrame],
+                 timestamps: List[Any], price_cache: Dict[str, Dict[Any, float]]):
+        self.key = key
+        self.all_data = all_data
+        self.timestamps = timestamps
+        self.price_cache = price_cache
+        self.total_steps = len(timestamps)
+
+
+class _Entry:
+    __slots__ = ("event", "dataset", "error", "negative_until")
+
+    def __init__(self):
+        self.event = threading.Event()
+        self.dataset: Optional[MarketDataset] = None
+        self.error: Optional[BaseException] = None
+        self.negative_until: float = 0.0
+
+
+_cache_lock = threading.Lock()
+_cache: "OrderedDict[Tuple, _Entry]" = OrderedDict()
+
+
+def _dataset_key(symbols, start_date, end_date) -> Tuple:
+    return (tuple(symbols), str(start_date), str(end_date))
+
+
+def peek(symbols, start_date, end_date) -> Optional[MarketDataset]:
+    """Non-blocking: the resident dataset, or None (miss / build in flight /
+    negative-cached failure). The only store call allowed under _create_lock."""
+    with _cache_lock:
+        entry = _cache.get(_dataset_key(symbols, start_date, end_date))
+        if entry is None or entry.dataset is None:
+            return None
+        _cache.move_to_end(entry.dataset.key)
+        return entry.dataset
+
+
+def get_dataset(symbols, start_date, end_date,
+                loader_factory: Optional[Callable[[], Any]] = None) -> MarketDataset:
+    """Blocking single-flight build-or-wait. NEVER call under _create_lock."""
+    key = _dataset_key(symbols, start_date, end_date)
+    factory = loader_factory or AlpacaDataLoader
+    while True:
+        with _cache_lock:
+            entry = _cache.get(key)
+            if (entry is not None and entry.error is not None
+                    and _now() >= entry.negative_until):
+                del _cache[key]  # negative entry expired: retry the build
+                entry = None
+            if entry is None:
+                entry = _Entry()
+                _cache[key] = entry
+                is_leader = True
+            else:
+                _cache.move_to_end(key)
+                is_leader = False
+
+        if is_leader:
+            try:
+                dataset = _build_dataset(key, symbols, start_date, end_date, factory)
+            except BaseException as exc:
+                with _cache_lock:
+                    entry.error = exc
+                    entry.negative_until = _now() + NEGATIVE_TTL_SECONDS
+                entry.event.set()
+                raise
+            with _cache_lock:
+                entry.dataset = dataset
+                _evict_lru_locked()
+            entry.event.set()
+            return dataset
+
+        entry.event.wait()
+        if entry.error is not None:
+            raise entry.error
+        if entry.dataset is not None:
+            with _cache_lock:
+                if _cache.get(key) is entry:
+                    _cache.move_to_end(key)
+            return entry.dataset
+        # Entry was reset underneath us (tests); retry from scratch.
+
+
+def _build_dataset(key, symbols, start_date, end_date, factory) -> MarketDataset:
+    loader = factory()
+    all_data = loader.fetch_bars(list(symbols), start_date, end_date)
+    if not all_data:
+        raise RuntimeError("No market data returned from Alpaca")
+    for symbol, df in all_data.items():
+        all_data[symbol] = TechnicalIndicators.calculate_indicators(df)
+    timestamps = _build_trading_timestamps(all_data)
+    if not timestamps:
+        raise RuntimeError("No trading hours in the selected date range")
+    price_cache = _build_price_cache(all_data, timestamps)
+    dataset = MarketDataset(key, all_data, timestamps, price_cache)
+    mb = sum(float(df.memory_usage(deep=True).sum()) for df in all_data.values()) / 1e6
+    print(f"📊 market-data dataset built: {key[1]}→{key[2]} "
+          f"({len(key[0])} syms, {dataset.total_steps} steps, ~{mb:.1f} MB)")
+    return dataset
+
+
+def _build_trading_timestamps(all_data: Dict[str, pd.DataFrame]) -> List[Any]:
+    """Moved verbatim from ExternalBacktestSession._build_trading_timestamps."""
+    all_timestamps: set = set()
+    for df in all_data.values():
+        all_timestamps.update(df.index)
+    ordered = sorted(all_timestamps)
+
+    min_required = int(len(all_data) * 0.8)
+    filtered = []
+    for ts in ordered:
+        real_count = sum(1 for df in all_data.values() if ts in df.index)
+        if real_count >= min_required:
+            filtered.append(ts)
+    ordered = filtered if filtered else ordered
+
+    market_hours = []
+    for ts in ordered:
+        ts_et = ts.astimezone(_ET_TZ)
+        hour, minute = ts_et.hour, ts_et.minute
+        is_market = (
+            (hour > 9 and hour < 16)
+            or (hour == 9 and minute >= 30)
+            or (hour == 16 and minute == 0)
+        )
+        if is_market:
+            market_hours.append(ts)
+    return market_hours
+
+
+def _build_price_cache(all_data: Dict[str, pd.DataFrame],
+                       timestamps: List[Any]) -> Dict[str, Dict[Any, float]]:
+    """Moved verbatim from ExternalBacktestSession._build_price_cache."""
+    cache: Dict[str, Dict[Any, float]] = {}
+    for symbol, df in all_data.items():
+        cache[symbol] = {}
+        last_price = None
+        for timestamp in timestamps:
+            if timestamp in df.index:
+                last_price = df.loc[timestamp, "close"]
+                cache[symbol][timestamp] = float(last_price)
+            elif last_price is not None:
+                cache[symbol][timestamp] = float(last_price)
+    return cache
+
+
+def _evict_lru_locked() -> None:
+    """Drop least-recently-used COMPLETED entries beyond the cap. In-flight
+    builds are never evicted. Sessions hold direct references, so eviction
+    only stops future sharing — it cannot break a live run."""
+    done = [k for k, e in _cache.items() if e.dataset is not None or e.error is not None]
+    excess = len(done) - MARKET_DATA_CACHE_MAX_ENTRIES
+    for k in done[:max(0, excess)]:
+        del _cache[k]
+
+
+def _reset_for_tests() -> None:
+    with _cache_lock:
+        for entry in _cache.values():
+            entry.event.set()  # release any stranded waiter
+        _cache.clear()

--- a/dashboard/backend/execution/backtest_backend.py
+++ b/dashboard/backend/execution/backtest_backend.py
@@ -84,6 +84,23 @@ class BacktestBackend(ExecutionBackend):
         self.session.load_market_data()
 
     def start_background_load(self) -> None:
+        # Fast path (runs under the shared create lock — peek only, never
+        # get_dataset): a resident dataset skips the loader thread entirely.
+        dataset = ext.market_data_store.peek(
+            DJIA_30, self.session.start_date, self.session.end_date)
+        if dataset is not None:
+            self.session.adopt_dataset(dataset)
+            # Mirror the background loader's post-load row transition, with the
+            # same don't-resurrect-a-terminal-run guard.
+            with self.session._step_lock:
+                status_now = self.session.status
+            if status_now not in TERMINAL_STATUSES:
+                try:
+                    run_repo.run_store.update_run(self.run_id, status="running")
+                except Exception:
+                    pass  # best-effort; both statuses count as active anyway
+            return
+
         def _load() -> None:
             try:
                 self.session.load_market_data()

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -53,8 +53,27 @@ os.environ.pop("USERS_DATABASE_URL", None)
 # imported.
 os.environ.pop("CONTENT_DATABASE_URL", None)
 
+# T1+ scale knobs are read once at import (like MAX_ACTIVE_RUNS_PER_AGENT); a
+# stray shell value would silently skew the whole run. Same rationale as the
+# DB-URL strips above. Later tiers append their vars here.
+os.environ.pop("MARKET_DATA_CACHE_MAX_ENTRIES", None)
+
 
 @atexit.register
 def _cleanup_test_db_dir() -> None:
     """Remove the temporary database directory when the test process exits."""
     shutil.rmtree(_TEST_DB_DIR, ignore_errors=True)
+
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_scale_state():
+    """The market-data store is a module-level cache shared across the test
+    process; without a per-test reset, one test's synthetic bars would be
+    served to every later test with the same (symbols, dates) key."""
+    from dashboard.backend.domain.backtesting import market_data_store
+    market_data_store._reset_for_tests()
+    yield
+    market_data_store._reset_for_tests()

--- a/dashboard/backend/tests/test_market_data_sharing.py
+++ b/dashboard/backend/tests/test_market_data_sharing.py
@@ -1,0 +1,72 @@
+"""Two same-config sessions share one dataset object; the loader runs once."""
+
+import threading
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import dashboard.backend.domain.backtesting.external_run_service as ebs
+from dashboard.backend.domain.backtesting import market_data_store as mds
+
+
+def _synth_bars(symbols, start, end):
+    idx = pd.date_range(start=start, end=str(end) + " 23:59", freq="1h", tz="UTC")
+    et = idx.tz_convert("US/Eastern")
+    mask = (et.dayofweek < 5) & (
+        ((et.hour > 9) & (et.hour < 16)) | ((et.hour == 16) & (et.minute == 0))
+    )
+    idx = idx[mask]
+    data = {}
+    for si, sym in enumerate(sorted(symbols)):
+        n = len(idx)
+        close = 100.0 + si + np.linspace(0, 1.0, n)
+        data[sym] = pd.DataFrame(
+            {"open": close, "high": close + 0.5, "low": close - 0.5,
+             "close": close, "volume": 1000.0}, index=idx)
+    return data
+
+
+class _CountingLoader:
+    calls = 0
+
+    def fetch_bars(self, symbols, start, end):
+        type(self).calls += 1
+        return _synth_bars(symbols, start, end)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(ebs, "AlpacaDataLoader", _CountingLoader)
+    monkeypatch.setattr(ebs, "_sessions", {})  # keep the global registry test-local
+    _CountingLoader.calls = 0
+    yield
+
+
+def _session(i):
+    return ebs.ExternalBacktestSession(
+        backtest_id=f"bt_share_{i}", session_id=f"sess_{i}", agent_name=f"a{i}",
+        model_name="m", start_date="2026-04-15", end_date="2026-04-16",
+    )
+
+
+def test_same_config_sessions_share_one_dataset_and_one_fetch():
+    s1, s2 = _session(1), _session(2)
+    s1.load_market_data()
+    s2.load_market_data()
+    assert _CountingLoader.calls == 1
+    assert s1.all_data is s2.all_data          # shared object identity
+    assert s1.price_cache is s2.price_cache
+    assert s1.timestamps is s2.timestamps
+    assert s1.status == s2.status == "waiting_decision"
+    assert s1.total_steps == s2.total_steps > 0
+
+
+def test_adopt_dataset_respects_terminal_status():
+    ds = mds.get_dataset(["AAPL", "MSFT"], "2026-04-15", "2026-04-16",
+                         loader_factory=_CountingLoader)
+    s = _session(3)
+    s.status = "closed"  # cancelled while loading
+    s.adopt_dataset(ds)
+    assert s.status == "closed"  # never resurrected
+    assert s.total_steps > 0     # data attached is fine; status is not touched

--- a/dashboard/backend/tests/test_market_data_sharing.py
+++ b/dashboard/backend/tests/test_market_data_sharing.py
@@ -70,3 +70,42 @@ def test_adopt_dataset_respects_terminal_status():
     s.adopt_dataset(ds)
     assert s.status == "closed"  # never resurrected
     assert s.total_steps > 0     # data attached is fine; status is not touched
+
+
+def test_v1_start_backtest_fast_path_skips_loader_thread():
+    # Warm the cache through a normal session load.
+    _session(0).load_market_data()
+    assert _CountingLoader.calls == 1
+
+    res = ebs.start_backtest(
+        session_id="sess_fast", agent_name="fast", model_name="m",
+        start_date="2026-04-15", end_date="2026-04-16",
+    )
+    assert res["status"] == "loading"  # wire literal is frozen (Decision 5)
+    session = ebs.get_session(res["backtest_id"])
+    # Resident hit: step 0 opened synchronously — no loader thread, no fetch.
+    assert session.status == "waiting_decision"
+    assert _CountingLoader.calls == 1
+
+
+def test_v2_start_background_load_fast_path(monkeypatch):
+    import dashboard.backend.execution.backtest_backend as bb_mod
+
+    _session(0).load_market_data()  # warm
+    assert _CountingLoader.calls == 1
+
+    row_updates = []
+
+    class _FakeRunStore:
+        def update_run(self, run_id, **kw):
+            row_updates.append((run_id, kw))
+
+    monkeypatch.setattr(bb_mod.run_repo, "run_store", _FakeRunStore())
+    backend = bb_mod.BacktestBackend(
+        run_id="run_fast", session_id="sess_v2", agent_name="a", model_name="m",
+        start_date="2026-04-15", end_date="2026-04-16",
+    )
+    backend.start_background_load()
+    assert backend.session.status == "waiting_decision"  # no thread needed
+    assert _CountingLoader.calls == 1
+    assert ("run_fast", {"status": "running"}) in row_updates

--- a/dashboard/backend/tests/test_market_data_store.py
+++ b/dashboard/backend/tests/test_market_data_store.py
@@ -182,3 +182,42 @@ def test_empty_fetch_raises_runtime_error():
 
     with pytest.raises(RuntimeError, match="No market data"):
         mds.get_dataset(SYMS, "2026-04-15", "2026-04-16", loader_factory=_Empty)
+
+
+def test_completed_leader_is_not_self_evicted_under_cap(monkeypatch):
+    """A slow-built dataset must survive its own completion. It is the hottest
+    entry (its requester is about to use it), so evicting it here would drop the
+    hot dataset AND let a same-key request racing into the pre-signal window
+    become a second leader (redundant build == single-flight violation).
+    Regression: the leader path must refresh LRU recency before eviction, like
+    every other access path already does."""
+    monkeypatch.setattr(mds, "MARKET_DATA_CACHE_MAX_ENTRIES", 1)
+
+    started, release = threading.Event(), threading.Event()
+
+    class _SlowLoader:
+        def fetch_bars(self, symbols, start, end):
+            started.set()
+            release.wait(5)
+            return _synth_bars(symbols, start, end)
+
+    slow = ("2026-04-13", "2026-04-14")
+    fast = ("2026-04-15", "2026-04-16")
+
+    t = threading.Thread(
+        target=lambda: mds.get_dataset(SYMS, *slow, loader_factory=_SlowLoader))
+    t.start()
+    assert started.wait(5)  # slow build is in flight (entry not yet 'done')
+
+    # This completes while the slow build is still running, so when the slow
+    # build finishes both entries are 'done' and cap=1 forces one eviction.
+    mds.get_dataset(SYMS, *fast, loader_factory=_CountingLoader)
+
+    release.set()
+    t.join(10)
+
+    # The just-completed (most-recently-used) slow entry is retained; the older
+    # fast entry is the eviction victim. The pre-fix behavior evicted the slow
+    # entry it had just built.
+    assert mds.peek(SYMS, *slow) is not None
+    assert mds.peek(SYMS, *fast) is None

--- a/dashboard/backend/tests/test_market_data_store.py
+++ b/dashboard/backend/tests/test_market_data_store.py
@@ -1,0 +1,184 @@
+"""Shared market-data store: blocking single-flight, key isolation, negative
+cache, LRU eviction (T1 of the 2026-07-24 agent-scale spec)."""
+
+import threading
+import time
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from dashboard.backend.domain.backtesting import market_data_store as mds
+
+
+def _synth_bars(symbols=("AAPL", "MSFT"), start="2026-04-15", end="2026-04-16"):
+    idx = pd.date_range(start=start, end=str(end) + " 23:59", freq="1h", tz="UTC")
+    et = idx.tz_convert("US/Eastern")
+    mask = (et.dayofweek < 5) & (
+        ((et.hour > 9) & (et.hour < 16)) | ((et.hour == 16) & (et.minute == 0))
+    )
+    idx = idx[mask]
+    data = {}
+    for si, sym in enumerate(sorted(symbols)):
+        n = len(idx)
+        close = 100.0 + si * 5 + np.linspace(0, 1.0, n)
+        df = pd.DataFrame(
+            {"open": close, "high": close + 0.5, "low": close - 0.5,
+             "close": close, "volume": 1000.0},
+            index=idx,
+        )
+        data[sym] = df
+    return data
+
+
+class _CountingLoader:
+    calls = 0
+
+    def fetch_bars(self, symbols, start, end):
+        type(self).calls += 1
+        return _synth_bars(symbols, start, end)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store():
+    mds._reset_for_tests()
+    _CountingLoader.calls = 0
+    yield
+    mds._reset_for_tests()
+
+
+SYMS = ["AAPL", "MSFT"]
+
+
+def test_build_returns_complete_bundle():
+    ds = mds.get_dataset(SYMS, "2026-04-15", "2026-04-16",
+                         loader_factory=_CountingLoader)
+    assert set(ds.all_data) == {"AAPL", "MSFT"}
+    assert ds.total_steps == len(ds.timestamps) > 0
+    assert "AAPL" in ds.price_cache
+    assert _CountingLoader.calls == 1
+
+
+def test_single_flight_one_build_for_concurrent_requesters():
+    n = 8
+    barrier = threading.Barrier(n)
+    out = [None] * n
+
+    def go(i):
+        barrier.wait()
+        out[i] = mds.get_dataset(SYMS, "2026-04-15", "2026-04-16",
+                                 loader_factory=_CountingLoader)
+
+    threads = [threading.Thread(target=go, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(10)
+    assert _CountingLoader.calls == 1
+    assert all(o is out[0] for o in out)  # identical object, not copies
+
+
+def test_key_isolation_by_date_range():
+    a = mds.get_dataset(SYMS, "2026-04-15", "2026-04-16", loader_factory=_CountingLoader)
+    b = mds.get_dataset(SYMS, "2026-04-13", "2026-04-14", loader_factory=_CountingLoader)
+    assert a is not b
+    assert _CountingLoader.calls == 2
+
+
+def test_peek_is_nonblocking_and_only_returns_resident():
+    assert mds.peek(SYMS, "2026-04-15", "2026-04-16") is None  # cold miss
+
+    started, release = threading.Event(), threading.Event()
+
+    class _SlowLoader:
+        def fetch_bars(self, symbols, start, end):
+            started.set()
+            release.wait(5)
+            return _synth_bars(symbols, start, end)
+
+    t = threading.Thread(
+        target=lambda: mds.get_dataset(SYMS, "2026-04-15", "2026-04-16",
+                                       loader_factory=_SlowLoader))
+    t.start()
+    assert started.wait(5)
+    assert mds.peek(SYMS, "2026-04-15", "2026-04-16") is None  # in-flight: still None
+    release.set()
+    t.join(10)
+    assert mds.peek(SYMS, "2026-04-15", "2026-04-16") is not None  # resident hit
+
+
+def test_build_failure_propagates_and_negative_caches(monkeypatch):
+    class _Boom:
+        calls = 0
+
+        def fetch_bars(self, symbols, start, end):
+            type(self).calls += 1
+            raise RuntimeError("alpaca down")
+
+    with pytest.raises(RuntimeError, match="alpaca down"):
+        mds.get_dataset(SYMS, "2026-04-15", "2026-04-16", loader_factory=_Boom)
+    # Within the negative TTL: same error, NO second fetch (no retry stampede).
+    with pytest.raises(RuntimeError, match="alpaca down"):
+        mds.get_dataset(SYMS, "2026-04-15", "2026-04-16", loader_factory=_Boom)
+    assert _Boom.calls == 1
+    # After the negative TTL the build is retried (and can now succeed).
+    real_now = time.monotonic()
+    monkeypatch.setattr(mds, "_now", lambda: real_now + 31.0)
+    ds = mds.get_dataset(SYMS, "2026-04-15", "2026-04-16",
+                         loader_factory=_CountingLoader)
+    assert ds.total_steps > 0
+    assert _CountingLoader.calls == 1
+
+
+def test_failure_propagates_to_concurrent_waiters():
+    started, release = threading.Event(), threading.Event()
+    errors = []
+
+    class _SlowBoom:
+        def fetch_bars(self, symbols, start, end):
+            started.set()
+            release.wait(5)
+            raise RuntimeError("alpaca down")
+
+    def leader():
+        try:
+            mds.get_dataset(SYMS, "2026-04-15", "2026-04-16", loader_factory=_SlowBoom)
+        except RuntimeError as e:
+            errors.append(("leader", str(e)))
+
+    def waiter():
+        started.wait(5)
+        try:
+            mds.get_dataset(SYMS, "2026-04-15", "2026-04-16", loader_factory=_SlowBoom)
+        except RuntimeError as e:
+            errors.append(("waiter", str(e)))
+
+    tl, tw = threading.Thread(target=leader), threading.Thread(target=waiter)
+    tl.start(); tw.start()
+    started.wait(5)
+    time.sleep(0.05)  # let the waiter reach event.wait()
+    release.set()
+    tl.join(10); tw.join(10)
+    assert sorted(who for who, _ in errors) == ["leader", "waiter"]
+    assert all("alpaca down" in msg for _, msg in errors)
+
+
+def test_lru_eviction_bounds_entries_and_never_breaks_holders(monkeypatch):
+    monkeypatch.setattr(mds, "MARKET_DATA_CACHE_MAX_ENTRIES", 2)
+    d1 = mds.get_dataset(SYMS, "2026-04-13", "2026-04-14", loader_factory=_CountingLoader)
+    mds.get_dataset(SYMS, "2026-04-15", "2026-04-16", loader_factory=_CountingLoader)
+    mds.get_dataset(SYMS, "2026-04-17", "2026-04-18", loader_factory=_CountingLoader)
+    assert mds.peek(SYMS, "2026-04-13", "2026-04-14") is None      # LRU-evicted
+    assert mds.peek(SYMS, "2026-04-15", "2026-04-16") is not None
+    assert mds.peek(SYMS, "2026-04-17", "2026-04-18") is not None
+    # The evicted dataset stays fully usable via the held reference (GC contract).
+    assert d1.total_steps > 0 and "AAPL" in d1.all_data
+
+
+def test_empty_fetch_raises_runtime_error():
+    class _Empty:
+        def fetch_bars(self, symbols, start, end):
+            return {}
+
+    with pytest.raises(RuntimeError, match="No market data"):
+        mds.get_dataset(SYMS, "2026-04-15", "2026-04-16", loader_factory=_Empty)

--- a/dashboard/backend/tests/test_pr71_review_fixes.py
+++ b/dashboard/backend/tests/test_pr71_review_fixes.py
@@ -53,17 +53,17 @@ def test_load_market_data_does_not_resurrect_a_cancelled_run(monkeypatch):
         model_name="m", start_date="2026-04-15", end_date="2026-04-16",
     )
 
-    class _Loader:
-        def fetch_bars(self, symbols, start, end):
-            return {"AAA": object()}
+    # load_market_data now delegates to the shared store; stub get_dataset so
+    # the terminal-status guard in adopt_dataset is exercised without a fetch.
+    class _FakeDataset:
+        all_data = {"AAA": object()}
+        timestamps = ["ts0"]
+        price_cache = {"AAA": {"ts0": 1.0}}
+        total_steps = 1
 
-    monkeypatch.setattr(svc, "AlpacaDataLoader", _Loader)
     monkeypatch.setattr(
-        svc.TechnicalIndicators, "calculate_indicators",
-        staticmethod(lambda df: df),
+        svc.market_data_store, "get_dataset", lambda *a, **k: _FakeDataset(),
     )
-    monkeypatch.setattr(session, "_build_trading_timestamps", lambda: ["ts0"])
-    monkeypatch.setattr(session, "_build_price_cache", lambda: {})
 
     # The agent cancelled while the fetch was running.
     session.status = "closed"

--- a/dashboard/backend/tests/test_pr71_review_fixes.py
+++ b/dashboard/backend/tests/test_pr71_review_fixes.py
@@ -90,6 +90,10 @@ def test_background_load_does_not_revive_a_cancelled_row(monkeypatch):
             self._step_lock = threading.Lock()
             self.status = "loading"
             self.error = None
+            # start_background_load's peek fast path reads these; the store is
+            # reset per test, so peek cold-misses and _load runs as intended.
+            self.start_date = "2026-04-15"
+            self.end_date = "2026-04-16"
 
         def load_market_data(self):
             # A cancel() landed mid-load; load_market_data's terminal guard

--- a/dashboard/backend/tests/test_run_lifecycle_unification.py
+++ b/dashboard/backend/tests/test_run_lifecycle_unification.py
@@ -546,6 +546,10 @@ def test_v2_row_transitions_to_running_after_load(monkeypatch):
         def __init__(self):
             self._step_lock = threading.Lock()
             self.status = "loading"
+            # start_background_load's peek fast path reads these; the store is
+            # reset per test, so peek cold-misses and _load runs as intended.
+            self.start_date = "2026-04-15"
+            self.end_date = "2026-04-16"
 
         def load_market_data(self):
             self.status = "waiting_decision"

--- a/dashboard/scripts/loadtest/README.md
+++ b/dashboard/scripts/loadtest/README.md
@@ -1,0 +1,23 @@
+# Protocol-agent load test
+
+Reproduces the 2026-07-24 concurrency measurements (spec:
+`docs/superpowers/specs/2026-07-24-agent-scale-sustainability-design.md`).
+
+Hermetic: synthetic market data (no Alpaca), fresh temp-dir SQLite, localhost
+only, no credentials. Never writes into the repo tree.
+
+## Run
+
+Terminal 1 (from the repo root):
+
+    N_AGENTS=100 python dashboard/scripts/loadtest/stress_serve.py
+    # prints:  artifacts dir: /tmp/atl_loadtest_XXXX
+
+Terminal 2:
+
+    python dashboard/scripts/loadtest/drive_agents.py 100 --artifacts /tmp/atl_loadtest_XXXX
+
+## Acceptance target (100 agents, 21-step runs, local dev hardware)
+
+0 timeout_holds, 0 failures, create p95 < 1 s, decision p95 < 1 s,
+total wall < 60 s, server RSS growth < 100 MB.

--- a/dashboard/scripts/loadtest/drive_agents.py
+++ b/dashboard/scripts/loadtest/drive_agents.py
@@ -1,0 +1,188 @@
+"""Simulate M concurrent protocol agents driving full backtests.
+
+Each agent: POST /api/v1/runs (3 trading days ~= 21 hourly steps), then loop
+GET steps/next -> POST decision until completed. Records per-endpoint latency,
+end-to-end run wall time, errors, steps lost to the decision deadline, and the
+server-reported timeout_holds counter (present once T3 ships; 0 before).
+
+Usage:
+    python dashboard/scripts/loadtest/drive_agents.py 100 --artifacts /tmp/atl_loadtest_xxx
+"""
+import argparse
+import json
+import os
+import statistics
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+parser = argparse.ArgumentParser()
+parser.add_argument("agents", type=int, nargs="?", default=10)
+parser.add_argument("--artifacts", required=True,
+                    help="artifacts dir printed by stress_serve.py")
+parser.add_argument("--base", default="http://127.0.0.1:8402")
+parser.add_argument("--allow-remote", action="store_true",
+                    help="required to target anything but localhost")
+args = parser.parse_args()
+
+host = urllib.parse.urlparse(args.base).hostname or ""
+if host not in ("127.0.0.1", "localhost", "::1") and not args.allow_remote:
+    sys.exit(f"refusing non-localhost target {args.base!r} (pass --allow-remote)")
+
+BASE = args.base
+M = args.agents
+AGENTS = json.load(open(os.path.join(args.artifacts, "agents.json")))
+PID_FILE = os.path.join(args.artifacts, "server.pid")
+
+samples = []          # (kind, ms, http_status)
+lock = threading.Lock()
+deadline_losses = []  # steps auto-held because our decision arrived too late
+server_holds = []     # server-reported timeout_holds per completed run (T3+)
+run_walls = []        # end-to-end seconds per completed run
+failures = []
+
+
+def req(method, path, key, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    r = urllib.request.Request(
+        BASE + path, data=data, method=method,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+    )
+    t0 = time.perf_counter()
+    try:
+        with urllib.request.urlopen(r, timeout=180) as resp:
+            payload = json.loads(resp.read())
+            return resp.status, payload, (time.perf_counter() - t0) * 1000
+    except urllib.error.HTTPError as e:
+        try:
+            payload = json.loads(e.read())
+        except Exception:
+            payload = {}
+        return e.code, payload, (time.perf_counter() - t0) * 1000
+    except Exception as e:
+        return -1, {"error": str(e)}, (time.perf_counter() - t0) * 1000
+
+
+def record(kind, ms, status):
+    with lock:
+        samples.append((kind, ms, status))
+
+
+def drive(agent):
+    key = agent["api_key"]
+    t_run = time.perf_counter()
+    status, body, ms = req("POST", "/api/v1/runs", key, {
+        "config": {"start_date": "2026-06-01", "end_date": "2026-06-03"},
+    })
+    record("create_run", ms, status)
+    if status != 200:
+        with lock:
+            failures.append(("create", status, str(body)[:150]))
+        return
+    run_id = body["run_id"]
+    lost = 0
+    first = True
+    for _ in range(400):  # hard cap: a run is ~21 steps
+        status, step, ms = req("GET", f"/api/v1/runs/{run_id}/steps/next", key)
+        record("steps_next", ms, status)
+        if status != 200:
+            with lock:
+                failures.append(("steps_next", status, str(step)[:150]))
+            return
+        st = step.get("status")
+        if st == "loading":
+            time.sleep(0.25)
+            continue
+        if st == "completed":
+            break
+        if st != "awaiting_decision":
+            with lock:
+                failures.append(("unexpected_step", 200, st or "?"))
+            return
+        orders = []
+        if first:
+            orders = [{"symbol": "AAPL", "side": "buy", "quantity": 5}]
+            first = False
+        status, res, ms = req(
+            "POST", f"/api/v1/runs/{run_id}/steps/{step['step_id']}/decision", key,
+            {"idempotency_key": uuid.uuid4().hex, "orders": orders,
+             "rationale": "load test decision"},
+        )
+        record("decision", ms, status)
+        if status == 409:
+            if "deadline" in str(res) or "finalized" in str(res):
+                lost += 1
+                continue  # step was auto-held under us; keep going
+            with lock:
+                failures.append(("decision409", 409, str(res)[:150]))
+            return
+        if status != 200:
+            with lock:
+                failures.append(("decision", status, str(res)[:150]))
+            return
+        if res.get("run_status") == "completed":
+            break
+    status, view, _ = req("GET", f"/api/v1/runs/{run_id}", key)
+    holds = 0
+    if status == 200:
+        holds = (view.get("engine_status") or {}).get("timeout_holds") or 0
+    with lock:
+        run_walls.append(time.perf_counter() - t_run)
+        deadline_losses.append(lost)
+        server_holds.append(holds)
+
+
+def server_stats():
+    try:
+        pid = int(open(PID_FILE).read())
+        st = open(f"/proc/{pid}/status").read()
+        rss = next(l for l in st.splitlines() if l.startswith("VmRSS")).split()[1]
+        thr = next(l for l in st.splitlines() if l.startswith("Threads")).split()[1]
+        return int(rss) // 1024, int(thr)
+    except Exception:
+        return -1, -1
+
+
+def dist(label, vals):
+    if not vals:
+        print(f"  {label:14s} (none)")
+        return
+    s = sorted(vals)
+    print(f"  {label:14s} n={len(s):5d}  med={statistics.median(s):8.1f}  "
+          f"p95={s[max(0, int(len(s)*0.95)-1)]:8.1f}  max={s[-1]:8.1f}")
+
+
+rss0, thr0 = server_stats()
+print(f"\n===== {M} concurrent agents =====  (server before: {rss0} MB RSS, {thr0} threads)")
+t0 = time.perf_counter()
+threads = [threading.Thread(target=drive, args=(a,)) for a in AGENTS[:M]]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+wall = time.perf_counter() - t0
+rss1, thr1 = server_stats()
+
+by_kind = {}
+for kind, ms, status in samples:
+    by_kind.setdefault(kind, []).append(ms)
+print(f"total wall: {wall:.1f}s  |  requests: {len(samples)}  |  "
+      f"throughput: {len(samples)/wall:.1f} req/s")
+print(f"server after: {rss1} MB RSS ({rss1-rss0:+d}), {thr1} threads ({thr1-thr0:+d})")
+print("per-request latency (ms):")
+for kind in ("create_run", "steps_next", "decision"):
+    dist(kind, by_kind.get(kind, []))
+print("end-to-end run wall time (s):")
+dist("full_run", run_walls)
+total_lost = sum(deadline_losses)
+runs_hit = sum(1 for x in deadline_losses if x)
+print(f"completed runs: {len(run_walls)}/{M}  |  client-observed deadline losses: "
+      f"{total_lost} (across {runs_hit} runs)  |  server timeout_holds: {sum(server_holds)}")
+if failures:
+    print(f"FAILURES: {len(failures)}")
+    for f in failures[:8]:
+        print("  ", f)

--- a/dashboard/scripts/loadtest/stress_serve.py
+++ b/dashboard/scripts/loadtest/stress_serve.py
@@ -1,0 +1,84 @@
+"""Serve the real app with synthetic market data + N pre-seeded protocol agents.
+
+Patches the Alpaca loader with a deterministic in-process generator so the
+load test measures OUR stack (locks, threadpool, SQLite, pandas, finalize),
+not Alpaca's API. Binds to localhost only. All artifacts (DB, agent keys,
+pid file) go to a fresh temp dir, printed at startup — never the repo tree.
+
+Usage (from the repo root):
+    N_AGENTS=100 python dashboard/scripts/loadtest/stress_serve.py
+"""
+import os
+import sys
+import json
+import tempfile
+
+ARTIFACTS = tempfile.mkdtemp(prefix="atl_loadtest_")
+os.environ["DATABASE_PATH"] = os.path.join(ARTIFACTS, "stress.db")
+# Ambient prod/dev URLs must never leak into a load test.
+os.environ.pop("CONTENT_DATABASE_URL", None)
+os.environ.pop("USERS_DATABASE_URL", None)
+sys.path.insert(0, os.getcwd())
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+
+def synth_bars(symbols, start, end):
+    idx = pd.date_range(start=start, end=str(end) + " 23:59", freq="1h", tz="UTC")
+    et = idx.tz_convert("US/Eastern")
+    mask = (et.dayofweek < 5) & (
+        ((et.hour > 9) & (et.hour < 16)) | ((et.hour == 16) & (et.minute == 0))
+    )
+    idx = idx[mask]
+    data = {}
+    for si, sym in enumerate(sorted(symbols)):
+        n = len(idx)
+        close = 100.0 + si * 5 + np.linspace(0, 2.0, n) + np.sin(np.arange(n) * 0.3) * 1.5
+        df = pd.DataFrame(
+            {"open": close - 0.2, "high": close + 0.5, "low": close - 0.5,
+             "close": close, "volume": 10000.0},
+            index=idx,
+        )
+        df.index.name = "timestamp"
+        data[sym] = df
+    return data
+
+
+class FakeAlpacaLoader:
+    def __init__(self, *a, **k):
+        pass
+
+    def fetch_bars(self, symbols, start, end):
+        return synth_bars(symbols, start, end)
+
+
+import dashboard.backend.domain.backtesting.external_run_service as ebs  # noqa: E402
+import dashboard.backend.domain.backtesting.engine as engine_mod  # noqa: E402
+
+ebs.AlpacaDataLoader = FakeAlpacaLoader
+engine_mod.create_market_data_provider = lambda ds=None: FakeAlpacaLoader()
+
+from dashboard.backend.domain.agents.repository import agent_store  # noqa: E402
+
+N = int(os.environ.get("N_AGENTS", "100"))
+agents = []
+for i in range(N):
+    a = agent_store.create_agent(
+        name=f"load-agent-{i}",
+        model_name="external/load-test",
+        agent_type="external",
+        description="concurrency load test",
+    )
+    agents.append({"agent_id": a["agent_id"], "api_key": a["api_key"]})
+
+with open(os.path.join(ARTIFACTS, "agents.json"), "w") as f:
+    json.dump(agents, f)
+with open(os.path.join(ARTIFACTS, "server.pid"), "w") as f:
+    f.write(str(os.getpid()))
+print(f"artifacts dir: {ARTIFACTS}", flush=True)
+print(f"seeded {N} agents; serving on 127.0.0.1:8402", flush=True)
+
+import uvicorn  # noqa: E402
+
+uvicorn.run("dashboard.backend.app:app", host="127.0.0.1", port=8402, log_level="warning")


### PR DESCRIPTION
T1 of `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md`
(spec: `docs/superpowers/specs/2026-07-24-agent-scale-sustainability-design.md`).

## Summary
- New `market_data_store`: one immutable dataset per `(symbols, start, end)` key, shared across same-config backtest sessions. Blocking single-flight (leader builds; waiters block on an Event and get the same object), failures propagate to all waiters + negative-cache 30s, LRU-bounded by `MARKET_DATA_CACHE_MAX_ENTRIES` (default 4).
- Sessions delegate: `load_market_data()` → store; new `adopt_dataset()` attaches the read-only bundle under the step lock (terminal-status guard preserved). `_build_trading_timestamps`/`_build_price_cache` (+ orphaned `pytz`/`ET_TZ`) moved into the store.
- `peek` fast path on both create surfaces (v1 `start_backtest`, v2 `start_background_load`): a resident dataset skips the loader thread and opens step 0 synchronously. Wire literal `"status": "loading"` unchanged.
- Hermetic load-test harness under `dashboard/scripts/loadtest/`.
- New env var `MARKET_DATA_CACHE_MAX_ENTRIES` (default 4); added to `.env.example`.

## Test plan
- [x] Full backend suite: `1274 passed, 34 skipped`.
- [x] New tests: single-flight, key isolation, negative cache, LRU, shared-identity, both fast paths.
- [x] Harness smoke (10 agents, local): `10/10 completed`, 0 failures, 0 deadline losses, 0 timeout_holds, create median 72.7ms; artifacts stay in `/tmp`. 100-agent acceptance target documented in the harness README.