### PR TITLE
fix: clear CodeQL #592 (INITIAL_CAPITAL re-export)

### DIFF
--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -31,7 +31,7 @@ from dashboard.backend.infrastructure.llm.validator import (
     actions_to_executable,
     parse_actions_payload,
 )
-from dashboard.backend.domain.backtesting.constants import INITIAL_CAPITAL, resolve_initial_capital
+from dashboard.backend.domain.backtesting.constants import resolve_initial_capital
 from dashboard.backend.domain.backtesting.metrics import (
     calculate_max_drawdown,
     calculate_sharpe,
@@ -41,17 +41,21 @@ from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataL
 
 from dashboard.backend.domain.backtesting import (
     baseline_worker,
+    constants as _constants,
     features as _features,
     market_data_store,
 )
 
-# Canonical re-export. external_run_service is the single wiring point that names
-# the concrete TechnicalIndicators; guard tests (test_canonical_consumers,
-# test_external_run_service_move) assert `svc.TechnicalIndicators` is that class.
-# Bound by assignment rather than a bare `from ... import TechnicalIndicators` so
-# the re-export is explicit and static analysis sees it as used — no
-# py/unused-import false positive. Do not remove (deleting it reddens those tests).
+# Canonical re-exports. external_run_service is the single wiring point that names
+# these concrete symbols; guard tests (test_canonical_consumers,
+# test_external_run_service_move) assert `svc.TechnicalIndicators` is that class and
+# `svc.INITIAL_CAPITAL` is the canonical constant. Bound by assignment rather than a
+# bare `from ... import X` so each re-export is explicit and static analysis sees it
+# as used — no py/unused-import false positive. Do not remove (deleting either
+# reddens those tests). resolve_initial_capital stays a direct import: it's called
+# in the body, so it's a genuine use, not a re-export.
 TechnicalIndicators = _features.TechnicalIndicators
+INITIAL_CAPITAL = _constants.INITIAL_CAPITAL
 
 DECISION_TIMEOUT_SECONDS = int(os.getenv("EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS", "60"))
 


### PR DESCRIPTION
Clears CodeQL **#592** — `py/unused-import` on `INITIAL_CAPITAL` in `external_run_service.py:34` (pre-existing accepted-baseline alert).

`INITIAL_CAPITAL` is an intentional **canonical re-export**: `test_external_run_service_move.py:65` asserts `svc.INITIAL_CAPITAL == INITIAL_CAPITAL`, so `py/unused-import` is a false positive — the name is used by a downstream guard test CodeQL can't see. Removing it would redden that test.

Fix = bind it by **explicit assignment** (`INITIAL_CAPITAL = _constants.INITIAL_CAPITAL`), the same pattern the sibling `TechnicalIndicators` re-export uses (landed in #213). Static analysis now sees a genuine use, so the alert clears at the source — no dismissal, nothing resurfaces on `main`.

- `resolve_initial_capital` stays a direct import (it's called in the body, a real use).
- No behavior change — a pure re-export rebind. 72 guard/compat/boundary tests green locally.
