### PR TITLE
feat(sdk): run vn.py CTA strategies on ATL

### DIFF
--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -312,7 +312,7 @@ class ExternalBacktestSession:
         for symbol in symbols:
             signal = signals[symbol]
             snapshot["top_signals"][symbol] = {
-                "price": float(signal.get("price") or 0),
+                "price": float(signal.get("price") if pd.notna(signal.get("price")) else 0),
                 "rsi": float(signal.get("rsi") if pd.notna(signal.get("rsi")) else 50),
                 "macd": float(signal.get("macd") if pd.notna(signal.get("macd")) else 0),
                 "macd_signal": float(
@@ -688,13 +688,24 @@ class ExternalBacktestSession:
     # Protocol adapters (read-only; used by the Agent-Environment Protocol)
     # ------------------------------------------------------------------
 
-    def _portfolio_state_at(self, timestamp) -> Dict[str, Any]:
-        market_data = self._market_data_at(timestamp)
+    def _portfolio_state_at(
+        self, timestamp, market_data: Optional[Dict[str, pd.Series]] = None
+    ) -> Dict[str, Any]:
+        if market_data is None:
+            market_data = self._market_data_at(timestamp)
         state = self.manager.get_portfolio_state(market_data, self.price_cache, timestamp)
         state["timestamp"] = timestamp
         return state
 
-    def protocol_portfolio(self, timestamp=None) -> Dict[str, Any]:
+    def protocol_market_data(self, timestamp) -> Dict[str, pd.Series]:
+        """Raw per-symbol OHLCV rows at ``timestamp``, for callers building more than
+        one protocol view (e.g. bars + portfolio) from a single snapshot without
+        repeating the lookup."""
+        return self._market_data_at(timestamp)
+
+    def protocol_portfolio(
+        self, timestamp=None, market_data: Optional[Dict[str, pd.Series]] = None
+    ) -> Dict[str, Any]:
         """Normalized {cash, equity, positions[]} snapshot for the protocol."""
         if timestamp is None and self.timestamps:
             idx = self.step_index if self.step_index < self.total_steps else self.total_steps - 1
@@ -706,7 +717,7 @@ class ExternalBacktestSession:
                 "equity": round(self.manager.cash, 2),
                 "positions": [],
             }
-        state = self._portfolio_state_at(timestamp)
+        state = self._portfolio_state_at(timestamp, market_data)
         positions = [
             {
                 "symbol": p["symbol"],
@@ -736,8 +747,18 @@ class ExternalBacktestSession:
             for sym, sig in state["market_signals"].items()
         }
 
-    def protocol_bars(self, timestamp=None) -> Dict[str, Dict[str, Any]]:
-        """Return normalized current OHLCV bars for protocol observations."""
+    def protocol_bars(
+        self, timestamp=None, market_data: Optional[Dict[str, pd.Series]] = None
+    ) -> Dict[str, Dict[str, Any]]:
+        """Return normalized current OHLCV bars for protocol observations.
+
+        Called unconditionally on every ``GET /steps/next`` poll for every running
+        agent, so a malformed bar must never raise out of here: that would
+        permanently wedge the polling run with an unstructured 500 (the step
+        timestamp doesn't advance until a decision is submitted, so the same bad
+        row would be hit again on every retry). Symbols that fail the sanity
+        check are dropped instead, mirroring protocol_current_prices's leniency.
+        """
         if timestamp is None and self.timestamps:
             idx = max(0, min(self.step_index, self.total_steps - 1))
             timestamp = self.timestamps[idx]
@@ -745,8 +766,10 @@ class ExternalBacktestSession:
             return {}
 
         allowed = set(self.symbols) if self.symbols else None
+        if market_data is None:
+            market_data = self._market_data_at(timestamp)
         bars: Dict[str, Dict[str, Any]] = {}
-        for symbol, row in self._market_data_at(timestamp).items():
+        for symbol, row in market_data.items():
             if allowed is not None and symbol not in allowed:
                 continue
 
@@ -762,9 +785,11 @@ class ExternalBacktestSession:
                 or values["high"] < max(values["open"], values["close"])
                 or values["low"] > min(values["open"], values["close"])
             ):
-                raise ValueError(
-                    f"Invalid protocol OHLCV bar for {symbol} at {timestamp!r}"
+                print(
+                    f"⚠️ Dropping invalid protocol OHLCV bar for {symbol} at "
+                    f"{timestamp!r}: {values!r}"
                 )
+                continue
 
             bars[symbol] = {
                 "timestamp": timestamp.isoformat()

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -18,6 +18,7 @@ import os
 import uuid
 import threading
 from datetime import datetime, timedelta, timezone
+from math import isfinite
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
@@ -734,6 +735,44 @@ class ExternalBacktestSession:
             sym: float(sig.get("price") or 0)
             for sym, sig in state["market_signals"].items()
         }
+
+    def protocol_bars(self, timestamp=None) -> Dict[str, Dict[str, Any]]:
+        """Return normalized current OHLCV bars for protocol observations."""
+        if timestamp is None and self.timestamps:
+            idx = max(0, min(self.step_index, self.total_steps - 1))
+            timestamp = self.timestamps[idx]
+        if timestamp is None:
+            return {}
+
+        allowed = set(self.symbols) if self.symbols else None
+        bars: Dict[str, Dict[str, Any]] = {}
+        for symbol, row in self._market_data_at(timestamp).items():
+            if allowed is not None and symbol not in allowed:
+                continue
+
+            values = {
+                field: float(row[field])
+                for field in ("open", "high", "low", "close", "volume")
+            }
+            prices = [values[field] for field in ("open", "high", "low", "close")]
+            if (
+                not all(isfinite(price) and price > 0 for price in prices)
+                or not isfinite(values["volume"])
+                or values["volume"] < 0
+                or values["high"] < max(values["open"], values["close"])
+                or values["low"] > min(values["open"], values["close"])
+            ):
+                raise ValueError(
+                    f"Invalid protocol OHLCV bar for {symbol} at {timestamp!r}"
+                )
+
+            bars[symbol] = {
+                "timestamp": timestamp.isoformat()
+                if hasattr(timestamp, "isoformat")
+                else str(timestamp),
+                **values,
+            }
+        return bars
 
     def executed_step_timestamp(self):
         """Timestamp of the most recently advanced step (post-submit)."""

--- a/dashboard/backend/domain/runs/service.py
+++ b/dashboard/backend/domain/runs/service.py
@@ -949,7 +949,8 @@ def get_result(run_id: str) -> Dict[str, Any]:
 def _build_step_view(run, session, seq, step_id, step) -> Dict[str, Any]:
     snapshot = step.get("market_snapshot", {})
     timestamp = session.timestamps[seq]
-    portfolio = session.protocol_portfolio(timestamp)
+    market_data = session.protocol_market_data(timestamp)
+    portfolio = session.protocol_portfolio(timestamp, market_data=market_data)
     return {
         "protocol_version": PROTOCOL_VERSION,
         "run_id": run.run_id,
@@ -960,7 +961,7 @@ def _build_step_view(run, session, seq, step_id, step) -> Dict[str, Any]:
         "status": "awaiting_decision",
         "observation": {
             "market": {
-                "bars": session.protocol_bars(timestamp),
+                "bars": session.protocol_bars(timestamp, market_data=market_data),
                 "features": snapshot.get("top_signals", {}),
                 "events": [],
             },

--- a/dashboard/backend/domain/runs/service.py
+++ b/dashboard/backend/domain/runs/service.py
@@ -948,7 +948,8 @@ def get_result(run_id: str) -> Dict[str, Any]:
 
 def _build_step_view(run, session, seq, step_id, step) -> Dict[str, Any]:
     snapshot = step.get("market_snapshot", {})
-    portfolio = session.protocol_portfolio(session.timestamps[seq])
+    timestamp = session.timestamps[seq]
+    portfolio = session.protocol_portfolio(timestamp)
     return {
         "protocol_version": PROTOCOL_VERSION,
         "run_id": run.run_id,
@@ -959,7 +960,7 @@ def _build_step_view(run, session, seq, step_id, step) -> Dict[str, Any]:
         "status": "awaiting_decision",
         "observation": {
             "market": {
-                "bars": {},
+                "bars": session.protocol_bars(timestamp),
                 "features": snapshot.get("top_signals", {}),
                 "events": [],
             },

--- a/dashboard/backend/tests/domain/backtesting/test_external_run_service_move.py
+++ b/dashboard/backend/tests/domain/backtesting/test_external_run_service_move.py
@@ -190,6 +190,95 @@ def test_protocol_bars_serializes_current_allowed_symbols_only():
     assert session.protocol_bars(timestamp + pd.Timedelta(hours=1)) == {}
 
 
+def test_protocol_bars_drops_invalid_rows_instead_of_raising():
+    """protocol_bars() is polled unconditionally on every /steps/next call; a
+    malformed bar must be dropped, not raised, or it permanently 500s the run's
+    step loop (the timestamp doesn't advance until a decision is submitted).
+    """
+    timestamp = pd.Timestamp(2026, 4, 15, 10, tz=ZoneInfo("US/Eastern"))
+    session = svc.ExternalBacktestSession(
+        backtest_id="bt-bad-bar",
+        session_id="sess-bad-bar",
+        agent_name="agent-bad-bar",
+        model_name="local-model",
+        start_date="2026-04-15",
+        end_date="2026-04-16",
+        symbols=["AAPL", "MSFT"],
+    )
+    session.all_data = {
+        "AAPL": pd.DataFrame(
+            {
+                "open": [100.0],
+                "high": [102.0],
+                "low": [99.0],
+                "close": [float("nan")],
+                "volume": [1_000_000],
+            },
+            index=pd.DatetimeIndex([timestamp]),
+        ),
+        "MSFT": pd.DataFrame(
+            {
+                "open": [200.0],
+                "high": [202.0],
+                "low": [199.0],
+                "close": [201.5],
+                "volume": [2_000_000],
+            },
+            index=pd.DatetimeIndex([timestamp]),
+        ),
+    }
+
+    bars = session.protocol_bars(timestamp)
+    assert "AAPL" not in bars
+    assert bars == {
+        "MSFT": {
+            "timestamp": timestamp.isoformat(),
+            "open": 200.0,
+            "high": 202.0,
+            "low": 199.0,
+            "close": 201.5,
+            "volume": 2_000_000.0,
+        }
+    }
+
+
+def test_protocol_bars_accepts_prefetched_market_data():
+    timestamp = pd.Timestamp(2026, 4, 15, 10, tz=ZoneInfo("US/Eastern"))
+    session = svc.ExternalBacktestSession(
+        backtest_id="bt-prefetch",
+        session_id="sess-prefetch",
+        agent_name="agent-prefetch",
+        model_name="local-model",
+        start_date="2026-04-15",
+        end_date="2026-04-16",
+        symbols=["AAPL"],
+    )
+    session.all_data = {
+        "AAPL": pd.DataFrame(
+            {
+                "open": [100.0],
+                "high": [102.0],
+                "low": [99.0],
+                "close": [101.5],
+                "volume": [1_000_000],
+            },
+            index=pd.DatetimeIndex([timestamp]),
+        ),
+    }
+
+    market_data = session.protocol_market_data(timestamp)
+    assert session.protocol_bars(timestamp, market_data=market_data) == {
+        "AAPL": {
+            "timestamp": timestamp.isoformat(),
+            "open": 100.0,
+            "high": 102.0,
+            "low": 99.0,
+            "close": 101.5,
+            "volume": 1_000_000.0,
+        }
+    }
+
+
 # ---------------------------------------------------------------------------
 # Result formatting / serialization against an isolated database
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/domain/backtesting/test_external_run_service_move.py
+++ b/dashboard/backend/tests/domain/backtesting/test_external_run_service_move.py
@@ -11,7 +11,9 @@ before. Engine-coupled, network-bound flows are exercised end-to-end by
 
 import ast
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
+import pandas as pd
 import pytest
 
 from dashboard.backend.database import BacktestDatabase
@@ -139,6 +141,53 @@ def test_get_decision_format_schema():
     action = fmt["actions"][0]
     for key in ("action", "symbol", "confidence", "reasoning", "position_size"):
         assert key in action
+
+
+def test_protocol_bars_serializes_current_allowed_symbols_only():
+    timestamp = pd.Timestamp(2026, 4, 15, 10, tz=ZoneInfo("US/Eastern"))
+    session = svc.ExternalBacktestSession(
+        backtest_id="bt-bars",
+        session_id="sess-bars",
+        agent_name="agent-bars",
+        model_name="local-model",
+        start_date="2026-04-15",
+        end_date="2026-04-16",
+        symbols=["AAPL"],
+    )
+    session.all_data = {
+        "AAPL": pd.DataFrame(
+            {
+                "open": [100.0],
+                "high": [102.0],
+                "low": [99.0],
+                "close": [101.5],
+                "volume": [1_000_000],
+            },
+            index=pd.DatetimeIndex([timestamp]),
+        ),
+        "MSFT": pd.DataFrame(
+            {
+                "open": [200.0],
+                "high": [202.0],
+                "low": [199.0],
+                "close": [201.5],
+                "volume": [2_000_000],
+            },
+            index=pd.DatetimeIndex([timestamp]),
+        ),
+    }
+
+    assert session.protocol_bars(timestamp) == {
+        "AAPL": {
+            "timestamp": timestamp.isoformat(),
+            "open": 100.0,
+            "high": 102.0,
+            "low": 99.0,
+            "close": 101.5,
+            "volume": 1_000_000.0,
+        }
+    }
+    assert session.protocol_bars(timestamp + pd.Timedelta(hours=1)) == {}
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/test_protocol_api.py
+++ b/dashboard/backend/tests/test_protocol_api.py
@@ -247,6 +247,37 @@ def test_observation_bars_are_complete_and_scoped_to_allowed_symbols(client):
     }
 
 
+class _BadBarLoader:
+    def fetch_bars(self, symbols, start, end):
+        data = _synthetic_bars()
+        data["AAPL"] = data["AAPL"].copy()
+        data["AAPL"].loc[data["AAPL"].index[0], "close"] = float("nan")
+        return data
+
+
+def test_observation_bars_drops_invalid_symbol_without_500ing_the_poll_loop(client, monkeypatch):
+    """A malformed bar must not raise out of /steps/next: the offending symbol
+    is dropped from ``bars`` and the endpoint stays pollable, instead of
+    permanently wedging the run with an unstructured 500.
+    """
+    import dashboard.backend.domain.backtesting.external_run_service as ebs
+
+    monkeypatch.setattr(ebs, "AlpacaDataLoader", _BadBarLoader)
+
+    agent_id, key, _ = _new_agent(client)
+    version_id = _new_version(client, agent_id, key)
+    run_id = _create_run(client, key, version_id)
+
+    step = _wait_for_step(client, run_id, key)
+    bars = step["observation"]["market"]["bars"]
+
+    assert "AAPL" not in bars
+    assert "MSFT" in bars
+
+    resp = client.get(f"/api/v1/runs/{run_id}/steps/next", headers={"X-API-Key": key})
+    assert resp.status_code == 200, resp.text
+
+
 def test_create_run_requires_api_key(client):
     resp = client.post("/api/v1/runs", json={"config": {"start_date": "2026-04-15", "end_date": "2026-04-16"}})
     assert resp.status_code == 401

--- a/dashboard/backend/tests/test_protocol_api.py
+++ b/dashboard/backend/tests/test_protocol_api.py
@@ -212,6 +212,41 @@ def test_create_run_and_first_step(client):
     assert step["constraints"]["allow_short"] is False
 
 
+def test_observation_bars_are_complete_and_scoped_to_allowed_symbols(client):
+    agent_id, key, _ = _new_agent(client)
+    version_id = _new_version(client, agent_id, key)
+    resp = client.post(
+        "/api/v1/runs",
+        json={
+            "agent_version_id": version_id,
+            "environment": {
+                "type": "backtest",
+                "environment_id": "us-equity-hourly-v1",
+            },
+            "config": {
+                "start_date": "2026-04-15",
+                "end_date": "2026-04-16",
+                "symbols": ["AAPL"],
+            },
+        },
+        headers={"X-API-Key": key},
+    )
+    assert resp.status_code == 200, resp.text
+
+    step = _wait_for_step(client, resp.json()["run_id"], key)
+    bars = step["observation"]["market"]["bars"]
+
+    assert set(bars) == {"AAPL"}
+    assert bars["AAPL"] == {
+        "timestamp": step["timestamp"],
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.0,
+        "volume": 1_000_000.0,
+    }
+
+
 def test_create_run_requires_api_key(client):
     resp = client.post("/api/v1/runs", json={"config": {"start_date": "2026-04-15", "end_date": "2026-04-16"}})
     assert resp.status_code == 401

--- a/dashboard/examples/vnpy_cta_atl_backtest.py
+++ b/dashboard/examples/vnpy_cta_atl_backtest.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Run a trusted local vn.py CtaTemplate strategy in an ATL backtest."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import sys
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+from urllib.parse import urljoin
+
+from agentictrading import ATLClient, __version__ as atl_sdk_version
+from agentictrading.integrations.vnpy_cta import (
+    VnpyCtaAdapter,
+    VnpyCtaATLRunner,
+    VnpyCtaRunSummary,
+    VnpyCtaRuntime,
+    build_safe_manifest,
+    sanitize_error_message,
+)
+
+
+DEFAULT_STRATEGY = "vnpy_cta_double_ma_strategy:DoubleMaStrategy"
+REQUIRED_ENVIRONMENT = ("ATL_BASE_URL", "ATL_API_KEY", "ATL_AGENT_VERSION_ID")
+DISPLAY_DIAGNOSTICS = (
+    "warmup_hold",
+    "strategy_hold",
+    "decision_submitted",
+    "fills",
+    "error_hold",
+    "unsupported_actions",
+    "local_rejections",
+    "atl_rejections",
+    "timed_out_orders",
+    "timeout_hold",
+    "fatal_data_error",
+    "run_error",
+    "terminal_bar_skipped",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a local vn.py CTA strategy against ATL hourly AAPL data."
+    )
+    parser.add_argument(
+        "--strategy",
+        default=DEFAULT_STRATEGY,
+        help="trusted local strategy as module:Class (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--settings-file",
+        help="JSON object containing CtaTemplate settings",
+    )
+    parser.add_argument("--symbol", default="AAPL", help="MVP symbol: AAPL")
+    parser.add_argument("--start", required=True, help="start date (YYYY-MM-DD)")
+    parser.add_argument("--end", required=True, help="end date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--initial-cash",
+        type=float,
+        default=None,
+        help="ATL starting cash; the current environment accepts its fixed value only",
+    )
+    parser.add_argument(
+        "--output",
+        help="audit artifact JSON path (default: ~/.agentictrading/vnpy-cta/runs/)",
+    )
+    return parser
+
+
+def validate_inputs(symbol: str, start: str, end: str) -> str:
+    normalized_symbol = str(symbol).strip().upper()
+    if normalized_symbol != "AAPL":
+        raise ValueError("vn.py CTA MVP supports AAPL only")
+    try:
+        start_date = date.fromisoformat(start)
+        end_date = date.fromisoformat(end)
+    except ValueError as exc:
+        raise ValueError("start and end must use YYYY-MM-DD") from exc
+    if end_date < start_date:
+        raise ValueError("end date must not be before start date")
+    return normalized_symbol
+
+
+def required_environment(environ: Mapping[str, str]) -> dict[str, str]:
+    missing = [name for name in REQUIRED_ENVIRONMENT if not environ.get(name, "").strip()]
+    if missing:
+        raise ValueError("missing required environment variables: " + ", ".join(missing))
+    return {name: environ[name].strip() for name in REQUIRED_ENVIRONMENT}
+
+
+def load_settings(path: Optional[str]) -> dict[str, Any]:
+    if not path:
+        return {}
+    settings_path = Path(path).expanduser()
+    try:
+        value = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read settings JSON: {settings_path}") from exc
+    if not isinstance(value, dict):
+        raise ValueError("settings file must contain one JSON object")
+    return value
+
+
+def load_strategy_class(spec: str) -> type:
+    module_name, separator, class_name = str(spec).strip().partition(":")
+    if not separator or not module_name or not class_name or ":" in class_name:
+        raise ValueError("strategy must use module:Class format")
+    module = importlib.import_module(module_name)
+    strategy_class = getattr(module, class_name, None)
+    if not isinstance(strategy_class, type):
+        raise ValueError(f"strategy class not found: {spec}")
+    return strategy_class
+
+
+def default_output_path() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    name = f"vnpy-cta-{stamp}-{uuid.uuid4().hex[:8]}.json"
+    return Path.home() / ".agentictrading" / "vnpy-cta" / "runs" / name
+
+
+def build_manifest(
+    *, strategy_spec: str, settings: Mapping[str, Any], runtime: Any
+) -> dict[str, Any]:
+    module_name, _, class_name = strategy_spec.partition(":")
+    return build_safe_manifest(
+        {
+            "strategy": {
+                "module": module_name,
+                "class": class_name,
+                "settings": dict(settings),
+            },
+            "versions": {
+                "agentictrading": atl_sdk_version,
+                "vnpy": runtime.bindings.vnpy_version,
+                "vnpy_ctastrategy": runtime.bindings.cta_version,
+            },
+        }
+    )
+
+
+def format_summary(summary: VnpyCtaRunSummary, *, base_url: str) -> str:
+    compare_url = summary.compare_url
+    result_url = urljoin(base_url.rstrip("/") + "/", compare_url) if compare_url else "not returned"
+    lines = [
+        "=== vn.py CTA -> ATL result ===",
+        f"run_id: {summary.run_id or 'unknown'}",
+        f"result_url: {result_url}",
+        f"clean: {str(summary.clean).lower()}",
+        "metrics:",
+    ]
+    if summary.metrics:
+        lines.extend(f"  {key}: {value}" for key, value in sorted(summary.metrics.items()))
+    else:
+        lines.append("  none")
+
+    lines.append("diagnostics:")
+    shown = set()
+    for key in DISPLAY_DIAGNOSTICS:
+        lines.append(f"  {key}: {summary.diagnostics.get(key, 0)}")
+        shown.add(key)
+    for key in sorted(set(summary.diagnostics) - shown):
+        lines.append(f"  {key}: {summary.diagnostics[key]}")
+    lines.extend(
+        [
+            f"artifact: {summary.artifact_path}",
+            f"artifact_sha256: {summary.artifact_sha256}",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def run_cli(
+    argv: Optional[Sequence[str]] = None,
+    *,
+    environ: Optional[Mapping[str, str]] = None,
+) -> VnpyCtaRunSummary:
+    args = build_parser().parse_args(argv)
+    symbol = validate_inputs(args.symbol, args.start, args.end)
+    if args.initial_cash is not None and args.initial_cash <= 0:
+        raise ValueError("initial cash must be positive")
+    env = required_environment(environ if environ is not None else os.environ)
+    settings = load_settings(args.settings_file)
+    output = Path(args.output).expanduser() if args.output else default_output_path()
+
+    # Importing this spec executes trusted local code with the current user's rights.
+    strategy_class = load_strategy_class(args.strategy)
+    runtime = VnpyCtaRuntime(strategy_class, symbol=symbol, settings=settings)
+    manifest = build_manifest(
+        strategy_spec=args.strategy,
+        settings=settings,
+        runtime=runtime,
+    )
+    adapter = VnpyCtaAdapter(runtime, symbol=symbol, manifest=manifest)
+
+    client = ATLClient(base_url=env["ATL_BASE_URL"], api_key=env["ATL_API_KEY"])
+    runner = VnpyCtaATLRunner(client, adapter, artifact_path=output)
+    summary = runner.run_backtest(
+        agent_version_id=env["ATL_AGENT_VERSION_ID"],
+        start_date=args.start,
+        end_date=args.end,
+        initial_cash=args.initial_cash,
+    )
+    print(format_summary(summary, base_url=env["ATL_BASE_URL"]))
+    return summary
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    try:
+        run_cli(argv)
+    except Exception as exc:
+        print(f"vn.py CTA backtest failed: {sanitize_error_message(exc)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dashboard/examples/vnpy_cta_double_ma_strategy.py
+++ b/dashboard/examples/vnpy_cta_double_ma_strategy.py
@@ -1,0 +1,74 @@
+"""Minimal streaming vn.py CTA strategy for the ATL integration example."""
+
+from __future__ import annotations
+
+from collections import deque
+
+from vnpy.trader.object import BarData
+from vnpy_ctastrategy import CtaTemplate
+
+
+class DoubleMaStrategy(CtaTemplate):
+    """Trade long-only crossovers after enough hourly bars have arrived."""
+
+    author = "Agentic Trading Lab"
+
+    fast_window = 5
+    slow_window = 20
+    fixed_size = 1
+
+    fast_ma = 0.0
+    slow_ma = 0.0
+
+    parameters = ["fast_window", "slow_window", "fixed_size"]
+    variables = ["fast_ma", "slow_ma"]
+
+    def __init__(self, cta_engine, strategy_name, vt_symbol, setting):
+        super().__init__(cta_engine, strategy_name, vt_symbol, setting)
+        if self.fast_window < 1 or self.slow_window <= self.fast_window:
+            raise ValueError("slow_window must be greater than fast_window >= 1")
+        if self.fixed_size < 1 or int(self.fixed_size) != self.fixed_size:
+            raise ValueError("fixed_size must be a positive integer")
+        self._closes = deque(maxlen=int(self.slow_window))
+        self._previous_fast = None
+        self._previous_slow = None
+
+    def on_init(self):
+        self.write_log("Double MA strategy initialized; waiting for streaming bars")
+
+    def on_start(self):
+        self.write_log("Double MA strategy started")
+
+    def on_stop(self):
+        self.write_log("Double MA strategy stopped")
+
+    def on_bar(self, bar: BarData):
+        close = float(bar.close_price)
+        self._closes.append(close)
+        if len(self._closes) < self.slow_window:
+            return
+
+        closes = list(self._closes)
+        self.fast_ma = sum(closes[-self.fast_window :]) / self.fast_window
+        self.slow_ma = sum(closes) / self.slow_window
+
+        if self._previous_fast is not None and self._previous_slow is not None:
+            crossed_up = (
+                self._previous_fast <= self._previous_slow
+                and self.fast_ma > self.slow_ma
+            )
+            crossed_down = (
+                self._previous_fast >= self._previous_slow
+                and self.fast_ma < self.slow_ma
+            )
+            if crossed_up and self.pos == 0:
+                self.buy(close, int(self.fixed_size))
+            elif crossed_down and self.pos > 0:
+                self.sell(close, int(self.pos))
+
+        self._previous_fast = self.fast_ma
+        self._previous_slow = self.slow_ma
+        self.put_event()
+
+
+__all__ = ["DoubleMaStrategy"]

--- a/docs/integrations/vnpy-cta.md
+++ b/docs/integrations/vnpy-cta.md
@@ -188,8 +188,13 @@ The command prints:
 
 The ATL URL shows the persisted equity curve, trades, and common metrics. The
 local JSON artifact records each input bar, signal bar, captured CTA request,
-mapped order, ATL fill or rejection, and error classification. It never stores
-the ATL API key or strategy source.
+mapped order, ATL fill or rejection, and error classification. The ATL API key
+and strategy source are never intentionally recorded, and settings fields with
+sensitive names (`api_key`, `token`, `secret`, `password`, ...) are redacted
+recursively; free-form text such as exception messages is best-effort
+redacted against common credential shapes (`key=value`, `key: value`,
+`Bearer <token>`, URL-embedded credentials), not guaranteed against every
+possible format.
 
 `clean: true` means the run had no error HOLDs, rejections, timeouts, or fatal
 data errors. It does not mean the strategy is profitable. A profitable backtest

--- a/docs/integrations/vnpy-cta.md
+++ b/docs/integrations/vnpy-cta.md
@@ -1,0 +1,210 @@
+# Run a Local vn.py CTA Strategy on ATL
+
+This integration runs an existing vn.py `CtaTemplate` strategy against the
+standard Agentic Trading Lab (ATL) US equity backtest environment. ATL produces
+the equity curve, trades, metrics, and execution results, while the integration
+writes a local audit artifact for vn.py-specific diagnostics.
+
+## Responsibilities
+
+- **The vn.py CTA strategy** contains the trading rules and calls `buy()` or
+  `sell()` as bars arrive.
+- **The local adapter** converts ATL OHLCV data into vn.py `BarData` and maps CTA
+  orders into ATL typed orders.
+- **ATL** provides historical market data, validates orders, simulates fills,
+  maintains cash and positions, and calculates performance metrics.
+
+The adapter works like an interpreter between a driver and a racetrack: the CTA
+strategy decides when to accelerate or brake, while ATL enforces the track rules
+and records the result.
+
+The first release follows this path:
+
+```text
+ATL AAPL hourly OHLCV
+  -> vn.py BarData
+  -> local CtaTemplate.on_bar()
+  -> buy()/sell()
+  -> ATL typed Order
+  -> ATL market-order simulation
+  -> equity curve, trades, metrics, and local artifact
+```
+
+Strategy source code always runs on the user's machine. ATL does not receive,
+store, or execute the Python strategy source.
+
+## Install
+
+Create an isolated Python 3.10 or newer environment:
+
+```bash
+python3.10 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e 'packaging/agentictrading[vnpy]'
+```
+
+The optional dependency versions are pinned to:
+
+- `vnpy==4.4.0`
+- `vnpy_ctastrategy==1.3.0`
+
+## Configure ATL
+
+Create an ATL Agent and AgentVersion, then set these environment variables:
+
+```bash
+export ATL_BASE_URL="https://agentictrading.onrender.com"
+export ATL_API_KEY="ag_xxxxxxxx"
+export ATL_AGENT_VERSION_ID="agv_xxxxxxxx"
+```
+
+This flow does not require an Alpaca key, Interactive Brokers account, TWS,
+IB Gateway, or any live brokerage account. The configured ATL environment
+provides the backtest data. The API key only identifies the ATL Agent.
+
+Never place a key in strategy source, a settings file, a command-line argument,
+or the Git repository.
+
+## Run the Included Double-Moving-Average Strategy
+
+Inspect the command without importing vn.py, reading credentials, or making a
+network request:
+
+```bash
+python dashboard/examples/vnpy_cta_atl_backtest.py --help
+```
+
+Run the included example:
+
+```bash
+python dashboard/examples/vnpy_cta_atl_backtest.py \
+  --start 2026-04-01 \
+  --end 2026-04-23 \
+  --symbol AAPL
+```
+
+The strategy warms up from the incoming bar stream. It buys when the fast
+moving average crosses above the slow moving average and sells an existing
+position on the opposite crossover. This deterministic example verifies the
+integration; it is not a recommended profitable strategy.
+
+Public strategy parameters can be supplied as JSON:
+
+```json
+{
+  "fast_window": 5,
+  "slow_window": 20,
+  "fixed_size": 1
+}
+```
+
+```bash
+python dashboard/examples/vnpy_cta_atl_backtest.py \
+  --settings-file ./vnpy-settings.json \
+  --start 2026-04-01 \
+  --end 2026-04-23
+```
+
+Use `--output` to select the local audit path. Without it, artifacts are written
+under `~/.agentictrading/vnpy-cta/runs/`. The CLI accepts `--initial-cash` for
+forward compatibility, but the current ATL environment fixes initial equity at
+1000, so the option should normally be omitted.
+
+## Run a Custom Strategy
+
+The CLI imports a strategy using `module:Class` syntax:
+
+```bash
+python dashboard/examples/vnpy_cta_atl_backtest.py \
+  --strategy my_strategy:DoubleMaStrategy \
+  --settings-file ./my-settings.json \
+  --symbol AAPL \
+  --start 2026-04-01 \
+  --end 2026-04-23 \
+  --output ./artifacts/my-vnpy-run.json
+```
+
+`my_strategy.py` must be importable from the current Python environment, and the
+class must inherit from `vnpy_ctastrategy.CtaTemplate`. Import only trusted local
+strategies because importing a module grants the same permissions as running
+that Python file directly.
+
+Settings are passed to the local strategy. Fields with sensitive names such as
+`api_key`, `token`, `secret`, and `password` are replaced with `<redacted>` in
+the ATL run configuration and the local artifact.
+
+## Execution Rules
+
+### T+1 one-bar delay
+
+A strategy only knows a bar's closing price after that bar has completed. Filling
+an order at the same close after observing it would introduce look-ahead bias.
+The adapter therefore delays strategy signals by one bar:
+
+1. The first bar is buffered and produces a normal HOLD.
+2. Step N processes the signal from bar N-1.
+3. ATL simulates the resulting order at step N.
+4. The final buffered bar has no later execution step and is recorded as
+   `terminal_bar_skipped`.
+
+### Orders and risk controls
+
+- The first release supports one US equity, `AAPL`, with hourly bars.
+- It is long-only: `buy` opens a long position, and `sell` can only reduce an
+  existing long position.
+- Quantities must be positive whole shares.
+- `short`, `cover`, stop, lock, net, and cancel requests are not executed and
+  are recorded in diagnostics.
+- A CTA price is preserved in the local artifact but is not enforced as a limit
+  price. The first release maps valid orders to ATL market orders.
+- ATL independently checks cash and the 25% maximum position weight. ATL's
+  response is authoritative for rejections.
+- ATL fill prices can differ from the vn.py limit-order backtesting engine, so
+  the two engines are not expected to produce identical results.
+
+## Current Limitations
+
+- `load_bar` does not query a vn.py database. It records
+  `history_preload_unavailable`, and the strategy must warm up from consecutive
+  `on_bar` calls.
+- Full `TargetPosTemplate` behavior, multiple symbols, TickData, A-shares,
+  futures, short selling, and margin trading are not supported.
+- The integration does not connect a vn.py Gateway, Interactive Brokers, TWS,
+  IB Gateway, Alpaca account, or any live broker.
+- This is a backtest integration, not live trading.
+- It does not place live orders or model persistent limit orders, stop orders,
+  partial fills, or order cancellation.
+
+## Read the Results
+
+The command prints:
+
+- the ATL `run_id` and result URL;
+- total return, Sharpe ratio, maximum drawdown, and trade count;
+- counts for normal HOLDs, error HOLDs, unsupported actions, local rejections,
+  ATL rejections, and timeouts;
+- the local artifact path and SHA-256 digest.
+
+The ATL URL shows the persisted equity curve, trades, and common metrics. The
+local JSON artifact records each input bar, signal bar, captured CTA request,
+mapped order, ATL fill or rejection, and error classification. It never stores
+the ATL API key or strategy source.
+
+`clean: true` means the run had no error HOLDs, rejections, timeouts, or fatal
+data errors. It does not mean the strategy is profitable. A profitable backtest
+also does not prove future performance.
+
+## Diagnostic Reference
+
+| Output | Meaning |
+|---|---|
+| `warmup_hold` | The first bar was buffered as expected. |
+| `strategy_hold` | The strategy ran normally and emitted no order. |
+| `error_hold` | `on_bar` raised an exception and the step became HOLD. |
+| `unsupported_actions` | The strategy requested an unsupported CTA action. |
+| `local_rejections` | Quantity, direction, or position checks failed locally. |
+| `atl_rejections` | ATL rejected an order for cash, risk, or protocol reasons. |
+| `timeout_hold` | The ATL decision deadline expired and the step became HOLD. |
+| `fatal_data_error` | OHLCV or timestamp data violated the adapter contract. |
+| `run_error` | An ATL API, network, or other run-level failure occurred. |

--- a/docs/source/lab/external_agents.rst
+++ b/docs/source/lab/external_agents.rst
@@ -245,6 +245,35 @@ it runs the whole poll/submit loop:
    print(result["metrics"], result.get("compare_url"))
 
 
+Run a local vn.py CTA strategy
+------------------------------
+
+The vn.py CTA adapter runs a trusted local ``CtaTemplate`` strategy against
+ATL's hourly AAPL backtest data. ATL supplies OHLCV bars and remains the source
+of truth for fills, positions, the equity curve, and metrics; the local adapter
+translates ``BarData`` and ``buy``/``sell`` calls without uploading strategy
+source code.
+
+Install the optional dependencies and run the bundled double-moving-average
+example:
+
+.. code-block:: bash
+
+   python -m pip install -e 'packaging/agentictrading[vnpy]'
+   export ATL_BASE_URL="https://agentictrading.onrender.com"
+   export ATL_API_KEY="ag_xxxxxxxx"
+   export ATL_AGENT_VERSION_ID="agv_xxxxxxxx"
+
+   python dashboard/examples/vnpy_cta_atl_backtest.py \
+     --start 2026-04-01 --end 2026-04-23 --symbol AAPL
+
+The MVP is long-only, uses T+1 market execution, and does not connect a broker
+or vn.py Gateway. See the `Chinese vn.py CTA guide
+<https://github.com/Open-Finance-Lab/AgenticTrading/blob/main/docs/integrations/vnpy-cta.md>`_
+for settings, custom ``module:Class`` strategies, audit artifacts, and the full
+compatibility limits.
+
+
 Plugging in an LLM
 ------------------
 

--- a/docs/source/lab/external_agents.rst
+++ b/docs/source/lab/external_agents.rst
@@ -268,7 +268,7 @@ example:
      --start 2026-04-01 --end 2026-04-23 --symbol AAPL
 
 The MVP is long-only, uses T+1 market execution, and does not connect a broker
-or vn.py Gateway. See the `Chinese vn.py CTA guide
+or vn.py Gateway. See the `vn.py CTA integration guide
 <https://github.com/Open-Finance-Lab/AgenticTrading/blob/main/docs/integrations/vnpy-cta.md>`_
 for settings, custom ``module:Class`` strategies, audit artifacts, and the full
 compatibility limits.

--- a/docs/superpowers/plans/2026-07-26-vnpy-cta-atl-integration.md
+++ b/docs/superpowers/plans/2026-07-26-vnpy-cta-atl-integration.md
@@ -1,0 +1,344 @@
+# vn.py CTA Strategy Integration Implementation Plan
+
+> Execute this plan as a sequence of loop-engineering cycles. Each task starts
+> with a failing test, adds the smallest implementation, verifies the affected
+> surface, and ends in a focused commit.
+
+**Goal:** Run a local, bar-driven vn.py `CtaTemplate` strategy against ATL,
+convert supported `buy` and `sell` calls into typed ATL orders with a one-bar
+delay, and produce both ATL performance results and a local audit artifact.
+
+**Architecture:** ATL populates the existing `Observation.market.bars` field.
+The local `VnpyCtaAdapter` buffers one bar, calls the strategy through a minimal
+`AtlCtaEngine`, maps captured orders, and delegates execution to the existing
+`ATLClient` and `AgentRunner`. ATL remains the only source of truth for market
+data, positions, fills, and equity.
+
+**Stack:** Python 3.10+, vn.py 4.4.0, `vnpy_ctastrategy` 1.3.0, the ATL
+`agentictrading` SDK, and pytest.
+
+**Design:**
+`docs/superpowers/specs/2026-07-26-vnpy-cta-atl-integration-design.md`
+
+## Global Constraints
+
+- Branch: `feat/vnpy-cta-integration`.
+- First release: `AAPL`, hourly bars, whole shares, long-only market orders.
+- Strategy source runs only on the user's trusted local machine.
+- ATL owns market data, positions, execution, and equity.
+- Every CTA signal is delayed by one bar to prevent look-ahead bias.
+- The CTA price is audited but is not enforced as an ATL limit price.
+- Unsupported operations are explicit diagnostics, never silent HOLDs.
+- Normal HOLDs, error HOLDs, local rejections, ATL rejections, and timeouts are
+  counted separately.
+- vn.py dependencies remain optional and are imported lazily.
+- Core SDK tests run without vn.py; formal-object compatibility tests may skip
+  when the optional packages are absent.
+- Backend protocol tests never depend on vn.py.
+- Automated tests do not call live ATL, Alpaca, or broker services.
+- Existing simulated vn.py market-data behavior remains unchanged.
+
+## Task 1: Populate Current OHLCV in ATL Observations
+
+**Files:**
+
+- Modify `dashboard/backend/domain/backtesting/external_run_service.py`.
+- Modify `dashboard/backend/domain/runs/service.py`.
+- Modify the directly affected backend tests.
+
+### Step 1: Add failing protocol tests
+
+Cover these cases:
+
+- `protocol_bars()` returns current `open`, `high`, `low`, `close`, `volume`,
+  and a timezone-aware `timestamp` for each allowed symbol with data.
+- Values are plain JSON-serializable floats.
+- A single-symbol run exposes only `AAPL`.
+- Existing market features, portfolio, constraints, and step timestamps remain
+  unchanged.
+- Missing bars are omitted instead of being synthesized or forward-filled from
+  the future.
+
+```bash
+python -m pytest \
+  dashboard/backend/tests/domain/backtesting/test_external_run_service_move.py \
+  dashboard/backend/tests/test_protocol_api.py -q \
+  -k 'protocol_bars or observation_bars'
+```
+
+Expected initial result: failure because observations still contain empty bars.
+
+### Step 2: Implement the protocol boundary
+
+Reuse the session's public market-data adapter and return an ordinary mapping:
+
+```python
+{
+    "AAPL": {
+        "timestamp": "2026-04-15T10:00:00-04:00",
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.5,
+        "volume": 1_000_000.0,
+    }
+}
+```
+
+Do not import vn.py in the backend.
+
+### Step 3: Verify
+
+```bash
+python -m pytest \
+  dashboard/backend/tests/domain/backtesting/test_external_run_service_move.py \
+  dashboard/backend/tests/test_protocol_api.py -q
+git diff --check
+```
+
+Commit: `feat(protocol): expose current OHLCV bars`
+
+## Task 2: Define Orders and the Audit Contract
+
+**Files:**
+
+- Add `packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_core.py`.
+- Add `packaging/agentictrading/src/agentictrading/integrations/vnpy_cta.py`.
+- Extend `packaging/agentictrading/tests/test_vnpy_cta_integration.py`.
+
+### Step 1: Add failing core tests
+
+Cover:
+
+- `LONG + OPEN` maps to buy and `SHORT + CLOSE` maps to sell.
+- Volume must be a finite positive integer and is not silently rounded.
+- A sale larger than the synchronized position is a local rejection.
+- Short, cover, stop, lock, and net requests are unsupported actions.
+- Original CTA prices are audited but do not become ATL limit prices.
+- Diagnostic categories cannot be conflated.
+- Artifacts support deterministic JSON round trips and SHA-256 validation.
+- Loading rejects malformed JSON, unknown schemas, duplicate steps, and invalid
+  statuses.
+- Credentials and sensitive settings are redacted.
+- Importing the public integration does not import optional vn.py packages.
+
+### Step 2: Implement a pure-Python core
+
+Add explicit dataclasses, mapping logic, serialization, validation, redaction,
+and hashing. This task does not import vn.py, create a strategy, or send HTTP.
+
+### Step 3: Verify
+
+```bash
+python -m pytest packaging/agentictrading/tests/test_vnpy_cta_integration.py -q
+python -m pytest packaging/agentictrading/tests -q
+git diff --check
+```
+
+Commit: `feat(sdk): add vn.py CTA audit contract`
+
+## Task 3: Bridge the vn.py Runtime
+
+**Files:**
+
+- Add `_vnpy_cta_runtime.py`.
+- Update the public vn.py integration facade.
+- Add the `vnpy` optional dependency group to the SDK package.
+- Extend integration tests.
+
+### Step 1: Add failing runtime tests
+
+Use injectable fake bindings to verify:
+
+- Missing or incompatible optional dependencies fail only when the runtime is
+  created and provide a clear installation command.
+- Lifecycle order is `on_init -> on_start -> on_bar... -> on_stop`.
+- Strategy `inited` and `trading` flags change at the correct boundaries.
+- ATL bars become formal `BarData` with gateway `ATL`, exchange `SMART`, interval
+  `HOUR`, and timezone-aware datetimes.
+- `load_bar` returns no history and records `history_preload_unavailable`.
+- Supported orders receive stable local IDs.
+- ATL fills and rejections generate final `OrderData`; fills also generate
+  `TradeData`.
+- Each ATL portfolio observation overwrites stale `strategy.pos` state.
+
+Add optional formal-object tests with `pytest.importorskip` while keeping the
+fake-runtime tests mandatory.
+
+### Step 2: Implement lazy bindings and the minimal engine
+
+Only `_vnpy_cta_runtime.py` may import vn.py at runtime. Pin the optional extra:
+
+```toml
+[project.optional-dependencies]
+vnpy = ["vnpy==4.4.0", "vnpy_ctastrategy==1.3.0"]
+```
+
+Do not add these packages to mandatory SDK dependencies.
+
+### Step 3: Verify
+
+```bash
+python -m pytest packaging/agentictrading/tests/test_vnpy_cta_integration.py -q
+python -m pytest packaging/agentictrading/tests -q
+git diff --check
+```
+
+Commit: `feat(sdk): bridge vn.py CTA runtime`
+
+## Task 4: Implement the One-Bar Adapter State Machine
+
+**Files:**
+
+- Add `_vnpy_cta_adapter.py`.
+- Update the public facade and integration tests.
+
+### Step 1: Add failing state-machine tests
+
+Cover:
+
+- The first observation buffers a bar and produces `warmup_hold`.
+- Step N synchronizes ATL state and processes only bar N-1.
+- The current bar cannot influence the current execution step.
+- Decisions contain only typed whole-share market orders.
+- Duplicate bars are rejected.
+- Missing or malformed OHLCV, naive timestamps, and symbol mismatches raise
+  `VnpyCtaDataError`.
+- Strategy inactivity is `strategy_hold`; exceptions are `error_hold`.
+- Supported and unsupported calls in one step are recorded independently.
+- Execution hooks preserve fills and rejections and drive runtime callbacks.
+- Finalization calls `on_stop` and records `terminal_bar_skipped`.
+- Every signal timestamp is earlier than its execution timestamp.
+
+### Step 2: Implement the adapter
+
+Keep the adapter focused on ordering, runtime calls, and audit state. Reuse
+`AgentRunner` for polling, deadlines, transport errors, and decision submission.
+
+### Step 3: Verify
+
+```bash
+python -m pytest packaging/agentictrading/tests/test_vnpy_cta_integration.py -q
+python -m pytest packaging/agentictrading/tests -q
+```
+
+Commit: `feat(sdk): adapt vn.py CTA signals at T+1`
+
+## Task 5: Compose the ATL Runner
+
+**Files:**
+
+- Add `_vnpy_cta_runner.py`.
+- Update adapter, facade, and integration tests.
+
+### Step 1: Add failing runner tests
+
+Verify that the runner:
+
+- creates `us-equity-hourly-v1` runs for `AAPL`;
+- stores integration and version metadata but no sensitive settings;
+- reuses bounded `AgentRunner` loading and execution polling;
+- submits each awaiting step exactly once;
+- classifies ATL deadline HOLDs without resubmitting;
+- retrieves `RunResult`, stops the runtime, and finalizes the artifact;
+- propagates API failures with the run ID instead of converting them to strategy
+  HOLDs;
+- reports all diagnostic and execution counts accurately;
+- marks runs with error HOLDs, fatal errors, or timeouts as not clean.
+
+### Step 2: Implement by composition
+
+Compose `AgentRunner(client, adapter)`. Do not duplicate authentication,
+idempotency, polling, or error handling.
+
+### Step 3: Verify
+
+```bash
+python -m pytest packaging/agentictrading/tests -q
+python -m pytest dashboard/backend/tests/test_protocol_api.py -q
+git diff --check
+```
+
+Commit: `feat(sdk): run vn.py CTA strategies on ATL`
+
+## Task 6: Add a Deterministic Example and Documentation
+
+**Files:**
+
+- Add `dashboard/examples/vnpy_cta_double_ma_strategy.py`.
+- Add `dashboard/examples/vnpy_cta_atl_backtest.py`.
+- Add `docs/integrations/vnpy-cta.md`.
+- Update `docs/source/lab/external_agents.rst`.
+- Extend integration tests.
+
+### Step 1: Add failing CLI and example tests
+
+Cover:
+
+- `--strategy module:Class`, `--settings-file`, `--symbol`, `--start`, `--end`,
+  `--initial-cash`, and `--output`;
+- rejection of unsupported symbols and invalid date ranges;
+- clear errors for missing ATL configuration;
+- `--help` without vn.py imports, credentials, or network access;
+- sensitive settings excluded from config, logs, and artifacts;
+- a final summary with URLs, metrics, diagnostics, artifact path, and digest;
+- a formal `CtaTemplate` example using only bars, buy, sell, and streaming warmup.
+
+### Step 2: Implement the local CLI
+
+Import and initialize the strategy before creating an ATL run. Write artifacts
+under `~/.agentictrading/vnpy-cta/runs/` by default and use temporary directories
+in tests.
+
+### Step 3: Document the user contract
+
+Document responsibilities, installation, configuration, custom strategy import,
+the complete data and order path, the one-bar delay, ATL risk controls, market
+order semantics, unsupported features, result inspection, artifact diagnostics,
+and the fact that backtest profit does not prove future performance.
+
+### Step 4: Verify
+
+```bash
+python dashboard/examples/vnpy_cta_atl_backtest.py --help
+python -m pytest packaging/agentictrading/tests/test_vnpy_cta_integration.py -q
+git diff --check
+```
+
+Commit: `docs: add vn.py CTA ATL quickstart`
+
+## Task 7: Complete Regression and Smoke Verification
+
+### Step 1: Run all affected tests
+
+```bash
+python -m pip install -e 'packaging/agentictrading[vnpy]'
+python -m pytest packaging/agentictrading/tests -q
+python -m pytest dashboard/backend/tests -q
+git diff --check
+```
+
+### Step 2: Run a deterministic offline loop
+
+Use fixed OHLCV and a fake ATL client. Require at least one buy and one sell,
+strictly later execution timestamps, no short position, no error or timeout
+HOLDs, no unexpected rejections, and an identical order sequence and artifact
+summary on replay.
+
+### Step 3: Audit the change set
+
+Confirm that no `.env`, API key, absolute user path, generated artifact,
+database, private strategy source, or browser output is committed.
+
+### Step 4: Run an authorized real-data smoke
+
+After explicit authorization, run the included strategy against ATL-provided
+AAPL data without connecting a broker. Record the run and result IDs, data
+range, curve points, execution and diagnostic counts, metrics, artifact path,
+and SHA-256 digest. Do not alter parameters to fabricate trades.
+
+### Step 5: Report the result
+
+Report the branch, commits, automated tests, offline evidence, real-data
+observations, and remaining scope. A real-data return is an observation, not a
+profitability claim.

--- a/docs/superpowers/specs/2026-07-26-vnpy-cta-atl-integration-design.md
+++ b/docs/superpowers/specs/2026-07-26-vnpy-cta-atl-integration-design.md
@@ -1,0 +1,282 @@
+# vn.py CTA Strategy Integration Design
+
+Date: 2026-07-26
+Status: Approved for implementation
+Target branch: `feat/vnpy-cta-integration`
+Original base: `origin/main@3a7781a`
+
+## 1. Context
+
+ATL already validates a data-format path that converts simulated prices through
+vn.py `BarData` and back into ATL OHLCV. That path does not run a user's vn.py
+strategy. This integration adds the opposite direction:
+
+```text
+ATL market data
+  -> vn.py BarData
+  -> local CtaTemplate strategy
+  -> buy/sell signal
+  -> ATL typed Order
+  -> ATL simulated execution
+  -> equity curve, trades, metrics, and an audit artifact
+```
+
+## 2. Goals
+
+The first release lets a user run an existing bar-driven vn.py `CtaTemplate`
+strategy locally while ATL remains the source of truth for market data,
+positions, execution, and performance.
+
+The supported scope is deliberately narrow:
+
+- one US equity, `AAPL`;
+- hourly bars;
+- long-only `buy` and `sell` actions;
+- positive whole-share quantities;
+- ATL market-order simulation;
+- trusted local strategy execution;
+- ATL-hosted curves, trades, and metrics;
+- local vn.py-specific audit artifacts.
+
+## 3. Non-goals
+
+The first release does not provide:
+
+- A-shares, futures, multiple symbols, or portfolio strategies;
+- short selling, margin, `short`, or `cover` execution;
+- TickData or live market feeds;
+- vn.py Gateway, Interactive Brokers, TWS, IB Gateway, or broker execution;
+- persistent limit orders, stop orders, cancellation, or partial fills;
+- full `TargetPosTemplate` semantics;
+- vn.py database preload through `load_bar`;
+- untrusted server-side Python execution;
+- a vn.py-specific leaderboard page;
+- identical results to vn.py's native backtesting engine.
+
+## 4. User Flow
+
+The user installs the optional vn.py dependencies in a trusted Python 3.10 or
+newer environment and runs:
+
+```bash
+python dashboard/examples/vnpy_cta_atl_backtest.py \
+  --strategy my_strategy:DoubleMaStrategy \
+  --symbol AAPL \
+  --start 2026-04-01 \
+  --end 2026-04-23
+```
+
+ATL credentials are supplied through environment variables. No Alpaca,
+Interactive Brokers, or other data-provider credential is read by this client.
+
+The command reports the ATL run and result URLs, common performance metrics,
+diagnostic counts, and the path and SHA-256 digest of the local audit artifact.
+
+## 5. Architecture
+
+```text
+ATL Run API
+  | Observation: current AAPL OHLCV, portfolio, and constraints
+  v
+VnpyCtaAdapter on the user's machine
+  | synchronize the ATL position
+  | convert ATL OHLCV to vn.py BarData
+  | apply a one-bar delay
+  | call CtaTemplate.on_bar()
+  | capture buy()/sell()
+  v
+ATL Decision and typed Order
+  |
+  v
+ATL validation and simulated execution
+  | cash and 25% position-weight checks
+  | long-only enforcement
+  | fills, equity curve, and metrics
+  +-> ATL persists common results
+  +-> local artifact persists vn.py diagnostics
+```
+
+The adapter never maintains a second cash or position ledger. ATL execution
+results and each subsequent portfolio observation are authoritative.
+
+## 6. Components
+
+### 6.1 Protocol bars
+
+The existing `observation.market.bars` field is populated with the complete
+current OHLCV bar for each allowed symbol that has data at the current step:
+
+```json
+{
+  "market": {
+    "bars": {
+      "AAPL": {
+        "timestamp": "2026-04-15T10:00:00-04:00",
+        "open": 198.1,
+        "high": 201.3,
+        "low": 197.8,
+        "close": 200.75,
+        "volume": 1280000.0
+      }
+    },
+    "features": {},
+    "events": []
+  }
+}
+```
+
+Timestamps are timezone-aware and match the step timestamp. Prices are finite
+and positive; volume is finite and non-negative. The backend returns ordinary
+dictionaries and does not depend on vn.py. Existing clients can ignore the
+newly populated field, preserving protocol 1.0 compatibility.
+
+### 6.2 `AtlCtaEngine`
+
+This minimal local engine satisfies the `CtaTemplate` boundary without copying
+vn.py's full CTA engine. It captures `send_order` calls, assigns stable local
+order IDs, records original CTA arguments for audit, reports backtesting mode,
+and records unsupported operations explicitly.
+
+It recognizes `Direction.LONG + Offset.OPEN` as a buy and
+`Direction.SHORT + Offset.CLOSE` as a sale of an existing long position. It does
+not own cash, positions, or execution state.
+
+### 6.3 `VnpyCtaRuntime`
+
+The runtime lazily loads the optional vn.py dependencies, validates compatible
+versions, constructs `AAPL.SMART` `BarData`, drives the strategy lifecycle, and
+converts ATL fills and rejections into vn.py callbacks.
+
+Lifecycle order is:
+
+```text
+construct
+  -> on_init()
+  -> inited=True
+  -> trading=True
+  -> on_start()
+  -> on_bar()/on_order()/on_trade()
+  -> on_stop()
+  -> trading=False
+```
+
+`load_bar` returns no database history and records
+`history_preload_unavailable`. Compatible strategies must warm up from the
+stream of `on_bar` calls.
+
+### 6.4 `VnpyCtaAdapter`
+
+The adapter implements the ATL SDK `decide(observation)` boundary. It validates
+bar data, synchronizes `strategy.pos` from the ATL portfolio, applies the
+one-bar delay, captures CTA orders, maps supported actions into typed ATL
+orders, and records every normal HOLD, error HOLD, rejection, timeout, and
+unsupported action.
+
+### 6.5 Runner and CLI
+
+`VnpyCtaATLRunner` composes the existing `ATLClient` and `AgentRunner`; it does
+not duplicate authentication, retry, idempotency, deadline, or polling logic.
+The example CLI imports a trusted local strategy, parses public settings, runs
+the backtest, and writes an artifact even when strategy-level errors occur.
+
+## 7. One-bar Execution Delay
+
+Calling `on_bar` after a bar closes and filling at the same close would leak
+future information. The adapter therefore uses this state machine:
+
+1. Buffer the first bar and submit a normal HOLD.
+2. At step N, synchronize the position from ATL.
+3. Pass buffered bar N-1 to `on_bar`.
+4. Map captured orders into the decision for step N.
+5. Buffer bar N for the next step.
+6. Apply ATL fills or rejections to vn.py callbacks.
+7. Record `terminal_bar_skipped` for the final bar, which has no later step.
+
+Every executable order has an execution timestamp later than its signal bar.
+
+## 8. Order Mapping
+
+```text
+strategy.buy(price, volume)
+  -> Order(symbol="AAPL", side="buy", quantity_type="shares",
+           quantity=volume, order_type="market")
+
+strategy.sell(price, volume)
+  -> Order(symbol="AAPL", side="sell", quantity_type="shares",
+           quantity=volume, order_type="market")
+```
+
+Volume must be a finite positive integer and is never silently rounded. A sell
+cannot exceed the synchronized long position. Unsupported directions or flags
+are recorded as `unsupported_action`. The original CTA price is audited but not
+enforced as a limit; every such mapping records `limit_price_not_enforced`.
+ATL independently applies cash and maximum-position-weight checks.
+
+## 9. Audit Artifact
+
+The local JSON artifact contains:
+
+- schema version and ATL run metadata;
+- ATL SDK, vn.py, and `vnpy_ctastrategy` versions;
+- strategy module, class, public settings, and optional code commit;
+- each observation timestamp and OHLCV bar;
+- captured CTA calls and mapped ATL orders;
+- ATL fills, warnings, rejections, and run status;
+- categorized HOLDs, unsupported actions, rejections, and timeouts;
+- summary counts and a SHA-256 digest.
+
+API keys, full environment variables, credentials embedded in URLs, and
+strategy source are excluded. Sensitive settings and error messages are
+redacted and bounded.
+
+## 10. Error Categories
+
+| Condition | Behavior | Category |
+|---|---|---|
+| Strategy emits no order | Submit empty orders | `strategy_hold` |
+| First bar is buffered | Submit empty orders | `warmup_hold` |
+| `on_bar` raises | Submit empty orders and continue | `error_hold` |
+| Unsupported CTA action | Ignore that call, keep valid calls | `unsupported_action` |
+| Invalid volume or excess sale | Reject locally | `local_rejection` |
+| ATL rejects an order | Preserve ATL validation | `atl_rejection` |
+| Decision deadline expires | Accept ATL automatic HOLD | `timeout_hold` |
+| Bar contract is invalid | Stop the local driver | `fatal_data_error` |
+| Final bar cannot execute | Do not call the strategy | `terminal_bar_skipped` |
+
+Error HOLDs are never counted as normal strategy HOLDs. Runs containing errors,
+fatal data failures, or timeouts remain useful for debugging but are not marked
+clean.
+
+## 11. Verification
+
+The test suite covers protocol serialization, optional dependency behavior,
+formal vn.py object construction, lifecycle ordering, order mapping, position
+reconciliation, T+1 execution, error classification, artifact validation and
+redaction, CLI behavior, and a deterministic offline end-to-end loop.
+
+The deterministic fixture must produce at least one buy and one sell, never
+create a short position, execute every order after its signal bar, and produce
+the same order sequence and artifact summary when replayed.
+
+A real-data smoke test records the ATL run, result, curve points, diagnostics,
+and artifact digest. Its return is evidence about the tested strategy and data,
+not proof of future profitability.
+
+## 12. Acceptance Criteria
+
+1. A local bar-driven `CtaTemplate` strategy runs with one command.
+2. ATL observations expose complete current OHLCV bars.
+3. The adapter constructs formal vn.py `BarData` objects.
+4. A deterministic AAPL fixture produces both buy and sell actions.
+5. Every strategy signal is executed with a one-bar delay.
+6. ATL persists an equity curve, trades, and standard metrics.
+7. The local artifact distinguishes all expected diagnostic categories.
+8. SDK users who do not install vn.py remain unaffected.
+9. SDK, backend, protocol, and end-to-end tests pass.
+10. Documentation states the execution differences and first-release limits.
+
+## 13. Future Work
+
+Later loops can evaluate multiple US equities, fuller order semantics, A-share
+market rules, vn.py Gateway support, isolated server-side execution, and
+vn.py-specific leaderboard diagnostics. None is part of this first release.

--- a/packaging/agentictrading/pyproject.toml
+++ b/packaging/agentictrading/pyproject.toml
@@ -44,6 +44,12 @@ classifiers = [
 # zero-dependency install.
 dependencies = ["tzdata; platform_system == 'Windows'"]
 
+[project.optional-dependencies]
+vnpy = [
+    "vnpy==4.4.0",
+    "vnpy_ctastrategy==1.3.0",
+]
+
 [project.urls]
 Homepage = "https://agentic-trading-lab.vercel.app/"
 Documentation = "https://finagent-orchestration.readthedocs.io/"

--- a/packaging/agentictrading/src/agentictrading/integrations/__init__.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/__init__.py
@@ -4,5 +4,8 @@ The public surface is defined once, by :mod:`.tradingagents`. Re-exporting it
 by name here meant two hand-maintained lists, which had already drifted apart.
 """
 
+from . import vnpy_cta
 from .tradingagents import *  # noqa: F401,F403
-from .tradingagents import __all__
+from .tradingagents import __all__ as _tradingagents_all
+
+__all__ = [*_tradingagents_all, "vnpy_cta"]

--- a/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_adapter.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_adapter.py
@@ -1,0 +1,363 @@
+"""T+1 AgentRunner adapter for local vn.py CtaTemplate strategies."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from ..models import Decision, ExecutionResult, Observation, RunResult
+from ._vnpy_cta_core import (
+    CapturedCtaOrder,
+    VnpyCtaAuditArtifact,
+    VnpyCtaAuditRecord,
+    build_audit_artifact,
+    build_safe_manifest,
+    map_captured_order,
+    sanitize_error_message,
+)
+
+
+class VnpyCtaDataError(RuntimeError):
+    """Raised when ATL's observation cannot satisfy the vn.py BarData contract."""
+
+
+@dataclass(frozen=True)
+class _PendingDecision:
+    sequence: int
+    execution_timestamp: str
+    submitted_captured: Tuple[CapturedCtaOrder, ...]
+
+
+def _parse_aware_timestamp(value: Any) -> datetime:
+    text = str(value or "").strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise VnpyCtaDataError(f"invalid Bar timestamp: {value!r}") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise VnpyCtaDataError("Bar timestamp must be timezone-aware")
+    return parsed
+
+
+class VnpyCtaAdapter:
+    """Translate delayed ATL observations into local CTA calls and Decisions."""
+
+    def __init__(
+        self,
+        runtime: Any,
+        *,
+        symbol: str,
+        manifest: Mapping[str, Any],
+    ) -> None:
+        self.runtime = runtime
+        self.symbol = str(symbol).upper()
+        if self.symbol != "AAPL":
+            raise ValueError("vn.py CTA MVP supports AAPL only")
+        self._manifest = build_safe_manifest(manifest)
+        self._records: list[VnpyCtaAuditRecord] = []
+        self._deferred_bar: Optional[Dict[str, Any]] = None
+        self._pending: Optional[_PendingDecision] = None
+        self._seen_timestamps: set[str] = set()
+        self._last_timestamp: Optional[datetime] = None
+        self._completed = False
+        self.runtime.start()
+
+    def _bar_from(self, observation: Observation) -> Dict[str, Any]:
+        bars = observation.market.get("bars") or {}
+        raw = bars.get(self.symbol)
+        if not isinstance(raw, Mapping):
+            raise VnpyCtaDataError(
+                f"Observation is missing the current {self.symbol} OHLCV bar"
+            )
+        timestamp = _parse_aware_timestamp(raw.get("timestamp"))
+        timestamp_text = timestamp.isoformat()
+        if timestamp_text in self._seen_timestamps:
+            raise VnpyCtaDataError(f"duplicate Bar timestamp: {timestamp_text}")
+        if self._last_timestamp is not None and timestamp <= self._last_timestamp:
+            raise VnpyCtaDataError("Bar timestamps must be strictly increasing")
+
+        try:
+            values = {
+                field: float(raw[field])
+                for field in ("open", "high", "low", "close", "volume")
+            }
+        except (KeyError, TypeError, ValueError) as exc:
+            raise VnpyCtaDataError("Bar is missing numeric OHLCV fields") from exc
+        if (
+            not all(
+                math.isfinite(values[field]) and values[field] > 0
+                for field in ("open", "high", "low", "close")
+            )
+            or not math.isfinite(values["volume"])
+            or values["volume"] < 0
+            or values["high"] < max(values["open"], values["close"])
+            or values["low"] > min(values["open"], values["close"])
+        ):
+            raise VnpyCtaDataError("Bar violates the OHLCV contract")
+        return {"symbol": self.symbol, "timestamp": timestamp_text, **values}
+
+    def _position_from(self, observation: Observation) -> int:
+        for position in observation.positions:
+            if str(position.get("symbol", "")).upper() != self.symbol:
+                continue
+            value = position.get("quantity", position.get("shares", 0))
+            if isinstance(value, bool):
+                raise VnpyCtaDataError("portfolio position must be an integer")
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError) as exc:
+                raise VnpyCtaDataError("portfolio position must be an integer") from exc
+            if not math.isfinite(numeric) or numeric < 0 or not numeric.is_integer():
+                raise VnpyCtaDataError("portfolio position must be a non-negative integer")
+            return int(numeric)
+        return 0
+
+    def _replace_record(self, sequence: int, **changes: Any) -> None:
+        for index, record in enumerate(self._records):
+            if record.sequence == sequence:
+                self._records[index] = replace(record, **changes)
+                return
+        raise RuntimeError(f"missing audit record sequence {sequence}")
+
+    def _mark_pending_timeout(self) -> None:
+        pending = self._pending
+        if pending is None:
+            return
+        record = next(
+            item for item in self._records if item.sequence == pending.sequence
+        )
+        diagnostics = dict(record.diagnostics)
+        if pending.submitted_captured:
+            diagnostics["timed_out_orders"] = len(pending.submitted_captured)
+        self._replace_record(
+            pending.sequence,
+            status="timeout_hold",
+            execution={"accepted": False, "outcome": "timeout_hold"},
+            diagnostics=diagnostics,
+        )
+        for captured in pending.submitted_captured:
+            self.runtime.reject_captured_order(
+                captured,
+                reason="timeout_hold",
+                timestamp=pending.execution_timestamp,
+            )
+        self._pending = None
+
+    @staticmethod
+    def _execution_dict(result: ExecutionResult) -> Dict[str, Any]:
+        return {
+            "accepted": result.accepted,
+            "fills": list(result.fills),
+            "warnings": list(result.warnings),
+            "rejections": list(result.rejections),
+            "portfolio_after": dict(result.portfolio_after),
+            "run_status": result.run_status,
+        }
+
+    def decide(self, observation: Observation) -> Decision:
+        if self._completed:
+            raise RuntimeError("vn.py CTA adapter has already completed")
+        self._mark_pending_timeout()
+        current_bar = self._bar_from(observation)
+        current_timestamp = current_bar["timestamp"]
+        position = self._position_from(observation)
+        self.runtime.sync_position(position)
+
+        sequence = len(self._records)
+        captured: Tuple[CapturedCtaOrder, ...] = ()
+        submitted_captured: list[CapturedCtaOrder] = []
+        orders = []
+        warnings: list[str] = []
+        diagnostics: Dict[str, int] = {}
+        error: Optional[str] = None
+
+        if self._deferred_bar is None:
+            status = "warmup_hold"
+            signal_timestamp = None
+            signal_bar: Dict[str, Any] = {}
+        else:
+            signal_bar = self._deferred_bar
+            signal_timestamp = str(signal_bar["timestamp"])
+            try:
+                captured = tuple(self.runtime.on_bar(signal_bar))
+            except Exception as exc:
+                captured = tuple(self.runtime.engine.drain_captured_orders())
+                status = "error_hold"
+                error = sanitize_error_message(exc)
+                for captured_order in captured:
+                    self.runtime.reject_captured_order(
+                        captured_order,
+                        reason="strategy_error",
+                        timestamp=current_timestamp,
+                    )
+            else:
+                for captured_order in captured:
+                    mapping = map_captured_order(
+                        captured_order,
+                        symbol=self.symbol,
+                        current_position=position,
+                    )
+                    warnings.extend(mapping.warnings)
+                    if mapping.order is not None:
+                        orders.append(mapping.order)
+                        submitted_captured.append(captured_order)
+                        continue
+                    key = (
+                        "unsupported_actions"
+                        if mapping.status == "unsupported_action"
+                        else "local_rejections"
+                    )
+                    diagnostics[key] = diagnostics.get(key, 0) + 1
+                    self.runtime.reject_captured_order(
+                        captured_order,
+                        reason=mapping.reason or mapping.status,
+                        timestamp=current_timestamp,
+                    )
+
+                if orders and diagnostics:
+                    status = "partial_submission"
+                elif orders:
+                    status = "decision_submitted"
+                elif diagnostics.get("local_rejections"):
+                    status = "local_rejection"
+                elif diagnostics.get("unsupported_actions"):
+                    status = "unsupported_action"
+                else:
+                    status = "strategy_hold"
+
+        record = VnpyCtaAuditRecord(
+            sequence=sequence,
+            observation_timestamp=current_timestamp,
+            signal_timestamp=signal_timestamp,
+            status=status,
+            bar=dict(current_bar),
+            signal_bar=dict(signal_bar),
+            captured_orders=captured,
+            submitted_orders=tuple(order.to_dict() for order in orders),
+            diagnostics=diagnostics,
+            warnings=tuple(dict.fromkeys(warnings)),
+            error=error,
+        )
+        self._records.append(record)
+        self._deferred_bar = current_bar
+        self._seen_timestamps.add(current_timestamp)
+        self._last_timestamp = _parse_aware_timestamp(current_timestamp)
+        self._pending = _PendingDecision(
+            sequence=sequence,
+            execution_timestamp=current_timestamp,
+            submitted_captured=tuple(submitted_captured),
+        )
+
+        return Decision(
+            orders=orders,
+            rationale=(
+                f"vn.py CTA {status}; signal={signal_timestamp or 'warmup'}"
+            ),
+            trace={
+                "integration": "vnpy_cta",
+                "status": status,
+                "sequence": sequence,
+                "signal_timestamp": signal_timestamp,
+                "observation_timestamp": current_timestamp,
+                "diagnostics": diagnostics,
+            },
+        )
+
+    def on_execution_result(self, result: ExecutionResult) -> None:
+        pending = self._pending
+        if pending is None:
+            raise RuntimeError("received execution result without a pending decision")
+        record = next(
+            item for item in self._records if item.sequence == pending.sequence
+        )
+        diagnostics = dict(record.diagnostics)
+        if result.fills:
+            diagnostics["fills"] = diagnostics.get("fills", 0) + len(result.fills)
+        if result.rejections:
+            diagnostics["atl_rejections"] = diagnostics.get(
+                "atl_rejections", 0
+            ) + len(result.rejections)
+        status = record.status
+        if result.rejections and not result.fills and pending.submitted_captured:
+            status = "atl_rejection"
+        elif result.rejections and result.fills:
+            status = "partial_submission"
+
+        self.runtime.apply_execution_result(
+            result,
+            captured_orders=pending.submitted_captured,
+            timestamp=pending.execution_timestamp,
+        )
+        self._replace_record(
+            pending.sequence,
+            status=status,
+            execution=self._execution_dict(result),
+            diagnostics=diagnostics,
+        )
+        self._pending = None
+
+    def on_run_completed(self, result: RunResult) -> None:
+        if self._completed:
+            return
+        self._mark_pending_timeout()
+        if result.run_id:
+            self._manifest["run_id"] = result.run_id
+        if self._deferred_bar is not None:
+            self._records.append(
+                VnpyCtaAuditRecord(
+                    sequence=len(self._records),
+                    observation_timestamp=str(self._deferred_bar["timestamp"]),
+                    signal_timestamp=str(self._deferred_bar["timestamp"]),
+                    status="terminal_bar_skipped",
+                    bar=dict(self._deferred_bar),
+                    signal_bar=dict(self._deferred_bar),
+                )
+            )
+        self.runtime.stop()
+        self._completed = True
+
+    def finalize_artifact(self) -> VnpyCtaAuditArtifact:
+        return build_audit_artifact(
+            manifest=self._manifest,
+            records=tuple(self._records),
+        )
+
+    @property
+    def manifest(self) -> Dict[str, Any]:
+        return build_safe_manifest(self._manifest)
+
+    def abort(self, error: Exception, *, status: str = "run_error") -> None:
+        """Stop a partial run and record an API/runtime failure without a HOLD."""
+        if self._completed:
+            return
+        pending = self._pending
+        if pending is not None:
+            for captured in pending.submitted_captured:
+                self.runtime.reject_captured_order(
+                    captured,
+                    reason="run_error",
+                    timestamp=pending.execution_timestamp,
+                )
+            self._pending = None
+        last_bar = dict(self._deferred_bar or {})
+        timestamp = str(last_bar.get("timestamp") or "run_not_started")
+        self._records.append(
+            VnpyCtaAuditRecord(
+                sequence=len(self._records),
+                observation_timestamp=timestamp,
+                status=status,
+                bar=last_bar,
+                error=sanitize_error_message(error),
+            )
+        )
+        try:
+            self.runtime.stop()
+        finally:
+            self._completed = True
+
+
+__all__ = ["VnpyCtaDataError", "VnpyCtaAdapter"]

--- a/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_adapter.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_adapter.py
@@ -16,6 +16,7 @@ from ._vnpy_cta_core import (
     build_safe_manifest,
     map_captured_order,
     sanitize_error_message,
+    validate_ohlcv_values,
 )
 
 
@@ -81,23 +82,9 @@ class VnpyCtaAdapter:
             raise VnpyCtaDataError("Bar timestamps must be strictly increasing")
 
         try:
-            values = {
-                field: float(raw[field])
-                for field in ("open", "high", "low", "close", "volume")
-            }
-        except (KeyError, TypeError, ValueError) as exc:
-            raise VnpyCtaDataError("Bar is missing numeric OHLCV fields") from exc
-        if (
-            not all(
-                math.isfinite(values[field]) and values[field] > 0
-                for field in ("open", "high", "low", "close")
-            )
-            or not math.isfinite(values["volume"])
-            or values["volume"] < 0
-            or values["high"] < max(values["open"], values["close"])
-            or values["low"] > min(values["open"], values["close"])
-        ):
-            raise VnpyCtaDataError("Bar violates the OHLCV contract")
+            values = validate_ohlcv_values(raw)
+        except ValueError as exc:
+            raise VnpyCtaDataError(f"Bar failed OHLCV validation: {exc}") from exc
         return {"symbol": self.symbol, "timestamp": timestamp_text, **values}
 
     def _position_from(self, observation: Observation) -> int:
@@ -185,7 +172,7 @@ class VnpyCtaAdapter:
             try:
                 captured = tuple(self.runtime.on_bar(signal_bar))
             except Exception as exc:
-                captured = tuple(self.runtime.engine.drain_captured_orders())
+                captured = tuple(self.runtime.drain_captured_orders())
                 status = "error_hold"
                 error = sanitize_error_message(exc)
                 for captured_order in captured:

--- a/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_core.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_core.py
@@ -1,0 +1,440 @@
+"""Dependency-free contracts for the vn.py CTA integration."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
+
+from ..models import Order
+
+
+ARTIFACT_SCHEMA_VERSION = "vnpy-cta-atl-v1"
+
+AUDIT_STATUSES = {
+    "atl_rejection",
+    "decision_submitted",
+    "error_hold",
+    "fatal_data_error",
+    "local_rejection",
+    "partial_submission",
+    "run_error",
+    "strategy_hold",
+    "terminal_bar_skipped",
+    "timeout_hold",
+    "unsupported_action",
+    "warmup_hold",
+}
+
+_SENSITIVE_KEYS = {
+    "apikey",
+    "authorization",
+    "credential",
+    "credentials",
+    "password",
+    "passwd",
+    "privatekey",
+    "secret",
+    "token",
+}
+_KEY_VALUE_RE = re.compile(
+    r"(?i)\b([a-z0-9_-]*(?:api[_-]?key|authorization|credential|password|passwd|secret|token))"
+    r"\s*=\s*[^\s,;]+"
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
+_URL_CREDENTIAL_RE = re.compile(r"(https?://)[^/@\s]+@", re.IGNORECASE)
+
+
+class ArtifactValidationError(ValueError):
+    """Raised when a vn.py CTA audit artifact violates its schema."""
+
+
+@dataclass(frozen=True)
+class CapturedCtaOrder:
+    """A normalized order call captured from a local CtaTemplate."""
+
+    order_id: str
+    timestamp: str
+    symbol: str
+    direction: str
+    offset: str
+    price: float
+    volume: float
+    stop: bool = False
+    lock: bool = False
+    net: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "order_id": self.order_id,
+            "timestamp": self.timestamp,
+            "symbol": self.symbol,
+            "direction": self.direction,
+            "offset": self.offset,
+            "price": self.price,
+            "volume": self.volume,
+            "stop": self.stop,
+            "lock": self.lock,
+            "net": self.net,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CapturedCtaOrder":
+        try:
+            return cls(
+                order_id=str(data["order_id"]),
+                timestamp=str(data["timestamp"]),
+                symbol=str(data["symbol"]),
+                direction=str(data["direction"]),
+                offset=str(data["offset"]),
+                price=float(data["price"]),
+                volume=float(data["volume"]),
+                stop=bool(data.get("stop", False)),
+                lock=bool(data.get("lock", False)),
+                net=bool(data.get("net", False)),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ArtifactValidationError("captured order fields are invalid") from exc
+
+
+@dataclass(frozen=True)
+class CtaOrderMapping:
+    """Result of translating one captured CTA order into an ATL Order."""
+
+    order: Optional[Order]
+    status: str
+    reason: Optional[str] = None
+    warnings: Tuple[str, ...] = ()
+
+
+def _finite_number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def map_captured_order(
+    captured: CapturedCtaOrder,
+    *,
+    symbol: str,
+    current_position: int,
+) -> CtaOrderMapping:
+    """Map the supported long-only CTA subset to ATL's market-order schema."""
+    expected_symbol = str(symbol).upper()
+    if str(captured.symbol).upper() != expected_symbol:
+        return CtaOrderMapping(None, "local_rejection", "symbol_mismatch")
+
+    price = _finite_number(captured.price)
+    if price is None or price <= 0:
+        return CtaOrderMapping(None, "local_rejection", "invalid_order_price")
+
+    volume = _finite_number(captured.volume)
+    if volume is None or volume <= 0 or not volume.is_integer():
+        return CtaOrderMapping(None, "local_rejection", "invalid_share_volume")
+    quantity = int(volume)
+
+    for enabled, reason in (
+        (captured.stop, "stop_not_supported"),
+        (captured.lock, "lock_not_supported"),
+        (captured.net, "net_not_supported"),
+    ):
+        if enabled:
+            return CtaOrderMapping(None, "unsupported_action", reason)
+
+    direction = str(captured.direction).strip().lower()
+    offset = str(captured.offset).strip().lower()
+    if direction == "long" and offset == "open":
+        side = "buy"
+    elif direction == "short" and offset == "close":
+        side = "sell"
+        if quantity > max(0, int(current_position)):
+            return CtaOrderMapping(
+                None, "local_rejection", "sell_exceeds_position"
+            )
+    elif direction == "short" and offset == "open":
+        return CtaOrderMapping(None, "unsupported_action", "short_not_supported")
+    elif direction == "long" and offset == "close":
+        return CtaOrderMapping(None, "unsupported_action", "cover_not_supported")
+    else:
+        return CtaOrderMapping(
+            None,
+            "unsupported_action",
+            f"unsupported_direction_offset:{direction}:{offset}",
+        )
+
+    return CtaOrderMapping(
+        order=Order(
+            symbol=expected_symbol,
+            side=side,
+            quantity=quantity,
+            quantity_type="shares",
+            order_type="market",
+        ),
+        status="mapped",
+        warnings=("limit_price_not_enforced",),
+    )
+
+
+def _normalized_key(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(value).lower())
+
+
+def _sensitive_key(key: Any) -> bool:
+    normalized = _normalized_key(key)
+    return normalized in _SENSITIVE_KEYS or any(
+        normalized.endswith(term) for term in _SENSITIVE_KEYS
+    )
+
+
+def _sanitize_text(value: str) -> str:
+    text = _KEY_VALUE_RE.sub(lambda match: f"{match.group(1)}=<redacted>", value)
+    text = _BEARER_RE.sub("Bearer <redacted>", text)
+    return _URL_CREDENTIAL_RE.sub(r"\1<redacted>@", text)
+
+
+def _sanitize_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): "<redacted>" if _sensitive_key(key) else _sanitize_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_value(item) for item in value]
+    if isinstance(value, str):
+        return _sanitize_text(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return _sanitize_text(str(value))
+
+
+def build_safe_manifest(values: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a JSON-safe manifest with credentials redacted recursively."""
+    sanitized = _sanitize_value(values)
+    if not isinstance(sanitized, dict):  # defensive: Mapping always maps to dict
+        raise TypeError("manifest must be a mapping")
+    return sanitized
+
+
+def sanitize_error_message(error: Any, *, max_length: int = 500) -> str:
+    """Remove common credential shapes and bound persisted exception text."""
+    return _sanitize_text(str(error)).strip()[:max_length]
+
+
+@dataclass(frozen=True)
+class VnpyCtaAuditRecord:
+    """One ATL step's local vn.py audit record."""
+
+    sequence: int
+    observation_timestamp: str
+    status: str
+    signal_timestamp: Optional[str] = None
+    bar: Dict[str, Any] = field(default_factory=dict)
+    signal_bar: Dict[str, Any] = field(default_factory=dict)
+    captured_orders: Tuple[CapturedCtaOrder, ...] = ()
+    submitted_orders: Tuple[Dict[str, Any], ...] = ()
+    execution: Optional[Dict[str, Any]] = None
+    diagnostics: Dict[str, int] = field(default_factory=dict)
+    warnings: Tuple[str, ...] = ()
+    error: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.sequence, int) or self.sequence < 0:
+            raise ArtifactValidationError("record sequence must be a non-negative integer")
+        if not str(self.observation_timestamp).strip():
+            raise ArtifactValidationError("record observation_timestamp is required")
+        if self.status not in AUDIT_STATUSES:
+            raise ArtifactValidationError(f"unsupported audit status: {self.status!r}")
+        for key, value in self.diagnostics.items():
+            if not str(key).strip() or key == "total_records":
+                raise ArtifactValidationError("invalid audit diagnostic key")
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ArtifactValidationError("audit diagnostic counts must be non-negative integers")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "sequence": self.sequence,
+            "observation_timestamp": self.observation_timestamp,
+            "signal_timestamp": self.signal_timestamp,
+            "status": self.status,
+            "bar": _sanitize_value(self.bar),
+            "signal_bar": _sanitize_value(self.signal_bar),
+            "captured_orders": [order.to_dict() for order in self.captured_orders],
+            "submitted_orders": [_sanitize_value(order) for order in self.submitted_orders],
+            "execution": _sanitize_value(self.execution),
+            "diagnostics": dict(self.diagnostics),
+            "warnings": list(self.warnings),
+            "error": sanitize_error_message(self.error) if self.error else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "VnpyCtaAuditRecord":
+        try:
+            return cls(
+                sequence=int(data["sequence"]),
+                observation_timestamp=str(data["observation_timestamp"]),
+                signal_timestamp=(
+                    str(data["signal_timestamp"])
+                    if data.get("signal_timestamp") is not None
+                    else None
+                ),
+                status=str(data["status"]),
+                bar=dict(data.get("bar") or {}),
+                signal_bar=dict(data.get("signal_bar") or {}),
+                captured_orders=tuple(
+                    CapturedCtaOrder.from_dict(item)
+                    for item in (data.get("captured_orders") or [])
+                ),
+                submitted_orders=tuple(
+                    dict(item) for item in (data.get("submitted_orders") or [])
+                ),
+                execution=(
+                    dict(data["execution"]) if data.get("execution") else None
+                ),
+                diagnostics={
+                    str(key): int(value)
+                    for key, value in dict(data.get("diagnostics") or {}).items()
+                },
+                warnings=tuple(str(item) for item in (data.get("warnings") or [])),
+                error=str(data["error"]) if data.get("error") else None,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ArtifactValidationError("audit record fields are invalid") from exc
+
+
+def _summary(records: Iterable[VnpyCtaAuditRecord]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    total = 0
+    for record in records:
+        total += 1
+        counts[record.status] = counts.get(record.status, 0) + 1
+        for key, value in record.diagnostics.items():
+            counts[key] = counts.get(key, 0) + value
+    counts["total_records"] = total
+    return dict(sorted(counts.items()))
+
+
+@dataclass(frozen=True)
+class VnpyCtaAuditArtifact:
+    """Credential-free, replayable evidence for one vn.py CTA ATL run."""
+
+    schema_version: str
+    manifest: Dict[str, Any]
+    records: Tuple[VnpyCtaAuditRecord, ...]
+    summary: Dict[str, int]
+
+    def __post_init__(self) -> None:
+        if self.schema_version != ARTIFACT_SCHEMA_VERSION:
+            raise ArtifactValidationError(
+                f"unsupported artifact schema: {self.schema_version!r}"
+            )
+        sequences = [record.sequence for record in self.records]
+        if len(sequences) != len(set(sequences)):
+            raise ArtifactValidationError("artifact has duplicate sequence values")
+        if sequences != sorted(sequences):
+            raise ArtifactValidationError("artifact records must be sequence ordered")
+        expected_summary = _summary(self.records)
+        if dict(self.summary) != expected_summary:
+            raise ArtifactValidationError("artifact summary does not match records")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "manifest": build_safe_manifest(self.manifest),
+            "records": [record.to_dict() for record in self.records],
+            "summary": dict(self.summary),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "VnpyCtaAuditArtifact":
+        try:
+            records = tuple(
+                VnpyCtaAuditRecord.from_dict(item)
+                for item in (data.get("records") or [])
+            )
+            return cls(
+                schema_version=str(data["schema_version"]),
+                manifest=build_safe_manifest(dict(data.get("manifest") or {})),
+                records=records,
+                summary={
+                    str(key): int(value)
+                    for key, value in dict(data.get("summary") or {}).items()
+                },
+            )
+        except ArtifactValidationError:
+            raise
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ArtifactValidationError("artifact fields are invalid") from exc
+
+
+def build_audit_artifact(
+    *,
+    manifest: Mapping[str, Any],
+    records: Iterable[VnpyCtaAuditRecord],
+) -> VnpyCtaAuditArtifact:
+    ordered = tuple(sorted(records, key=lambda record: record.sequence))
+    return VnpyCtaAuditArtifact(
+        schema_version=ARTIFACT_SCHEMA_VERSION,
+        manifest=build_safe_manifest(manifest),
+        records=ordered,
+        summary=_summary(ordered),
+    )
+
+
+def _artifact_json(artifact: VnpyCtaAuditArtifact) -> str:
+    return json.dumps(
+        artifact.to_dict(),
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+        allow_nan=False,
+    ) + "\n"
+
+
+def save_audit_artifact(
+    artifact: VnpyCtaAuditArtifact,
+    path: Path | str,
+) -> str:
+    """Write an artifact and return the SHA-256 of the exact file bytes."""
+    destination = Path(path).expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = _artifact_json(artifact)
+    destination.write_text(payload, encoding="utf-8")
+    return sha256(payload.encode("utf-8")).hexdigest()
+
+
+def load_audit_artifact(path: Path | str) -> VnpyCtaAuditArtifact:
+    """Load and fully validate a vn.py CTA audit artifact."""
+    try:
+        raw = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ArtifactValidationError(
+            f"artifact is not readable JSON: {sanitize_error_message(exc)}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise ArtifactValidationError("artifact JSON must be an object")
+    return VnpyCtaAuditArtifact.from_dict(raw)
+
+
+__all__ = [
+    "ARTIFACT_SCHEMA_VERSION",
+    "AUDIT_STATUSES",
+    "ArtifactValidationError",
+    "CapturedCtaOrder",
+    "CtaOrderMapping",
+    "VnpyCtaAuditRecord",
+    "VnpyCtaAuditArtifact",
+    "map_captured_order",
+    "build_safe_manifest",
+    "sanitize_error_message",
+    "build_audit_artifact",
+    "save_audit_artifact",
+    "load_audit_artifact",
+]

--- a/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_core.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_core.py
@@ -43,7 +43,7 @@ _SENSITIVE_KEYS = {
 }
 _KEY_VALUE_RE = re.compile(
     r"(?i)\b([a-z0-9_-]*(?:api[_-]?key|authorization|credential|password|passwd|secret|token))"
-    r"\s*=\s*[^\s,;]+"
+    r"['\"]?\s*[:=]\s*['\"]?[^\s,;'\"]+['\"]?"
 )
 _BEARER_RE = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
 _URL_CREDENTIAL_RE = re.compile(r"(https?://)[^/@\s]+@", re.IGNORECASE)
@@ -119,6 +119,39 @@ def _finite_number(value: Any) -> Optional[float]:
     except (TypeError, ValueError):
         return None
     return number if math.isfinite(number) else None
+
+
+_OHLCV_FIELDS = ("open", "high", "low", "close", "volume")
+
+
+def validate_ohlcv_values(raw: Mapping[str, Any]) -> Dict[str, float]:
+    """Extract and sanity-check an OHLCV bar's numeric fields.
+
+    Shared by both the adapter (validating an incoming ATL observation) and
+    the runtime (validating a bar payload before building vn.py's BarData) —
+    same package, same contract, so one copy instead of two independently
+    drifting ones. Raises ``ValueError`` on any missing/non-numeric field or
+    contract violation (non-finite, non-positive price, negative volume,
+    high/low inconsistent with open/close); callers decide what to do with
+    that (reject the bar, hold, etc.) since the right response differs by
+    caller.
+    """
+    try:
+        values = {field: float(raw[field]) for field in _OHLCV_FIELDS}
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("bar is missing numeric OHLCV fields") from exc
+    if (
+        not all(
+            math.isfinite(values[field]) and values[field] > 0
+            for field in ("open", "high", "low", "close")
+        )
+        or not math.isfinite(values["volume"])
+        or values["volume"] < 0
+        or values["high"] < max(values["open"], values["close"])
+        or values["low"] > min(values["open"], values["close"])
+    ):
+        raise ValueError("bar violates the OHLCV contract")
+    return values
 
 
 def map_captured_order(

--- a/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_runner.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_runner.py
@@ -1,0 +1,140 @@
+"""Run a local vn.py CTA adapter through ATL's existing typed AgentRunner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..runner import AgentRunner
+from ..models import RunResult
+from ._vnpy_cta_adapter import VnpyCtaAdapter, VnpyCtaDataError
+from ._vnpy_cta_core import (
+    ARTIFACT_SCHEMA_VERSION,
+    VnpyCtaAuditArtifact,
+    build_safe_manifest,
+    save_audit_artifact,
+)
+
+
+_UNCLEAN_COUNTERS = {
+    "atl_rejections",
+    "atl_rejection",
+    "error_hold",
+    "fatal_data_error",
+    "local_rejections",
+    "run_error",
+    "timed_out_orders",
+    "timeout_hold",
+    "unsupported_actions",
+}
+
+
+@dataclass(frozen=True)
+class VnpyCtaRunSummary:
+    """Final ATL result plus local vn.py-specific audit evidence."""
+
+    result: RunResult
+    artifact: VnpyCtaAuditArtifact
+    artifact_path: Path
+    artifact_sha256: str
+    clean: bool
+
+    @property
+    def run_id(self) -> Optional[str]:
+        return self.result.run_id
+
+    @property
+    def metrics(self) -> Dict[str, Any]:
+        return dict(self.result.metrics)
+
+    @property
+    def diagnostics(self) -> Dict[str, int]:
+        return dict(self.artifact.summary)
+
+    @property
+    def compare_url(self) -> Optional[str]:
+        value = self.result.raw.get("compare_url") if self.result.raw else None
+        return str(value) if value else None
+
+
+class VnpyCtaATLRunner:
+    """Thin orchestration wrapper; HTTP and step semantics stay in AgentRunner."""
+
+    def __init__(
+        self,
+        client: Any,
+        adapter: VnpyCtaAdapter,
+        *,
+        artifact_path: Path | str,
+    ) -> None:
+        self.client = client
+        self.adapter = adapter
+        self.artifact_path = Path(artifact_path).expanduser()
+
+    @staticmethod
+    def _dates(start_date: str, end_date: str) -> None:
+        try:
+            start = date.fromisoformat(start_date)
+            end = date.fromisoformat(end_date)
+        except ValueError as exc:
+            raise ValueError("start_date and end_date must use YYYY-MM-DD") from exc
+        if end < start:
+            raise ValueError("end_date must not be before start_date")
+
+    def _save_partial(self, error: Exception) -> None:
+        status = "fatal_data_error" if isinstance(error, VnpyCtaDataError) else "run_error"
+        self.adapter.abort(error, status=status)
+        save_audit_artifact(self.adapter.finalize_artifact(), self.artifact_path)
+
+    def run_backtest(
+        self,
+        *,
+        agent_version_id: str,
+        start_date: str,
+        end_date: str,
+        initial_cash: Optional[float] = None,
+        poll_interval: float = 2.0,
+        max_wait_seconds: Optional[float] = 300.0,
+    ) -> VnpyCtaRunSummary:
+        self._dates(start_date, end_date)
+        config = build_safe_manifest(
+            {
+                "integration": "vnpy_cta",
+                "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
+                "integration_manifest": self.adapter.manifest,
+            }
+        )
+        runner = AgentRunner(self.client, self.adapter)
+        try:
+            result = runner.run_backtest(
+                agent_version_id,
+                environment_id="us-equity-hourly-v1",
+                start_date=start_date,
+                end_date=end_date,
+                symbols=["AAPL"],
+                initial_cash=initial_cash,
+                config=config,
+                poll_interval=poll_interval,
+                max_wait_seconds=max_wait_seconds,
+            )
+        except Exception as exc:
+            self._save_partial(exc)
+            raise
+
+        artifact = self.adapter.finalize_artifact()
+        digest = save_audit_artifact(artifact, self.artifact_path)
+        clean = not any(
+            artifact.summary.get(counter, 0) > 0 for counter in _UNCLEAN_COUNTERS
+        )
+        return VnpyCtaRunSummary(
+            result=result,
+            artifact=artifact,
+            artifact_path=self.artifact_path,
+            artifact_sha256=digest,
+            clean=clean,
+        )
+
+
+__all__ = ["VnpyCtaRunSummary", "VnpyCtaATLRunner"]

--- a/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_runtime.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_runtime.py
@@ -1,0 +1,486 @@
+"""Lazy vn.py runtime bridge used by the local CTA adapter."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from types import ModuleType
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+
+from ..models import ExecutionResult
+from ._vnpy_cta_core import CapturedCtaOrder, sanitize_error_message
+
+
+class VnpyCtaDependencyError(RuntimeError):
+    """Raised when the optional vn.py CTA runtime is unavailable."""
+
+
+class VnpyCtaCompatibilityError(RuntimeError):
+    """Raised when installed vn.py packages are outside the supported range."""
+
+
+@dataclass(frozen=True)
+class VnpyBindings:
+    """All optional vn.py symbols needed by the integration."""
+
+    vnpy_version: str
+    cta_version: str
+    CtaTemplate: type
+    EngineType: Any
+    BarData: type
+    OrderData: type
+    TradeData: type
+    Direction: Any
+    Offset: Any
+    Exchange: Any
+    Interval: Any
+    Status: Any
+    OrderType: Any
+
+
+def _module(import_module: Callable[[str], ModuleType], name: str) -> ModuleType:
+    try:
+        return import_module(name)
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise VnpyCtaDependencyError(
+            "vn.py CTA integration requires optional dependencies; install with "
+            "pip install 'agentictrading[vnpy]'"
+        ) from exc
+
+
+def load_vnpy_bindings(
+    *,
+    import_module: Callable[[str], ModuleType] = importlib.import_module,
+    version_resolver: Callable[[str], str] = importlib.metadata.version,
+) -> VnpyBindings:
+    """Import vn.py symbols only when a caller explicitly creates the runtime."""
+    constants = _module(import_module, "vnpy.trader.constant")
+    objects = _module(import_module, "vnpy.trader.object")
+    cta = _module(import_module, "vnpy_ctastrategy")
+    cta_base = _module(import_module, "vnpy_ctastrategy.base")
+    try:
+        vnpy_version = version_resolver("vnpy")
+        cta_version = version_resolver("vnpy_ctastrategy")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise VnpyCtaDependencyError(
+            "vn.py CTA package metadata is missing; install with "
+            "pip install 'agentictrading[vnpy]'"
+        ) from exc
+
+    return VnpyBindings(
+        vnpy_version=vnpy_version,
+        cta_version=cta_version,
+        CtaTemplate=cta.CtaTemplate,
+        EngineType=cta_base.EngineType,
+        BarData=objects.BarData,
+        OrderData=objects.OrderData,
+        TradeData=objects.TradeData,
+        Direction=constants.Direction,
+        Offset=constants.Offset,
+        Exchange=constants.Exchange,
+        Interval=constants.Interval,
+        Status=constants.Status,
+        OrderType=constants.OrderType,
+    )
+
+
+def _major_minor(version: str) -> Tuple[int, int]:
+    match = re.match(r"^(\d+)\.(\d+)", str(version))
+    if not match:
+        raise VnpyCtaCompatibilityError(f"invalid package version: {version!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def _validate_versions(bindings: VnpyBindings) -> None:
+    vnpy = _major_minor(bindings.vnpy_version)
+    cta = _major_minor(bindings.cta_version)
+    if vnpy[0] != 4 or vnpy < (4, 4):
+        raise VnpyCtaCompatibilityError(
+            f"unsupported vnpy version {bindings.vnpy_version!r}; expected >=4.4,<5"
+        )
+    if cta[0] != 1 or cta < (1, 3):
+        raise VnpyCtaCompatibilityError(
+            "unsupported vnpy_ctastrategy version "
+            f"{bindings.cta_version!r}; expected >=1.3,<2"
+        )
+
+
+def _enum_name(value: Any) -> str:
+    name = getattr(value, "name", None)
+    return str(name if name is not None else value).strip().lower()
+
+
+def _aware_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        text = str(value).strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise ValueError(f"invalid timezone-aware timestamp: {value!r}") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"invalid timezone-aware timestamp: {value!r}")
+    return parsed
+
+
+class AtlCtaEngine:
+    """Minimal engine surface that captures CtaTemplate order calls."""
+
+    def __init__(self, bindings: VnpyBindings, *, symbol: str) -> None:
+        self.bindings = bindings
+        self.symbol = symbol.upper()
+        self.current_timestamp: Optional[str] = None
+        self.events: list[Dict[str, Any]] = []
+        self._captured: list[CapturedCtaOrder] = []
+        self._next_order = 1
+
+    def send_order(
+        self,
+        strategy: Any,
+        direction: Any,
+        offset: Any,
+        price: float,
+        volume: float,
+        stop: bool,
+        lock: bool,
+        net: bool,
+    ) -> list[str]:
+        order_id = f"atl-cta-{self._next_order}"
+        self._next_order += 1
+        self._captured.append(
+            CapturedCtaOrder(
+                order_id=order_id,
+                timestamp=self.current_timestamp or "",
+                symbol=self.symbol,
+                direction=_enum_name(direction),
+                offset=_enum_name(offset),
+                price=price,
+                volume=volume,
+                stop=bool(stop),
+                lock=bool(lock),
+                net=bool(net),
+            )
+        )
+        return [order_id]
+
+    def drain_captured_orders(self) -> Tuple[CapturedCtaOrder, ...]:
+        captured = tuple(self._captured)
+        self._captured.clear()
+        return captured
+
+    def cancel_order(self, strategy: Any, vt_orderid: str) -> None:
+        self.events.append(
+            {"type": "cancel_not_supported", "order_id": str(vt_orderid)}
+        )
+
+    def cancel_all(self, strategy: Any) -> None:
+        self.events.append({"type": "cancel_all_not_supported"})
+
+    def get_engine_type(self) -> Any:
+        return self.bindings.EngineType.BACKTESTING
+
+    def get_pricetick(self, strategy: Any) -> float:
+        return 0.01
+
+    def get_size(self, strategy: Any) -> int:
+        return 1
+
+    def load_bar(
+        self,
+        vt_symbol: str,
+        days: int,
+        interval: Any,
+        callback: Callable[..., Any],
+        use_database: bool = False,
+    ) -> list[Any]:
+        self.events.append(
+            {
+                "type": "history_preload_unavailable",
+                "vt_symbol": str(vt_symbol),
+                "days": int(days),
+                "use_database": bool(use_database),
+            }
+        )
+        return []
+
+    def load_tick(self, *args: Any, **kwargs: Any) -> list[Any]:
+        self.events.append({"type": "tick_history_not_supported"})
+        return []
+
+    def write_log(self, msg: str, strategy: Any = None) -> None:
+        self.events.append(
+            {"type": "strategy_log", "message": sanitize_error_message(msg)}
+        )
+
+    def put_strategy_event(self, strategy: Any) -> None:
+        return None
+
+    def send_notification(self, msg: str, strategy: Any) -> None:
+        self.events.append(
+            {
+                "type": "notification_not_sent",
+                "message": sanitize_error_message(msg),
+            }
+        )
+
+    def sync_strategy_data(self, strategy: Any) -> None:
+        self.events.append({"type": "strategy_sync_local_only"})
+
+
+class VnpyCtaRuntime:
+    """Own a local CtaTemplate instance and translate ATL lifecycle callbacks."""
+
+    def __init__(
+        self,
+        strategy_class: type,
+        *,
+        symbol: str,
+        settings: Mapping[str, Any],
+        strategy_name: Optional[str] = None,
+        bindings: Optional[VnpyBindings] = None,
+    ) -> None:
+        self.bindings = bindings or load_vnpy_bindings()
+        _validate_versions(self.bindings)
+        if not isinstance(strategy_class, type) or not issubclass(
+            strategy_class, self.bindings.CtaTemplate
+        ):
+            raise VnpyCtaCompatibilityError(
+                "strategy class must inherit vnpy_ctastrategy.CtaTemplate"
+            )
+
+        self.symbol = str(symbol).upper()
+        if self.symbol != "AAPL":
+            raise VnpyCtaCompatibilityError("vn.py CTA MVP supports AAPL only")
+        self.engine = AtlCtaEngine(self.bindings, symbol=self.symbol)
+        self.strategy = strategy_class(
+            self.engine,
+            strategy_name or strategy_class.__name__,
+            f"{self.symbol}.SMART",
+            dict(settings),
+        )
+        self.started = False
+        self._next_trade = 1
+
+    @property
+    def events(self) -> list[Dict[str, Any]]:
+        return self.engine.events
+
+    def start(self) -> None:
+        if self.started:
+            return
+        self.strategy.on_init()
+        self.strategy.inited = True
+        self.strategy.trading = True
+        self.strategy.on_start()
+        self.started = True
+
+    def stop(self) -> None:
+        if not self.started:
+            return
+        try:
+            self.strategy.on_stop()
+        finally:
+            self.strategy.trading = False
+            self.started = False
+
+    def sync_position(self, quantity: Any) -> None:
+        if isinstance(quantity, bool):
+            raise ValueError("position must be a non-negative integer")
+        try:
+            numeric = float(quantity)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("position must be a non-negative integer") from exc
+        if not math.isfinite(numeric) or numeric < 0 or not numeric.is_integer():
+            raise ValueError("position must be a non-negative integer")
+        self.strategy.pos = int(numeric)
+
+    def _bar_data(self, payload: Mapping[str, Any]) -> Any:
+        timestamp = _aware_datetime(payload.get("timestamp"))
+        try:
+            values = {
+                field: float(payload[field])
+                for field in ("open", "high", "low", "close", "volume")
+            }
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("bar payload is missing numeric OHLCV fields") from exc
+        if (
+            not all(math.isfinite(values[key]) and values[key] > 0 for key in ("open", "high", "low", "close"))
+            or not math.isfinite(values["volume"])
+            or values["volume"] < 0
+            or values["high"] < max(values["open"], values["close"])
+            or values["low"] > min(values["open"], values["close"])
+        ):
+            raise ValueError("bar payload violates the OHLCV contract")
+        return self.bindings.BarData(
+            gateway_name="ATL",
+            symbol=self.symbol,
+            exchange=self.bindings.Exchange.SMART,
+            datetime=timestamp,
+            interval=self.bindings.Interval.HOUR,
+            open_price=values["open"],
+            high_price=values["high"],
+            low_price=values["low"],
+            close_price=values["close"],
+            volume=values["volume"],
+        )
+
+    def on_bar(self, payload: Mapping[str, Any]) -> Tuple[CapturedCtaOrder, ...]:
+        if not self.started:
+            raise RuntimeError("vn.py CTA runtime must be started before on_bar")
+        bar = self._bar_data(payload)
+        self.engine.current_timestamp = bar.datetime.isoformat()
+        self.strategy.on_bar(bar)
+        return self.engine.drain_captured_orders()
+
+    def _enum_member(self, enum: Any, name: str) -> Any:
+        return getattr(enum, str(name).upper())
+
+    def _order_data(
+        self,
+        captured: CapturedCtaOrder,
+        *,
+        status: Any,
+        traded: float,
+        timestamp: str,
+    ) -> Any:
+        return self.bindings.OrderData(
+            gateway_name="ATL",
+            symbol=self.symbol,
+            exchange=self.bindings.Exchange.SMART,
+            orderid=captured.order_id,
+            type=self.bindings.OrderType.MARKET,
+            direction=self._enum_member(self.bindings.Direction, captured.direction),
+            offset=self._enum_member(self.bindings.Offset, captured.offset),
+            price=float(captured.price),
+            volume=float(captured.volume),
+            traded=float(traded),
+            status=status,
+            datetime=_aware_datetime(timestamp),
+            reference="ATL vn.py CTA adapter",
+        )
+
+    def reject_captured_order(
+        self,
+        captured: CapturedCtaOrder,
+        *,
+        reason: str,
+        timestamp: str,
+    ) -> None:
+        order = self._order_data(
+            captured,
+            status=self.bindings.Status.REJECTED,
+            traded=0,
+            timestamp=timestamp,
+        )
+        self.strategy.on_order(order)
+        self.events.append(
+            {
+                "type": "order_rejected",
+                "order_id": captured.order_id,
+                "reason": sanitize_error_message(reason),
+            }
+        )
+
+    @staticmethod
+    def _captured_side(captured: CapturedCtaOrder) -> Optional[str]:
+        pair = (captured.direction.lower(), captured.offset.lower())
+        if pair == ("long", "open"):
+            return "buy"
+        if pair == ("short", "close"):
+            return "sell"
+        return None
+
+    def apply_execution_result(
+        self,
+        result: ExecutionResult,
+        *,
+        captured_orders: Sequence[CapturedCtaOrder],
+        timestamp: str,
+    ) -> None:
+        unused_fills = list(result.fills)
+        rejections = list(result.rejections)
+        for captured in captured_orders:
+            side = self._captured_side(captured)
+            fill_index = next(
+                (
+                    index
+                    for index, fill in enumerate(unused_fills)
+                    if str(fill.get("symbol", "")).upper() == self.symbol
+                    and str(fill.get("side", "")).lower() == side
+                ),
+                None,
+            )
+            if fill_index is not None:
+                fill = unused_fills.pop(fill_index)
+                filled = float(fill.get("filled_quantity") or 0)
+                status = (
+                    self.bindings.Status.ALLTRADED
+                    if filled >= float(captured.volume)
+                    else self.bindings.Status.PARTTRADED
+                )
+                self.strategy.on_order(
+                    self._order_data(
+                        captured,
+                        status=status,
+                        traded=filled,
+                        timestamp=timestamp,
+                    )
+                )
+                if filled > 0:
+                    if side == "buy":
+                        self.strategy.pos += filled
+                    elif side == "sell":
+                        self.strategy.pos -= filled
+                    trade = self.bindings.TradeData(
+                        gateway_name="ATL",
+                        symbol=self.symbol,
+                        exchange=self.bindings.Exchange.SMART,
+                        orderid=captured.order_id,
+                        tradeid=f"atl-trade-{self._next_trade}",
+                        direction=self._enum_member(
+                            self.bindings.Direction, captured.direction
+                        ),
+                        offset=self._enum_member(self.bindings.Offset, captured.offset),
+                        price=float(fill.get("fill_price") or 0),
+                        volume=filled,
+                        datetime=_aware_datetime(timestamp),
+                    )
+                    self._next_trade += 1
+                    self.strategy.on_trade(trade)
+                continue
+
+            rejection_index = next(
+                (
+                    index
+                    for index, item in enumerate(rejections)
+                    if str((item.get("order") or {}).get("symbol", "")).upper()
+                    == self.symbol
+                    and str((item.get("order") or {}).get("side", "")).lower()
+                    == side
+                ),
+                None,
+            )
+            if rejection_index is not None:
+                rejection = rejections.pop(rejection_index)
+                self.reject_captured_order(
+                    captured,
+                    reason=str(rejection.get("reason") or "atl_rejection"),
+                    timestamp=timestamp,
+                )
+
+
+__all__ = [
+    "VnpyCtaDependencyError",
+    "VnpyCtaCompatibilityError",
+    "VnpyBindings",
+    "load_vnpy_bindings",
+    "AtlCtaEngine",
+    "VnpyCtaRuntime",
+]

--- a/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_runtime.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/_vnpy_cta_runtime.py
@@ -12,7 +12,7 @@ from types import ModuleType
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
 from ..models import ExecutionResult
-from ._vnpy_cta_core import CapturedCtaOrder, sanitize_error_message
+from ._vnpy_cta_core import CapturedCtaOrder, sanitize_error_message, validate_ohlcv_values
 
 
 class VnpyCtaDependencyError(RuntimeError):
@@ -303,21 +303,7 @@ class VnpyCtaRuntime:
 
     def _bar_data(self, payload: Mapping[str, Any]) -> Any:
         timestamp = _aware_datetime(payload.get("timestamp"))
-        try:
-            values = {
-                field: float(payload[field])
-                for field in ("open", "high", "low", "close", "volume")
-            }
-        except (KeyError, TypeError, ValueError) as exc:
-            raise ValueError("bar payload is missing numeric OHLCV fields") from exc
-        if (
-            not all(math.isfinite(values[key]) and values[key] > 0 for key in ("open", "high", "low", "close"))
-            or not math.isfinite(values["volume"])
-            or values["volume"] < 0
-            or values["high"] < max(values["open"], values["close"])
-            or values["low"] > min(values["open"], values["close"])
-        ):
-            raise ValueError("bar payload violates the OHLCV contract")
+        values = validate_ohlcv_values(payload)
         return self.bindings.BarData(
             gateway_name="ATL",
             symbol=self.symbol,
@@ -337,6 +323,17 @@ class VnpyCtaRuntime:
         bar = self._bar_data(payload)
         self.engine.current_timestamp = bar.datetime.isoformat()
         self.strategy.on_bar(bar)
+        return self.drain_captured_orders()
+
+    def drain_captured_orders(self) -> Tuple[CapturedCtaOrder, ...]:
+        """Orders captured by the engine since the last drain.
+
+        Exposed at the runtime's lifecycle level (rather than requiring
+        callers to reach into ``self.engine``) so a caller recovering from a
+        ``strategy.on_bar()`` exception can collect whatever orders the
+        strategy sent before it raised, without depending on the concrete
+        engine implementation.
+        """
         return self.engine.drain_captured_orders()
 
     def _enum_member(self, enum: Any, name: str) -> Any:
@@ -397,6 +394,36 @@ class VnpyCtaRuntime:
             return "sell"
         return None
 
+    @staticmethod
+    def _closest_quantity_match(
+        candidate_indices: list[int],
+        items: Sequence[Mapping[str, Any]],
+        volume: float,
+        quantity_of: Callable[[Mapping[str, Any]], Any],
+    ) -> Optional[int]:
+        """Among same-symbol/same-side candidates, prefer the one whose
+        submitted quantity is closest to ``volume``. ATL's ``orders-v1`` wire
+        schema carries no client-supplied order id to correlate fills or
+        rejections back to a specific captured order, so (symbol, side) alone
+        is ambiguous whenever a strategy emits more than one same-side order
+        in a single ``on_bar()`` call; matching on quantity too is a
+        best-effort tie-breaker, not a guarantee.
+        """
+        best_index: Optional[int] = None
+        best_distance: Optional[float] = None
+        for index in candidate_indices:
+            try:
+                requested = float(quantity_of(items[index]))
+            except (TypeError, ValueError):
+                continue
+            distance = abs(requested - float(volume))
+            if best_distance is None or distance < best_distance:
+                best_distance = distance
+                best_index = index
+        if best_index is not None:
+            return best_index
+        return candidate_indices[0] if candidate_indices else None
+
     def apply_execution_result(
         self,
         result: ExecutionResult,
@@ -408,14 +435,17 @@ class VnpyCtaRuntime:
         rejections = list(result.rejections)
         for captured in captured_orders:
             side = self._captured_side(captured)
-            fill_index = next(
-                (
-                    index
-                    for index, fill in enumerate(unused_fills)
-                    if str(fill.get("symbol", "")).upper() == self.symbol
-                    and str(fill.get("side", "")).lower() == side
-                ),
-                None,
+            fill_candidates = [
+                index
+                for index, fill in enumerate(unused_fills)
+                if str(fill.get("symbol", "")).upper() == self.symbol
+                and str(fill.get("side", "")).lower() == side
+            ]
+            fill_index = self._closest_quantity_match(
+                fill_candidates,
+                unused_fills,
+                captured.volume,
+                lambda fill: fill.get("requested_quantity"),
             )
             if fill_index is not None:
                 fill = unused_fills.pop(fill_index)
@@ -456,16 +486,18 @@ class VnpyCtaRuntime:
                     self.strategy.on_trade(trade)
                 continue
 
-            rejection_index = next(
-                (
-                    index
-                    for index, item in enumerate(rejections)
-                    if str((item.get("order") or {}).get("symbol", "")).upper()
-                    == self.symbol
-                    and str((item.get("order") or {}).get("side", "")).lower()
-                    == side
-                ),
-                None,
+            rejection_candidates = [
+                index
+                for index, item in enumerate(rejections)
+                if str((item.get("order") or {}).get("symbol", "")).upper()
+                == self.symbol
+                and str((item.get("order") or {}).get("side", "")).lower() == side
+            ]
+            rejection_index = self._closest_quantity_match(
+                rejection_candidates,
+                rejections,
+                captured.volume,
+                lambda item: (item.get("order") or {}).get("quantity"),
             )
             if rejection_index is not None:
                 rejection = rejections.pop(rejection_index)

--- a/packaging/agentictrading/src/agentictrading/integrations/vnpy_cta.py
+++ b/packaging/agentictrading/src/agentictrading/integrations/vnpy_cta.py
@@ -1,0 +1,53 @@
+"""Public, lazily extensible API for the vn.py CTA integration."""
+
+from ._vnpy_cta_core import (
+    ARTIFACT_SCHEMA_VERSION,
+    AUDIT_STATUSES,
+    ArtifactValidationError,
+    CapturedCtaOrder,
+    CtaOrderMapping,
+    VnpyCtaAuditArtifact,
+    VnpyCtaAuditRecord,
+    build_audit_artifact,
+    build_safe_manifest,
+    load_audit_artifact,
+    map_captured_order,
+    sanitize_error_message,
+    save_audit_artifact,
+)
+from ._vnpy_cta_runtime import (
+    AtlCtaEngine,
+    VnpyBindings,
+    VnpyCtaCompatibilityError,
+    VnpyCtaDependencyError,
+    VnpyCtaRuntime,
+    load_vnpy_bindings,
+)
+from ._vnpy_cta_adapter import VnpyCtaAdapter, VnpyCtaDataError
+from ._vnpy_cta_runner import VnpyCtaATLRunner, VnpyCtaRunSummary
+
+__all__ = [
+    "ARTIFACT_SCHEMA_VERSION",
+    "AUDIT_STATUSES",
+    "ArtifactValidationError",
+    "CapturedCtaOrder",
+    "CtaOrderMapping",
+    "VnpyCtaAuditArtifact",
+    "VnpyCtaAuditRecord",
+    "map_captured_order",
+    "build_safe_manifest",
+    "sanitize_error_message",
+    "build_audit_artifact",
+    "save_audit_artifact",
+    "load_audit_artifact",
+    "VnpyCtaDependencyError",
+    "VnpyCtaCompatibilityError",
+    "VnpyBindings",
+    "load_vnpy_bindings",
+    "AtlCtaEngine",
+    "VnpyCtaRuntime",
+    "VnpyCtaDataError",
+    "VnpyCtaAdapter",
+    "VnpyCtaRunSummary",
+    "VnpyCtaATLRunner",
+]

--- a/packaging/agentictrading/tests/test_vnpy_cta_integration.py
+++ b/packaging/agentictrading/tests/test_vnpy_cta_integration.py
@@ -1,0 +1,1469 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import math
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from agentictrading.integrations.vnpy_cta import (
+    ARTIFACT_SCHEMA_VERSION,
+    ArtifactValidationError,
+    AtlCtaEngine,
+    CapturedCtaOrder,
+    VnpyBindings,
+    VnpyCtaAdapter,
+    VnpyCtaAuditArtifact,
+    VnpyCtaAuditRecord,
+    VnpyCtaCompatibilityError,
+    VnpyCtaDependencyError,
+    VnpyCtaDataError,
+    VnpyCtaRuntime,
+    VnpyCtaATLRunner,
+    VnpyCtaRunSummary,
+    build_audit_artifact,
+    build_safe_manifest,
+    load_audit_artifact,
+    map_captured_order,
+    load_vnpy_bindings,
+    sanitize_error_message,
+    save_audit_artifact,
+)
+from agentictrading import ATLAPIError, ATLConflictError
+from agentictrading.models import ExecutionResult, Observation, Run, RunResult, Step
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_example(filename: str, module_name: str):
+    path = _REPO_ROOT / "dashboard" / "examples" / filename
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _captured(**overrides) -> CapturedCtaOrder:
+    values = {
+        "order_id": "atl-cta-1",
+        "timestamp": "2026-04-15T10:00:00-04:00",
+        "symbol": "AAPL",
+        "direction": "long",
+        "offset": "open",
+        "price": 101.25,
+        "volume": 2.0,
+        "stop": False,
+        "lock": False,
+        "net": False,
+    }
+    values.update(overrides)
+    return CapturedCtaOrder(**values)
+
+
+def _record(sequence: int = 0, *, status: str = "strategy_hold") -> VnpyCtaAuditRecord:
+    return VnpyCtaAuditRecord(
+        sequence=sequence,
+        observation_timestamp=f"2026-04-15T{10 + sequence:02d}:00:00-04:00",
+        signal_timestamp=None,
+        status=status,
+        bar={"symbol": "AAPL", "close": 100.0 + sequence},
+    )
+
+
+def test_public_import_does_not_load_optional_vnpy_dependencies():
+    sys.modules.pop("vnpy", None)
+    sys.modules.pop("vnpy_ctastrategy", None)
+
+    module = importlib.reload(importlib.import_module("agentictrading.integrations.vnpy_cta"))
+
+    assert module.ARTIFACT_SCHEMA_VERSION == "vnpy-cta-atl-v1"
+    assert "vnpy" not in sys.modules
+    assert "vnpy_ctastrategy" not in sys.modules
+
+
+def test_maps_long_open_to_market_buy_and_audits_limit_price():
+    mapped = map_captured_order(_captured(), symbol="AAPL", current_position=0)
+
+    assert mapped.status == "mapped"
+    assert mapped.reason is None
+    assert mapped.warnings == ("limit_price_not_enforced",)
+    assert mapped.order is not None
+    assert mapped.order.to_dict() == {
+        "symbol": "AAPL",
+        "side": "buy",
+        "quantity_type": "shares",
+        "quantity": 2,
+        "order_type": "market",
+    }
+
+
+def test_maps_short_close_to_sell_only_with_enough_position():
+    captured = _captured(direction="short", offset="close", volume=3)
+
+    mapped = map_captured_order(captured, symbol="AAPL", current_position=5)
+    rejected = map_captured_order(captured, symbol="AAPL", current_position=2)
+
+    assert mapped.order is not None
+    assert mapped.order.side == "sell"
+    assert mapped.order.quantity == 3
+    assert rejected.order is None
+    assert rejected.status == "local_rejection"
+    assert rejected.reason == "sell_exceeds_position"
+
+
+@pytest.mark.parametrize("volume", [0, -1, 1.5, math.nan, math.inf])
+def test_rejects_non_positive_non_integer_or_non_finite_volume(volume):
+    mapped = map_captured_order(
+        _captured(volume=volume), symbol="AAPL", current_position=0
+    )
+
+    assert mapped.order is None
+    assert mapped.status == "local_rejection"
+    assert mapped.reason == "invalid_share_volume"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"direction": "short", "offset": "open"}, "short_not_supported"),
+        ({"direction": "long", "offset": "close"}, "cover_not_supported"),
+        ({"stop": True}, "stop_not_supported"),
+        ({"lock": True}, "lock_not_supported"),
+        ({"net": True}, "net_not_supported"),
+    ],
+)
+def test_unsupported_cta_actions_are_explicit(overrides, reason):
+    mapped = map_captured_order(
+        _captured(**overrides), symbol="AAPL", current_position=5
+    )
+
+    assert mapped.order is None
+    assert mapped.status == "unsupported_action"
+    assert mapped.reason == reason
+
+
+def test_rejects_wrong_symbol_and_invalid_audit_price():
+    wrong_symbol = map_captured_order(
+        _captured(symbol="MSFT"), symbol="AAPL", current_position=0
+    )
+    invalid_price = map_captured_order(
+        _captured(price=math.nan), symbol="AAPL", current_position=0
+    )
+
+    assert (wrong_symbol.status, wrong_symbol.reason) == (
+        "local_rejection",
+        "symbol_mismatch",
+    )
+    assert (invalid_price.status, invalid_price.reason) == (
+        "local_rejection",
+        "invalid_order_price",
+    )
+
+
+def test_safe_manifest_and_error_message_remove_credentials():
+    manifest = build_safe_manifest(
+        {
+            "strategy": "demo:DoubleMaStrategy",
+            "settings": {
+                "fast_window": 5,
+                "api_key": "sk-super-secret",
+                "nested": {"password": "open-sesame"},
+            },
+            "endpoint": "https://user:password@example.com/path",
+            "authorization": "Bearer top-secret-token",
+        }
+    )
+    error = sanitize_error_message(
+        "request failed ATL_API_KEY=abc123 Bearer bearer-secret "
+        "https://alice:pw@example.com/private"
+    )
+    encoded = json.dumps(manifest, sort_keys=True)
+
+    assert manifest["strategy"] == "demo:DoubleMaStrategy"
+    assert manifest["settings"]["fast_window"] == 5
+    assert "sk-super-secret" not in encoded
+    assert "open-sesame" not in encoded
+    assert "password@example" not in encoded
+    assert "top-secret-token" not in encoded
+    assert "abc123" not in error
+    assert "bearer-secret" not in error
+    assert "alice:pw" not in error
+
+
+def test_artifact_round_trip_has_stable_summary_and_sha256(tmp_path):
+    artifact = build_audit_artifact(
+        manifest=build_safe_manifest({"strategy": "demo:DoubleMaStrategy"}),
+        records=(
+            _record(0, status="warmup_hold"),
+            _record(1, status="strategy_hold"),
+            _record(2, status="error_hold"),
+            _record(3, status="timeout_hold"),
+        ),
+    )
+    path = tmp_path / "audit.json"
+
+    digest = save_audit_artifact(artifact, path)
+    loaded = load_audit_artifact(path)
+
+    assert len(digest) == 64
+    assert loaded == artifact
+    assert loaded.schema_version == ARTIFACT_SCHEMA_VERSION
+    assert loaded.summary == {
+        "error_hold": 1,
+        "strategy_hold": 1,
+        "timeout_hold": 1,
+        "total_records": 4,
+        "warmup_hold": 1,
+    }
+    assert save_audit_artifact(loaded, path) == digest
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-json",
+        json.dumps([]),
+        json.dumps(
+            {
+                "schema_version": "unknown-v9",
+                "manifest": {},
+                "records": [],
+                "summary": {"total_records": 0},
+            }
+        ),
+    ],
+)
+def test_artifact_loader_rejects_invalid_json_shape_or_schema(tmp_path, payload):
+    path = tmp_path / "bad.json"
+    path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(ArtifactValidationError):
+        load_audit_artifact(path)
+
+
+def test_artifact_rejects_unknown_status_and_duplicate_sequences():
+    with pytest.raises(ArtifactValidationError, match="status"):
+        _record(status="mystery")
+
+    with pytest.raises(ArtifactValidationError, match="duplicate sequence"):
+        VnpyCtaAuditArtifact(
+            schema_version=ARTIFACT_SCHEMA_VERSION,
+            manifest={},
+            records=(_record(0), _record(0)),
+            summary={"strategy_hold": 2, "total_records": 2},
+        )
+
+
+class _Direction(Enum):
+    LONG = "long"
+    SHORT = "short"
+
+
+class _Offset(Enum):
+    OPEN = "open"
+    CLOSE = "close"
+
+
+class _Exchange(Enum):
+    SMART = "SMART"
+
+
+class _Interval(Enum):
+    HOUR = "1h"
+
+
+class _Status(Enum):
+    ALLTRADED = "all traded"
+    PARTTRADED = "part traded"
+    REJECTED = "rejected"
+
+
+class _OrderType(Enum):
+    MARKET = "market"
+
+
+class _EngineType(Enum):
+    BACKTESTING = "backtesting"
+
+
+class _DataObject:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _CtaTemplate:
+    pass
+
+
+class _RecordingStrategy(_CtaTemplate):
+    def __init__(self, engine, strategy_name, vt_symbol, setting):
+        self.cta_engine = engine
+        self.strategy_name = strategy_name
+        self.vt_symbol = vt_symbol
+        self.setting = setting
+        self.inited = False
+        self.trading = False
+        self.pos = 0
+        self.events = []
+
+    def on_init(self):
+        self.events.append("init")
+        self.cta_engine.load_bar(self.vt_symbol, 10, _Interval.HOUR, self.on_bar)
+
+    def on_start(self):
+        self.events.append("start")
+
+    def on_stop(self):
+        self.events.append("stop")
+
+    def on_bar(self, bar):
+        self.events.append(("bar", bar))
+        self.cta_engine.send_order(
+            self,
+            _Direction.LONG,
+            _Offset.OPEN,
+            bar.close_price,
+            2,
+            False,
+            False,
+            False,
+        )
+
+    def on_order(self, order):
+        self.events.append(("order", order))
+
+    def on_trade(self, trade):
+        self.events.append(("trade", trade))
+
+
+def _fake_bindings(
+    *, vnpy_version: str = "4.4.0", cta_version: str = "1.3.0"
+) -> VnpyBindings:
+    return VnpyBindings(
+        vnpy_version=vnpy_version,
+        cta_version=cta_version,
+        CtaTemplate=_CtaTemplate,
+        EngineType=_EngineType,
+        BarData=_DataObject,
+        OrderData=_DataObject,
+        TradeData=_DataObject,
+        Direction=_Direction,
+        Offset=_Offset,
+        Exchange=_Exchange,
+        Interval=_Interval,
+        Status=_Status,
+        OrderType=_OrderType,
+    )
+
+
+def _bar_payload(hour: int = 10):
+    return {
+        "timestamp": f"2026-04-15T{hour:02d}:00:00-04:00",
+        "open": 100.0,
+        "high": 102.0,
+        "low": 99.0,
+        "close": 101.5,
+        "volume": 1_000_000.0,
+    }
+
+
+def test_load_vnpy_bindings_reports_missing_optional_dependency():
+    def missing_import(name):
+        raise ModuleNotFoundError(name)
+
+    with pytest.raises(VnpyCtaDependencyError, match=r"agentictrading\[vnpy\]"):
+        load_vnpy_bindings(import_module=missing_import)
+
+
+@pytest.mark.parametrize(
+    ("vnpy_version", "cta_version"),
+    [("4.3.9", "1.3.0"), ("5.0.0", "1.3.0"), ("4.4.0", "1.2.9"), ("4.4.0", "2.0.0")],
+)
+def test_runtime_rejects_incompatible_vnpy_versions(vnpy_version, cta_version):
+    with pytest.raises(VnpyCtaCompatibilityError):
+        VnpyCtaRuntime(
+            _RecordingStrategy,
+            symbol="AAPL",
+            settings={},
+            bindings=_fake_bindings(
+                vnpy_version=vnpy_version, cta_version=cta_version
+            ),
+        )
+
+
+def test_runtime_runs_lifecycle_builds_bar_and_captures_order():
+    runtime = VnpyCtaRuntime(
+        _RecordingStrategy,
+        symbol="AAPL",
+        settings={"fast_window": 5},
+        bindings=_fake_bindings(),
+    )
+
+    runtime.start()
+    captured = runtime.on_bar(_bar_payload())
+
+    assert runtime.strategy.inited is True
+    assert runtime.strategy.trading is True
+    assert runtime.strategy.vt_symbol == "AAPL.SMART"
+    assert runtime.strategy.setting == {"fast_window": 5}
+    assert runtime.strategy.events[:2] == ["init", "start"]
+    bar = runtime.strategy.events[2][1]
+    assert bar.gateway_name == "ATL"
+    assert bar.symbol == "AAPL"
+    assert bar.exchange is _Exchange.SMART
+    assert bar.interval is _Interval.HOUR
+    assert bar.datetime.isoformat() == _bar_payload()["timestamp"]
+    assert bar.close_price == 101.5
+    assert captured == (
+        _captured(order_id="atl-cta-1", price=101.5, volume=2),
+    )
+    assert runtime.engine.drain_captured_orders() == ()
+    assert any(event["type"] == "history_preload_unavailable" for event in runtime.events)
+
+    runtime.stop()
+    assert runtime.strategy.events[-1] == "stop"
+    assert runtime.strategy.trading is False
+
+
+def test_runtime_syncs_position_and_emits_fill_callbacks():
+    runtime = VnpyCtaRuntime(
+        _RecordingStrategy,
+        symbol="AAPL",
+        settings={},
+        bindings=_fake_bindings(),
+    )
+    runtime.start()
+    captured = runtime.on_bar(_bar_payload())
+    result = ExecutionResult(
+        accepted=True,
+        fills=[
+            {
+                "symbol": "AAPL",
+                "side": "buy",
+                "requested_quantity": 2,
+                "filled_quantity": 2,
+                "fill_price": 102.0,
+            }
+        ],
+        validation={"passed": True, "warnings": [], "rejections": []},
+    )
+
+    runtime.apply_execution_result(
+        result,
+        captured_orders=captured,
+        timestamp="2026-04-15T11:00:00-04:00",
+    )
+
+    order = next(
+        event[1]
+        for event in runtime.strategy.events
+        if isinstance(event, tuple) and event[0] == "order"
+    )
+    trade = next(
+        event[1]
+        for event in runtime.strategy.events
+        if isinstance(event, tuple) and event[0] == "trade"
+    )
+    assert order.orderid == "atl-cta-1"
+    assert order.status is _Status.ALLTRADED
+    assert order.traded == 2
+    assert trade.orderid == "atl-cta-1"
+    assert trade.price == 102.0
+    assert runtime.strategy.pos == 2
+
+    runtime.sync_position(7)
+    assert runtime.strategy.pos == 7
+
+
+def test_runtime_emits_rejected_order_callback_without_trade():
+    runtime = VnpyCtaRuntime(
+        _RecordingStrategy,
+        symbol="AAPL",
+        settings={},
+        bindings=_fake_bindings(),
+    )
+    runtime.start()
+    captured = runtime.on_bar(_bar_payload())
+
+    runtime.reject_captured_order(
+        captured[0],
+        reason="exceeds_max_position_weight",
+        timestamp="2026-04-15T11:00:00-04:00",
+    )
+
+    order_events = [
+        event[1]
+        for event in runtime.strategy.events
+        if isinstance(event, tuple) and event[0] == "order"
+    ]
+    trade_events = [
+        event[1]
+        for event in runtime.strategy.events
+        if isinstance(event, tuple) and event[0] == "trade"
+    ]
+    assert len(order_events) == 1
+    assert order_events[0].status is _Status.REJECTED
+    assert trade_events == []
+    assert runtime.strategy.pos == 0
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("vnpy") is None
+    or importlib.util.find_spec("vnpy_ctastrategy") is None,
+    reason="optional vn.py CTA dependencies are not installed",
+)
+def test_runtime_constructs_real_vnpy_objects_when_optional_extra_is_installed():
+    bindings = load_vnpy_bindings()
+
+    class RealStrategy(bindings.CtaTemplate):
+        def on_init(self):
+            return None
+
+    runtime = VnpyCtaRuntime(
+        RealStrategy,
+        symbol="AAPL",
+        settings={},
+        bindings=bindings,
+    )
+    runtime.start()
+
+    captured = runtime.on_bar(_bar_payload())
+    bar = runtime._bar_data(_bar_payload())
+
+    assert captured == ()
+    assert isinstance(bar, bindings.BarData)
+    assert bar.vt_symbol == "AAPL.SMART"
+    runtime.stop()
+
+
+class _AdapterEngine:
+    def drain_captured_orders(self):
+        return ()
+
+
+class _AdapterRuntime:
+    def __init__(self, order_specs=()):
+        self.engine = _AdapterEngine()
+        self.order_specs = list(order_specs)
+        self.started = False
+        self.stopped = False
+        self.position_syncs = []
+        self.bars = []
+        self.applied = []
+        self.rejected = []
+        self.raise_on_bar = None
+        self.strategy = SimpleNamespace(__class__=SimpleNamespace(__name__="FakeStrategy"))
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def sync_position(self, quantity):
+        self.position_syncs.append(quantity)
+
+    def on_bar(self, bar):
+        self.bars.append(dict(bar))
+        if self.raise_on_bar is not None:
+            raise self.raise_on_bar
+        specs = self.order_specs.pop(0) if self.order_specs else ()
+        return tuple(
+            _captured(
+                order_id=f"atl-cta-{index + 1}",
+                timestamp=bar["timestamp"],
+                price=bar["close"],
+                **spec,
+            )
+            for index, spec in enumerate(specs)
+        )
+
+    def apply_execution_result(self, result, *, captured_orders, timestamp):
+        self.applied.append((result, tuple(captured_orders), timestamp))
+
+    def reject_captured_order(self, captured, *, reason, timestamp):
+        self.rejected.append((captured, reason, timestamp))
+
+
+def _observation(hour: int, *, position: int = 0, bar_overrides=None) -> Observation:
+    bar = _bar_payload(hour)
+    if bar_overrides:
+        bar.update(bar_overrides)
+    positions = []
+    if position:
+        positions.append({"symbol": "AAPL", "quantity": position})
+    return Observation(
+        market={"bars": {"AAPL": bar}, "features": {}, "events": []},
+        portfolio={"cash": 1_000.0, "equity": 1_000.0, "positions": positions},
+    )
+
+
+def _execution(*, fills=None, rejections=None) -> ExecutionResult:
+    return ExecutionResult(
+        accepted=True,
+        fills=list(fills or []),
+        validation={
+            "passed": not rejections,
+            "warnings": [],
+            "rejections": list(rejections or []),
+        },
+        portfolio_after={"cash": 1_000.0, "equity": 1_000.0, "positions": []},
+        run_status="running",
+    )
+
+
+def _adapter(runtime: _AdapterRuntime) -> VnpyCtaAdapter:
+    return VnpyCtaAdapter(
+        runtime,
+        symbol="AAPL",
+        manifest={"strategy": "tests:FakeStrategy"},
+    )
+
+
+def test_adapter_first_observation_is_warmup_hold():
+    runtime = _AdapterRuntime()
+    adapter = _adapter(runtime)
+
+    decision = adapter.decide(_observation(10))
+
+    assert runtime.started is True
+    assert runtime.bars == []
+    assert decision.orders == []
+    assert decision.trace["status"] == "warmup_hold"
+    assert decision.trace["observation_timestamp"] == _bar_payload(10)["timestamp"]
+    adapter.on_execution_result(_execution())
+    artifact = adapter.finalize_artifact()
+    assert artifact.records[0].bar["timestamp"] == _bar_payload(10)["timestamp"]
+    assert artifact.records[0].signal_bar == {}
+    assert artifact.summary == {
+        "total_records": 1,
+        "warmup_hold": 1,
+    }
+
+
+def test_adapter_processes_only_previous_bar_and_syncs_current_position():
+    runtime = _AdapterRuntime(order_specs=[({"volume": 2},)])
+    adapter = _adapter(runtime)
+    adapter.decide(_observation(10))
+    adapter.on_execution_result(_execution())
+
+    decision = adapter.decide(_observation(11, position=3))
+
+    assert runtime.position_syncs == [0, 3]
+    assert [bar["timestamp"] for bar in runtime.bars] == [
+        _bar_payload(10)["timestamp"]
+    ]
+    assert decision.trace["signal_timestamp"] == _bar_payload(10)["timestamp"]
+    assert decision.trace["observation_timestamp"] == _bar_payload(11)["timestamp"]
+    assert [order.to_dict() for order in decision.orders] == [
+        {
+            "symbol": "AAPL",
+            "side": "buy",
+            "quantity_type": "shares",
+            "quantity": 2,
+            "order_type": "market",
+        }
+    ]
+    record = adapter.finalize_artifact().records[-1]
+    assert record.bar["timestamp"] == _bar_payload(11)["timestamp"]
+    assert record.signal_bar["timestamp"] == _bar_payload(10)["timestamp"]
+
+
+def test_adapter_execution_hook_updates_runtime_and_artifact():
+    runtime = _AdapterRuntime(order_specs=[({"volume": 2},)])
+    adapter = _adapter(runtime)
+    adapter.decide(_observation(10))
+    adapter.on_execution_result(_execution())
+    adapter.decide(_observation(11))
+    fill = {
+        "symbol": "AAPL",
+        "side": "buy",
+        "requested_quantity": 2,
+        "filled_quantity": 2,
+        "fill_price": 102.0,
+    }
+
+    adapter.on_execution_result(_execution(fills=[fill]))
+    artifact = adapter.finalize_artifact()
+
+    assert len(runtime.applied) == 2
+    assert runtime.applied[-1][2] == _bar_payload(11)["timestamp"]
+    assert artifact.records[-1].execution["fills"] == [fill]
+    assert artifact.records[-1].diagnostics == {"fills": 1}
+    assert artifact.summary["fills"] == 1
+
+
+def test_adapter_mixed_supported_and_unsupported_orders_are_audited():
+    runtime = _AdapterRuntime(
+        order_specs=[
+            (
+                {"volume": 1},
+                {"direction": "short", "offset": "open", "volume": 1},
+            )
+        ]
+    )
+    adapter = _adapter(runtime)
+    adapter.decide(_observation(10))
+    adapter.on_execution_result(_execution())
+
+    decision = adapter.decide(_observation(11, position=5))
+
+    assert len(decision.orders) == 1
+    assert decision.trace["status"] == "partial_submission"
+    assert decision.trace["diagnostics"] == {"unsupported_actions": 1}
+    assert len(runtime.rejected) == 1
+    assert runtime.rejected[0][1] == "short_not_supported"
+
+
+def test_adapter_strategy_exception_is_error_hold_not_strategy_hold():
+    runtime = _AdapterRuntime()
+    adapter = _adapter(runtime)
+    adapter.decide(_observation(10))
+    adapter.on_execution_result(_execution())
+    runtime.raise_on_bar = RuntimeError("API_KEY=secret strategy failed")
+
+    decision = adapter.decide(_observation(11))
+    artifact = adapter.finalize_artifact()
+
+    assert decision.orders == []
+    assert decision.trace["status"] == "error_hold"
+    assert "secret" not in artifact.records[-1].error
+    assert runtime.rejected == []
+    assert artifact.summary["error_hold"] == 1
+    assert artifact.summary.get("strategy_hold", 0) == 0
+
+
+@pytest.mark.parametrize(
+    "observation",
+    [
+        Observation(market={"bars": {}}, portfolio={"positions": []}),
+        _observation(10, bar_overrides={"timestamp": "2026-04-15T10:00:00"}),
+        _observation(10, bar_overrides={"close": math.nan}),
+    ],
+)
+def test_adapter_rejects_missing_naive_or_invalid_bars(observation):
+    adapter = _adapter(_AdapterRuntime())
+
+    with pytest.raises(VnpyCtaDataError):
+        adapter.decide(observation)
+
+
+def test_adapter_rejects_duplicate_observation_timestamp():
+    adapter = _adapter(_AdapterRuntime())
+    adapter.decide(_observation(10))
+    adapter.on_execution_result(_execution())
+
+    with pytest.raises(VnpyCtaDataError, match="duplicate"):
+        adapter.decide(_observation(10))
+
+
+def test_adapter_marks_missing_execution_hook_as_timeout_on_next_step():
+    runtime = _AdapterRuntime()
+    adapter = _adapter(runtime)
+    adapter.decide(_observation(10))
+
+    adapter.decide(_observation(11))
+    artifact = adapter.finalize_artifact()
+
+    assert artifact.records[0].status == "timeout_hold"
+    assert artifact.summary["timeout_hold"] == 1
+
+
+def test_adapter_completion_stops_runtime_and_records_terminal_bar():
+    runtime = _AdapterRuntime()
+    adapter = _adapter(runtime)
+    adapter.decide(_observation(10))
+    adapter.on_execution_result(_execution())
+
+    adapter.on_run_completed(RunResult(run_id="run_test", status="completed"))
+    artifact = adapter.finalize_artifact()
+
+    assert runtime.stopped is True
+    assert artifact.records[-1].status == "terminal_bar_skipped"
+    assert artifact.records[-1].signal_timestamp == _bar_payload(10)["timestamp"]
+    assert artifact.summary["terminal_bar_skipped"] == 1
+
+
+def test_artifact_summary_aggregates_record_diagnostics():
+    record = VnpyCtaAuditRecord(
+        sequence=0,
+        observation_timestamp=_bar_payload(10)["timestamp"],
+        status="partial_submission",
+        diagnostics={"unsupported_actions": 2, "local_rejections": 1},
+    )
+
+    artifact = build_audit_artifact(manifest={}, records=[record])
+
+    assert artifact.summary == {
+        "local_rejections": 1,
+        "partial_submission": 1,
+        "total_records": 1,
+        "unsupported_actions": 2,
+    }
+
+
+class _RunnerClient:
+    def __init__(self, steps, *, result=None, conflict_code=None, next_error=None):
+        self.steps = list(steps)
+        self.result = result or RunResult(
+            run_id="run_vnpy",
+            result_run_id="ext_vnpy",
+            status="completed",
+            metrics={"total_return": 0.02, "num_trades": 1},
+            equity_curve=[{"timestamp": "2026-04-15T11:00:00-04:00", "equity": 1020}],
+        )
+        self.conflict_code = conflict_code
+        self.next_error = next_error
+        self.create_calls = []
+        self.submitted = []
+
+    def create_run(self, agent_version_id, **kwargs):
+        self.create_calls.append((agent_version_id, kwargs))
+        return Run(run_id="run_vnpy", status="running")
+
+    def get_next_step(self, run_id):
+        if self.next_error is not None:
+            raise self.next_error
+        return self.steps.pop(0)
+
+    def submit_decision(self, run_id, step_id, decision):
+        self.submitted.append(decision)
+        if self.conflict_code:
+            code = self.conflict_code
+            self.conflict_code = None
+            raise ATLConflictError("late", code=code)
+        fills = []
+        if decision.orders:
+            order = decision.orders[0]
+            fills = [
+                {
+                    "symbol": order.symbol,
+                    "side": order.side,
+                    "requested_quantity": order.quantity,
+                    "filled_quantity": order.quantity,
+                    "fill_price": 102.0,
+                }
+            ]
+        return _execution(fills=fills)
+
+    def get_run_result(self, run_id):
+        return self.result
+
+    def get_run_metrics(self, run_id):
+        return self.result.metrics
+
+    def wait(self, seconds):
+        return None
+
+
+def _awaiting_step(sequence: int, hour: int) -> Step:
+    return Step(
+        status="awaiting_decision",
+        run_id="run_vnpy",
+        step_id=f"step_{sequence}",
+        sequence=sequence,
+        timestamp=_bar_payload(hour)["timestamp"],
+        observation=_observation(hour),
+    )
+
+
+def _completed_step() -> Step:
+    return Step(status="completed", run_id="run_vnpy", result_run_id="ext_vnpy")
+
+
+def test_vnpy_runner_completes_with_existing_agent_runner_and_safe_config(tmp_path):
+    runtime = _AdapterRuntime(order_specs=[({"volume": 2},)])
+    adapter = VnpyCtaAdapter(
+        runtime,
+        symbol="AAPL",
+        manifest={
+            "strategy": "tests:FakeStrategy",
+            "settings": {"fast_window": 5, "api_key": "never-persist"},
+        },
+    )
+    client = _RunnerClient(
+        [_awaiting_step(0, 10), _awaiting_step(1, 11), _completed_step()]
+    )
+    artifact_path = tmp_path / "vnpy-run.json"
+    runner = VnpyCtaATLRunner(client, adapter, artifact_path=artifact_path)
+
+    summary = runner.run_backtest(
+        agent_version_id="agv_vnpy",
+        start_date="2026-04-15",
+        end_date="2026-04-16",
+        poll_interval=0.001,
+    )
+
+    assert isinstance(summary, VnpyCtaRunSummary)
+    assert summary.run_id == "run_vnpy"
+    assert summary.clean is True
+    assert summary.metrics["total_return"] == 0.02
+    assert len(summary.artifact_sha256) == 64
+    assert artifact_path.exists()
+    assert len(client.submitted) == 2
+    _, create_kwargs = client.create_calls[0]
+    assert create_kwargs["environment_id"] == "us-equity-hourly-v1"
+    assert create_kwargs["symbols"] == ["AAPL"]
+    encoded_config = json.dumps(create_kwargs["config"], sort_keys=True)
+    assert create_kwargs["config"]["integration"] == "vnpy_cta"
+    assert "never-persist" not in encoded_config
+
+
+def test_vnpy_runner_marks_autoheld_timeout_unclean(tmp_path):
+    adapter = _adapter(_AdapterRuntime())
+    client = _RunnerClient(
+        [_awaiting_step(0, 10), _completed_step()],
+        conflict_code="decision_deadline_exceeded",
+    )
+    runner = VnpyCtaATLRunner(
+        client, adapter, artifact_path=tmp_path / "timeout.json"
+    )
+
+    summary = runner.run_backtest(
+        agent_version_id="agv_vnpy",
+        start_date="2026-04-15",
+        end_date="2026-04-16",
+        poll_interval=0.001,
+    )
+
+    assert summary.clean is False
+    assert summary.diagnostics["timeout_hold"] == 1
+
+
+def test_vnpy_runner_persists_partial_artifact_and_reraises_api_error(tmp_path):
+    artifact_path = tmp_path / "failed.json"
+    adapter = _adapter(_AdapterRuntime())
+    error = ATLAPIError("backend failed", code="backend_failed")
+    client = _RunnerClient([], next_error=error)
+    runner = VnpyCtaATLRunner(client, adapter, artifact_path=artifact_path)
+
+    with pytest.raises(ATLAPIError) as raised:
+        runner.run_backtest(
+            agent_version_id="agv_vnpy",
+            start_date="2026-04-15",
+            end_date="2026-04-16",
+        )
+
+    assert raised.value is error
+    assert raised.value.run_id == "run_vnpy"
+    assert artifact_path.exists()
+    artifact = load_audit_artifact(artifact_path)
+    assert artifact.summary["run_error"] == 1
+    assert artifact.summary.get("error_hold", 0) == 0
+
+
+def test_vnpy_runner_classifies_bad_ohlcv_as_fatal_data_error(tmp_path):
+    artifact_path = tmp_path / "bad-bar.json"
+    adapter = _adapter(_AdapterRuntime())
+    bad_step = _awaiting_step(0, 10)
+    bad_step.observation.market["bars"]["AAPL"]["close"] = math.nan
+    client = _RunnerClient([bad_step])
+    runner = VnpyCtaATLRunner(client, adapter, artifact_path=artifact_path)
+
+    with pytest.raises(VnpyCtaDataError):
+        runner.run_backtest(
+            agent_version_id="agv_vnpy",
+            start_date="2026-04-15",
+            end_date="2026-04-16",
+        )
+
+    artifact = load_audit_artifact(artifact_path)
+    assert artifact.summary["fatal_data_error"] == 1
+    assert artifact.summary.get("run_error", 0) == 0
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [("not-a-date", "2026-04-16"), ("2026-04-17", "2026-04-16")],
+)
+def test_vnpy_runner_rejects_bad_dates_before_creating_run(tmp_path, start, end):
+    client = _RunnerClient([])
+    runner = VnpyCtaATLRunner(
+        client,
+        _adapter(_AdapterRuntime()),
+        artifact_path=tmp_path / "unused.json",
+    )
+
+    with pytest.raises(ValueError):
+        runner.run_backtest(
+            agent_version_id="agv_vnpy",
+            start_date=start,
+            end_date=end,
+        )
+
+    assert client.create_calls == []
+
+
+def test_vnpy_cli_help_is_lazy_and_needs_no_credentials(tmp_path):
+    script = _REPO_ROOT / "dashboard" / "examples" / "vnpy_cta_atl_backtest.py"
+    blocked = tmp_path / "blocked-imports"
+    blocked.mkdir()
+    (blocked / "vnpy_ctastrategy.py").write_text(
+        "raise RuntimeError('vnpy_ctastrategy imported during --help')\n",
+        encoding="utf-8",
+    )
+    vnpy_package = blocked / "vnpy"
+    vnpy_package.mkdir()
+    (vnpy_package / "__init__.py").write_text(
+        "raise RuntimeError('vnpy imported during --help')\n",
+        encoding="utf-8",
+    )
+    env = dict(os.environ)
+    source = str(_REPO_ROOT / "packaging" / "agentictrading" / "src")
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(blocked), source, env.get("PYTHONPATH")) if part
+    )
+    env.pop("ATL_BASE_URL", None)
+    env.pop("ATL_API_KEY", None)
+    env.pop("ATL_AGENT_VERSION_ID", None)
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    for option in (
+        "--strategy",
+        "--settings-file",
+        "--symbol",
+        "--start",
+        "--end",
+        "--initial-cash",
+        "--output",
+    ):
+        assert option in result.stdout
+
+
+def test_vnpy_cli_validates_inputs_environment_and_strategy_spec(tmp_path, monkeypatch):
+    cli = _load_example("vnpy_cta_atl_backtest.py", "_test_vnpy_cta_cli_validation")
+
+    assert cli.validate_inputs("aapl", "2026-04-15", "2026-04-16") == "AAPL"
+    with pytest.raises(ValueError, match="AAPL only"):
+        cli.validate_inputs("MSFT", "2026-04-15", "2026-04-16")
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        cli.validate_inputs("AAPL", "bad-date", "2026-04-16")
+    with pytest.raises(ValueError, match="end date"):
+        cli.validate_inputs("AAPL", "2026-04-17", "2026-04-16")
+    with pytest.raises(ValueError) as missing:
+        cli.required_environment({})
+    for name in ("ATL_BASE_URL", "ATL_API_KEY", "ATL_AGENT_VERSION_ID"):
+        assert name in str(missing.value)
+
+    module_path = tmp_path / "trusted_strategy.py"
+    module_path.write_text("class TrustedStrategy:\n    pass\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    strategy = cli.load_strategy_class("trusted_strategy:TrustedStrategy")
+    assert strategy.__name__ == "TrustedStrategy"
+    with pytest.raises(ValueError, match="module:Class"):
+        cli.load_strategy_class("trusted_strategy")
+
+
+def test_vnpy_cli_initializes_strategy_before_client_and_redacts_settings(
+    tmp_path, monkeypatch, capsys
+):
+    cli = _load_example("vnpy_cta_atl_backtest.py", "_test_vnpy_cta_cli_run")
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps({"fast_window": 2, "api_key": "settings-secret"}),
+        encoding="utf-8",
+    )
+    events = []
+    seen = {}
+
+    class FakeRuntime:
+        def __init__(self, strategy_class, *, symbol, settings):
+            events.append("runtime")
+            seen["runtime_settings"] = dict(settings)
+            self.bindings = SimpleNamespace(vnpy_version="4.4.0", cta_version="1.3.0")
+
+    class FakeAdapter:
+        def __init__(self, runtime, *, symbol, manifest):
+            events.append("adapter")
+            seen["manifest"] = manifest
+
+    class FakeClient:
+        def __init__(self, *, base_url, api_key):
+            events.append("client")
+            assert api_key == "atl-secret"
+
+    class FakeRunner:
+        def __init__(self, client, adapter, *, artifact_path):
+            events.append("runner")
+            self.artifact_path = Path(artifact_path)
+
+        def run_backtest(self, **kwargs):
+            events.append("run")
+            artifact = build_audit_artifact(manifest={}, records=())
+            return VnpyCtaRunSummary(
+                result=RunResult(
+                    run_id="run_cli",
+                    status="completed",
+                    metrics={"total_return": 0.01},
+                    raw={"compare_url": "/compare?run_ids=ext_cli"},
+                ),
+                artifact=artifact,
+                artifact_path=self.artifact_path,
+                artifact_sha256="a" * 64,
+                clean=True,
+            )
+
+    def fake_load_strategy(spec):
+        events.append("strategy_import")
+        return type("Strategy", (), {})
+
+    monkeypatch.setattr(cli, "load_strategy_class", fake_load_strategy)
+    monkeypatch.setattr(cli, "VnpyCtaRuntime", FakeRuntime)
+    monkeypatch.setattr(cli, "VnpyCtaAdapter", FakeAdapter)
+    monkeypatch.setattr(cli, "ATLClient", FakeClient)
+    monkeypatch.setattr(cli, "VnpyCtaATLRunner", FakeRunner)
+
+    summary = cli.run_cli(
+        [
+            "--strategy",
+            "trusted:Strategy",
+            "--settings-file",
+            str(settings_path),
+            "--symbol",
+            "AAPL",
+            "--start",
+            "2026-04-15",
+            "--end",
+            "2026-04-16",
+            "--output",
+            str(tmp_path / "audit.json"),
+        ],
+        environ={
+            "ATL_BASE_URL": "https://atl.example",
+            "ATL_API_KEY": "atl-secret",
+            "ATL_AGENT_VERSION_ID": "agv_cli",
+        },
+    )
+
+    assert summary.run_id == "run_cli"
+    assert events == ["strategy_import", "runtime", "adapter", "client", "runner", "run"]
+    assert seen["runtime_settings"]["api_key"] == "settings-secret"
+    encoded_manifest = json.dumps(seen["manifest"], sort_keys=True)
+    assert "settings-secret" not in encoded_manifest
+    assert "atl-secret" not in capsys.readouterr().out
+
+
+def test_vnpy_cli_summary_contains_result_metrics_diagnostics_and_artifact(tmp_path):
+    cli = _load_example("vnpy_cta_atl_backtest.py", "_test_vnpy_cta_cli_summary")
+    artifact = build_audit_artifact(
+        manifest={}, records=(_record(status="strategy_hold"),)
+    )
+    summary = VnpyCtaRunSummary(
+        result=RunResult(
+            run_id="run_summary",
+            status="completed",
+            metrics={"total_return": 0.025, "sharpe_ratio": 1.2},
+            raw={"compare_url": "/compare?run_ids=ext_summary"},
+        ),
+        artifact=artifact,
+        artifact_path=tmp_path / "summary.json",
+        artifact_sha256="b" * 64,
+        clean=False,
+    )
+
+    output = cli.format_summary(summary, base_url="https://atl.example/api")
+
+    assert "run_summary" in output
+    assert "https://atl.example/compare?run_ids=ext_summary" in output
+    assert "total_return: 0.025" in output
+    assert "sharpe_ratio: 1.2" in output
+    assert "strategy_hold: 1" in output
+    assert "error_hold: 0" in output
+    assert str(tmp_path / "summary.json") in output
+    assert "b" * 64 in output
+
+
+def test_vnpy_double_ma_example_streams_bars_and_emits_buy_then_sell(monkeypatch):
+    class FakeCtaTemplate:
+        def __init__(self, engine, strategy_name, vt_symbol, setting):
+            self.cta_engine = engine
+            self.strategy_name = strategy_name
+            self.vt_symbol = vt_symbol
+            self.pos = 0
+            self.buy_calls = []
+            self.sell_calls = []
+            for name, value in setting.items():
+                setattr(self, name, value)
+
+        def buy(self, price, volume):
+            self.buy_calls.append((price, volume))
+
+        def sell(self, price, volume):
+            self.sell_calls.append((price, volume))
+
+        def write_log(self, message):
+            return None
+
+        def put_event(self):
+            return None
+
+    fake_cta = ModuleType("vnpy_ctastrategy")
+    fake_cta.CtaTemplate = FakeCtaTemplate
+    fake_vnpy = ModuleType("vnpy")
+    fake_trader = ModuleType("vnpy.trader")
+    fake_object = ModuleType("vnpy.trader.object")
+    fake_object.BarData = SimpleNamespace
+    monkeypatch.setitem(sys.modules, "vnpy", fake_vnpy)
+    monkeypatch.setitem(sys.modules, "vnpy.trader", fake_trader)
+    monkeypatch.setitem(sys.modules, "vnpy.trader.object", fake_object)
+    monkeypatch.setitem(sys.modules, "vnpy_ctastrategy", fake_cta)
+    example = _load_example(
+        "vnpy_cta_double_ma_strategy.py", "_test_vnpy_double_ma_strategy"
+    )
+    strategy = example.DoubleMaStrategy(
+        object(),
+        "double_ma",
+        "AAPL.SMART",
+        {"fast_window": 2, "slow_window": 3, "fixed_size": 1},
+    )
+
+    for close in (3, 2, 1, 2):
+        strategy.on_bar(SimpleNamespace(close_price=close))
+    assert strategy.buy_calls == []
+
+    strategy.on_bar(SimpleNamespace(close_price=3))
+    assert strategy.buy_calls == [(3.0, 1)]
+    strategy.pos = 1
+    strategy.on_bar(SimpleNamespace(close_price=2))
+    strategy.on_bar(SimpleNamespace(close_price=1))
+    assert strategy.sell_calls == [(1.0, 1)]
+
+
+def test_vnpy_cta_guide_covers_execution_contract_and_limits():
+    guide = (_REPO_ROOT / "docs" / "integrations" / "vnpy-cta.md").read_text(
+        encoding="utf-8"
+    )
+    for required in (
+        "ATL AAPL hourly OHLCV",
+        "module:Class",
+        "Alpaca key",
+        "T+1",
+        "25%",
+        "load_bar",
+        "TargetPosTemplate",
+        "A-shares",
+        "live trading",
+        "artifact",
+        "does not mean the strategy is profitable",
+    ):
+        assert required in guide
+
+    external_agents = (
+        _REPO_ROOT / "docs" / "source" / "lab" / "external_agents.rst"
+    ).read_text(encoding="utf-8")
+    assert "Run a local vn.py CTA strategy" in external_agents
+    assert "docs/integrations/vnpy-cta.md" in external_agents
+
+
+class _DeterministicCtaClient:
+    def __init__(self):
+        self.closes = (3.0, 2.0, 1.0, 2.0, 3.0, 2.0, 1.0, 2.0)
+        self.start = datetime(2026, 4, 15, 10, tzinfo=timezone.utc)
+        self.index = 0
+        self.position = 0
+        self.minimum_position = 0
+        self.orders = []
+        self.rejections = []
+
+    def create_run(self, agent_version_id, **kwargs):
+        return Run(run_id="run_real_vnpy_offline", status="running")
+
+    def _timestamp(self, index):
+        return (self.start + timedelta(hours=index)).isoformat()
+
+    def get_next_step(self, run_id):
+        if self.index >= len(self.closes):
+            return Step(
+                status="completed",
+                run_id=run_id,
+                result_run_id="ext_real_vnpy_offline",
+            )
+        close = self.closes[self.index]
+        timestamp = self._timestamp(self.index)
+        positions = (
+            [{"symbol": "AAPL", "quantity": self.position}]
+            if self.position
+            else []
+        )
+        observation = Observation(
+            market={
+                "bars": {
+                    "AAPL": {
+                        "timestamp": timestamp,
+                        "open": close,
+                        "high": close + 0.25,
+                        "low": close - 0.25,
+                        "close": close,
+                        "volume": 10_000.0,
+                    }
+                },
+                "features": {},
+                "events": [],
+            },
+            portfolio={
+                "cash": 1_000.0,
+                "equity": 1_000.0,
+                "positions": positions,
+            },
+        )
+        return Step(
+            status="awaiting_decision",
+            run_id=run_id,
+            step_id=f"step_{self.index}",
+            sequence=self.index,
+            timestamp=timestamp,
+            observation=observation,
+        )
+
+    def submit_decision(self, run_id, step_id, decision):
+        timestamp = self._timestamp(self.index)
+        fills = []
+        for order in decision.orders:
+            quantity = int(order.quantity)
+            if order.side == "buy":
+                self.position += quantity
+            elif order.side == "sell" and quantity <= self.position:
+                self.position -= quantity
+            else:
+                rejection = {
+                    "order": order.to_dict(),
+                    "reason": "unexpected_offline_order",
+                }
+                self.rejections.append(rejection)
+                continue
+            fill = {
+                "symbol": order.symbol,
+                "side": order.side,
+                "requested_quantity": quantity,
+                "filled_quantity": quantity,
+                "fill_price": self.closes[self.index],
+            }
+            fills.append(fill)
+            self.orders.append(
+                {
+                    "side": order.side,
+                    "quantity": quantity,
+                    "signal_timestamp": decision.trace["signal_timestamp"],
+                    "execution_timestamp": timestamp,
+                }
+            )
+        self.minimum_position = min(self.minimum_position, self.position)
+        self.index += 1
+        positions = (
+            [{"symbol": "AAPL", "quantity": self.position}]
+            if self.position
+            else []
+        )
+        return ExecutionResult(
+            accepted=not self.rejections,
+            fills=fills,
+            validation={
+                "passed": not self.rejections,
+                "warnings": [],
+                "rejections": list(self.rejections),
+            },
+            portfolio_after={
+                "cash": 1_000.0,
+                "equity": 1_000.0,
+                "positions": positions,
+            },
+            run_status="running",
+        )
+
+    def get_run_result(self, run_id):
+        return RunResult(
+            run_id=run_id,
+            result_run_id="ext_real_vnpy_offline",
+            status="completed",
+            metrics={"num_trades": len(self.orders), "total_return": 0.0},
+            equity_curve=[
+                {"timestamp": self._timestamp(index), "equity": 1_000.0}
+                for index in range(len(self.closes))
+            ],
+        )
+
+    def get_run_metrics(self, run_id):
+        return {"num_trades": len(self.orders), "total_return": 0.0}
+
+    def wait(self, seconds):
+        return None
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("vnpy") is None
+    or importlib.util.find_spec("vnpy_ctastrategy") is None,
+    reason="optional vn.py CTA dependencies are not installed",
+)
+def test_real_vnpy_double_ma_offline_loop_is_t1_long_only_and_deterministic(tmp_path):
+    example = _load_example(
+        "vnpy_cta_double_ma_strategy.py", "_test_real_vnpy_double_ma_strategy"
+    )
+
+    def run_once(name):
+        runtime = VnpyCtaRuntime(
+            example.DoubleMaStrategy,
+            symbol="AAPL",
+            settings={"fast_window": 2, "slow_window": 3, "fixed_size": 1},
+        )
+        adapter = VnpyCtaAdapter(
+            runtime,
+            symbol="AAPL",
+            manifest={"strategy": "example:DoubleMaStrategy"},
+        )
+        client = _DeterministicCtaClient()
+        summary = VnpyCtaATLRunner(
+            client,
+            adapter,
+            artifact_path=tmp_path / f"{name}.json",
+        ).run_backtest(
+            agent_version_id="agv_real_vnpy_offline",
+            start_date="2026-04-15",
+            end_date="2026-04-16",
+            poll_interval=0.001,
+        )
+        return client, summary
+
+    first_client, first = run_once("first")
+    second_client, second = run_once("second")
+
+    assert [order["side"] for order in first_client.orders] == ["buy", "sell"]
+    assert first_client.orders == second_client.orders
+    assert first_client.minimum_position == 0
+    assert first_client.position == 0
+    assert first_client.rejections == []
+    for order in first_client.orders:
+        signal = datetime.fromisoformat(order["signal_timestamp"])
+        execution = datetime.fromisoformat(order["execution_timestamp"])
+        assert execution > signal
+
+    for counter in (
+        "error_hold",
+        "timeout_hold",
+        "unsupported_actions",
+        "local_rejections",
+        "atl_rejections",
+    ):
+        assert first.diagnostics.get(counter, 0) == 0
+    assert first.clean is True
+    assert first.diagnostics == second.diagnostics
+    assert first.artifact.to_dict() == second.artifact.to_dict()
+    assert first.artifact_sha256 == second.artifact_sha256

--- a/packaging/agentictrading/tests/test_vnpy_cta_integration.py
+++ b/packaging/agentictrading/tests/test_vnpy_cta_integration.py
@@ -17,7 +17,6 @@ import pytest
 from agentictrading.integrations.vnpy_cta import (
     ARTIFACT_SCHEMA_VERSION,
     ArtifactValidationError,
-    AtlCtaEngine,
     CapturedCtaOrder,
     VnpyBindings,
     VnpyCtaAdapter,

--- a/packaging/agentictrading/tests/test_vnpy_cta_integration.py
+++ b/packaging/agentictrading/tests/test_vnpy_cta_integration.py
@@ -201,6 +201,21 @@ def test_safe_manifest_and_error_message_remove_credentials():
     assert "alice:pw" not in error
 
 
+def test_error_message_redacts_colon_and_json_style_credentials():
+    """The equals-only regex missed header-dump and JSON-embedded credentials
+    (e.g. an HTTP client's ``X-API-Key: <key>`` header repr, or a stringified
+    JSON payload) — both are plausible shapes for a credential to leak into
+    an exception's ``str()``.
+    """
+    error = sanitize_error_message(
+        "request failed headers={'X-API-Key': 'ag_live_abc123'} "
+        'body={"api_key": "sk-json-secret", "symbol": "AAPL"}'
+    )
+    assert "ag_live_abc123" not in error
+    assert "sk-json-secret" not in error
+    assert "AAPL" in error  # non-sensitive fields must survive redaction
+
+
 def test_artifact_round_trip_has_stable_summary_and_sha256(tmp_path):
     artifact = build_audit_artifact(
         manifest=build_safe_manifest({"strategy": "demo:DoubleMaStrategy"}),
@@ -486,6 +501,94 @@ def test_runtime_syncs_position_and_emits_fill_callbacks():
     assert runtime.strategy.pos == 7
 
 
+class _TwoOrderStrategy(_CtaTemplate):
+    """Emits two same-side orders of different sizes from a single on_bar()."""
+
+    def __init__(self, engine, strategy_name, vt_symbol, setting):
+        self.cta_engine = engine
+        self.pos = 0
+        self.events = []
+
+    def on_init(self):
+        return None
+
+    def on_start(self):
+        return None
+
+    def on_stop(self):
+        return None
+
+    def on_bar(self, bar):
+        self.events.append(("bar", bar))
+        self.cta_engine.send_order(
+            self, _Direction.LONG, _Offset.OPEN, bar.close_price, 1, False, False, False
+        )
+        self.cta_engine.send_order(
+            self, _Direction.LONG, _Offset.OPEN, bar.close_price, 3, False, False, False
+        )
+
+    def on_order(self, order):
+        self.events.append(("order", order))
+
+    def on_trade(self, trade):
+        self.events.append(("trade", trade))
+
+
+def test_apply_execution_result_matches_multiple_same_side_orders_by_quantity():
+    """(symbol, side) alone can't disambiguate two same-side captured orders;
+    ATL's orders-v1 wire schema has no client order id, so requested_quantity
+    is the only extra signal available — verify it's used to avoid pairing
+    fills to the wrong captured order.
+    """
+    runtime = VnpyCtaRuntime(
+        _TwoOrderStrategy,
+        symbol="AAPL",
+        settings={},
+        bindings=_fake_bindings(),
+    )
+    runtime.start()
+    captured = runtime.on_bar(_bar_payload())
+    assert [order.volume for order in captured] == [1, 3]
+
+    # Fills listed in the OPPOSITE order from submission: a pure (symbol, side)
+    # first-match would pair the 1-share order with the 3-share fill.
+    result = ExecutionResult(
+        accepted=True,
+        fills=[
+            {
+                "symbol": "AAPL",
+                "side": "buy",
+                "requested_quantity": 3,
+                "filled_quantity": 3,
+                "fill_price": 103.0,
+            },
+            {
+                "symbol": "AAPL",
+                "side": "buy",
+                "requested_quantity": 1,
+                "filled_quantity": 1,
+                "fill_price": 101.0,
+            },
+        ],
+        validation={"passed": True, "warnings": [], "rejections": []},
+    )
+
+    runtime.apply_execution_result(
+        result,
+        captured_orders=captured,
+        timestamp="2026-04-15T11:00:00-04:00",
+    )
+
+    trades = [event[1] for event in runtime.strategy.events if event[0] == "trade"]
+    assert len(trades) == 2
+    by_order_id = {trade.orderid: trade for trade in trades}
+    assert by_order_id[captured[0].order_id].volume == 1
+    assert by_order_id[captured[0].order_id].price == 101.0
+    assert by_order_id[captured[1].order_id].volume == 3
+    assert by_order_id[captured[1].order_id].price == 103.0
+    assert runtime.strategy.pos == 4
+
+
 def test_runtime_emits_rejected_order_callback_without_trade():
     runtime = VnpyCtaRuntime(
         _RecordingStrategy,
@@ -594,6 +697,9 @@ class _AdapterRuntime:
 
     def reject_captured_order(self, captured, *, reason, timestamp):
         self.rejected.append((captured, reason, timestamp))
+
+    def drain_captured_orders(self):
+        return self.engine.drain_captured_orders()
 
 
 def _observation(hour: int, *, position: int = 0, bar_overrides=None) -> Observation:


### PR DESCRIPTION
## Summary

- expose the current OHLCV bar in protocol observations for external strategy runtimes
- add an optional vn.py CTA integration for trusted local `CtaTemplate` strategies
- adapt vn.py `buy` and `sell` signals into ATL orders with T+1 execution semantics
- persist deterministic audit artifacts with strategy inputs, captured orders, ATL responses, and diagnostics
- add a runnable double-moving-average example, an English quickstart, and English design and implementation documents

## Validation

- `171 passed` in `packaging/agentictrading/tests`
- `1571 passed, 34 skipped` in `dashboard/backend/tests`
- `222 passed` across the SDK and directly affected protocol/backtest tests after the documentation cleanup
- deterministic offline smoke produced a complete `buy -> sell` loop
- real Alpaca hourly AAPL smoke completed 105 steps with no adapter, timeout, or fatal-data errors; the strategy emitted three one-share buy orders, all correctly rejected by the ATL `max_position_weight=0.25` constraint because AAPL was above $250 in a $1,000 account
- no Chinese text or Chinese filenames in the PR diff or commit history
- `git diff --check origin/main...HEAD`

## Scope

This first version runs trusted local, bar-driven vn.py `CtaTemplate` strategies. It does not execute untrusted uploaded Python, connect a live broker, or reproduce the full vn.py CTA engine. Hosted smoke runs require this branch to be deployed first because the current production protocol does not yet include `market.bars`.