### PR TITLE
perf: auth cache + last_used_at debounce + pg connection pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,11 @@ DATABASE_PATH=dashboard/storage/data/backtest.db
 # number; raise only after a measured smoke run at the higher value.
 # MAX_ACTIVE_RUNS_GLOBAL=100
 
+# Auth cache TTL for agent API keys (seconds; +-20% jitter; 0 disables).
+# Rotation/deletion invalidates immediately; other agent-record edits
+# propagate within the TTL. Default 10.
+# AGENT_AUTH_CACHE_TTL_SECONDS=10
+
 # User accounts (optional). When set, signup/login/session data is stored in
 # this Postgres database instead of the local SQLite file above -- required
 # on hosts with an ephemeral/disk-less filesystem (e.g. Render free tier),

--- a/dashboard/backend/api/protocol_auth.py
+++ b/dashboard/backend/api/protocol_auth.py
@@ -10,12 +10,12 @@ from typing import Any, Dict, Optional
 
 from fastapi import HTTPException, Request
 
-from dashboard.backend.domain.agents.repository import agent_store
+from dashboard.backend.domain.agents import auth_cache
 
 
 def resolve_agent_by_key(x_api_key: Optional[str]) -> Dict[str, Any]:
     """Resolve an Agent API key to the agent, or raise 401."""
-    agent = agent_store.resolve_api_key(x_api_key or "")
+    agent = auth_cache.resolve_api_key(x_api_key or "")
     if not agent:
         raise HTTPException(status_code=401, detail="Invalid or missing API key (X-API-Key)")
     return agent

--- a/dashboard/backend/api/v2/agents.py
+++ b/dashboard/backend/api/v2/agents.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 
 from dashboard.backend.api.rate_limit import FixedWindowRateLimiter, client_key
 from dashboard.backend.domain.agents.repository import agent_store
+from dashboard.backend.domain.agents import auth_cache
 from dashboard.backend.api.v2.errors import ApiError
 from dashboard.backend.api.v2.auth_scopes import resolve_agent, require_scope
 
@@ -74,4 +75,5 @@ def rotate_key(agent_id: str, agent: dict = Depends(require_scope("agents:regist
     new_key = agent_store.rotate_api_key(agent_id)
     if not new_key:
         raise ApiError("agent_not_found", "Agent not found", status=404)
+    auth_cache.invalidate_agent(agent_id)
     return {"agent_id": agent_id, "api_key": new_key}

--- a/dashboard/backend/api/v2/auth_scopes.py
+++ b/dashboard/backend/api/v2/auth_scopes.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from fastapi import Header
 
-from dashboard.backend.domain.agents.repository import agent_store
+from dashboard.backend.domain.agents import auth_cache
 from dashboard.backend.api.v2.errors import ApiError
 
 SCOPES: List[str] = [
@@ -21,7 +21,7 @@ def parse_scopes(csv: str) -> List[str]:
 
 def resolve_agent(x_api_key: Optional[str]) -> dict:
     """Resolve an X-API-Key to an agent record, or raise unauthorized."""
-    agent = agent_store.resolve_api_key((x_api_key or "").strip())
+    agent = auth_cache.resolve_api_key((x_api_key or "").strip())
     if not agent:
         raise ApiError("unauthorized", "Invalid or missing API key", status=401)
     return agent

--- a/dashboard/backend/db_pool.py
+++ b/dashboard/backend/db_pool.py
@@ -1,0 +1,59 @@
+"""Shared psycopg3 connection pools, one per database URL (T4).
+
+Replaces the fresh psycopg.connect() (a full TLS handshake to Neon) every
+store call used to pay. Small and short-lived by design: max_size 5 fits the
+single-worker deployment, and max_idle 300s closes idle sockets before Neon's
+scale-to-zero suspend can hand back a dead one. row_factory is configured at
+pool construction because every twin relies on dict-style row access.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Dict
+
+from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
+
+from dashboard.backend.db_url import describe_database_url
+
+# Max seconds a caller waits for a pooled connection before .connection()
+# raises PoolTimeout (a psycopg.OperationalError subclass). Bounds request
+# latency on a down/cold DB: psycopg.connect() failed fast, but a pool retries
+# creation in the background, so an unbounded wait would inherit the 30s pool
+# default. 10s tolerates a Neon scale-to-zero resume while failing loud on a
+# genuine outage. A module constant (not env) so tests can monkeypatch it low
+# and not pay the full wait on the fail-loud "unreachable URL" cases.
+POOL_TIMEOUT_SECONDS = 10.0
+
+_pools: Dict[str, ConnectionPool] = {}
+_lock = threading.Lock()
+
+
+def get_pool(database_url: str) -> ConnectionPool:
+    """One cached pool per URL; construction is lazy and logged."""
+    with _lock:
+        pool = _pools.get(database_url)
+        if pool is None:
+            pool = ConnectionPool(
+                database_url,
+                min_size=0,
+                max_size=5,
+                max_idle=300,
+                timeout=POOL_TIMEOUT_SECONDS,
+                kwargs={"row_factory": dict_row},
+                open=True,
+            )
+            _pools[database_url] = pool
+            print(f"🏊 pg pool created for {describe_database_url(database_url)}")
+    return pool
+
+
+def _reset_for_tests() -> None:
+    with _lock:
+        for pool in _pools.values():
+            try:
+                pool.close()
+            except Exception:
+                pass
+        _pools.clear()

--- a/dashboard/backend/domain/agents/auth_cache.py
+++ b/dashboard/backend/domain/agents/auth_cache.py
@@ -1,0 +1,84 @@
+"""In-process TTL cache for API-key auth + last_used_at debounce (T4).
+
+Sits ABOVE the repository so the SQLite/Postgres twins stay dumb. Only the
+per-request hot paths (v1 resolve_agent_by_key, v2 auth_scopes.resolve_agent)
+route through here; management endpoints resolve directly for always-fresh
+auth. Revocation/rotation propagates within <=TTL for entries nobody
+invalidates; the delete/rotate paths call invalidate_agent() for immediate
+effect (required: rotate_api_key blind-UPDATEs by agent id, so the OLD hash —
+the cache key — is never in scope there; hence the reverse index).
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import threading
+import time
+from typing import Any, Dict, Optional, Set, Tuple
+
+from dashboard.backend.domain.agents import repository as _repo
+from dashboard.backend.domain.agents.repository import _hash_api_key
+
+# Read once at import; 0 disables. +-20% per-entry jitter keeps 100 agents'
+# entries from expiring in lockstep and stampeding the DB/pool.
+AGENT_AUTH_CACHE_TTL_SECONDS = float(os.getenv("AGENT_AUTH_CACHE_TTL_SECONDS", "10"))
+LAST_USED_WRITE_INTERVAL_SECONDS = 60.0
+
+_now = time.monotonic  # test seam
+
+
+def _jitter() -> float:
+    return random.uniform(0.8, 1.2)
+
+
+_lock = threading.Lock()
+_by_hash: Dict[str, Tuple[float, Dict[str, Any]]] = {}   # hash -> (expires_at, agent)
+_hashes_by_agent: Dict[str, Set[str]] = {}               # agent_id -> {hashes}
+_last_write: Dict[str, float] = {}                       # hash -> last touch time
+
+
+def resolve_api_key(api_key: str) -> Optional[Dict[str, Any]]:
+    """Cached resolve. Falls through to the store on miss/expiry; debounces
+    the store's last_used_at write to once per LAST_USED_WRITE_INTERVAL."""
+    if not api_key or not api_key.strip():
+        return None
+    ttl = AGENT_AUTH_CACHE_TTL_SECONDS
+    if ttl <= 0:
+        # Late-bound module attribute so per-test store swaps apply.
+        return _repo.agent_store.resolve_api_key(api_key)
+
+    key_hash = _hash_api_key(api_key.strip())
+    now = _now()
+    with _lock:
+        hit = _by_hash.get(key_hash)
+        if hit is not None and hit[0] > now:
+            return dict(hit[1])
+        should_touch = (now - _last_write.get(key_hash, float("-inf"))
+                        >= LAST_USED_WRITE_INTERVAL_SECONDS)
+
+    agent = _repo.agent_store.resolve_api_key(api_key, touch=should_touch)
+    if agent is None:
+        return None  # misses are not cached: an invalid key always re-checks
+
+    with _lock:
+        _by_hash[key_hash] = (now + ttl * _jitter(), dict(agent))
+        _hashes_by_agent.setdefault(agent["agent_id"], set()).add(key_hash)
+        if should_touch:
+            _last_write[key_hash] = now
+    return agent
+
+
+def invalidate_agent(agent_id: str) -> None:
+    """Immediate eviction for delete/rotate (old hash found via reverse index)."""
+    with _lock:
+        for key_hash in _hashes_by_agent.pop(agent_id, set()):
+            _by_hash.pop(key_hash, None)
+            _last_write.pop(key_hash, None)
+
+
+def _reset_for_tests() -> None:
+    with _lock:
+        _by_hash.clear()
+        _hashes_by_agent.clear()
+        _last_write.clear()

--- a/dashboard/backend/domain/agents/auth_cache.py
+++ b/dashboard/backend/domain/agents/auth_cache.py
@@ -36,6 +36,23 @@ _lock = threading.Lock()
 _by_hash: Dict[str, Tuple[float, Dict[str, Any]]] = {}   # hash -> (expires_at, agent)
 _hashes_by_agent: Dict[str, Set[str]] = {}               # agent_id -> {hashes}
 _last_write: Dict[str, float] = {}                       # hash -> last touch time
+# Bumped on every invalidate_agent(). A resolve snapshots it before the unlocked
+# DB read and re-checks it before filling the cache, so a rotate/delete landing
+# mid-resolve cannot have its stale pre-rotation snapshot written back AFTER
+# invalidate_agent already ran — invalidate_agent could not see a hash the
+# resolve had not yet inserted, so without this guard the revoked key would
+# authenticate straight from the cache until the TTL elapsed.
+_invalidation_epoch = 0
+
+
+def _copy_agent(agent: Dict[str, Any]) -> Dict[str, Any]:
+    """Independent copy so neither the caller nor the cache can mutate the
+    other's view. Only ``scopes`` is a mutable nested value; the rest scalars."""
+    out = dict(agent)
+    scopes = out.get("scopes")
+    if isinstance(scopes, list):
+        out["scopes"] = list(scopes)
+    return out
 
 
 def resolve_api_key(api_key: str) -> Optional[Dict[str, Any]]:
@@ -53,32 +70,42 @@ def resolve_api_key(api_key: str) -> Optional[Dict[str, Any]]:
     with _lock:
         hit = _by_hash.get(key_hash)
         if hit is not None and hit[0] > now:
-            return dict(hit[1])
+            return _copy_agent(hit[1])
         should_touch = (now - _last_write.get(key_hash, float("-inf"))
                         >= LAST_USED_WRITE_INTERVAL_SECONDS)
+        epoch_at_miss = _invalidation_epoch
 
     agent = _repo.agent_store.resolve_api_key(api_key, touch=should_touch)
     if agent is None:
         return None  # misses are not cached: an invalid key always re-checks
 
     with _lock:
-        _by_hash[key_hash] = (now + ttl * _jitter(), dict(agent))
-        _hashes_by_agent.setdefault(agent["agent_id"], set()).add(key_hash)
-        if should_touch:
-            _last_write[key_hash] = now
+        # Skip the fill if an invalidation raced our unlocked DB read: the
+        # snapshot may already be stale (the key was just rotated/deleted). This
+        # request read a valid row and may proceed, but caching it would
+        # resurrect a revoked key for the whole TTL.
+        if _invalidation_epoch == epoch_at_miss:
+            _by_hash[key_hash] = (now + ttl * _jitter(), _copy_agent(agent))
+            _hashes_by_agent.setdefault(agent["agent_id"], set()).add(key_hash)
+            if should_touch:
+                _last_write[key_hash] = now
     return agent
 
 
 def invalidate_agent(agent_id: str) -> None:
     """Immediate eviction for delete/rotate (old hash found via reverse index)."""
+    global _invalidation_epoch
     with _lock:
+        _invalidation_epoch += 1
         for key_hash in _hashes_by_agent.pop(agent_id, set()):
             _by_hash.pop(key_hash, None)
             _last_write.pop(key_hash, None)
 
 
 def _reset_for_tests() -> None:
+    global _invalidation_epoch
     with _lock:
         _by_hash.clear()
         _hashes_by_agent.clear()
         _last_write.clear()
+        _invalidation_epoch = 0

--- a/dashboard/backend/domain/agents/auth_cache.py
+++ b/dashboard/backend/domain/agents/auth_cache.py
@@ -7,10 +7,20 @@ auth. Revocation/rotation propagates within <=TTL for entries nobody
 invalidates; the delete/rotate paths call invalidate_agent() for immediate
 effect (required: rotate_api_key blind-UPDATEs by agent id, so the OLD hash —
 the cache key — is never in scope there; hence the reverse index).
+
+Scope: the cache is process-local (plain module globals under a threading
+lock), so invalidate_agent()'s "immediate effect" is per-process. A
+multi-worker deployment (uvicorn --workers N) would keep a revoked key valid
+on every OTHER worker for up to the TTL; the shipping deploy is single-worker
+(see db_pool.py's max_size note), so before enabling workers keep the TTL low
+or move invalidation cross-process. Growth is bounded by the live-agent count,
+not by request volume: misses are never cached and rotate/delete evict, so a
+valid key holds at most one entry across the three maps.
 """
 
 from __future__ import annotations
 
+import copy
 import os
 import random
 import threading
@@ -47,11 +57,16 @@ _invalidation_epoch = 0
 
 def _copy_agent(agent: Dict[str, Any]) -> Dict[str, Any]:
     """Independent copy so neither the caller nor the cache can mutate the
-    other's view. Only ``scopes`` is a mutable nested value; the rest scalars."""
+    other's view. ``scopes`` (list of str) and ``pipeline`` (JSON-decoded list
+    of step dicts, so arbitrarily nested) are the mutable nested fields; every
+    other field from _public_agent() is a scalar and rides along by value."""
     out = dict(agent)
     scopes = out.get("scopes")
     if isinstance(scopes, list):
         out["scopes"] = list(scopes)
+    pipeline = out.get("pipeline")
+    if pipeline is not None:
+        out["pipeline"] = copy.deepcopy(pipeline)
     return out
 
 

--- a/dashboard/backend/domain/agents/repository.py
+++ b/dashboard/backend/domain/agents/repository.py
@@ -339,7 +339,7 @@ class AgentStore:
         conn.close()
         return _public_agent(row) if row else None
 
-    def resolve_api_key(self, api_key: str) -> Optional[Dict[str, Any]]:
+    def resolve_api_key(self, api_key: str, touch: bool = True) -> Optional[Dict[str, Any]]:
         if not api_key or not api_key.strip():
             return None
         key_hash = _hash_api_key(api_key.strip())
@@ -350,7 +350,7 @@ class AgentStore:
             (key_hash,),
         )
         row = cursor.fetchone()
-        if row:
+        if row and touch:
             cursor.execute(
                 "UPDATE external_agents SET last_used_at = ? WHERE agent_id = ?",
                 (_utcnow_iso(), row["agent_id"]),

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -15,9 +15,6 @@ import json
 import uuid
 from typing import Any, Dict, List, Optional
 
-import psycopg
-from psycopg.rows import dict_row
-
 from dashboard.backend.db_url import require_postgres_url
 from dashboard.backend.domain.agents.repository import (
     DEFAULT_SCOPES,
@@ -36,8 +33,11 @@ class PostgresAgentStore:
         self.database_url = require_postgres_url(database_url)
         self._init_schema()
 
-    def _get_connection(self) -> psycopg.Connection:
-        return psycopg.connect(self.database_url, row_factory=dict_row)
+    def _get_connection(self):
+        # Pooled checkout: same context-manager transaction semantics as
+        # psycopg.connect (commit on clean exit), returned to the pool on close.
+        from dashboard.backend.db_pool import get_pool
+        return get_pool(self.database_url).connection()
 
     def _init_schema(self) -> None:
         # ADDING A COLUMN LATER? It must go in an `ALTER TABLE ... ADD COLUMN IF

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -306,7 +306,7 @@ class PostgresAgentStore:
                 row = cur.fetchone()
         return _public_agent(row) if row else None
 
-    def resolve_api_key(self, api_key: str) -> Optional[Dict[str, Any]]:
+    def resolve_api_key(self, api_key: str, touch: bool = True) -> Optional[Dict[str, Any]]:
         if not api_key or not api_key.strip():
             return None
         key_hash = _hash_api_key(api_key.strip())
@@ -317,7 +317,7 @@ class PostgresAgentStore:
                     (key_hash,),
                 )
                 row = cur.fetchone()
-                if row:
+                if row and touch:
                     cur.execute(
                         "UPDATE external_agents SET last_used_at = %s WHERE agent_id = %s",
                         (_utcnow_iso(), row["agent_id"]),

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -17,6 +17,7 @@ preserved exactly; only the call site moved.
 from typing import Any, Dict, List, Optional, Tuple
 
 from dashboard.backend.domain.agents.repository import agent_store, _UNSET
+from dashboard.backend.domain.agents import auth_cache
 from dashboard.backend.domain.agents.version_repository import (
     VALID_EXECUTION_MODES,
     VALID_VERIFICATION_LEVELS,
@@ -379,10 +380,14 @@ class AgentService:
         return self.agents.resolve_api_key(api_key)
 
     def delete_agent(self, agent_id: str) -> bool:
-        return self.agents.delete_agent(agent_id)
+        result = self.agents.delete_agent(agent_id)
+        auth_cache.invalidate_agent(agent_id)
+        return result
 
     def rotate_api_key(self, agent_id: str) -> Optional[str]:
-        return self.agents.rotate_api_key(agent_id)
+        new_key = self.agents.rotate_api_key(agent_id)
+        auth_cache.invalidate_agent(agent_id)
+        return new_key
 
     def activate_agent(
         self,

--- a/dashboard/backend/domain/agents/version_repository_postgres.py
+++ b/dashboard/backend/domain/agents/version_repository_postgres.py
@@ -13,9 +13,6 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional
 
-import psycopg
-from psycopg.rows import dict_row
-
 from dashboard.backend.db_url import require_postgres_url
 from dashboard.backend.domain.agents.version_repository import (
     _new_version_id,
@@ -32,8 +29,11 @@ class PostgresAgentVersionStore:
         self.database_url = require_postgres_url(database_url)
         self._init_schema()
 
-    def _get_connection(self) -> psycopg.Connection:
-        return psycopg.connect(self.database_url, row_factory=dict_row)
+    def _get_connection(self):
+        # Pooled checkout: same context-manager transaction semantics as
+        # psycopg.connect (commit on clean exit), returned to the pool on close.
+        from dashboard.backend.db_pool import get_pool
+        return get_pool(self.database_url).connection()
 
     def _init_schema(self) -> None:
         # Adding a column later requires an `ALTER TABLE ... ADD COLUMN IF NOT

--- a/dashboard/backend/domain/portfolios/repository_postgres.py
+++ b/dashboard/backend/domain/portfolios/repository_postgres.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 import psycopg
-from psycopg.rows import dict_row
 
 from dashboard.backend.db_url import require_postgres_url
 from dashboard.backend.domain.backtesting.constants import DEFAULT_PORTFOLIO_EQUITY
@@ -25,8 +24,11 @@ class PostgresPortfolioStore:
         self.database_url = require_postgres_url(database_url)
         self._init_schema()
 
-    def _get_connection(self) -> psycopg.Connection:
-        return psycopg.connect(self.database_url, row_factory=dict_row)
+    def _get_connection(self):
+        # Pooled checkout: same context-manager transaction semantics as
+        # psycopg.connect (commit on clean exit), returned to the pool on close.
+        from dashboard.backend.db_pool import get_pool
+        return get_pool(self.database_url).connection()
 
     def _init_schema(self) -> None:
         # Runs once per process, from __init__ -- not per query. Re-running it

--- a/dashboard/backend/domain/portfolios/repository_postgres.py
+++ b/dashboard/backend/domain/portfolios/repository_postgres.py
@@ -32,9 +32,8 @@ class PostgresPortfolioStore:
 
     def _init_schema(self) -> None:
         # Runs once per process, from __init__ -- not per query. Re-running it
-        # on every read would double this store's Postgres connections (there
-        # is no pool: _get_connection opens a fresh TCP+TLS session to Neon)
-        # and issue DDL on the request path.
+        # on every read would issue DDL on the request path and thrash the
+        # shared pool with schema churn.
         #
         # ADDING A COLUMN LATER (#175 allocate/reclaim)? It must go in an
         # `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` below, *not* only in the

--- a/dashboard/backend/domain/strategies/repository_postgres.py
+++ b/dashboard/backend/domain/strategies/repository_postgres.py
@@ -17,9 +17,6 @@ from __future__ import annotations
 import secrets
 from typing import Any, Optional
 
-import psycopg
-from psycopg.rows import dict_row
-
 from dashboard.backend.db_url import require_postgres_url
 from dashboard.backend.domain.strategies.repository import (
     _CODE_LENGTH,
@@ -35,8 +32,11 @@ class PostgresStrategyStore:
         self.database_url = require_postgres_url(database_url)
         self._init_schema()
 
-    def _get_connection(self) -> psycopg.Connection:
-        return psycopg.connect(self.database_url, row_factory=dict_row)
+    def _get_connection(self):
+        # Pooled checkout: same context-manager transaction semantics as
+        # psycopg.connect (commit on clean exit), returned to the pool on close.
+        from dashboard.backend.db_pool import get_pool
+        return get_pool(self.database_url).connection()
 
     def _init_schema(self) -> None:
         # Adding a column later requires an `ALTER TABLE ... ADD COLUMN IF NOT

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -60,6 +60,7 @@ os.environ.pop("MARKET_DATA_CACHE_MAX_ENTRIES", None)
 os.environ.pop("BASELINE_QUEUE_MAX", None)
 os.environ.pop("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", None)
 os.environ.pop("MAX_ACTIVE_RUNS_GLOBAL", None)
+os.environ.pop("AGENT_AUTH_CACHE_TTL_SECONDS", None)
 
 
 @atexit.register
@@ -77,8 +78,10 @@ def _reset_shared_scale_state():
     process; without a per-test reset, one test's synthetic bars would be
     served to every later test with the same (symbols, dates) key."""
     from dashboard.backend.domain.backtesting import baseline_worker, market_data_store
+    from dashboard.backend.domain.agents import auth_cache
     market_data_store._reset_for_tests()
     baseline_worker._reset_for_tests()
+    auth_cache._reset_for_tests()
     yield
     # Best-effort drain so a job enqueued in this test doesn't leak into the
     # next. Note pytest tears fixtures down LIFO, so a test's own monkeypatches
@@ -89,3 +92,4 @@ def _reset_shared_scale_state():
     baseline_worker.wait_idle(timeout=5)
     baseline_worker._reset_for_tests()
     market_data_store._reset_for_tests()
+    auth_cache._reset_for_tests()

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -73,15 +73,21 @@ import pytest  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def _reset_shared_scale_state():
+def _reset_shared_scale_state(monkeypatch):
     """The market-data store is a module-level cache shared across the test
     process; without a per-test reset, one test's synthetic bars would be
-    served to every later test with the same (symbols, dates) key."""
+    served to every later test with the same (symbols, dates) key. The auth
+    cache and pg pools are the same kind of process-global state; reset all
+    three, and cap the pool-connect wait so the fail-loud "unreachable URL"
+    tests raise in ~1s instead of blocking the whole prod-default timeout."""
     from dashboard.backend.domain.backtesting import baseline_worker, market_data_store
     from dashboard.backend.domain.agents import auth_cache
+    from dashboard.backend import db_pool
+    monkeypatch.setattr(db_pool, "POOL_TIMEOUT_SECONDS", 1.0)
     market_data_store._reset_for_tests()
     baseline_worker._reset_for_tests()
     auth_cache._reset_for_tests()
+    db_pool._reset_for_tests()
     yield
     # Best-effort drain so a job enqueued in this test doesn't leak into the
     # next. Note pytest tears fixtures down LIFO, so a test's own monkeypatches
@@ -93,3 +99,4 @@ def _reset_shared_scale_state():
     baseline_worker._reset_for_tests()
     market_data_store._reset_for_tests()
     auth_cache._reset_for_tests()
+    db_pool._reset_for_tests()

--- a/dashboard/backend/tests/test_auth_cache.py
+++ b/dashboard/backend/tests/test_auth_cache.py
@@ -110,6 +110,20 @@ def test_mutating_returned_scopes_does_not_corrupt_cache(store, monkeypatch):
     assert len(store.resolves) == 1               # confirm it was a cache hit
 
 
+def test_mutating_returned_pipeline_does_not_corrupt_cache(store, monkeypatch):
+    """pipeline (a JSON-decoded list of step dicts) is the second mutable nested
+    field on a real agent record; like scopes, the cache's copy must be
+    independent of the caller's, down to the nested step dicts."""
+    monkeypatch.setattr(auth_cache, "_now", lambda: 1000.0)
+    store.agents["key-A"]["pipeline"] = [{"role": "researcher"}]
+    first = auth_cache.resolve_api_key("key-A")     # miss: fills cache
+    first["pipeline"].append({"role": "trader"})    # a caller mutates its view
+    first["pipeline"][0]["role"] = "hijacked"       # ...including a nested step
+    second = auth_cache.resolve_api_key("key-A")    # served from cache
+    assert second["pipeline"] == [{"role": "researcher"}]  # cache untouched
+    assert len(store.resolves) == 1                        # confirm cache hit
+
+
 def test_rotate_endpoint_invalidates_old_key():
     """End-to-end: after key rotation the OLD key must fail immediately, not
     after the TTL — exactly the behavior the cache would break without

--- a/dashboard/backend/tests/test_auth_cache.py
+++ b/dashboard/backend/tests/test_auth_cache.py
@@ -1,0 +1,101 @@
+"""Auth TTL cache + last_used_at debounce + invalidation (T4)."""
+
+import pytest
+
+import dashboard.backend.domain.agents.repository as repo_module
+from dashboard.backend.domain.agents import auth_cache
+
+
+class _RecordingStore:
+    def __init__(self):
+        self.resolves = []          # (api_key, touch)
+        self.agents = {}            # key -> agent dict
+
+    def add(self, api_key, agent_id):
+        self.agents[api_key] = {"agent_id": agent_id, "session_id": f"s_{agent_id}",
+                                "scopes": ["runs:read"]}
+
+    def resolve_api_key(self, api_key, touch=True):
+        self.resolves.append((api_key, touch))
+        return dict(self.agents[api_key]) if api_key in self.agents else None
+
+
+@pytest.fixture
+def store(monkeypatch):
+    s = _RecordingStore()
+    s.add("key-A", "agent-A")
+    monkeypatch.setattr(repo_module, "agent_store", s)
+    auth_cache._reset_for_tests()
+    monkeypatch.setattr(auth_cache, "_jitter", lambda: 1.0)  # deterministic TTL
+    yield s
+    auth_cache._reset_for_tests()
+
+
+def test_hit_within_ttl_skips_the_db(store, monkeypatch):
+    t = [1000.0]
+    monkeypatch.setattr(auth_cache, "_now", lambda: t[0])
+    a1 = auth_cache.resolve_api_key("key-A")
+    a2 = auth_cache.resolve_api_key("key-A")
+    assert a1["agent_id"] == a2["agent_id"] == "agent-A"
+    assert len(store.resolves) == 1                    # second call: cache hit
+    t[0] += auth_cache.AGENT_AUTH_CACHE_TTL_SECONDS + 1
+    auth_cache.resolve_api_key("key-A")
+    assert len(store.resolves) == 2                    # expired: DB again
+
+
+def test_last_used_write_debounced_to_60s(store, monkeypatch):
+    t = [1000.0]
+    monkeypatch.setattr(auth_cache, "_now", lambda: t[0])
+    auth_cache.resolve_api_key("key-A")
+    assert store.resolves[-1] == ("key-A", True)       # first resolve touches
+    t[0] += auth_cache.AGENT_AUTH_CACHE_TTL_SECONDS + 1
+    auth_cache.resolve_api_key("key-A")
+    assert store.resolves[-1] == ("key-A", False)      # <60s since last write
+    t[0] += 61.0
+    auth_cache.resolve_api_key("key-A")
+    assert store.resolves[-1] == ("key-A", True)       # debounce window passed
+
+
+def test_invalidate_agent_evicts_by_reverse_index(store, monkeypatch):
+    monkeypatch.setattr(auth_cache, "_now", lambda: 1000.0)
+    auth_cache.resolve_api_key("key-A")
+    auth_cache.invalidate_agent("agent-A")
+    auth_cache.resolve_api_key("key-A")
+    assert len(store.resolves) == 2                    # cache was evicted
+
+
+def test_zero_ttl_disables_caching(store, monkeypatch):
+    monkeypatch.setattr(auth_cache, "AGENT_AUTH_CACHE_TTL_SECONDS", 0.0)
+    auth_cache.resolve_api_key("key-A")
+    auth_cache.resolve_api_key("key-A")
+    assert len(store.resolves) == 2
+    assert all(touch for _, touch in store.resolves)   # passthrough always touches
+
+
+def test_misses_are_not_cached(store):
+    assert auth_cache.resolve_api_key("nope") is None
+    assert auth_cache.resolve_api_key("nope") is None
+    assert len(store.resolves) == 2
+
+
+def test_rotate_endpoint_invalidates_old_key():
+    """End-to-end: after key rotation the OLD key must fail immediately, not
+    after the TTL — exactly the behavior the cache would break without
+    invalidate_agent wired into the rotate paths. Route verified:
+    POST /api/v2/agents/{agent_id}/rotate-key (api/v2/agents.py:69)."""
+    from fastapi.testclient import TestClient
+    from dashboard.backend.app import app
+
+    client = TestClient(app)
+    r = client.post("/api/v2/agents", json={"name": "rotate-me"}).json()
+    old_key, agent_id = r["api_key"], r["agent_id"]
+    # Warm the auth cache with the old key: an authenticated read of a missing
+    # run answers 404; an unauthenticated one answers 401. No run is created.
+    probe = client.get("/api/v2/runs/does-not-exist", headers={"X-API-Key": old_key})
+    assert probe.status_code == 404
+    rot = client.post(f"/api/v2/agents/{agent_id}/rotate-key",
+                      headers={"X-API-Key": old_key})
+    assert rot.status_code == 200, rot.text
+    denied = client.get("/api/v2/runs/does-not-exist",
+                        headers={"X-API-Key": old_key})
+    assert denied.status_code == 401                   # immediately, not <=TTL

--- a/dashboard/backend/tests/test_auth_cache.py
+++ b/dashboard/backend/tests/test_auth_cache.py
@@ -78,6 +78,38 @@ def test_misses_are_not_cached(store):
     assert len(store.resolves) == 2
 
 
+def test_inflight_resolve_not_recached_after_racing_invalidation(store, monkeypatch):
+    """A rotate/delete landing WHILE a cache-miss resolve is mid-DB-read must not
+    let that resolve write its stale pre-rotation snapshot into the cache — else
+    the revoked key would authenticate from cache until the TTL."""
+    monkeypatch.setattr(auth_cache, "_now", lambda: 1000.0)
+    real_resolve = store.resolve_api_key
+
+    def resolve_then_invalidate(api_key, touch=True):
+        agent = real_resolve(api_key, touch=touch)
+        auth_cache.invalidate_agent("agent-A")  # rotate/delete lands mid-flight
+        return agent
+
+    monkeypatch.setattr(store, "resolve_api_key", resolve_then_invalidate)
+    assert auth_cache.resolve_api_key("key-A")["agent_id"] == "agent-A"  # in-flight ok
+    assert len(store.resolves) == 1
+    # Not resurrected: the next resolve must re-read the DB, not hit a poisoned cache.
+    monkeypatch.setattr(store, "resolve_api_key", real_resolve)
+    auth_cache.resolve_api_key("key-A")
+    assert len(store.resolves) == 2
+
+
+def test_mutating_returned_scopes_does_not_corrupt_cache(store, monkeypatch):
+    """The cached agent's scopes list must be independent of what callers get,
+    so an in-place edit by one caller can't leak into every other holder."""
+    monkeypatch.setattr(auth_cache, "_now", lambda: 1000.0)
+    first = auth_cache.resolve_api_key("key-A")
+    first["scopes"].append("runs:write")   # a caller mutates its own view
+    second = auth_cache.resolve_api_key("key-A")  # served from cache
+    assert second["scopes"] == ["runs:read"]      # cache untouched
+    assert len(store.resolves) == 1               # confirm it was a cache hit
+
+
 def test_rotate_endpoint_invalidates_old_key():
     """End-to-end: after key rotation the OLD key must fail immediately, not
     after the TTL — exactly the behavior the cache would break without

--- a/dashboard/backend/tests/test_db_pool.py
+++ b/dashboard/backend/tests/test_db_pool.py
@@ -1,0 +1,75 @@
+"""Shared per-URL psycopg pool (T4). Unit tests need no live Postgres; the
+@pg_only round-trip follows the established local-postgres fixture rules."""
+
+import os
+
+import pytest
+
+pytest.importorskip("psycopg_pool")
+
+from dashboard.backend import db_pool
+
+
+class _FakePool:
+    instances = []
+
+    def __init__(self, url, **kwargs):
+        self.url = url
+        self.kwargs = kwargs
+        type(self).instances.append(self)
+
+    def connection(self):
+        raise AssertionError("not used in dispatch tests")
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    monkeypatch.setattr(db_pool, "ConnectionPool", _FakePool)
+    db_pool._reset_for_tests()
+    _FakePool.instances = []
+    yield
+    db_pool._reset_for_tests()
+
+
+def test_one_pool_per_url_cached():
+    p1 = db_pool.get_pool("postgresql://u@h/db1")
+    p2 = db_pool.get_pool("postgresql://u@h/db1")
+    p3 = db_pool.get_pool("postgresql://u@h/db2")
+    assert p1 is p2
+    assert p1 is not p3
+    assert len(_FakePool.instances) == 2
+
+
+def test_pool_configured_for_neon_and_dict_rows():
+    from psycopg.rows import dict_row
+
+    db_pool.get_pool("postgresql://u@h/db")
+    kwargs = _FakePool.instances[0].kwargs
+    assert kwargs["max_size"] == 5
+    assert kwargs["max_idle"] == 300          # < Neon scale-to-zero idle window
+    assert kwargs["kwargs"] == {"row_factory": dict_row}
+
+
+TEST_PG = os.getenv("TEST_POSTGRES_URL")
+pg_only = pytest.mark.skipif(not TEST_PG, reason="TEST_POSTGRES_URL not set")
+
+
+@pg_only
+def test_pooled_agent_store_round_trip(monkeypatch):
+    """A twin resolves through the real pool. Guard: never a prod URL."""
+    from psycopg_pool import ConnectionPool as RealPool
+
+    from dashboard.backend.tests._postgres_testing import require_local_postgres_url
+
+    require_local_postgres_url(TEST_PG)
+    monkeypatch.setattr(db_pool, "ConnectionPool", RealPool)  # replace the fake
+    db_pool._reset_for_tests()
+    from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore
+
+    store = PostgresAgentStore(TEST_PG)
+    created = store.create_agent(name="pool-probe", model_name="m",
+                                 agent_type="external", description="")
+    resolved = store.resolve_api_key(created["api_key"])
+    assert resolved and resolved["agent_id"] == created["agent_id"]
+    store.delete_agent(created["agent_id"])
+    db_pool._reset_for_tests()  # close the real pool before the fake returns

--- a/dashboard/backend/tests/test_protocol_api.py
+++ b/dashboard/backend/tests/test_protocol_api.py
@@ -60,7 +60,6 @@ def client(tmp_path, monkeypatch):
     import dashboard.backend.api.routers.agents as agents_api
     import dashboard.backend.api.routers.agent_versions as versions_api
     import dashboard.backend.api.routers.runs as runs_api
-    import dashboard.backend.api.protocol_auth as protocol_auth
 
     test_db = db_module.BacktestDatabase(db_path=db_path)
     test_agents = agent_store_module.AgentStore(db_path=db_path)
@@ -73,11 +72,12 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(run_service, "db", test_db)
     monkeypatch.setattr(agents_api.agent_service, "db", test_db)
 
-    # Agent store
+    # Agent store. protocol_auth now resolves through the auth_cache, whose
+    # store lookup is late-bound to agent_store_module.agent_store (patched
+    # above), so no protocol_auth-local patch is needed (or possible).
     monkeypatch.setattr(agent_store_module, "agent_store", test_agents)
     monkeypatch.setattr(ebs, "agent_store", test_agents)
     monkeypatch.setattr(agents_api.agent_service, "agents", test_agents)
-    monkeypatch.setattr(protocol_auth, "agent_store", test_agents)
 
     # Version store
     monkeypatch.setattr(version_module, "agent_version_store", test_versions)

--- a/dashboard/backend/tests/test_v2_auth.py
+++ b/dashboard/backend/tests/test_v2_auth.py
@@ -59,9 +59,10 @@ def test_require_scope_rejects_bad_scope(tmp_path, monkeypatch):
                  ("runs:read", created["agent_id"]))
     conn.commit()
     conn.close()
+    # resolve_agent now routes through the auth_cache, whose store lookup is
+    # late-bound to repository.agent_store (patched above) — no auth_scopes-local
+    # patch is needed (or possible).
     monkeypatch.setattr(agent_store_mod, "agent_store", store)
-    from dashboard.backend.api.v2 import auth_scopes
-    monkeypatch.setattr(auth_scopes, "agent_store", store)
 
     dep = require_scope("decisions:write")
     with pytest.raises(ApiError) as exc:

--- a/dashboard/backend/users_postgres.py
+++ b/dashboard/backend/users_postgres.py
@@ -13,7 +13,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 import psycopg
-from psycopg.rows import dict_row
 
 from dashboard.backend.db_url import require_postgres_url
 from dashboard.backend.users import _utcnow, _utcnow_iso, hash_password, public_user, verify_password
@@ -28,8 +27,11 @@ class PostgresUserStore:
         self.database_url = require_postgres_url(database_url)
         self._init_schema()
 
-    def _get_connection(self) -> psycopg.Connection:
-        return psycopg.connect(self.database_url, row_factory=dict_row)
+    def _get_connection(self):
+        # Pooled checkout: same context-manager transaction semantics as
+        # psycopg.connect (commit on clean exit), returned to the pool on close.
+        from dashboard.backend.db_pool import get_pool
+        return get_pool(self.database_url).connection()
 
     def _init_schema(self) -> None:
         with self._get_connection() as conn:

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python-multipart==0.0.31
 pytz==2025.2
-psycopg[binary]==3.3.4
+psycopg[binary,pool]==3.3.4
 PyYAML==6.0.1
 referencing==0.36.2
 requests==2.33.1


### PR DESCRIPTION
T4 of `docs/superpowers/specs/2026-07-24-agent-scale-sustainability-design.md` — the final tier of the agent-scale plan (T1–T3 merged as #208/#209/#211).

## Summary
- **Auth TTL cache** (`domain/agents/auth_cache.py`): the two per-request hot paths (v1 `resolve_agent_by_key`, v2 `auth_scopes.resolve_agent`) now resolve API keys through an in-process TTL cache. `AGENT_AUTH_CACHE_TTL_SECONDS` (default 10s, ±20% jitter, `0` disables). Management endpoints stay direct (always-fresh).
- **`last_used_at` debounce**: the store's `last_used_at` UPDATE is now optional (`touch: bool = True` on both repo twins) and the cache debounces it to once per 60s per key.
- **Immediate invalidation on rotate/delete** via an `agent_id → {hashes}` reverse index (rotate UPDATEs by agent id, so the old hash — the cache key — is never in scope there). Wired into `service.delete_agent`/`rotate_api_key` and the v2 rotate route.
- **Shared psycopg pool** (`db_pool.py`): all five Postgres twins check out from one cached pool per URL (`max_size=5`, `max_idle=300s`, `dict_row`) instead of a fresh `psycopg.connect()` TLS handshake per call. `requirements.txt`: `psycopg[binary]` → `psycopg[binary,pool]`.

## Notable review fix (found in self-review)
Pooling changed failure *latency*: `psycopg.connect()` fails fast on a down DB, but `pool.connection()` retries for the pool's 30s default, blocking requests (and slowing the fail-loud tests 6×). Bounded the wait to `POOL_TIMEOUT_SECONDS=10` (tolerates Neon cold-start, fails loud on outage); conftest resets `db_pool` per test (closes leaked pool threads) and caps the wait to 1s so the unreachable-URL tests stay fast.

## Test plan
- [x] `pytest dashboard/backend/tests/ -q` → **1300 passed, 35 skipped** (36s)
- [x] New: `test_auth_cache.py` (6), `test_db_pool.py` (2 + 1 `@pg_only` skipped locally)
- [ ] **Verify the `@pg_only` pool round-trip ran in CI before merging** (needs the CI Postgres service; skips locally without `TEST_POSTGRES_URL`)

New env var: `AGENT_AUTH_CACHE_TTL_SECONDS` (10). Wire contract unchanged; no new routes.