### PR TITLE
chore: sweep CodeQL quality alerts

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -18,7 +18,6 @@ import threading
 import time
 import uuid
 from functools import lru_cache
-from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 

--- a/dashboard/backend/api/v2/runs.py
+++ b/dashboard/backend/api/v2/runs.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, Header, Request, Response
+from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel, Field
 
 from dashboard.backend.domain.backtesting import external_run_service as ext

--- a/dashboard/backend/baseline_generator.py
+++ b/dashboard/backend/baseline_generator.py
@@ -15,9 +15,7 @@ Same logic, different contexts.
 
 import json
 import os
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple
-from datetime import datetime, timedelta
 
 from dashboard.backend.paths import CREDENTIALS_DIR
 from dashboard.backend.domain.backtesting.constants import INITIAL_CAPITAL
@@ -28,14 +26,6 @@ from dashboard.backend.infrastructure.market_data.alpaca_bars import (
 # NOTE: domain.leaderboard.strategies._common is imported lazily inside the
 # methods that need it — the strategies package imports this module back
 # (buy_hold et al.), so a top-level import here is a circular import.
-
-# Try to import numpy
-try:
-    import numpy as np
-except ImportError:
-    import subprocess
-    subprocess.check_call(["pip", "install", "numpy"])
-    import numpy as np
 
 try:
     import pandas as pd

--- a/dashboard/backend/cache.py
+++ b/dashboard/backend/cache.py
@@ -3,10 +3,8 @@ Simple in-memory cache with TTL (time-to-live) for paper trading data.
 Reduces redundant API calls to Alpaca.
 """
 
-import json
 import time
 from typing import Optional, Dict, Any, Callable, Set
-from datetime import datetime, timedelta
 from threading import Lock
 
 

--- a/dashboard/backend/database.py
+++ b/dashboard/backend/database.py
@@ -10,7 +10,6 @@ import sqlite3
 import json
 import os
 from pathlib import Path
-from datetime import datetime
 from typing import List, Dict, Optional, Any
 
 from dashboard.backend.paths import DEFAULT_DB_PATH

--- a/dashboard/backend/domain/backtesting/baselines/paper.py
+++ b/dashboard/backend/domain/backtesting/baselines/paper.py
@@ -15,10 +15,8 @@ import json
 import requests
 import os
 import uuid
-from pathlib import Path
 from typing import Dict, List, Optional
 from datetime import datetime, timedelta
-import sys
 
 from dashboard.backend.paths import CREDENTIALS_DIR
 

--- a/dashboard/backend/equity_plot.py
+++ b/dashboard/backend/equity_plot.py
@@ -17,7 +17,7 @@ import pytz
 from matplotlib.figure import Figure
 from matplotlib.ticker import FixedFormatter, FixedLocator, FuncFormatter, NullFormatter
 
-from dashboard.backend.chart_style import PLAYGROUND_THEME, series_color, series_kind
+from dashboard.backend.chart_style import PLAYGROUND_THEME, series_color
 from dashboard.backend.domain.leaderboard.strategies._yahoo import fetch_index_hourly
 
 _ET = pytz.timezone("US/Eastern")

--- a/dashboard/backend/infrastructure/brokers/alpaca_paper.py
+++ b/dashboard/backend/infrastructure/brokers/alpaca_paper.py
@@ -12,9 +12,7 @@ tracking and orchestration live in
 import json
 import requests
 import os
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple
-from datetime import datetime, timedelta
+from typing import Dict, List, Optional
 from dataclasses import dataclass
 
 from dashboard.backend.paths import CREDENTIALS_DIR

--- a/dashboard/backend/infrastructure/llm/validator.py
+++ b/dashboard/backend/infrastructure/llm/validator.py
@@ -16,7 +16,6 @@ import logging
 import re
 from typing import Dict, Any, List, Optional, Tuple
 from enum import Enum
-from decimal import Decimal
 from datetime import datetime
 from pydantic import BaseModel, field_validator, ValidationError, ConfigDict
 

--- a/dashboard/backend/infrastructure/market_data/quotes.py
+++ b/dashboard/backend/infrastructure/market_data/quotes.py
@@ -14,7 +14,6 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import requests
@@ -219,6 +218,9 @@ class AlpacaMarketData:
                         "changePercent": round(change_percent, 2) if change_percent is not None else None,
                         "timestamp": datetime.now().isoformat()
                     }
+                else:
+                    print(f"❌ {symbol}: No 'quote' key in Alpaca response")
+                    return None
             else:
                 print(f"❌ {symbol}: Error fetching quote: {response.status_code} - {response.text[:200]}")
                 return None
@@ -272,7 +274,6 @@ class AlpacaMarketData:
                             return prev_close if prev_close > 0 else None
                         except (ValueError, TypeError) as e:
                             print(f"⚠️ {symbol}: Could not parse IEX bar data: {e}")
-                            pass
                     elif len(bars_sorted) == 1:
                         try:
                             bar_timestamp = bars_sorted[0].get("t", "unknown")
@@ -281,7 +282,6 @@ class AlpacaMarketData:
                             return prev_close if prev_close > 0 else None
                         except (ValueError, TypeError) as e:
                             print(f"⚠️ {symbol}: Could not parse IEX bar data: {e}")
-                            pass
             
             # ===== ATTEMPT 2: Try SIP with delayed end time (15+ mins ago) =====
             # Only query SIP data up to 15 minutes ago to avoid "recent SIP data" restriction
@@ -310,7 +310,6 @@ class AlpacaMarketData:
                             return prev_close if prev_close > 0 else None
                         except (ValueError, TypeError) as e:
                             print(f"⚠️ {symbol}: Could not parse SIP bar data: {e}")
-                            pass
                     elif len(bars_sorted) == 1:
                         try:
                             bar_timestamp = bars_sorted[0].get("t", "unknown")
@@ -319,7 +318,6 @@ class AlpacaMarketData:
                             return prev_close if prev_close > 0 else None
                         except (ValueError, TypeError) as e:
                             print(f"⚠️ {symbol}: Could not parse SIP bar data: {e}")
-                            pass
             
             # ===== BOTH FAILED: Return None =====
             print(f"⚠️ {symbol}: Could not fetch previous_close (IEX and SIP both unavailable)")

--- a/dashboard/backend/llm_integration_example.py
+++ b/dashboard/backend/llm_integration_example.py
@@ -13,6 +13,7 @@ DO NOT expose websearch, browser, or HTTP tools to the LLM.
 
 import json
 import logging
+import os
 from typing import Dict, Optional, Any
 
 # NOTE: This requires anthropic library

--- a/dashboard/backend/llm_integration_example.py
+++ b/dashboard/backend/llm_integration_example.py
@@ -14,8 +14,6 @@ DO NOT expose websearch, browser, or HTTP tools to the LLM.
 import json
 import logging
 from typing import Dict, Optional, Any
-from datetime import datetime
-import asyncio
 
 # NOTE: This requires anthropic library
 # pip install anthropic
@@ -26,8 +24,7 @@ from anthropic import Anthropic
 from dashboard.backend.infrastructure.llm.validator import (
     validate_llm_response,
     create_safe_prompt,
-    log_audit_trail,
-    PortfolioConstraints
+    log_audit_trail
 )
 
 logger = logging.getLogger(__name__)

--- a/dashboard/backend/tests/backtesting/test_portfolio_manager_move.py
+++ b/dashboard/backend/tests/backtesting/test_portfolio_manager_move.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import pandas as pd
 import pytest
 
+from dashboard.backend.domain.backtesting import portfolio_manager
 from dashboard.backend.domain.backtesting.portfolio_manager import (
     PortfolioManager as CanonicalPortfolioManager,
 )
@@ -312,8 +313,7 @@ def test_safe_trading_threads_custom_strategy_prompt(monkeypatch):
 
 
 def test_module_docstring_no_longer_claims_verbatim_identity():
-    import dashboard.backend.domain.backtesting.portfolio_manager as pm_mod
-    doc = pm_mod.__doc__ or ""
+    doc = portfolio_manager.__doc__ or ""
     assert "functionally identical" not in doc
     assert "Moved verbatim" not in doc
     # It must instead disclose the safe_trading divergence.

--- a/dashboard/backend/tests/domain/agents/test_repository_move.py
+++ b/dashboard/backend/tests/domain/agents/test_repository_move.py
@@ -13,8 +13,6 @@ import pytest
 from dashboard.backend.domain.agents import repository
 from dashboard.backend.domain.agents.repository import AgentStore
 
-_REPO_ROOT = Path(__file__).resolve().parents[5]
-
 
 @pytest.fixture
 def store(tmp_path):

--- a/dashboard/backend/tests/domain/agents/test_service.py
+++ b/dashboard/backend/tests/domain/agents/test_service.py
@@ -25,8 +25,6 @@ from dashboard.backend.domain.agents.service import (
     sample_equity_sparkline,
 )
 
-_REPO_ROOT = Path(__file__).resolve().parents[5]
-
 
 @pytest.fixture
 def svc(tmp_path):

--- a/dashboard/backend/tests/domain/leaderboard/test_strategies_move.py
+++ b/dashboard/backend/tests/domain/leaderboard/test_strategies_move.py
@@ -15,7 +15,6 @@ from dashboard.backend.domain.leaderboard import strategies as canon
 from dashboard.backend.domain.leaderboard.strategies import (
     llm_agent as llm_agent_module,
 )
-from dashboard.backend.domain.leaderboard.strategies.base import BaselineStrategy
 from dashboard.backend.domain.leaderboard.strategies.buy_hold import BuyHoldStrategy
 from dashboard.backend.domain.leaderboard.strategies.equal_weight_buyhold import (
     EqualWeightBuyHoldStrategy,

--- a/dashboard/backend/tests/domain/runs/test_repository_move.py
+++ b/dashboard/backend/tests/domain/runs/test_repository_move.py
@@ -13,8 +13,6 @@ import pytest
 from dashboard.backend.domain.runs import repository
 from dashboard.backend.domain.runs.repository import RunStore
 
-_REPO_ROOT = Path(__file__).resolve().parents[5]
-
 _RUN_KEYS = {
     "run_id", "agent_id", "agent_version_id", "session_id", "environment_id",
     "environment_type", "config", "backtest_id", "result_run_id", "status",

--- a/dashboard/backend/tests/domain/strategies/test_strategy_store.py
+++ b/dashboard/backend/tests/domain/strategies/test_strategy_store.py
@@ -11,9 +11,8 @@ import uuid
 import pytest
 from fastapi.testclient import TestClient
 
-import dashboard.backend.domain.strategies.repository as strategies_module
 from dashboard.backend.app import app
-from dashboard.backend.domain.strategies.repository import StrategyStore
+from dashboard.backend.domain.strategies.repository import StrategyStore, secrets
 
 
 def _store(tmp_path):
@@ -101,12 +100,12 @@ def test_create_retries_past_a_code_collision(tmp_path, monkeypatch):
     first = store.create(prompt="first strategy")
 
     codes = iter([first["code"], "fresh456"])
-    # NB: strategies_module.secrets IS the stdlib secrets module, so this
+    # NB: secrets IS the stdlib secrets module, so this
     # patches token_hex process-wide rather than just this module's view of
     # it. Harmless -- monkeypatch restores it and nothing else in this test
     # calls token_hex -- but don't read it as module-scoped.
     monkeypatch.setattr(
-        strategies_module.secrets, "token_hex", lambda nbytes: next(codes)
+        secrets, "token_hex", lambda nbytes: next(codes)
     )
 
     second = store.create(prompt="second strategy")
@@ -127,7 +126,7 @@ def test_create_widens_code_space_after_20_collisions(tmp_path, monkeypatch):
             return first["code"]  # every narrow attempt collides
         return "w" * 16  # the widened attempt succeeds
 
-    monkeypatch.setattr(strategies_module.secrets, "token_hex", fake_token_hex)
+    monkeypatch.setattr(secrets, "token_hex", fake_token_hex)
 
     second = store.create(prompt="second strategy")
     assert second["code"] == "w" * 16
@@ -141,7 +140,7 @@ def test_create_raises_when_even_widened_code_collides(tmp_path, monkeypatch):
     first = store.create(prompt="first strategy")
 
     monkeypatch.setattr(
-        strategies_module.secrets, "token_hex", lambda nbytes: first["code"]
+        secrets, "token_hex", lambda nbytes: first["code"]
     )
 
     with pytest.raises(RuntimeError):

--- a/dashboard/backend/tests/infrastructure/brokers/test_alpaca_paper.py
+++ b/dashboard/backend/tests/infrastructure/brokers/test_alpaca_paper.py
@@ -15,7 +15,6 @@ from dashboard.backend.infrastructure.brokers import alpaca_paper
 from dashboard.backend.infrastructure.brokers.alpaca_paper import (
     AlpacaPaperTradingClient,
     Position,
-    Trade,
 )
 
 _BACKEND = Path(__file__).resolve().parents[3]

--- a/dashboard/backend/tests/infrastructure/llm/test_prompts.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_prompts.py
@@ -3,7 +3,6 @@
 import ast
 from pathlib import Path
 
-from dashboard.backend.infrastructure.llm import prompts as prompts_mod
 from dashboard.backend.infrastructure.llm.prompts import (
     create_custom_algo_prompt,
     parse_risk_rules,

--- a/dashboard/backend/tests/infrastructure/llm/test_token_cost.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_token_cost.py
@@ -3,7 +3,6 @@
 import ast
 from pathlib import Path
 
-from dashboard.backend.infrastructure.llm import token_cost as tc
 from dashboard.backend.infrastructure.llm.token_cost import (
     CHARS_PER_TOKEN,
     estimate_cost_usd,

--- a/dashboard/backend/tests/infrastructure/llm/test_validator.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_validator.py
@@ -12,7 +12,6 @@ from dashboard.backend.infrastructure.llm import validator as validator_mod
 from dashboard.backend.infrastructure.llm.validator import (
     DJIA_30,
     TOP_10_STOCKS,
-    LLMTradingDecision,
     TradingAction,
     actions_to_executable,
     parse_actions_payload,

--- a/dashboard/backend/tests/llm/test_backtest_harness.py
+++ b/dashboard/backend/tests/llm/test_backtest_harness.py
@@ -14,13 +14,6 @@ from dashboard.backend.domain.backtesting import (
     portfolio_manager as portfolio_manager_module,
 )
 import dashboard.backend.infrastructure.llm.backtest_harness as harness
-from dashboard.backend.infrastructure.llm.backtest_harness import (
-    SYSTEM_PROMPT,
-    extract_response_text,
-    extract_token_usage,
-    parse_llm_response,
-    request_trading_decision,
-)
 from dashboard.scripts import backtest_hourly_agent as bha
 
 
@@ -107,37 +100,37 @@ def test_legacy_method_still_defined():
 
 def test_request_uses_default_model_and_params():
     client = _FakeClient(_FakeResponse('{"actions": []}'))
-    request_trading_decision(client, prompt="HELLO")
+    harness.request_trading_decision(client, prompt="HELLO")
     cap = client.captured
     assert cap["model"] == harness.LLM_MODEL_NAME
     assert cap["max_tokens"] == 2000
-    assert cap["system"] == SYSTEM_PROMPT
+    assert cap["system"] == harness.SYSTEM_PROMPT
     assert cap["messages"] == [{"role": "user", "content": "HELLO"}]
 
 
 def test_request_model_override():
     client = _FakeClient(_FakeResponse("{}"))
-    request_trading_decision(client, prompt="P", model="custom-model")
+    harness.request_trading_decision(client, prompt="P", model="custom-model")
     assert client.captured["model"] == "custom-model"
 
 
 def test_request_includes_explicit_zero_temperature():
     client = _FakeClient(_FakeResponse("{}"))
-    request_trading_decision(client, prompt="P", temperature=0)
+    harness.request_trading_decision(client, prompt="P", temperature=0)
     assert client.captured["temperature"] == 0
 
 
 def test_request_omits_temperature_when_unset():
     client = _FakeClient(_FakeResponse("{}"))
-    request_trading_decision(client, prompt="P")
+    harness.request_trading_decision(client, prompt="P")
     assert "temperature" not in client.captured
 
 
 def test_system_prompt_required_fragments():
     # Assert stable required fragments of the current (unchanged) prompt.
-    assert "expert quantitative trading advisor" in SYSTEM_PROMPT
-    assert '"actions" array' in SYSTEM_PROMPT
-    assert "ONLY valid JSON" in SYSTEM_PROMPT
+    assert "expert quantitative trading advisor" in harness.SYSTEM_PROMPT
+    assert '"actions" array' in harness.SYSTEM_PROMPT
+    assert "ONLY valid JSON" in harness.SYSTEM_PROMPT
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +139,7 @@ def test_system_prompt_required_fragments():
 
 def test_extract_response_text():
     resp = _FakeResponse("hello world")
-    assert extract_response_text(resp) == "hello world"
+    assert harness.extract_response_text(resp) == "hello world"
 
 
 def test_extract_response_text_skips_thinking_block():
@@ -162,7 +155,7 @@ def test_extract_response_text_skips_thinking_block():
     class _Resp:
         content = [_Thinking(), _Text()]
 
-    assert extract_response_text(_Resp()) == '{"actions": []}'
+    assert harness.extract_response_text(_Resp()) == '{"actions": []}'
 
 
 def test_extract_response_text_joins_multiple_text_blocks():
@@ -174,7 +167,7 @@ def test_extract_response_text_joins_multiple_text_blocks():
     class _Resp:
         content = [_Text('{"actions":'), _Text(" []}")]
 
-    assert extract_response_text(_Resp()) == '{"actions":\n []}'
+    assert harness.extract_response_text(_Resp()) == '{"actions":\n []}'
 
 
 def test_extract_response_text_raises_when_only_thinking():
@@ -185,7 +178,7 @@ def test_extract_response_text_raises_when_only_thinking():
         content = [_Thinking()]
 
     try:
-        extract_response_text(_Resp())
+        harness.extract_response_text(_Resp())
         assert False, "expected AttributeError"
     except AttributeError as exc:
         assert "No text content block" in str(exc)
@@ -193,17 +186,17 @@ def test_extract_response_text_raises_when_only_thinking():
 
 def test_extract_token_usage_present():
     resp = _FakeResponse("{}", usage=_FakeUsage(123, 45))
-    assert extract_token_usage(resp) == (123, 45)
+    assert harness.extract_token_usage(resp) == (123, 45)
 
 
 def test_extract_token_usage_missing():
     resp = _FakeResponse("{}", usage=None)
-    assert extract_token_usage(resp) == (0, 0)
+    assert harness.extract_token_usage(resp) == (0, 0)
 
 
 def test_extract_token_usage_none_fields_coerced_zero():
     resp = _FakeResponse("{}", usage=_FakeUsage(None, None))
-    assert extract_token_usage(resp) == (0, 0)
+    assert harness.extract_token_usage(resp) == (0, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -211,46 +204,46 @@ def test_extract_token_usage_none_fields_coerced_zero():
 # ---------------------------------------------------------------------------
 
 def test_parse_valid_json_object():
-    out = parse_llm_response('{"actions": [{"symbol": "AAPL", "action": "buy"}]}')
+    out = harness.parse_llm_response('{"actions": [{"symbol": "AAPL", "action": "buy"}]}')
     assert out == {"actions": [{"symbol": "AAPL", "action": "buy"}]}
 
 
 def test_parse_fenced_json():
-    out = parse_llm_response('```json\n{"actions": []}\n```')
+    out = harness.parse_llm_response('```json\n{"actions": []}\n```')
     assert out == {"actions": []}
 
 
 def test_parse_plain_fence():
-    out = parse_llm_response('```\n{"actions": [1]}\n```')
+    out = harness.parse_llm_response('```\n{"actions": [1]}\n```')
     assert out == {"actions": [1]}
 
 
 def test_parse_surrounding_text():
-    out = parse_llm_response('Here is my answer: {"actions": []} thanks')
+    out = harness.parse_llm_response('Here is my answer: {"actions": []} thanks')
     assert out == {"actions": []}
 
 
 def test_parse_no_json_returns_none():
-    assert parse_llm_response("no json here") is None
+    assert harness.parse_llm_response("no json here") is None
 
 
 def test_parse_empty_string_returns_none():
-    assert parse_llm_response("") is None
+    assert harness.parse_llm_response("") is None
 
 
 def test_parse_trailing_comma_fixed():
     # fix_json_formatting repairs trailing commas
-    out = parse_llm_response('{"actions": [1, 2,]}')
+    out = harness.parse_llm_response('{"actions": [1, 2,]}')
     assert out == {"actions": [1, 2]}
 
 
 def test_parse_unrecoverable_returns_none():
-    assert parse_llm_response("{ this : is : not json ]") is None
+    assert harness.parse_llm_response("{ this : is : not json ]") is None
 
 
 def test_parse_non_dict_json_returns_none():
     # "[1,2]" has no braces -> no JSON found -> None
-    assert parse_llm_response("[1, 2, 3]") is None
+    assert harness.parse_llm_response("[1, 2, 3]") is None
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/test_agent_runs_metadata.py
+++ b/dashboard/backend/tests/test_agent_runs_metadata.py
@@ -9,8 +9,6 @@ records its effective cap there.
 
 import sqlite3
 
-import pytest
-
 from dashboard.backend.database import BacktestDatabase
 
 

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -1,8 +1,6 @@
 """Tests for registered external agents API."""
 
-import sys
 import uuid
-from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -273,7 +271,8 @@ def test_leaked_session_id_cannot_take_over_agent(client):
     leaked_session_id = created["session_id"]
 
     attacker = {"X-Session-Id": leaked_session_id}
-    assert client.delete(f"/api/v1/agents/{agent_id}", headers=attacker).status_code == 403
+    delete_response = client.delete(f"/api/v1/agents/{agent_id}", headers=attacker)
+    assert delete_response.status_code == 403
     assert (
         client.post(f"/api/v1/agents/{agent_id}/rotate-api-key", headers=attacker).status_code
         == 403
@@ -349,7 +348,6 @@ def test_builtin_listing_batches_run_stats_queries(client, monkeypatch):
     """LOW #9 — the public, unauthenticated /agents/builtin listing must not
     issue one runs-by-session query per agent (N+1): the stats lookup happens
     in a single batched query no matter how many builtin agents exist."""
-    headers = {"X-Session-Id": str(uuid.uuid4())}
     for i in range(3):
         resp = client.post(
             "/api/v1/agents",

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -3,7 +3,6 @@ Auth API tests using a temporary SQLite database.
 """
 
 import base64
-import sys
 import tempfile
 from pathlib import Path
 
@@ -23,9 +22,9 @@ def temp_user_store():
 
 @pytest.fixture
 def client(temp_user_store, monkeypatch):
-    import dashboard.backend.users as users_module
+    from dashboard.backend import users
 
-    monkeypatch.setattr(users_module, "user_store", temp_user_store)
+    monkeypatch.setattr(users, "user_store", temp_user_store)
     return TestClient(app)
 
 

--- a/dashboard/backend/tests/test_backtest_isolation.py
+++ b/dashboard/backend/tests/test_backtest_isolation.py
@@ -5,21 +5,19 @@ Uses a temporary test database.
 
 import pytest
 import tempfile
-import sys
 from pathlib import Path
 
 # Add backend to path
 from fastapi.testclient import TestClient
-from dashboard.backend.app import app
-from dashboard.backend.database import BacktestDatabase
 import uuid
 
 @pytest.fixture
 def temp_db():
     """Create a temporary test database."""
+    import dashboard.backend.database as db_module
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        test_db = BacktestDatabase(db_path=db_path)
+        test_db = db_module.BacktestDatabase(db_path=db_path)
         yield test_db
         # Cleanup happens automatically when tmpdir is deleted
 
@@ -37,7 +35,7 @@ def client(temp_db, monkeypatch):
     monkeypatch.setattr(db_module, "db", temp_db)
     monkeypatch.setattr(backtests_module, "db", temp_db)
 
-    return TestClient(app)
+    return TestClient(app_module.app)
 
 def test_runs_listing_is_public_by_design(client, temp_db):
     """GET /runs is a PUBLIC listing (run metadata only): the route docstring

--- a/dashboard/backend/tests/test_baseline_generator_offline.py
+++ b/dashboard/backend/tests/test_baseline_generator_offline.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-import dashboard.backend.baseline_generator as baseline_module
+from dashboard.backend import baseline_generator as baseline_module
 from dashboard.backend.baseline_generator import BaselineGenerator
 from dashboard.backend.infrastructure.market_data.alpaca_bars import (
     MarketDataUnavailableError,

--- a/dashboard/backend/tests/test_baseline_resolver.py
+++ b/dashboard/backend/tests/test_baseline_resolver.py
@@ -1,8 +1,5 @@
 """Tests for baseline run pairing with external backtests."""
 
-import sys
-from pathlib import Path
-
 from dashboard.backend.baseline_resolver import resolve_baselines_for_run
 
 

--- a/dashboard/backend/tests/test_chart_style.py
+++ b/dashboard/backend/tests/test_chart_style.py
@@ -7,7 +7,6 @@ from dashboard.backend.chart_style import (
     series_kind,
 )
 from dashboard.backend.equity_plot import (
-    gapless_chart_x_labels,
     resolve_agent_chart_label,
 )
 

--- a/dashboard/backend/tests/test_discord_linking.py
+++ b/dashboard/backend/tests/test_discord_linking.py
@@ -8,14 +8,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 from dashboard.backend.app import app
-from dashboard.backend.users import UserStore
+import dashboard.backend.users as users_module
 from dashboard.backend.api import discord_oauth
 
 
 @pytest.fixture
 def temp_user_store(tmp_path, monkeypatch):
-    store = UserStore(db_path=tmp_path / "discord_auth.db")
-    import dashboard.backend.users as users_module
+    store = users_module.UserStore(db_path=tmp_path / "discord_auth.db")
 
     monkeypatch.setattr(users_module, "user_store", store)
     # discord router imports user_store at module level — re-bind it too

--- a/dashboard/backend/tests/test_execution_backends.py
+++ b/dashboard/backend/tests/test_execution_backends.py
@@ -21,7 +21,6 @@ def test_paper_backend_is_designed_for_stub():
 import pandas as pd
 
 import dashboard.backend.execution.backtest_backend as bb_mod
-from dashboard.backend.execution.backtest_backend import BacktestBackend, load_news_sentiment
 from dashboard.backend.api.v2.models import ContextEnvelope, SubmitAck
 
 
@@ -31,7 +30,7 @@ def test_news_sentiment_fail_closed_when_plan1_absent(monkeypatch):
     import sys
     monkeypatch.setitem(sys.modules,
                         "dashboard.backend.integrations.news_sentiment", None)
-    sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
+    sentiment, overview = bb_mod.load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
     assert sentiment == {}
     assert overview is None
 
@@ -60,7 +59,7 @@ def test_backtest_backend_emits_typed_context(monkeypatch):
     monkeypatch.setattr(bb_mod.ext, "AlpacaDataLoader", lambda: _Loader())
     monkeypatch.setattr(bb_mod, "DJIA_30", symbols, raising=False)
 
-    backend = BacktestBackend(
+    backend = bb_mod.BacktestBackend(
         run_id="run_test_1", session_id="sess_1", agent_name="a",
         model_name="m", start_date="2026-04-15", end_date="2026-04-16",
     )
@@ -98,7 +97,7 @@ def test_news_sentiment_fail_closed_when_loader_raises(monkeypatch):
     # Plan 1 adapter exists but throws at call time → still fail-closed.
     _install_fake_adapter(monkeypatch, RuntimeError("news service down"))
 
-    sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
+    sentiment, overview = bb_mod.load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
     assert sentiment == {} and overview is None
 
 
@@ -115,7 +114,7 @@ def test_news_sentiment_loader_failure_is_logged(monkeypatch, caplog):
     _install_fake_adapter(monkeypatch, KeyError("sentiment_score"))
 
     with caplog.at_level("ERROR"):
-        sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
+        sentiment, overview = bb_mod.load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
 
     assert sentiment == {} and overview is None
     assert any("sentiment_score" in r.getMessage() for r in caplog.records)
@@ -129,7 +128,7 @@ def test_news_sentiment_import_failure_is_logged(monkeypatch, caplog):
                         "dashboard.backend.integrations.news_sentiment", None)
 
     with caplog.at_level("ERROR"):
-        sentiment, overview = load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
+        sentiment, overview = bb_mod.load_news_sentiment(["AAPL"], "2026-04-15T10:30:00+00:00")
 
     assert sentiment == {} and overview is None
     assert any("news_sentiment" in r.getMessage() for r in caplog.records)
@@ -138,7 +137,7 @@ def test_news_sentiment_import_failure_is_logged(monkeypatch, caplog):
 def test_apply_decisions_executes_pre_validated_actions():
     # Per-action validation now happens at the v2 boundary (validate_actions);
     # the backend receives only valid actions and reports execution results.
-    backend = BacktestBackend.__new__(BacktestBackend)
+    backend = bb_mod.BacktestBackend.__new__(bb_mod.BacktestBackend)
     backend.run_id = "run_exec"
 
     class _StubSession:
@@ -172,7 +171,7 @@ def test_cancel_makes_context_report_closed(monkeypatch):
     monkeypatch.setattr(bb_mod.ext, "AlpacaDataLoader", lambda: _Loader())
     monkeypatch.setattr(bb_mod, "DJIA_30", symbols, raising=False)
 
-    backend = BacktestBackend(
+    backend = bb_mod.BacktestBackend(
         run_id="run_closed_1", session_id="sess_c", agent_name="a",
         model_name="m", start_date="2026-04-15", end_date="2026-04-16",
     )

--- a/dashboard/backend/tests/test_external_backtest_api.py
+++ b/dashboard/backend/tests/test_external_backtest_api.py
@@ -1,11 +1,11 @@
 """Tests for external agent backtest API."""
 
-import sys
-import uuid
-from pathlib import Path
-
 import pytest
 from fastapi.testclient import TestClient
+
+import dashboard.backend.app as app_module
+import dashboard.backend.database as db_module
+import dashboard.backend.domain.backtesting.external_run_service as svc
 
 from dashboard.backend.app import app
 from dashboard.backend.database import BacktestDatabase
@@ -18,10 +18,6 @@ from dashboard.backend.domain.backtesting.external_run_service import (
 
 @pytest.fixture
 def client(temp_db, monkeypatch):
-    import dashboard.backend.app as app_module
-    import dashboard.backend.database as db_module
-    import dashboard.backend.domain.backtesting.external_run_service as svc
-
     monkeypatch.setattr(app_module, "db", temp_db)
     monkeypatch.setattr(db_module, "db", temp_db)
     monkeypatch.setattr(svc, "db", temp_db)

--- a/dashboard/backend/tests/test_leaderboard_api.py
+++ b/dashboard/backend/tests/test_leaderboard_api.py
@@ -1,8 +1,5 @@
 """Tests for leaderboard API."""
 
-import sys
-from pathlib import Path
-
 import pytest
 from fastapi.testclient import TestClient
 

--- a/dashboard/backend/tests/test_llm_endpoint_integration.py
+++ b/dashboard/backend/tests/test_llm_endpoint_integration.py
@@ -12,13 +12,10 @@ These are endpoint-level tests (not just unit tests of the validator).
 
 import pytest
 import json
-import sys
-from pathlib import Path
-from unittest.mock import AsyncMock, patch, MagicMock
 
 # Add backend to path
 from fastapi.testclient import TestClient
-from dashboard.backend.infrastructure.llm.validator import validate_llm_response, LLMTradingDecision
+from dashboard.backend.infrastructure.llm.validator import validate_llm_response
 
 
 # ============================================================================

--- a/dashboard/backend/tests/test_llm_validator.py
+++ b/dashboard/backend/tests/test_llm_validator.py
@@ -12,15 +12,10 @@ Tests:
 
 import pytest
 import json
-import sys
-from pathlib import Path
 
-# Add backend to path
 from dashboard.backend.infrastructure.llm.validator import (
     validate_llm_response,
-    LLMTradingDecision,
     TradingAction,
-    DJIA_30,
     create_safe_prompt
 )
 

--- a/dashboard/backend/tests/test_market_data_errors.py
+++ b/dashboard/backend/tests/test_market_data_errors.py
@@ -13,11 +13,6 @@ import pytest
 
 import dashboard.backend.baseline_generator as bg_mod
 import dashboard.backend.infrastructure.market_data.alpaca_bars as bars_mod
-from dashboard.backend.baseline_generator import BaselineGenerator
-from dashboard.backend.infrastructure.market_data.alpaca_bars import (
-    AlpacaDataLoader,
-    MarketDataUnavailableError,
-)
 
 
 def _clear_creds(monkeypatch, tmp_path, mod):
@@ -31,20 +26,20 @@ def _clear_creds(monkeypatch, tmp_path, mod):
 def test_market_data_error_is_a_plain_exception():
     """The whole point of the class fix: `except Exception` at server
     boundaries must catch it (SystemExit never was)."""
-    assert issubclass(MarketDataUnavailableError, Exception)
-    assert not issubclass(MarketDataUnavailableError, SystemExit)
+    assert issubclass(bars_mod.MarketDataUnavailableError, Exception)
+    assert not issubclass(bars_mod.MarketDataUnavailableError, SystemExit)
 
 
 def test_alpaca_loader_missing_credentials_raises_not_exits(monkeypatch, tmp_path):
     _clear_creds(monkeypatch, tmp_path, bars_mod)
-    with pytest.raises(MarketDataUnavailableError):
-        AlpacaDataLoader()
+    with pytest.raises(bars_mod.MarketDataUnavailableError):
+        bars_mod.AlpacaDataLoader()
 
 
 def test_baseline_fetch_missing_credentials_raises_not_exits(monkeypatch, tmp_path):
     _clear_creds(monkeypatch, tmp_path, bg_mod)
-    generator = BaselineGenerator()
-    with pytest.raises(MarketDataUnavailableError):
+    generator = bg_mod.BaselineGenerator()
+    with pytest.raises(bars_mod.MarketDataUnavailableError):
         generator._ensure_credentials()
 
 
@@ -59,7 +54,7 @@ def test_engine_load_data_empty_raises_not_exits():
     backtester.end_date = "2026-01-02"
     backtester.data_source = "alpaca"
     backtester.symbols = ["AAPL"]
-    with pytest.raises(MarketDataUnavailableError):
+    with pytest.raises(bars_mod.MarketDataUnavailableError):
         backtester.load_data()
 
 

--- a/dashboard/backend/tests/test_module_identity.py
+++ b/dashboard/backend/tests/test_module_identity.py
@@ -9,7 +9,7 @@ a module would mean two copies of its import-time singleton state.
 
 import sys
 
-import dashboard.backend.app  # noqa: F401  -- import for its full module graph
+import dashboard.backend.app as _app  # Load full module graph for canonical identity checks
 
 CRITICAL_MODULES = [
     "database",

--- a/dashboard/backend/tests/test_pr71_review_fixes.py
+++ b/dashboard/backend/tests/test_pr71_review_fixes.py
@@ -16,7 +16,6 @@ Each test pins a defect surfaced by the review and is red before its fix:
 import threading
 import uuid
 
-import pytest
 from fastapi.testclient import TestClient
 
 import dashboard.backend.api.v2.runs as runs_mod

--- a/dashboard/backend/tests/test_protocol_api.py
+++ b/dashboard/backend/tests/test_protocol_api.py
@@ -4,10 +4,8 @@ Uses synthetic in-memory market data so no Alpaca/Yahoo network access is
 required. The whole protocol stack is exercised through the public HTTP API.
 """
 
-import sys
 import time
 import uuid
-from pathlib import Path
 
 import pandas as pd
 import pytest

--- a/dashboard/backend/tests/test_run_lifecycle_unification.py
+++ b/dashboard/backend/tests/test_run_lifecycle_unification.py
@@ -16,7 +16,6 @@ exactly like v1 runs do:
 """
 
 import sqlite3
-import time
 import uuid
 
 import pytest
@@ -599,7 +598,7 @@ def test_runstore_survives_partially_migrated_schema(tmp_path):
     conn.commit()
     conn.close()
 
-    store = RunStore(path)  # must add only heartbeat_at, without crashing
+    RunStore(path)  # must add only heartbeat_at, without crashing
     conn = sqlite3.connect(str(path))
     cols = {row[1] for row in conn.execute("PRAGMA table_info(protocol_runs)")}
     conn.close()

--- a/dashboard/backend/tests/test_strategy_store_postgres.py
+++ b/dashboard/backend/tests/test_strategy_store_postgres.py
@@ -25,17 +25,19 @@ pg_only = pytest.mark.skipif(
 # --- dispatch tests ----------------------------------------------------------
 
 def test_build_strategy_store_defaults_to_sqlite(monkeypatch, capsys):
-    import dashboard.backend.domain.strategies.repository as strategies_module
+    from dashboard.backend.domain.strategies.repository import (
+        StrategyStore,
+        _build_strategy_store,
+    )
 
     monkeypatch.delenv("CONTENT_DATABASE_URL", raising=False)
-    store = strategies_module._build_strategy_store()
-    assert isinstance(store, strategies_module.StrategyStore)
+    store = _build_strategy_store()
+    assert isinstance(store, StrategyStore)
     assert "strategy_store backend: sqlite (ephemeral on Render)" in capsys.readouterr().out
 
 
 def test_build_strategy_store_picks_postgres_when_url_set(monkeypatch, capsys):
-    import dashboard.backend.domain.strategies.repository as strategies_module
-    import dashboard.backend.domain.strategies.repository_postgres as strategies_pg_module
+    from dashboard.backend.domain.strategies.repository import _build_strategy_store
 
     created = {}
 
@@ -44,11 +46,12 @@ def test_build_strategy_store_picks_postgres_when_url_set(monkeypatch, capsys):
             created["database_url"] = database_url
 
     monkeypatch.setattr(
-        strategies_pg_module, "PostgresStrategyStore", FakePostgresStrategyStore
+        "dashboard.backend.domain.strategies.repository_postgres.PostgresStrategyStore",
+        FakePostgresStrategyStore,
     )
     monkeypatch.setenv("CONTENT_DATABASE_URL", "postgresql://fake/db")
 
-    store = strategies_module._build_strategy_store()
+    store = _build_strategy_store()
 
     assert isinstance(store, FakePostgresStrategyStore)
     assert created["database_url"] == "postgresql://fake/db"
@@ -57,14 +60,17 @@ def test_build_strategy_store_picks_postgres_when_url_set(monkeypatch, capsys):
 
 def test_build_strategy_store_ignores_users_database_url(monkeypatch, capsys):
     """See the agent-store twin of this test (test_agent_store_postgres.py)."""
-    import dashboard.backend.domain.strategies.repository as strategies_module
+    from dashboard.backend.domain.strategies.repository import (
+        StrategyStore,
+        _build_strategy_store,
+    )
 
     monkeypatch.delenv("CONTENT_DATABASE_URL", raising=False)
     monkeypatch.setenv("USERS_DATABASE_URL", "postgresql://fake/users")
 
-    store = strategies_module._build_strategy_store()
+    store = _build_strategy_store()
 
-    assert isinstance(store, strategies_module.StrategyStore)
+    assert isinstance(store, StrategyStore)
     assert (
         "strategy_store backend: sqlite (ephemeral on Render)"
         in capsys.readouterr().out
@@ -135,13 +141,13 @@ def test_create_get_set_last_run_postgres(pg_strategy_store):
 
 @pg_only
 def test_create_retries_past_a_code_collision_postgres(pg_strategy_store, monkeypatch):
-    import dashboard.backend.domain.strategies.repository_postgres as strategies_pg_module
+    from dashboard.backend.domain.strategies.repository_postgres import secrets
 
     first = pg_strategy_store.create(prompt="first strategy")
 
     codes = iter([first["code"], "fresh456"])
     monkeypatch.setattr(
-        strategies_pg_module.secrets, "token_hex", lambda nbytes: next(codes)
+        secrets, "token_hex", lambda nbytes: next(codes)
     )
 
     second = pg_strategy_store.create(prompt="second strategy")
@@ -153,8 +159,8 @@ def test_create_retries_past_a_code_collision_postgres(pg_strategy_store, monkey
 def test_create_widens_code_space_after_20_collisions_postgres(
     pg_strategy_store, monkeypatch
 ):
-    import dashboard.backend.domain.strategies.repository_postgres as strategies_pg_module
     from dashboard.backend.domain.strategies.repository import _CODE_LENGTH
+    from dashboard.backend.domain.strategies.repository_postgres import secrets
 
     first = pg_strategy_store.create(prompt="first strategy")
 
@@ -167,7 +173,7 @@ def test_create_widens_code_space_after_20_collisions_postgres(
             return first["code"]
         return "w" * 16
 
-    monkeypatch.setattr(strategies_pg_module.secrets, "token_hex", fake_token_hex)
+    monkeypatch.setattr(secrets, "token_hex", fake_token_hex)
 
     second = pg_strategy_store.create(prompt="second strategy")
     assert second["code"] == "w" * 16
@@ -183,12 +189,12 @@ def test_create_widens_code_space_after_20_collisions_postgres(
 def test_create_raises_when_even_widened_code_collides_postgres(
     pg_strategy_store, monkeypatch
 ):
-    import dashboard.backend.domain.strategies.repository_postgres as strategies_pg_module
+    from dashboard.backend.domain.strategies.repository_postgres import secrets
 
     first = pg_strategy_store.create(prompt="first strategy")
 
     monkeypatch.setattr(
-        strategies_pg_module.secrets, "token_hex", lambda nbytes: first["code"]
+        secrets, "token_hex", lambda nbytes: first["code"]
     )
 
     with pytest.raises(RuntimeError):

--- a/dashboard/backend/tests/test_users_postgres.py
+++ b/dashboard/backend/tests/test_users_postgres.py
@@ -57,9 +57,9 @@ def test_build_user_store_picks_postgres_when_url_set(monkeypatch):
 @pytest.fixture
 def temp_postgres_store():
     require_local_postgres_url(TEST_POSTGRES_URL)
-    from dashboard.backend.users_postgres import PostgresUserStore
+    import dashboard.backend.users_postgres as users_postgres_module
 
-    store = PostgresUserStore(TEST_POSTGRES_URL)
+    store = users_postgres_module.PostgresUserStore(TEST_POSTGRES_URL)
     with store._get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute("DELETE FROM auth_sessions")
@@ -243,9 +243,9 @@ def test_change_password_and_avatar_postgres(pg_client, temp_postgres_store):
 
     # Prove the write landed in Postgres and sessions were pruned there.
     user = temp_postgres_store.get_user_by_email("nina@example.com")
-    from dashboard.backend.users import verify_password
+    import dashboard.backend.users as users_module
 
-    assert verify_password("new-sturdy-pw-2", user["password_hash"])
+    assert users_module.verify_password("new-sturdy-pw-2", user["password_hash"])
     assert pg_client.get(
         "/api/auth/me", headers={"Authorization": f"Bearer {token_a}"}
     ).status_code == 200

--- a/dashboard/backend/tests/test_v2_merge_hardening.py
+++ b/dashboard/backend/tests/test_v2_merge_hardening.py
@@ -12,11 +12,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 import dashboard.backend.api.v2.runs as runs_mod
-import dashboard.backend.execution.backtest_backend as bb_mod
 from dashboard.backend.api.v2.errors import ApiError
 from dashboard.backend.api.v2.rate_limit import TokenBucketLimiter
 from dashboard.backend.app import app
-from dashboard.backend.execution.backtest_backend import BacktestBackend
+from dashboard.backend.execution.backtest_backend import BacktestBackend, ext
 from dashboard.backend.tests._v2_fakes import FakeBackend
 
 client = TestClient(app)
@@ -39,7 +38,7 @@ def test_background_load_systemexit_marks_run_failed(monkeypatch):
         def __init__(self):
             raise SystemExit(1)
 
-    monkeypatch.setattr(bb_mod.ext, "AlpacaDataLoader", _Boom)
+    monkeypatch.setattr(ext, "AlpacaDataLoader", _Boom)
     backend = BacktestBackend(
         run_id="run_se_guard", session_id="sess_se", agent_name="a",
         model_name="m", start_date="2026-04-15", end_date="2026-04-16",

--- a/dashboard/examples/external_agent_client.py
+++ b/dashboard/examples/external_agent_client.py
@@ -436,8 +436,6 @@ def main() -> int:
                 print(f"\nCompleted early. Chart: {base}{result['compare_url']}")
                 return 0
 
-    return 0
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -5528,7 +5528,6 @@ function displayAccountMetrics(account) {
     const dayPnLEl = document.getElementById('dayPnL');
     if (dayPnLEl) {
         const dayPnL = parseFloat(account.day_pnl) || 0;
-        const dayPnLPercent = parseFloat(account.equity) ? (dayPnL / parseFloat(account.equity)) * 100 : 0;
         dayPnLEl.textContent = (dayPnL >= 0 ? '+' : '') + formatCurrency(dayPnL);
         dayPnLEl.className = 'paper-value ' + (dayPnL >= 0 ? 'positive' : 'negative');
     }
@@ -5743,9 +5742,6 @@ function displayTrades(trades) {
             const idParts = trade.id.split('::');
             if (idParts[0].length >= 14) {
                 const ts = idParts[0];
-                const year = parseInt(ts.substring(0, 4));
-                const month = parseInt(ts.substring(4, 6));
-                const day = parseInt(ts.substring(6, 8));
                 const hour = parseInt(ts.substring(8, 10));
                 const minute = parseInt(ts.substring(10, 12));
                 timeStr = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;

--- a/dashboard/scripts/alpaca_trader_with_committee.py
+++ b/dashboard/scripts/alpaca_trader_with_committee.py
@@ -12,9 +12,8 @@ The committee discusses the proposed trade and votes on execution.
 
 import json
 import subprocess
-import sys
 from pathlib import Path
-from datetime import datetime, time
+from datetime import datetime
 
 # Direct-execution bootstrap: make the repo root importable so canonical
 # `dashboard.backend.*` imports resolve (no-op when run as part of the package).
@@ -65,7 +64,7 @@ class AlpacaBotWithCommittee:
                 timeout=10
             )
             return result.stdout
-        except:
+        except Exception:
             return None
     
     def parse_account(self, output):
@@ -81,19 +80,19 @@ class AlpacaBotWithCommittee:
                 try:
                     value = line.split("$")[1].replace(",", "").strip()
                     account["buying_power"] = float(value)
-                except:
+                except Exception:
                     pass
             elif "Cash:" in line and "Portfolio" not in line:
                 try:
                     value = line.split("$")[1].replace(",", "").strip()
                     account["cash"] = float(value)
-                except:
+                except Exception:
                     pass
             elif "Portfolio Value:" in line:
                 try:
                     value = line.split("$")[1].replace(",", "").strip()
                     account["portfolio_value"] = float(value)
-                except:
+                except Exception:
                     pass
         
         return account if account else None
@@ -115,7 +114,7 @@ class AlpacaBotWithCommittee:
                     quote["mid"] = (bid + ask) / 2
                     quote["spread"] = ask - bid
                     return quote
-                except:
+                except Exception:
                     pass
         
         return None
@@ -215,7 +214,7 @@ def log_action(action, details):
     if LOG_FILE.exists():
         try:
             logs = json.loads(LOG_FILE.read_text())
-        except:
+        except Exception:
             logs = []
     
     logs.append({

--- a/dashboard/scripts/backtest.py
+++ b/dashboard/scripts/backtest.py
@@ -24,9 +24,8 @@ import json
 import subprocess
 from pathlib import Path
 from datetime import datetime, timedelta
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List
 import argparse
-import sys
 import uuid
 import requests
 
@@ -38,7 +37,7 @@ except ImportError:
     subprocess.check_call(["pip", "install", "numpy"])
     import numpy as np
 
-from backtest_engine import BacktestEngine, TradeType
+from backtest_engine import BacktestEngine
 
 # Direct-execution bootstrap: make the repo root importable so canonical
 # `dashboard.backend.*` imports resolve (no-op when run as part of the package).
@@ -142,15 +141,6 @@ class PriceFetcher:
         except Exception as e:
             print(f"    ❌ Error fetching {symbol}: {e}")
             return {}
-            if current.weekday() < 5:
-                # Random walk with slight upward drift
-                change = np.random.normal(0.0005, 0.02)  # 0.05% drift, 2% volatility
-                price = price * (1 + change)
-                prices[current.strftime("%Y-%m-%d")] = round(price, 2)
-            
-            current += timedelta(days=1)
-        
-        return prices
 
 
 # ============================================================================

--- a/dashboard/scripts/backtest_custom_algo.py
+++ b/dashboard/scripts/backtest_custom_algo.py
@@ -40,11 +40,6 @@ from backtest_hourly_agent import (  # noqa: E402
     HAS_ANTHROPIC,
 )
 
-try:
-    from anthropic import Anthropic
-except ImportError:
-    Anthropic = None  # type: ignore
-
 
 class CustomAlgoPortfolioManager(PortfolioManager):
     """Portfolio manager with user strategy blocks + enforced stop-loss rules."""
@@ -342,8 +337,6 @@ class CustomAlgoBacktester(HourlyBacktester):
         )
         db.insert_equity_points(run_id, equity_curve)
 
-        wins = sum(1 for t in manager.trades if t.get("side") == "SELL" and t.get("cost", 0) < t.get("proceeds", 0))
-        losses = max(1, sum(1 for t in manager.trades if t.get("side") == "SELL") - wins)
         wl = len([t for t in manager.trades if t.get("side") == "BUY"]) / max(1, len([t for t in manager.trades if t.get("side") == "SELL"]))
 
         result = {

--- a/dashboard/scripts/backtest_engine.py
+++ b/dashboard/scripts/backtest_engine.py
@@ -10,8 +10,8 @@ Simulates trading performance of different strategies:
 
 import json
 from pathlib import Path
-from datetime import datetime, timedelta
-from typing import List, Dict, Optional, Tuple
+from datetime import datetime
+from typing import List, Dict
 from dataclasses import dataclass, asdict
 import numpy as np
 from enum import Enum

--- a/dashboard/scripts/backtest_hourly_agent.py
+++ b/dashboard/scripts/backtest_hourly_agent.py
@@ -19,15 +19,7 @@ Usage:
 import sys
 import json
 import argparse
-import os
-import re
 from pathlib import Path
-from datetime import datetime, timedelta
-from typing import Dict, List, Tuple, Optional
-import uuid
-import numpy as np
-import pandas as pd
-import requests
 
 # Bootstrap for non-package execution contexts: when this module is run directly
 # as a file (``python dashboard/scripts/backtest_hourly_agent.py``) or imported
@@ -45,9 +37,7 @@ if not __package__:
 
 from dashboard.backend.paths import CREDENTIALS_DIR
 from dashboard.backend.database import db
-import dashboard.backend.infrastructure.llm.token_cost as token_cost
-from dashboard.backend.baseline_generator import generate_baselines
-from dashboard.backend.infrastructure.llm.validator import create_safe_prompt, create_prompt, validate_llm_response, LLMTradingDecision, DJIA_30
+from dashboard.backend.infrastructure.llm.validator import DJIA_30
 
 # Optional: LLM integration. Phase 2C2 moved the Anthropic SDK import, the
 # default model name, and the LLM request/parse workflow into the canonical

--- a/dashboard/scripts/check_alpaca_subscription.py
+++ b/dashboard/scripts/check_alpaca_subscription.py
@@ -4,7 +4,6 @@ Check your Alpaca account data subscription tier.
 """
 
 import json
-from pathlib import Path
 import sys
 
 # Direct-execution bootstrap: make the repo root importable so canonical

--- a/dashboard/scripts/diagnose_alpaca_data.py
+++ b/dashboard/scripts/diagnose_alpaca_data.py
@@ -7,7 +7,6 @@ Let's inspect what Alpaca is actually returning.
 """
 
 import json
-from pathlib import Path
 from datetime import datetime, timedelta
 import sys
 

--- a/packaging/agentictrading/src/agentictrading/runner.py
+++ b/packaging/agentictrading/src/agentictrading/runner.py
@@ -30,7 +30,6 @@ because a local hook failed.
 
 from __future__ import annotations
 
-import time
 from typing import Any, Dict, List, Optional, Union
 
 try:  # Protocol is available on 3.8+; guard for older typing backends.


### PR DESCRIPTION
Per-file triage of the 187 open CodeQL quality alerts (all `note`/`warning`-level; **0 security-severity**).

- **127 fixed** — unused imports removed, dual `import`/`from` consolidated, dead/unreachable code dropped, 1 `side-effect-in-assert` (the lone `error`) hoisted out of the assert.
- **60 left deliberately** — 27 false positives, 20 justified `empty-except` (best-effort cleanup; no logging added since it's invisible in prod here), 8 by-design `cyclic-import`, 4 module-attribute re-export FPs (caught & reverted by the test gate), 1 flagged possible-forgotten-assertion (`test_v2_runs.py`).
- Also fixes a pre-existing `NameError` — missing `import os` in the `llm_integration_example` demo.

**Verified:** backend suite `1303 passed / 0 failed`, packaging `41 passed`, AST undefined-name scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111tshvfyesPeSwjFH5ewbe