### PR TITLE
feat: T3 deadline 60s, timeout_holds, run cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,11 @@ DATABASE_PATH=dashboard/storage/data/backtest.db
 # itself is unaffected). Default 500.
 # BASELINE_QUEUE_MAX=500
 
+# Global backstop: max active (non-terminal) runs across ALL agents; creates
+# beyond this 429 with Retry-After. 0 disables. Default 100 -- the tested
+# number; raise only after a measured smoke run at the higher value.
+# MAX_ACTIVE_RUNS_GLOBAL=100
+
 # User accounts (optional). When set, signup/login/session data is stored in
 # this Postgres database instead of the local SQLite file above -- required
 # on hosts with an ephemeral/disk-less filesystem (e.g. Render free tier),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Pipeline is **backtest → SQLite → API → dashboard**. The backend is layere
 
 ### External agents & Agent-Environment Protocol (`/api/v1`)
 
-- **Protocol Run API** (`api/routers/runs.py` → `domain/runs/*`): an external agent authenticates with its Agent API key (`X-API-Key`) and drives a backtest step-by-step (`POST /api/v1/runs`, poll steps, submit decisions). Each step has a decision deadline (default 60s); a late decision auto-holds that step rather than failing the run.
+- **Protocol Run API** (`api/routers/runs.py` → `domain/runs/*`): an external agent authenticates with its Agent API key (`X-API-Key`) and drives a backtest step-by-step (`POST /api/v1/runs`, poll steps, submit decisions). Each step has a decision deadline (default 60s); a late decision auto-holds that step rather than failing the run. A server-wide active-run backstop (`MAX_ACTIVE_RUNS_GLOBAL`, default 100; 0 disables) rejects creates on both surfaces with 429 + `Retry-After` once at capacity.
 - **External backtest engine** (`domain/backtesting/external_run_service.py`): the hour-by-hour session behind both the protocol and the legacy `/api/v1/backtest/*` routes.
 - **PyPI client** (`packaging/agentictrading/`): stdlib-only Python SDK + `AgentRunner`. Published via `.github/workflows/publish-pypi.yml`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Pipeline is **backtest → SQLite → API → dashboard**. The backend is layere
 
 ### External agents & Agent-Environment Protocol (`/api/v1`)
 
-- **Protocol Run API** (`api/routers/runs.py` → `domain/runs/*`): an external agent authenticates with its Agent API key (`X-API-Key`) and drives a backtest step-by-step (`POST /api/v1/runs`, poll steps, submit decisions). Each step has a decision deadline (default 30s); a late decision auto-holds that step rather than failing the run.
+- **Protocol Run API** (`api/routers/runs.py` → `domain/runs/*`): an external agent authenticates with its Agent API key (`X-API-Key`) and drives a backtest step-by-step (`POST /api/v1/runs`, poll steps, submit decisions). Each step has a decision deadline (default 60s); a late decision auto-holds that step rather than failing the run.
 - **External backtest engine** (`domain/backtesting/external_run_service.py`): the hour-by-hour session behind both the protocol and the legacy `/api/v1/backtest/*` routes.
 - **PyPI client** (`packaging/agentictrading/`): stdlib-only Python SDK + `AgentRunner`. Published via `.github/workflows/publish-pypi.yml`.
 

--- a/dashboard/backend/api/routers/runs.py
+++ b/dashboard/backend/api/routers/runs.py
@@ -39,7 +39,8 @@ class CreateRunBody(BaseModel):
 
 
 def _handle_protocol_error(exc: ProtocolError):
-    raise HTTPException(status_code=exc.status_code, detail=exc.to_body())
+    raise HTTPException(status_code=exc.status_code, detail=exc.to_body(),
+                        headers=exc.headers or None)
 
 
 def _require_run_owner(run_id: str, agent: Dict[str, Any]) -> Dict[str, Any]:

--- a/dashboard/backend/api/v2/errors.py
+++ b/dashboard/backend/api/v2/errors.py
@@ -27,6 +27,7 @@ ERROR_CODES = [
     "validation_failed", "step_already_closed", "run_not_found", "agent_not_found",
     "unauthorized", "forbidden_scope", "rate_limited", "universe_violation",
     "insufficient_cash", "invalid_symbol", "invalid_status", "too_many_active_runs",
+    "too_many_active_runs_global",
 ]
 
 

--- a/dashboard/backend/api/v2/runs.py
+++ b/dashboard/backend/api/v2/runs.py
@@ -30,6 +30,7 @@ from dashboard.backend.database import db
 # correctness of the cap beats create throughput. Long work (market-data
 # load) stays off the lock (background thread).
 from dashboard.backend.domain.runs.service import (
+    MAX_ACTIVE_RUNS_GLOBAL,
     MAX_ACTIVE_RUNS_PER_AGENT,
     _create_lock as _shared_create_lock,
 )
@@ -354,6 +355,20 @@ def create_run(body: CreateRunBody, response: Response,
                 status=429, retryable=True,
                 details={"active_runs": active, "limit": MAX_ACTIVE_RUNS_PER_AGENT},
             )
+        if MAX_ACTIVE_RUNS_GLOBAL > 0:
+            total = run_repo.run_store.count_active_runs_total()
+            if total >= MAX_ACTIVE_RUNS_GLOBAL:
+                raise ApiError(
+                    "too_many_active_runs_global",
+                    f"The server is at its active-run capacity "
+                    f"({total} of {MAX_ACTIVE_RUNS_GLOBAL}); retry shortly",
+                    status=429, retryable=True,
+                    details={"active_runs_total": total,
+                             "limit": MAX_ACTIVE_RUNS_GLOBAL},
+                    # Explicit: ApiError's auto Retry-After injection only
+                    # fires for code "rate_limited".
+                    headers={"Retry-After": "30"},
+                )
         run_id = _mint_run_id()
         backend = BacktestBackend(
             run_id=run_id, session_id=agent["session_id"], agent_name=body.agent_name,

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -42,7 +42,7 @@ from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataL
 
 from dashboard.backend.domain.backtesting import baseline_worker, market_data_store
 
-DECISION_TIMEOUT_SECONDS = int(os.getenv("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", "30"))
+DECISION_TIMEOUT_SECONDS = int(os.getenv("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", "60"))
 
 _sessions: Dict[str, "ExternalBacktestSession"] = {}
 _lock = threading.Lock()

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -107,6 +107,8 @@ def build_final_metrics(run: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         "input_tokens": run.get("input_tokens"),
         "output_tokens": run.get("output_tokens"),
         "est_cost_usd": run.get("est_cost_usd"),
+        "timeout_holds": (run.get("metadata") or {}).get("timeout_holds")
+        if isinstance(run.get("metadata"), dict) else None,
     }
 
 
@@ -167,6 +169,9 @@ class ExternalBacktestSession:
         self.llm_calls = 0
         self.est_input_tokens = 0
         self.est_output_tokens = 0
+        # Integrity counter: steps auto-held because their decision deadline
+        # passed (see _advance_step). Surfaced at every result surface.
+        self.timeout_holds = 0
 
         self._step_lock = threading.Lock()
 
@@ -365,6 +370,7 @@ class ExternalBacktestSession:
                     "run_id": self.run_id,
                     "baseline_run_ids": baseline_ids,
                     "total_steps": self.total_steps,
+                    "timeout_holds": self.timeout_holds,
                     "metrics": self._final_metrics(),
                     "compare_url": self._compare_url(baseline_ids),
                     "session_id": self.session_id,
@@ -482,6 +488,12 @@ class ExternalBacktestSession:
         decision_source: str,
         raw_actions: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
+        if decision_source == "timeout_hold":
+            # Integrity counter: steps the server auto-held past the deadline.
+            # A latency-corrupted run stays green but is now VISIBLE at every
+            # surface where its results appear (status, result metrics,
+            # agent_runs.metadata).
+            self.timeout_holds += 1
         timestamp = self.timestamps[self.step_index]
         market_data = self._market_data_at(timestamp)
 
@@ -552,6 +564,10 @@ class ExternalBacktestSession:
             input_tokens=self.est_input_tokens,
             output_tokens=self.est_output_tokens,
             est_cost_usd=est_cost,
+            metadata={
+                "decision_timeout_seconds": DECISION_TIMEOUT_SECONDS,
+                "timeout_holds": self.timeout_holds,
+            },
         )
         db.insert_equity_points(self.run_id, equity_curve)
         db.insert_trades(self.run_id, self.manager.trades)
@@ -625,6 +641,7 @@ class ExternalBacktestSession:
                 "agent_name": self.agent_name,
                 "model_name": self.model_name,
                 "run_id": self.run_id,
+                "timeout_holds": self.timeout_holds,
             }
             if self.status == "waiting_decision":
                 base["decision_deadline_at"] = _iso(self._deadline_at())
@@ -901,5 +918,7 @@ def get_run_result(run_id: str, session_id: str) -> Optional[Dict[str, Any]]:
             "input_tokens": run.get("input_tokens"),
             "output_tokens": run.get("output_tokens"),
             "est_cost_usd": run.get("est_cost_usd"),
+            "timeout_holds": (run.get("metadata") or {}).get("timeout_holds")
+            if isinstance(run.get("metadata"), dict) else None,
         },
     }

--- a/dashboard/backend/domain/runs/protocol.py
+++ b/dashboard/backend/domain/runs/protocol.py
@@ -27,12 +27,16 @@ VALID_ORDER_TYPES = {"market"}
 class ProtocolError(Exception):
     """Raised for protocol-level failures; mapped to an HTTP error envelope."""
 
-    def __init__(self, code: str, message: str, status_code: int = 400, details: Any = None):
+    def __init__(self, code: str, message: str, status_code: int = 400,
+                 details: Any = None, headers: Optional[Dict[str, str]] = None):
         super().__init__(message)
         self.code = code
         self.message = message
         self.status_code = status_code
         self.details = details
+        # Response headers (e.g. Retry-After on 429) — forwarded to the
+        # HTTPException by the router's _handle_protocol_error.
+        self.headers = headers or {}
 
     def to_body(self) -> Dict[str, Any]:
         return error_body(self.code, self.message, self.details)

--- a/dashboard/backend/domain/runs/repository.py
+++ b/dashboard/backend/domain/runs/repository.py
@@ -282,6 +282,25 @@ class RunStore:
         conn.close()
         return int(count)
 
+    def count_active_runs_total(self) -> int:
+        """Active runs across ALL agents — the global backstop cap's count.
+
+        Deliberately reconciliation-free: both surfaces flip their row to a
+        terminal status synchronously inside the finalizing request, so a raw
+        COUNT tracks reality; the residual (terminal run, no subsequent poll)
+        is bounded by the reaper interval and errs toward a spurious 429 —
+        the safe direction, and Retry-After tells the client when to retry."""
+        placeholders = ",".join("?" for _ in self._ACTIVE_STATUSES)
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            f"SELECT COUNT(*) FROM protocol_runs WHERE status IN ({placeholders})",
+            self._ACTIVE_STATUSES,
+        )
+        (count,) = cursor.fetchone()
+        conn.close()
+        return int(count)
+
     def fail_unfinished_runs(self) -> int:
         """Mark runs left non-terminal by a crash/restart as failed.
 

--- a/dashboard/backend/domain/runs/service.py
+++ b/dashboard/backend/domain/runs/service.py
@@ -51,6 +51,11 @@ _registry_lock = threading.Lock()
 
 # Cap concurrent (non-terminal) runs per agent to bound resource use / abuse.
 MAX_ACTIVE_RUNS_PER_AGENT = int(os.getenv("MAX_ACTIVE_RUNS_PER_AGENT", "5"))
+# Global backstop across ALL agents (Decision 3 of the 2026-07-24 scale spec):
+# beyond this, creates 429 with Retry-After instead of degrading everyone.
+# Default 100 = the highest load ever exercised by the loadtest harness; raise
+# it only after a measured smoke run at the higher value. 0 disables.
+MAX_ACTIVE_RUNS_GLOBAL = int(os.getenv("MAX_ACTIVE_RUNS_GLOBAL", "100"))
 # How often the background reaper drains abandoned runs and evicts terminal ones.
 REAPER_INTERVAL_SECONDS = float(os.getenv("RUN_REAPER_INTERVAL_SECONDS", "60"))
 # Startup recovery marks ALL non-terminal rows failed; only correct when a single
@@ -436,6 +441,19 @@ def create_run(
                     f"(limit {MAX_ACTIVE_RUNS_PER_AGENT}); wait for one to finish",
                     429,
                     details={"active_runs": active, "limit": MAX_ACTIVE_RUNS_PER_AGENT},
+                )
+
+        if MAX_ACTIVE_RUNS_GLOBAL > 0:
+            total = run_store.count_active_runs_total()
+            if total >= MAX_ACTIVE_RUNS_GLOBAL:
+                raise ProtocolError(
+                    "too_many_active_runs_global",
+                    f"The server is at its active-run capacity "
+                    f"({total} of {MAX_ACTIVE_RUNS_GLOBAL}); retry shortly",
+                    429,
+                    details={"active_runs_total": total,
+                             "limit": MAX_ACTIVE_RUNS_GLOBAL},
+                    headers={"Retry-After": "30"},
                 )
 
         start_res = ebs.start_backtest(

--- a/dashboard/backend/tests/_v2_fakes.py
+++ b/dashboard/backend/tests/_v2_fakes.py
@@ -37,8 +37,8 @@ class FakeBackend(ExecutionBackend):
             "loop": self.loop, "status": "waiting_decision",
             "step_index": self.step_index, "total_steps": self.total_steps,
             "timestamp": "2026-04-15T13:30:00+00:00",
-            "decision_deadline_at": "2026-04-15T13:30:30+00:00",
-            "decision_timeout_seconds": 30, "universe": list(UNIVERSE),
+            "decision_deadline_at": "2026-04-15T13:31:00+00:00",
+            "decision_timeout_seconds": 60, "universe": list(UNIVERSE),
             "portfolio": {"cash": 100000.0, "positions_value": 0.0,
                           "total_equity": 100000.0, "num_positions": 0},
             "current_holdings": {}, "recent_trades": [], "top_signals": {},
@@ -87,7 +87,7 @@ class FakeBackend(ExecutionBackend):
             "trades": [], "decisions": [], "metrics": self._metrics(),
             "manifest": {"agent_name": "fake", "model_name": "m", "mode": "backtest",
                          "universe": "djia_30", "start_date": "2026-04-15",
-                         "end_date": "2026-04-16", "decision_timeout_seconds": 30,
+                         "end_date": "2026-04-16", "decision_timeout_seconds": 60,
                          "schema_version": SCHEMA_VERSION, "news_sentiment_source": None},
         }
 

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -58,6 +58,7 @@ os.environ.pop("CONTENT_DATABASE_URL", None)
 # DB-URL strips above. Later tiers append their vars here.
 os.environ.pop("MARKET_DATA_CACHE_MAX_ENTRIES", None)
 os.environ.pop("BASELINE_QUEUE_MAX", None)
+os.environ.pop("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", None)
 
 
 @atexit.register

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -59,6 +59,7 @@ os.environ.pop("CONTENT_DATABASE_URL", None)
 os.environ.pop("MARKET_DATA_CACHE_MAX_ENTRIES", None)
 os.environ.pop("BASELINE_QUEUE_MAX", None)
 os.environ.pop("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", None)
+os.environ.pop("MAX_ACTIVE_RUNS_GLOBAL", None)
 
 
 @atexit.register

--- a/dashboard/backend/tests/test_deadline_and_holds.py
+++ b/dashboard/backend/tests/test_deadline_and_holds.py
@@ -1,0 +1,9 @@
+"""T3: 60 s deadline default + the timeout_holds integrity counter."""
+
+import dashboard.backend.domain.backtesting.external_run_service as ebs
+
+
+def test_default_decision_timeout_is_60():
+    # conftest strips EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS at import, so
+    # the module constant IS the default.
+    assert ebs.DECISION_TIMEOUT_SECONDS == 60

--- a/dashboard/backend/tests/test_deadline_and_holds.py
+++ b/dashboard/backend/tests/test_deadline_and_holds.py
@@ -7,3 +7,87 @@ def test_default_decision_timeout_is_60():
     # conftest strips EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS at import, so
     # the module constant IS the default.
     assert ebs.DECISION_TIMEOUT_SECONDS == 60
+
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import dashboard.backend.database as db_module
+from dashboard.backend.domain.backtesting import baseline_worker as bw
+
+
+def _synth_bars(symbols, start, end):
+    idx = pd.date_range(start=start, end=str(end) + " 23:59", freq="1h", tz="UTC")
+    et = idx.tz_convert("US/Eastern")
+    mask = (et.dayofweek < 5) & (
+        ((et.hour > 9) & (et.hour < 16)) | ((et.hour == 16) & (et.minute == 0))
+    )
+    idx = idx[mask]
+    data = {}
+    for si, sym in enumerate(sorted(symbols)):
+        n = len(idx)
+        close = 100.0 + si + np.linspace(0, 1.0, n)
+        data[sym] = pd.DataFrame(
+            {"open": close, "high": close + 0.5, "low": close - 0.5,
+             "close": close, "volume": 1000.0}, index=idx)
+    return data
+
+
+class _Loader:
+    def fetch_bars(self, symbols, start, end):
+        return _synth_bars(symbols, start, end)
+
+
+@pytest.fixture
+def session(monkeypatch, tmp_path):
+    test_db = db_module.BacktestDatabase(db_path=tmp_path / "holds.db")
+    monkeypatch.setattr(db_module, "db", test_db)
+    monkeypatch.setattr(ebs, "db", test_db)
+    monkeypatch.setattr(ebs, "AlpacaDataLoader", _Loader)
+    monkeypatch.setattr(bw.HourlyBacktester, "run_buyhold_baseline",
+                        lambda self: (None, None))
+    monkeypatch.setattr(bw.HourlyBacktester, "run_djia_baseline",
+                        lambda self: (None, None))
+    s = ebs.ExternalBacktestSession(
+        backtest_id="bt_holds", session_id="sess_h", agent_name="a",
+        model_name="m", start_date="2026-04-15", end_date="2026-04-16",
+    )
+    s.load_market_data()
+    return s, test_db
+
+
+def test_expired_poll_increments_timeout_holds(session, monkeypatch):
+    s, test_db = session
+    monkeypatch.setattr(ebs, "DECISION_TIMEOUT_SECONDS", 0.0)
+    s.drain_expired()  # every step auto-holds
+    assert s.status == "completed"
+    assert s.timeout_holds == s.total_steps
+    assert s.get_status()["timeout_holds"] == s.total_steps
+    step_view = s.get_current_step()
+    assert step_view["status"] == "completed"
+    assert step_view["timeout_holds"] == s.total_steps
+    row = test_db.get_run(s.run_id)
+    assert row["metadata"]["timeout_holds"] == s.total_steps
+    assert row["metadata"]["decision_timeout_seconds"] == 0.0
+    metrics = ebs.build_final_metrics(row)
+    assert metrics["timeout_holds"] == s.total_steps
+
+
+def test_late_submit_increments_timeout_holds(session, monkeypatch):
+    s, _ = session
+    assert s.timeout_holds == 0
+    monkeypatch.setattr(ebs, "DECISION_TIMEOUT_SECONDS", 0.0)  # deadline now past
+    res = s.submit_decisions({"actions": []})
+    assert res["accepted"] is False and res["outcome"] == "timeout_hold"
+    assert s.timeout_holds == 1
+
+
+def test_clean_run_reports_zero_holds(session):
+    s, test_db = session
+    for _ in range(s.total_steps):
+        s.submit_decisions({"actions": []})
+    assert s.status == "completed"
+    assert s.timeout_holds == 0
+    assert test_db.get_run(s.run_id)["metadata"]["timeout_holds"] == 0
+    assert ebs.get_run_result(s.run_id, "sess_h")["metrics"]["timeout_holds"] == 0

--- a/dashboard/backend/tests/test_global_run_cap.py
+++ b/dashboard/backend/tests/test_global_run_cap.py
@@ -1,0 +1,133 @@
+"""Global active-run backstop cap (T3): 429 too_many_active_runs_global with
+Retry-After on BOTH create surfaces; 0 disables; per-agent cap unchanged."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import dashboard.backend.api.v2.runs as runs_mod
+import dashboard.backend.domain.runs.service as run_service
+from dashboard.backend.app import app
+from dashboard.backend.domain.runs.repository import run_store
+
+client = TestClient(app)
+
+
+def _agent(name):
+    r = client.post("/api/v2/agents", json={"name": name}).json()
+    return r["api_key"], r["session_id"], r["agent_id"]
+
+
+class _StubBackend:
+    loop = "lockstep"
+    news_sentiment_source = None
+
+    def __init__(self, **kwargs):
+        self._active = True
+
+    def start_background_load(self):
+        pass
+
+    def is_active(self):
+        return self._active
+
+    def status(self):
+        return {"status": "waiting_decision"}
+
+    def advance(self):
+        pass
+
+    def cancel(self):
+        self._active = False
+
+
+def _seed_active_run(agent_id, sid, n=1):
+    for i in range(n):
+        run_store.create_run(
+            agent_id=agent_id, agent_version_id=None, session_id=sid,
+            environment_id="us-equity-hourly-v1", environment_type="backtest",
+            config={}, backtest_id=f"bt_cap_{agent_id}_{i}", status="running",
+        )
+
+
+def test_count_active_runs_total_spans_agents():
+    _, sid_a, aid_a = _agent("cap-count-a")
+    _, sid_b, aid_b = _agent("cap-count-b")
+    before = run_store.count_active_runs_total()
+    _seed_active_run(aid_a, sid_a)
+    _seed_active_run(aid_b, sid_b)
+    assert run_store.count_active_runs_total() == before + 2
+
+
+def test_v2_global_cap_rejects_with_retry_after(monkeypatch):
+    key_b, _, _ = _agent("cap-v2-victim")
+    _, sid_a, aid_a = _agent("cap-v2-filler")
+    _seed_active_run(aid_a, sid_a)
+    monkeypatch.setattr(runs_mod, "MAX_ACTIVE_RUNS_GLOBAL",
+                        run_store.count_active_runs_total())
+    monkeypatch.setattr(runs_mod, "BacktestBackend", _StubBackend)
+    resp = client.post(
+        "/api/v2/runs",
+        json={"start_date": "2026-04-15", "end_date": "2026-04-16"},
+        headers={"X-API-Key": key_b},
+    )
+    assert resp.status_code == 429, resp.text
+    assert resp.json()["error"]["code"] == "too_many_active_runs_global"
+    assert resp.json()["error"]["retryable"] is True
+    assert resp.headers.get("Retry-After") == "30"
+
+
+def test_v1_global_cap_rejects_with_retry_after(monkeypatch):
+    _, sid_a, aid_a = _agent("cap-v1-filler")
+    _, sid_b, aid_b = _agent("cap-v1-victim")
+    _seed_active_run(aid_a, sid_a)
+    monkeypatch.setattr(run_service, "MAX_ACTIVE_RUNS_GLOBAL",
+                        run_store.count_active_runs_total())
+    with pytest.raises(run_service.ProtocolError) as ei:
+        run_service.create_run(
+            agent={"agent_id": aid_b, "session_id": sid_b, "name": "x"},
+            agent_version=None,
+            environment_id="us-equity-hourly-v1",
+            config={"start_date": "2026-04-15", "end_date": "2026-04-16"},
+        )
+    assert ei.value.code == "too_many_active_runs_global"
+    assert ei.value.status_code == 429
+    assert ei.value.headers == {"Retry-After": "30"}
+
+
+def test_zero_disables_the_global_cap(monkeypatch):
+    key, _, _ = _agent("cap-disabled")
+    _, sid_a, aid_a = _agent("cap-disabled-filler")
+    _seed_active_run(aid_a, sid_a, n=3)
+    monkeypatch.setattr(runs_mod, "MAX_ACTIVE_RUNS_GLOBAL", 0)
+    monkeypatch.setattr(runs_mod, "BacktestBackend", _StubBackend)
+    resp = client.post(
+        "/api/v2/runs",
+        json={"start_date": "2026-04-15", "end_date": "2026-04-16"},
+        headers={"X-API-Key": key},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_schema_endpoint_reports_the_new_code():
+    resp = client.get("/api/v2/schema")
+    assert "too_many_active_runs_global" in resp.json()["error_codes"]
+
+
+def test_v1_global_cap_over_http_carries_retry_after(monkeypatch):
+    """End-to-end v1: _handle_protocol_error must forward ProtocolError.headers
+    onto the HTTPException so the 429 actually carries Retry-After."""
+    key, _, _ = _agent("cap-v1-http")          # v2-registered key works on v1 too
+    _, sid_f, aid_f = _agent("cap-v1-http-filler")
+    _seed_active_run(aid_f, sid_f)
+    monkeypatch.setattr(run_service, "MAX_ACTIVE_RUNS_GLOBAL",
+                        run_store.count_active_runs_total())
+    resp = client.post(
+        "/api/v1/runs",
+        json={"environment": {"type": "backtest",
+                              "environment_id": "us-equity-hourly-v1"},
+              "config": {"start_date": "2026-04-15", "end_date": "2026-04-16"}},
+        headers={"X-API-Key": key},
+    )
+    assert resp.status_code == 429, resp.text
+    assert resp.json()["detail"]["error"]["code"] == "too_many_active_runs_global"
+    assert resp.headers.get("Retry-After") == "30"

--- a/docs/api/agent-environment-protocol-v1.md
+++ b/docs/api/agent-environment-protocol-v1.md
@@ -290,7 +290,7 @@ always empty — do not wait for them to populate.
   sequence check.
 
 The decision timeout is controlled by
-`EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS` (default 30s).
+`EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS` (default 60s).
 
 ---
 

--- a/docs/api/agent-environment-protocol-v1.md
+++ b/docs/api/agent-environment-protocol-v1.md
@@ -350,6 +350,7 @@ All protocol errors use a consistent envelope (delivered as the HTTP `detail`):
 | 409  | `decision_deadline_exceeded` | decision arrived after the deadline (step auto-held) |
 | 409  | `run_not_completed` | results requested before completion |
 | 429  | `too_many_active_runs` | per-agent concurrent-run cap exceeded |
+| 429  | `too_many_active_runs_global` | server-wide active-run capacity reached — retry after the `Retry-After` header (seconds) |
 | 500  | `run_failed` | the run's backtest failed |
 
 Every 4xx from these routes uses the envelope above (delivered as the HTTP

--- a/packaging/agentictrading/README.md
+++ b/packaging/agentictrading/README.md
@@ -44,10 +44,12 @@ result = AgentRunner(client=client, agent=MyAgent()).run_backtest(
 print(result.metrics)
 ```
 
-> **Decision deadline.** Each step has a decision window (default **30s**). If
+> **Decision deadline.** Each step has a decision window (default **60s**). If
 > your `decide()` plus submission takes longer, the backend auto-holds that step
 > (no trade) and `AgentRunner` advances to the next one — a single slow decision
 > never aborts the run. Keep `decide()` well under the window for live trading.
+> If the backend returns **429** (server at capacity), wait and retry with
+> backoff — the client does not retry for you.
 
 ## Quickstart
 

--- a/packaging/agentictrading/src/agentictrading/runner.py
+++ b/packaging/agentictrading/src/agentictrading/runner.py
@@ -59,7 +59,7 @@ _FAILED_STATES = {"failed", "cancelled", "canceled"}
 
 # Conflict codes that mean "the step was auto-held server-side; the run is still
 # live" — e.g. the agent took longer than the environment's decision window
-# (default 30s). These must NOT abort the run.
+# (default 60s). These must NOT abort the run.
 #
 # NOTE: a genuinely-late decision surfaces as ``decision_deadline_exceeded``: the
 # backend consults the engine decision log and, when the step was auto-held with
@@ -114,7 +114,7 @@ class AgentRunner:
 
         Note
         ----
-        The environment enforces a per-step decision deadline (default 30s). If
+        The environment enforces a per-step decision deadline (default 60s). If
         ``agent.decide`` plus submission takes longer, the backend auto-holds
         that step and the runner advances to the next one instead of failing —
         so a single slow decision never aborts the whole run.


### PR DESCRIPTION
T3 of `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md`.

## Summary
- **Deadline default 30→60s** (`EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS`) — slow LLM agents get more headroom before a step auto-holds.
- **`timeout_holds` integrity counter** surfaced at every result surface (status, current-step completed view, result metrics, `agent_runs.metadata`) — a latency-corrupted run stays green but is now visible. Closes the "protocol runs never populate metadata" gap.
- **Global active-run backstop cap** — `MAX_ACTIVE_RUNS_GLOBAL` (default 100; 0 disables). Both create surfaces reject with `429 too_many_active_runs_global` + `Retry-After: 30` once at capacity, instead of degrading everyone. `count_active_runs_total` is reconciliation-free (errs toward a spurious 429, the safe direction). Code registered in `/api/v2/schema`.

## Wire contract
No new routes; no new status literals. New payload keys (`timeout_holds`) are additive. New error code `too_many_active_runs_global` registered in the v2 schema.

## Test plan
- [x] `test_deadline_and_holds.py` (7 cases) green
- [x] `test_global_run_cap.py` (6 cases incl. end-to-end v1 HTTP Retry-After) green
- [x] Full suite: `1292 passed, 34 skipped`