### PR TITLE
feat: background baseline worker + finalize split

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,10 @@ DATABASE_PATH=dashboard/storage/data/backtest.db
 # in memory for reuse across backtest runs (LRU beyond this). Default 4.
 # MARKET_DATA_CACHE_MAX_ENTRIES=4
 
+# Max queued background baseline-generation jobs (drops beyond this; the run
+# itself is unaffected). Default 500.
+# BASELINE_QUEUE_MAX=500
+
 # User accounts (optional). When set, signup/login/session data is stored in
 # this Postgres database instead of the local SQLite file above -- required
 # on hosts with an ephemeral/disk-less filesystem (e.g. Render free tier),

--- a/dashboard/backend/domain/backtesting/baseline_worker.py
+++ b/dashboard/backend/domain/backtesting/baseline_worker.py
@@ -1,0 +1,163 @@
+"""Background baseline generation with config-level dedup (T2).
+
+Baselines (buy-hold + DJIA) depend only on the run *config*, not the agent, so
+a wave of same-config finalizes needs exactly one baseline pair. Finalize
+enqueues a job here and returns; one lazily-started daemon thread drains the
+queue (single consumer — the dedup cache therefore needs no lock: job N for a
+config fully completes, DB write included, before job N+1 dequeues).
+
+Degradation semantics match today's best-effort baselines: a full queue drops
+the job with a printed error (the run stays completed without baselines), a
+failure is printed and swallowed, and jobs are lost on process restart —
+identical durability to the old in-request path, which lost baselines on a
+mid-finalize restart too.
+
+Each job carries a direct reference to its dataset's ``all_data`` (the T1
+bundle), so LRU eviction between enqueue and drain can never force a
+refetch/rebuild storm; same-config jobs share one object, bounding pinned
+memory by the distinct configs in the queue.
+
+``publish`` callbacks must swap in a NEW dict (never mutate one the session
+already exposed) — see ExternalBacktestSession._publish_baselines.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from dashboard.backend import database as db_module
+from dashboard.backend.domain.backtesting.engine import HourlyBacktester
+
+BASELINE_QUEUE_MAX = int(os.getenv("BASELINE_QUEUE_MAX", "500"))
+QUEUE_DEPTH_WARN = 25
+
+_STOP = object()
+
+
+class BaselineJob:
+    __slots__ = ("run_id", "session_id", "start_date", "end_date", "mode",
+                 "all_data", "publish")
+
+    def __init__(self, *, run_id: str, session_id: str, start_date: str,
+                 end_date: str, mode: str, all_data: Dict[str, Any],
+                 publish: Callable[[Dict[str, str]], None]):
+        self.run_id = run_id
+        self.session_id = session_id
+        self.start_date = start_date
+        self.end_date = end_date
+        self.mode = mode
+        self.all_data = all_data
+        self.publish = publish
+
+
+_queue: "queue.Queue" = queue.Queue(maxsize=BASELINE_QUEUE_MAX)
+_worker_thread: Optional[threading.Thread] = None
+_worker_lock = threading.Lock()
+# (start, end, mode) -> {"buy_and_hold": id, "djia": id}. Single-consumer, so
+# unlocked access is safe; grows one tiny entry per distinct config.
+_completed: Dict[Tuple[str, str, str], Dict[str, str]] = {}
+
+
+def submit(job: BaselineJob) -> bool:
+    """Enqueue baseline generation for a finalized run. Never blocks or raises."""
+    _ensure_worker()
+    try:
+        _queue.put_nowait(job)
+    except queue.Full:
+        print(f"⚠️ Baseline queue full ({_queue.maxsize}); dropping baselines "
+              f"for {job.run_id} (run saved)")
+        return False
+    depth = _queue.qsize()
+    if depth > QUEUE_DEPTH_WARN:
+        print(f"⚠️ Baseline queue depth {depth} — worker backlog")
+    return True
+
+
+def _ensure_worker() -> None:
+    global _worker_thread
+    with _worker_lock:
+        if _worker_thread is not None and _worker_thread.is_alive():
+            return
+        _worker_thread = threading.Thread(
+            target=_drain_forever, args=(_queue,), daemon=True,
+            name="baseline-worker")
+        _worker_thread.start()
+
+
+def _drain_forever(q: "queue.Queue") -> None:
+    while True:
+        job = q.get()
+        try:
+            if job is _STOP:
+                return
+            _run_job(job)
+        # SystemExit guard mirrors the old in-finalize catch: a daemon thread
+        # swallows SystemExit silently, which would kill the worker forever.
+        except (Exception, SystemExit) as exc:
+            print(f"⚠️ Baseline generation failed (run saved): {exc}")
+        finally:
+            q.task_done()
+
+
+def _run_job(job: BaselineJob) -> None:
+    key = (job.start_date, job.end_date, job.mode)
+    ids = _completed.get(key)
+    if ids is None:
+        backtester = HourlyBacktester(
+            job.start_date, job.end_date, job.session_id,
+            use_llm=False, mode=job.mode,
+        )
+        backtester.all_data = job.all_data
+        buyhold_id, _ = backtester.run_buyhold_baseline()
+        djia_id, _ = backtester.run_djia_baseline()
+        ids = {}
+        if buyhold_id:
+            ids["buy_and_hold"] = buyhold_id
+        if djia_id:
+            ids["djia"] = djia_id
+        _completed[key] = ids
+    # db is late-bound through the module attribute so per-test DB swaps
+    # (monkeypatch.setattr(db_module, "db", ...)) reach the worker thread.
+    db_module.db.update_run_baselines(
+        job.run_id,
+        djia_run_id=ids.get("djia"),
+        buyhold_run_id=ids.get("buy_and_hold"),
+    )
+    job.publish(dict(ids))
+
+
+def wait_idle(timeout: float = 30.0) -> bool:
+    """Test helper: True once every enqueued job (publish included) finished."""
+    import time
+    deadline = time.monotonic() + timeout
+    with _queue.all_tasks_done:
+        while _queue.unfinished_tasks:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            _queue.all_tasks_done.wait(remaining)
+    return True
+
+
+def _reset_for_tests(maxsize: Optional[int] = None) -> None:
+    """Fresh queue + dedup cache; wakes a worker blocked on the old queue."""
+    global _queue, _worker_thread
+    with _worker_lock:
+        old_q = _queue
+        _completed.clear()
+        _queue = queue.Queue(
+            maxsize=maxsize if maxsize is not None else BASELINE_QUEUE_MAX)
+        if _worker_thread is not None and _worker_thread.is_alive():
+            try:
+                old_q.put_nowait(_STOP)
+            except queue.Full:
+                try:
+                    old_q.get_nowait()
+                    old_q.task_done()
+                except queue.Empty:
+                    pass
+                old_q.put_nowait(_STOP)
+        _worker_thread = None

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -40,8 +40,7 @@ from dashboard.backend.domain.backtesting.metrics import (
 from dashboard.backend.domain.backtesting.portfolio_manager import PortfolioManager
 from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
 
-from dashboard.backend.domain.backtesting.engine import HourlyBacktester
-from dashboard.backend.domain.backtesting import market_data_store
+from dashboard.backend.domain.backtesting import baseline_worker, market_data_store
 
 DECISION_TIMEOUT_SECONDS = int(os.getenv("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", "30"))
 
@@ -557,44 +556,29 @@ class ExternalBacktestSession:
         db.insert_trades(self.run_id, self.manager.trades)
         db.insert_decisions(self.run_id, self.decision_log)
 
-        # The run is fully persisted now — publish "completed" BEFORE the slow,
-        # best-effort baseline generation below. is_active()/cancel() read
-        # self.status without _step_lock; if the flip waited until after the
-        # baselines (two full backtests, seconds-to-minutes, all under the step
-        # lock) a cancel would block for that whole window and the cap would
-        # keep counting a finished run. baseline_run_ids fills in just below,
-        # still before _finalize returns, so the locked callers see the
-        # complete envelope.
+        # The run is fully persisted now — publish "completed" here, in-request.
+        # is_active()/cancel() read self.status without _step_lock, so the flip
+        # must land before this method returns (T1 already moved the slow work —
+        # the market-data build — out of finalize; T2 below moves baselines out
+        # too). baseline_run_ids stays {} in the envelope this finalize returns;
+        # the worker fills it in asynchronously and later polls self-heal (see
+        # _publish_baselines).
         self.status = "completed"
 
-        try:
-            backtester = HourlyBacktester(
-                self.start_date,
-                self.end_date,
-                self.session_id,
-                use_llm=False,
-                mode=self.mode,
-            )
-            backtester.all_data = self.all_data
-            buyhold_id, _ = backtester.run_buyhold_baseline()
-            djia_id, _ = backtester.run_djia_baseline()
-            if buyhold_id:
-                self.baseline_run_ids["buy_and_hold"] = buyhold_id
-            if djia_id:
-                self.baseline_run_ids["djia"] = djia_id
-            db.update_run_baselines(
-                self.run_id,
-                djia_run_id=djia_id,
-                buyhold_run_id=buyhold_id,
-            )
-        # Baseline generation is strictly best-effort and must never break — or
-        # hang — run finalization. A credential-less environment now raises
-        # MarketDataUnavailableError (a plain Exception, B0 deep fix), but the
-        # SystemExit catch stays as defense-in-depth: any regression back to a
-        # BaseException here would propagate into the ASGI worker and wedge
-        # the request future forever (the original B0 hang).
-        except (Exception, SystemExit) as exc:
-            print(f"⚠️ Baseline generation failed (run saved): {exc}")
+        # Background half (T2): baselines depend only on the run config, so
+        # they move to the deduping worker. The job pins all_data (the shared
+        # T1 bundle) so cache eviction can't force a rebuild, and publishes
+        # back via _publish_baselines. Queue-full/failure degrade exactly like
+        # the old best-effort inline path: run saved, baselines absent.
+        baseline_worker.submit(baseline_worker.BaselineJob(
+            run_id=self.run_id,
+            session_id=self.session_id,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            mode=self.mode,
+            all_data=self.all_data,
+            publish=self._publish_baselines,
+        ))
 
         try:
             agent_store.register_or_get_agent(
@@ -605,6 +589,17 @@ class ExternalBacktestSession:
         except Exception as exc:
             print(f"⚠️ Agent auto-register failed (run saved): {exc}")
         # status is already "completed" (set before the baseline block above).
+
+    def _publish_baselines(self, ids: Dict[str, str]) -> None:
+        """Worker-thread callback: swap in a NEW dict in one statement.
+
+        get_status()/get_current_step() alias baseline_run_ids out from under
+        _step_lock and serialize it after releasing the lock — an in-place
+        write from the worker could tear a poll response mid-iteration. A
+        single reference assignment is GIL-atomic: readers see the old (empty)
+        dict or the new (complete) one, never a hybrid.
+        """
+        self.baseline_run_ids = dict(ids)
 
     def _compare_url(self) -> Optional[str]:
         return build_compare_url(self.run_id, self.baseline_run_ids)

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -358,14 +358,15 @@ class ExternalBacktestSession:
                 return {"status": "failed", "error": self.error}
 
             if self.status == "completed":
+                baseline_ids = self.baseline_run_ids  # one snapshot for both fields
                 return {
                     "status": "completed",
                     "backtest_id": self.backtest_id,
                     "run_id": self.run_id,
-                    "baseline_run_ids": self.baseline_run_ids,
+                    "baseline_run_ids": baseline_ids,
                     "total_steps": self.total_steps,
                     "metrics": self._final_metrics(),
-                    "compare_url": self._compare_url(),
+                    "compare_url": self._compare_url(baseline_ids),
                     "session_id": self.session_id,
                 }
 
@@ -601,8 +602,12 @@ class ExternalBacktestSession:
         """
         self.baseline_run_ids = dict(ids)
 
-    def _compare_url(self) -> Optional[str]:
-        return build_compare_url(self.run_id, self.baseline_run_ids)
+    def _compare_url(self, baseline_run_ids: Optional[Dict[str, str]] = None) -> Optional[str]:
+        # Callers that ALSO surface baseline_run_ids in the same response pass a
+        # snapshot so the two fields can't straddle the worker's one-time async
+        # publish (T2: _publish_baselines rebinds the dict). Default reads live.
+        ids = self.baseline_run_ids if baseline_run_ids is None else baseline_run_ids
+        return build_compare_url(self.run_id, ids)
 
     def _final_metrics(self) -> Dict[str, Any]:
         if not self.run_id:
@@ -624,9 +629,10 @@ class ExternalBacktestSession:
             if self.status == "waiting_decision":
                 base["decision_deadline_at"] = _iso(self._deadline_at())
             if self.status == "completed":
+                baseline_ids = self.baseline_run_ids  # one snapshot for both fields
                 base["metrics"] = self._final_metrics()
-                base["baseline_run_ids"] = self.baseline_run_ids
-                base["compare_url"] = self._compare_url()
+                base["baseline_run_ids"] = baseline_ids
+                base["compare_url"] = self._compare_url(baseline_ids)
             if self.error:
                 base["error"] = self.error
             return base

--- a/dashboard/backend/tests/backtesting/test_canonical_consumers.py
+++ b/dashboard/backend/tests/backtesting/test_canonical_consumers.py
@@ -84,11 +84,16 @@ def test_external_backtest_service_uses_canonical_symbols():
     assert ebs.PortfolioManager is PortfolioManager
     assert ebs.AlpacaDataLoader is AlpacaDataLoader
     assert ebs.TechnicalIndicators is TechnicalIndicators
-    # Phase 2C5: HourlyBacktester is now the canonical engine class.
-    assert ebs.HourlyBacktester is HourlyBacktester
-    assert ebs.HourlyBacktester.__module__ == (
+    # T2: HourlyBacktester consumption moved from the service to the deduping
+    # baseline_worker; the worker binds the canonical engine class, and the
+    # service no longer references it at all.
+    from dashboard.backend.domain.backtesting import baseline_worker as bw
+
+    assert bw.HourlyBacktester is HourlyBacktester
+    assert bw.HourlyBacktester.__module__ == (
         "dashboard.backend.domain.backtesting.engine"
     )
+    assert not hasattr(ebs, "HourlyBacktester")
     assert not hasattr(ebs, "bha")
 
 

--- a/dashboard/backend/tests/backtesting/test_engine_move.py
+++ b/dashboard/backend/tests/backtesting/test_engine_move.py
@@ -148,10 +148,16 @@ def test_no_backend_source_imports_scripts():
 
 
 def test_external_backtest_service_uses_canonical_engine():
+    # T2 moved baseline generation off the finalize request into the deduping
+    # baseline_worker, so the worker (not the service) is now the backend's
+    # HourlyBacktester consumer. It must still bind the canonical engine class,
+    # never the legacy flat script.
     import dashboard.backend.domain.backtesting.external_run_service as ebs
+    from dashboard.backend.domain.backtesting import baseline_worker as bw
 
-    assert ebs.HourlyBacktester is HourlyBacktester
-    assert ebs.HourlyBacktester.__module__ == ENGINE_MODULE
+    assert bw.HourlyBacktester is HourlyBacktester
+    assert bw.HourlyBacktester.__module__ == ENGINE_MODULE
+    assert not hasattr(ebs, "HourlyBacktester")  # moved out of the service (T2)
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -57,6 +57,7 @@ os.environ.pop("CONTENT_DATABASE_URL", None)
 # stray shell value would silently skew the whole run. Same rationale as the
 # DB-URL strips above. Later tiers append their vars here.
 os.environ.pop("MARKET_DATA_CACHE_MAX_ENTRIES", None)
+os.environ.pop("BASELINE_QUEUE_MAX", None)
 
 
 @atexit.register
@@ -73,7 +74,16 @@ def _reset_shared_scale_state():
     """The market-data store is a module-level cache shared across the test
     process; without a per-test reset, one test's synthetic bars would be
     served to every later test with the same (symbols, dates) key."""
-    from dashboard.backend.domain.backtesting import market_data_store
+    from dashboard.backend.domain.backtesting import baseline_worker, market_data_store
     market_data_store._reset_for_tests()
+    baseline_worker._reset_for_tests()
     yield
+    # Best-effort drain so a job enqueued in this test doesn't leak into the
+    # next. Note pytest tears fixtures down LIFO, so a test's own monkeypatches
+    # may already be reverted here — in practice patched baseline fakes return
+    # instantly, so the queue is empty long before teardown. Any T2 test that
+    # gates or slows the worker must call baseline_worker.wait_idle() itself
+    # before returning (every test in this plan does).
+    baseline_worker.wait_idle(timeout=5)
+    baseline_worker._reset_for_tests()
     market_data_store._reset_for_tests()

--- a/dashboard/backend/tests/domain/backtesting/test_external_run_service_move.py
+++ b/dashboard/backend/tests/domain/backtesting/test_external_run_service_move.py
@@ -52,8 +52,12 @@ def test_service_wires_canonical_symbols():
     from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
     from dashboard.backend.domain.agents.repository import agent_store
     from dashboard.backend.domain.backtesting.constants import INITIAL_CAPITAL
+    from dashboard.backend.domain.backtesting import baseline_worker as bw
 
-    assert svc.HourlyBacktester is HourlyBacktester
+    # T2: HourlyBacktester is consumed by the baseline_worker now, not the
+    # service; the service no longer imports it.
+    assert bw.HourlyBacktester is HourlyBacktester
+    assert not hasattr(svc, "HourlyBacktester")
     assert svc.PortfolioManager is PortfolioManager
     assert svc.TechnicalIndicators is TechnicalIndicators
     assert svc.AlpacaDataLoader is AlpacaDataLoader

--- a/dashboard/backend/tests/test_baseline_worker.py
+++ b/dashboard/backend/tests/test_baseline_worker.py
@@ -1,0 +1,105 @@
+"""Baseline worker: dedup by config, atomic publish, overflow drop (T2)."""
+
+import threading
+
+import pytest
+
+import dashboard.backend.database as db_module
+from dashboard.backend.domain.backtesting import baseline_worker as bw
+
+
+class _FakeBacktester:
+    instances = 0
+
+    def __init__(self, start, end, session_id, use_llm=False, mode="safe_trading"):
+        type(self).instances += 1
+        self.all_data = None
+
+    def run_buyhold_baseline(self):
+        return f"buyhold_{type(self).instances}", []
+
+    def run_djia_baseline(self):
+        return f"djia_{type(self).instances}", []
+
+
+class _RecordingDb:
+    def __init__(self):
+        self.baseline_writes = []
+
+    def update_run_baselines(self, run_id, *, djia_run_id=None, buyhold_run_id=None):
+        self.baseline_writes.append((run_id, djia_run_id, buyhold_run_id))
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    bw._reset_for_tests()
+    _FakeBacktester.instances = 0
+    fake_db = _RecordingDb()
+    monkeypatch.setattr(db_module, "db", fake_db)
+    monkeypatch.setattr(bw, "HourlyBacktester", _FakeBacktester)
+    yield fake_db
+    bw._reset_for_tests()
+
+
+def _job(run_id, start="2026-04-15", end="2026-04-16", mode="safe_trading",
+         publish=None):
+    return bw.BaselineJob(
+        run_id=run_id, session_id=f"sess_{run_id}", start_date=start,
+        end_date=end, mode=mode, all_data={"AAPL": object()},
+        publish=publish or (lambda ids: None),
+    )
+
+
+def test_same_config_jobs_run_baselines_once(_isolate):
+    published = {}
+    for i in range(3):
+        assert bw.submit(_job(f"r{i}", publish=lambda ids, i=i: published.__setitem__(i, ids)))
+    assert bw.wait_idle(10)
+    assert _FakeBacktester.instances == 1                      # dedup: 1, not 3
+    assert len(_isolate.baseline_writes) == 3                  # every run row linked
+    assert published[0] == published[1] == published[2]
+    assert published[0] == {"buy_and_hold": "buyhold_1", "djia": "djia_1"}
+    assert published[0] is not published[1]                    # fresh dict per job
+
+
+def test_distinct_configs_run_their_own_baselines():
+    assert bw.submit(_job("a", start="2026-04-13", end="2026-04-14"))
+    assert bw.submit(_job("b", start="2026-04-15", end="2026-04-16"))
+    assert bw.wait_idle(10)
+    assert _FakeBacktester.instances == 2
+
+
+def test_job_failure_is_swallowed_and_worker_continues(capsys, monkeypatch):
+    class _Boom(_FakeBacktester):
+        def run_buyhold_baseline(self):
+            raise RuntimeError("baseline blew up")
+
+    monkeypatch.setattr(bw, "HourlyBacktester", _Boom)
+    done = threading.Event()
+    bw.submit(_job("bad"))
+    assert bw.wait_idle(10)
+    monkeypatch.setattr(bw, "HourlyBacktester", _FakeBacktester)
+    bw.submit(_job("good", start="2026-05-01", end="2026-05-02",
+                   publish=lambda ids: done.set()))
+    assert bw.wait_idle(10) and done.is_set()   # worker survived the failure
+    assert "Baseline generation failed" in capsys.readouterr().out
+
+
+def test_full_queue_drops_job_with_print(capsys, monkeypatch):
+    bw._reset_for_tests(maxsize=1)
+    entered, release = threading.Event(), threading.Event()
+
+    class _Blocking(_FakeBacktester):
+        def run_buyhold_baseline(self):
+            entered.set()
+            release.wait(10)
+            return "buyhold_x", []
+
+    monkeypatch.setattr(bw, "HourlyBacktester", _Blocking)
+    assert bw.submit(_job("one", start="2026-06-01", end="2026-06-02"))
+    assert entered.wait(10)                     # worker busy on job one
+    assert bw.submit(_job("two", start="2026-06-03", end="2026-06-04"))  # fills slot
+    assert bw.submit(_job("three", start="2026-06-05", end="2026-06-06")) is False
+    assert "Baseline queue full" in capsys.readouterr().out
+    release.set()
+    assert bw.wait_idle(10)

--- a/dashboard/backend/tests/test_finalize_split.py
+++ b/dashboard/backend/tests/test_finalize_split.py
@@ -1,0 +1,119 @@
+"""Finalize split (T2): the final submit persists + completes in-request;
+baselines arrive asynchronously via the worker; polled surfaces self-heal."""
+
+import threading
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import dashboard.backend.database as db_module
+import dashboard.backend.domain.backtesting.external_run_service as ebs
+from dashboard.backend.domain.backtesting import baseline_worker as bw
+
+
+def _synth_bars(symbols, start, end):
+    idx = pd.date_range(start=start, end=str(end) + " 23:59", freq="1h", tz="UTC")
+    et = idx.tz_convert("US/Eastern")
+    mask = (et.dayofweek < 5) & (
+        ((et.hour > 9) & (et.hour < 16)) | ((et.hour == 16) & (et.minute == 0))
+    )
+    idx = idx[mask]
+    data = {}
+    for si, sym in enumerate(sorted(symbols)):
+        n = len(idx)
+        close = 100.0 + si + np.linspace(0, 1.0, n)
+        data[sym] = pd.DataFrame(
+            {"open": close, "high": close + 0.5, "low": close - 0.5,
+             "close": close, "volume": 1000.0}, index=idx)
+    return data
+
+
+class _Loader:
+    def fetch_bars(self, symbols, start, end):
+        return _synth_bars(symbols, start, end)
+
+
+class _FakeBacktester:
+    instances = 0
+    gate = None  # when set (threading.Event), baselines wait on it
+
+    def __init__(self, start, end, session_id, use_llm=False, mode="safe_trading"):
+        type(self).instances += 1
+        self.all_data = None
+
+    def run_buyhold_baseline(self):
+        if type(self).gate is not None:
+            type(self).gate.wait(10)
+        return "buyhold_shared", []
+
+    def run_djia_baseline(self):
+        return "djia_shared", []
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    test_db = db_module.BacktestDatabase(db_path=tmp_path / "finalize_split.db")
+    monkeypatch.setattr(db_module, "db", test_db)
+    monkeypatch.setattr(ebs, "db", test_db)
+    monkeypatch.setattr(ebs, "AlpacaDataLoader", _Loader)
+    monkeypatch.setattr(ebs, "_sessions", {})
+    monkeypatch.setattr(bw, "HourlyBacktester", _FakeBacktester)
+    bw._reset_for_tests()
+    _FakeBacktester.instances = 0
+    _FakeBacktester.gate = None
+    yield test_db
+    bw._reset_for_tests()
+
+
+def _run_to_completion(i):
+    s = ebs.ExternalBacktestSession(
+        backtest_id=f"bt_fin_{i}", session_id=f"sess_{i}", agent_name=f"a{i}",
+        model_name="m", start_date="2026-04-15", end_date="2026-04-16",
+    )
+    s.load_market_data()
+    last = None
+    for _ in range(s.total_steps):
+        last = s.submit_decisions({"actions": []})
+    return s, last
+
+
+def test_final_submit_completes_before_baselines(_isolate):
+    _FakeBacktester.gate = threading.Event()  # hold the worker mid-baseline
+    s, last = _run_to_completion(0)
+    # The one-shot decision response: completed + persisted, baselines pending.
+    assert last["status"] == "completed"
+    assert last["run_id"] == s.run_id
+    assert last["metrics"]["final_equity"] is not None       # results persisted
+    assert last["compare_url"] == f"/compare?run_ids={s.run_id}"  # no baseline ids
+    assert s.baseline_run_ids == {}
+    assert _isolate.get_run(s.run_id) is not None
+    _FakeBacktester.gate.set()
+    assert bw.wait_idle(10)
+    # Polled surfaces self-heal once the worker lands.
+    status = s.get_status()
+    assert status["baseline_run_ids"] == {"buy_and_hold": "buyhold_shared",
+                                          "djia": "djia_shared"}
+    assert "buyhold_shared" in status["compare_url"]
+    row = _isolate.get_run(s.run_id)
+    assert row["baseline_buyhold_run_id"] == "buyhold_shared"
+    assert row["baseline_djia_run_id"] == "djia_shared"
+
+
+def test_same_config_finalizes_share_one_baseline_pair(_isolate):
+    s1, _ = _run_to_completion(1)
+    s2, _ = _run_to_completion(2)
+    assert bw.wait_idle(10)
+    assert _FakeBacktester.instances == 1  # 2 runs, 1 baseline backtester
+    assert s1.baseline_run_ids == s2.baseline_run_ids
+    assert s1.baseline_run_ids is not s2.baseline_run_ids  # swapped-in copies
+    assert _isolate.get_run(s1.run_id)["baseline_djia_run_id"] == "djia_shared"
+    assert _isolate.get_run(s2.run_id)["baseline_djia_run_id"] == "djia_shared"
+
+
+def test_evicted_session_still_gets_db_baselines(_isolate):
+    s, _ = _run_to_completion(3)
+    ebs.evict_session(s.backtest_id)  # reaper freed the session before the worker ran
+    assert bw.wait_idle(10)
+    row = _isolate.get_run(s.run_id)
+    assert row["baseline_buyhold_run_id"] == "buyhold_shared"  # DB is source of truth

--- a/dashboard/backend/tests/test_pr71_review_fixes.py
+++ b/dashboard/backend/tests/test_pr71_review_fixes.py
@@ -209,7 +209,8 @@ def test_finalize_marks_completed_before_baselines(monkeypatch, tmp_path):
         def run_djia_baseline(self):
             return (None, None)
 
-    monkeypatch.setattr(svc, "HourlyBacktester", _BlockingBacktester)
+    from dashboard.backend.domain.backtesting import baseline_worker as bw
+    monkeypatch.setattr(bw, "HourlyBacktester", _BlockingBacktester)
 
     session = svc.ExternalBacktestSession(
         backtest_id="bt_fin", session_id="s", agent_name="a", model_name="m",

--- a/dashboard/backend/tests/test_protocol_api.py
+++ b/dashboard/backend/tests/test_protocol_api.py
@@ -91,8 +91,9 @@ def client(tmp_path, monkeypatch):
 
     # Synthetic data + fast, network-free finalize
     monkeypatch.setattr(ebs, "AlpacaDataLoader", _FakeLoader)
-    monkeypatch.setattr(ebs.HourlyBacktester, "run_buyhold_baseline", lambda self: (None, None))
-    monkeypatch.setattr(ebs.HourlyBacktester, "run_djia_baseline", lambda self: (None, None))
+    from dashboard.backend.domain.backtesting import baseline_worker as bw
+    monkeypatch.setattr(bw.HourlyBacktester, "run_buyhold_baseline", lambda self: (None, None))
+    monkeypatch.setattr(bw.HourlyBacktester, "run_djia_baseline", lambda self: (None, None))
     monkeypatch.setattr(ebs, "DECISION_TIMEOUT_SECONDS", 300)
 
     # Isolate the in-memory run/session registries between tests.

--- a/docs/api/agent-environment-protocol-v1.md
+++ b/docs/api/agent-environment-protocol-v1.md
@@ -323,6 +323,11 @@ GET /api/v1/runs/{run_id}/result
 `result` is available only once the run is `completed`; otherwise it returns
 `409 run_not_completed`.
 
+Baseline comparison runs (`baseline_run_ids`, the baseline ids inside
+`compare_url`) are generated asynchronously after completion and normally land
+within seconds; poll `GET /api/v1/runs/{run_id}` to pick them up. The decision
+response that completes the run is a snapshot from before they exist.
+
 ---
 
 ## 11. Error format


### PR DESCRIPTION
T2 of `docs/superpowers/specs/2026-07-24-agent-scale-sustainability-design.md`.

## Summary
- Baseline generation moves off the finalize request into a lazily-started, single-consumer `baseline_worker` daemon. The final decision submit now returns in ms (was seconds-to-minutes holding `_step_lock`).
- Config-level dedup: a same-config wave runs **2** baseline backtests (buy-hold + DJIA), not 2N. Runs share one baseline pair via `_completed[(start,end,mode)]`.
- Async publish self-heals: `_finalize` returns a completed envelope with empty `baseline_run_ids`; the worker swaps in a new dict (GIL-atomic) and later polls / the DB pick it up.
- New env var: `BASELINE_QUEUE_MAX` (default 500). Overflow / failure degrade exactly like the old best-effort inline path (run saved, baselines absent).

## Dedup safety (spec Step 7 — verified at source)
Shared baseline rows are written under the *first* finalizer's `session_id`, so both consumer paths were confirmed non-session-scoped:
- `db.delete_run(run_id)` deletes only that run's own rows — never the runs its `baseline_*_run_id` columns point at.
- The compare view reads baselines through the public `/compare` endpoint (`db.get_run`/`db.get_equity_curve`, explicitly "not filtered by session").

No fallback to per-run baselines needed.

## Notes
- The plan's fixture-grep (`tests/*.py`, non-recursive) missed three canonical-wiring move-tests under `tests/backtesting/` and `tests/domain/backtesting/`; the `HourlyBacktester` consumer moved service→worker, so those assertions were redirected to `baseline_worker`. Corrected one now-stale finalize comment as well.

## Test plan
- [x] `test_baseline_worker.py`, `test_finalize_split.py` (new) pass
- [x] Contract pins pass unchanged: `test_run_lifecycle_unification.py`, `test_protocol_api.py`, `test_execution_backends.py`, `test_pr71_review_fixes.py`
- [x] Full backend suite: 1282 passed, 34 skipped