### PR TITLE
fix: close CodeQL alerts (agent-scale PRs + log-injection)

### DIFF
--- a/dashboard/backend/db_pool.py
+++ b/dashboard/backend/db_pool.py
@@ -55,5 +55,5 @@ def _reset_for_tests() -> None:
             try:
                 pool.close()
             except Exception:
-                pass
+                pass  # best-effort teardown: a pool that won't close must not break test reset
         _pools.clear()

--- a/dashboard/backend/domain/backtesting/baseline_worker.py
+++ b/dashboard/backend/domain/backtesting/baseline_worker.py
@@ -158,6 +158,6 @@ def _reset_for_tests(maxsize: Optional[int] = None) -> None:
                     old_q.get_nowait()
                     old_q.task_done()
                 except queue.Empty:
-                    pass
+                    pass  # queue drained concurrently; nothing to evict before enqueuing _STOP
                 old_q.put_nowait(_STOP)
         _worker_thread = None

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -32,7 +32,6 @@ from dashboard.backend.infrastructure.llm.validator import (
     parse_actions_payload,
 )
 from dashboard.backend.domain.backtesting.constants import INITIAL_CAPITAL, resolve_initial_capital
-from dashboard.backend.domain.backtesting.features import TechnicalIndicators
 from dashboard.backend.domain.backtesting.metrics import (
     calculate_max_drawdown,
     calculate_sharpe,

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -37,15 +37,21 @@ from dashboard.backend.domain.backtesting.metrics import (
     calculate_sharpe,
 )
 from dashboard.backend.domain.backtesting.portfolio_manager import PortfolioManager
-# Canonical re-export: unused in this module's body, but external_run_service is
-# the wiring point that names the single TechnicalIndicators implementation. Guard
-# tests (test_canonical_consumers, test_external_run_service_move) assert its
-# presence, so this import is deliberate — CodeQL py/unused-import #1110 is a
-# false positive and is dismissed. Do not delete.
-from dashboard.backend.domain.backtesting.features import TechnicalIndicators  # noqa: F401
 from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
 
-from dashboard.backend.domain.backtesting import baseline_worker, market_data_store
+from dashboard.backend.domain.backtesting import (
+    baseline_worker,
+    features as _features,
+    market_data_store,
+)
+
+# Canonical re-export. external_run_service is the single wiring point that names
+# the concrete TechnicalIndicators; guard tests (test_canonical_consumers,
+# test_external_run_service_move) assert `svc.TechnicalIndicators` is that class.
+# Bound by assignment rather than a bare `from ... import TechnicalIndicators` so
+# the re-export is explicit and static analysis sees it as used — no
+# py/unused-import false positive. Do not remove (deleting it reddens those tests).
+TechnicalIndicators = _features.TechnicalIndicators
 
 DECISION_TIMEOUT_SECONDS = int(os.getenv("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", "60"))
 

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -37,6 +37,12 @@ from dashboard.backend.domain.backtesting.metrics import (
     calculate_sharpe,
 )
 from dashboard.backend.domain.backtesting.portfolio_manager import PortfolioManager
+# Canonical re-export: unused in this module's body, but external_run_service is
+# the wiring point that names the single TechnicalIndicators implementation. Guard
+# tests (test_canonical_consumers, test_external_run_service_move) assert its
+# presence, so this import is deliberate — CodeQL py/unused-import #1110 is a
+# false positive and is dismissed. Do not delete.
+from dashboard.backend.domain.backtesting.features import TechnicalIndicators  # noqa: F401
 from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
 
 from dashboard.backend.domain.backtesting import baseline_worker, market_data_store

--- a/dashboard/backend/infrastructure/llm/validator.py
+++ b/dashboard/backend/infrastructure/llm/validator.py
@@ -22,6 +22,21 @@ from pydantic import BaseModel, field_validator, ValidationError, ConfigDict
 
 logger = logging.getLogger(__name__)
 
+# Any C0 control char (incl. CR/LF) or DEL — the log-injection surface.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _safe_log_value(value: Any, limit: int = 500) -> str:
+    """Neutralize untrusted (LLM/attacker-controlled) text before it reaches a log
+    record. Strips CR/LF — the sanitizer CodeQL py/log-injection recognizes — plus
+    other control chars, so a crafted response cannot forge or split log lines, and
+    bounds length. Sanitizes only what is *logged*; never the value trading
+    validation runs against, so the LLM safety boundary is unchanged.
+    """
+    text = str(value)[:limit].replace("\r", " ").replace("\n", " ")
+    return _CONTROL_CHARS.sub(" ", text)
+
+
 # DJIA 30 constituents. Source: S&P Dow Jones Indices, effective 2026-06-29
 # (GOOGL replaced VZ). Canonical for ATL — the backtest script and the v2 API
 # contract import this (guarded by tests/test_djia30_universe.py). Reconcile
@@ -180,7 +195,7 @@ def validate_llm_response(
        "function_calls" in raw_response or "invoke" in raw_response:
         logger.error(
             "🚨 SECURITY: LLM attempted tool calling! Rejecting response entirely.",
-            extra={"raw_response_preview": raw_response[:200]}
+            extra={"raw_response_preview": _safe_log_value(raw_response, 200)}
         )
         return None
     
@@ -191,8 +206,9 @@ def validate_llm_response(
         json_data = json.loads(raw_response)
     except json.JSONDecodeError as e:
         logger.warning(
-            f"❌ Invalid JSON from LLM: {e}",
-            extra={"raw_response_preview": raw_response[:200]}
+            "❌ Invalid JSON from LLM: %s",
+            _safe_log_value(e, 200),
+            extra={"raw_response_preview": _safe_log_value(raw_response, 200)}
         )
         return None
     
@@ -203,8 +219,12 @@ def validate_llm_response(
         decision = LLMTradingDecision(**json_data)
     except ValidationError as e:
         logger.warning(
-            f"❌ Schema validation failed: {e}",
-            extra={"errors": e.errors(), "json_data": json_data}
+            "❌ Schema validation failed: %s",
+            _safe_log_value(e, 500),
+            extra={
+                "errors": _safe_log_value(e.errors(), 500),
+                "json_data": _safe_log_value(json_data, 500),
+            }
         )
         return None
 

--- a/dashboard/backend/tests/test_market_data_sharing.py
+++ b/dashboard/backend/tests/test_market_data_sharing.py
@@ -1,7 +1,5 @@
 """Two same-config sessions share one dataset object; the loader runs once."""
 
-import threading
-
 import numpy as np
 import pandas as pd
 import pytest

--- a/dashboard/scripts/loadtest/drive_agents.py
+++ b/dashboard/scripts/loadtest/drive_agents.py
@@ -35,7 +35,8 @@ if host not in ("127.0.0.1", "localhost", "::1") and not args.allow_remote:
 
 BASE = args.base
 M = args.agents
-AGENTS = json.load(open(os.path.join(args.artifacts, "agents.json")))
+with open(os.path.join(args.artifacts, "agents.json")) as _f:
+    AGENTS = json.load(_f)
 PID_FILE = os.path.join(args.artifacts, "server.pid")
 
 samples = []          # (kind, ms, http_status)
@@ -138,8 +139,10 @@ def drive(agent):
 
 def server_stats():
     try:
-        pid = int(open(PID_FILE).read())
-        st = open(f"/proc/{pid}/status").read()
+        with open(PID_FILE) as f:
+            pid = int(f.read())
+        with open(f"/proc/{pid}/status") as f:
+            st = f.read()
         rss = next(l for l in st.splitlines() if l.startswith("VmRSS")).split()[1]
         thr = next(l for l in st.splitlines() if l.startswith("Threads")).split()[1]
         return int(rss) // 1024, int(thr)


### PR DESCRIPTION
Closes the CodeQL alerts GHAS attributed to the agent-scale PRs #208/#209/#211/#212, plus the one medium log-injection alert (#1105) surfaced alongside them.

| Alert | Origin PR | File | Rule | Resolution |
|---|---|---|---|---|
| #1105 | #199 | `validator.py:207` | log-injection (**medium**) | sanitize LLM payload before logging (`_safe_log_value`, applied to all 3 pre-validation sinks) |
| #1112 | #212 | `db_pool.py:57` | empty-except | explanatory comment |
| #1111 | #209 | `baseline_worker.py:160` | empty-except | explanatory comment |
| #1110 / #1113 | #208 | `external_run_service.py` | unused-import (`TechnicalIndicators`) | **explicit re-export** — `import features as _features; TechnicalIndicators = _features.TechnicalIndicators` (genuinely used → CodeQL no longer flags it) |
| #1106 | #208 | `test_market_data_sharing.py:3` | unused-import (`threading`) | remove |
| #1107/#1108/#1109 | #208 | `loadtest/drive_agents.py` | file-not-closed ×3 | `with open(...)` |

Notes:
- **#1110 / #1113**: `TechnicalIndicators` is an intentional canonical re-export two guard tests assert (`test_canonical_consumers`, `test_external_run_service_move`), so `py/unused-import` is a false positive. Removing it reddened those tests; the final fix binds it as an **explicit assignment re-export**, which static analysis sees as used — clears the alert at the source, no dismissal, nothing to resurface on `main`. (The sibling pre-existing baseline alert #592 `INITIAL_CAPITAL` is the same pattern; left as-is per the accepted CodeQL baseline.)
- **#1105**: `validator.py` logged raw, unvalidated LLM output straight into log records. CodeQL flagged only line 207, but two sibling sinks (181/193) are the same pattern, so all three are hardened (cf. the #1098 XSS fix). Log output only — validation / tool-call rejection logic unchanged, per the LLM safety-boundary contract.

GHAS scan of the four scale PRs: **Dependabot 0**, **secret-scanning none**. Fixed alerts auto-close on the next `main` CodeQL scan after merge.
