### PR TITLE
docs: Agent Marketplace and Robinhood live trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,14 @@ Start with a market question or trading idea, then turn it into an agent you can
 
 - **Create trading agents your way**  
 Choose a model, data source, and trading prompt, or connect your own agent through our API.
+- **Start from a template**  
+Copy a ready-made agent out of the Agent Marketplace, then customize its prompts and backtest it.
 - **Build an agent-powered portfolio**  
 Give multiple agents simulated capital and manage them as your own virtual trading team.
 - **Test before using real capital**  
 Move from historical backtests to live-market paper trading in one workflow.
+- **Go live when you're ready**  
+Connect a real Robinhood account and let an agent trade it under per-order risk caps. Off by default, with a review-only mode that shows what an agent *would* do before it can act — see [Live Trading](docs/source/lab/live_trading.rst).
 - **See every run, decision, and reason**  
 Monitor positions, trades, portfolio changes, and the reasoning behind each action.
 - **Measure more than returns**  
@@ -72,12 +76,12 @@ AgenticTrading/
 │   │   ├── api/               # /api routers + Agent API v2 (/api/v2)
 │   │   ├── domain/            # Business logic (runs, backtesting, leaderboard, trading, …)
 │   │   ├── execution/         # v2 execution backends (backtest live; paper stub)
-│   │   ├── infrastructure/    # LLM validator, market data, Alpaca broker
+│   │   ├── infrastructure/    # LLM validator, market data, Alpaca + Robinhood brokers
 │   │   └── integrations/      # Discord bot, etc.
 │   ├── frontend/              # Static assets: landing (/) + dashboard (/app)
 │   ├── landing/               # Vite/React landing source (builds into frontend/)
 │   ├── scripts/               # CLI backtests (backtest_hourly_agent.py, …)
-│   ├── config/                # defaults.json, leaderboard.json
+│   ├── config/                # defaults.json, leaderboard.json, marketplace.json
 │   └── storage/               # data/backtest.db + backups/
 ├── packaging/agentictrading/  # PyPI SDK (AgentRunner + HTTP client)
 ├── credentials/               # Local only — not in git (see alpaca.json.example)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,9 @@ Welcome to the **Agentic Trading** documentation.
    lab/key_features
    lab/getting_started
    lab/accounts
+   lab/marketplace
    lab/external_agents
+   lab/live_trading
    lab/architecture
    lab/agent_api
 

--- a/docs/source/lab/getting_started.rst
+++ b/docs/source/lab/getting_started.rst
@@ -11,6 +11,13 @@ Run a backtest in the dashboard
 
 Results appear in **Trading Performance** (agent vs. buy-and-hold vs. DJIA).
 
+Start from a template
+---------------------
+
+Rather than writing an agent from scratch, open **Playground → Agent
+Marketplace** and copy a ready-made template into **My Agents**, then edit its
+prompts and backtest it. See :doc:`marketplace`.
+
 Accounts (optional)
 -------------------
 
@@ -61,6 +68,13 @@ Use **either** environment variables **or** a local credentials file.
    cp credentials/alpaca.json.example credentials/alpaca.json
 
 The ``credentials/`` directory is not tracked in git. See ``credentials/README.md``.
+
+Configure Robinhood live trading (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Live trading against a real brokerage account is off unless you configure it,
+and orders are never sent unless you also set ``ROBINHOOD_EXECUTE=true``. See
+:ref:`robinhood-config` for the full variable list.
 
 Start the API server
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/lab/key_features.rst
+++ b/docs/source/lab/key_features.rst
@@ -5,4 +5,6 @@ Key Features
 - **Educational playground** — Explore trading without wiring up APIs and infrastructure yourself.
 - **Interactive backtesting** — Custom date ranges and assets from the web dashboard.
 - **Performance metrics** — Final portfolio value, cumulative return, max drawdown, Sharpe ratio, and equity-curve comparison views.
+- **Agent Marketplace** — Copy ready-made agent templates into your own workspace and customize them.
+- **Live trading** — Connect a real Robinhood account and let an agent propose orders under hard risk caps, with a review-only mode by default.
 - **Optional accounts** — Sign in to persist your agents, attribute leaderboard runs, and link Discord.

--- a/docs/source/lab/live_trading.rst
+++ b/docs/source/lab/live_trading.rst
@@ -1,0 +1,214 @@
+Live Trading with Robinhood
+===========================
+
+Agents can be connected to a **real Robinhood brokerage account** and asked to
+propose and place orders against it. This is separate from :doc:`backtesting
+<getting_started>` (historical data) and from Alpaca paper trading (simulated
+money): here the account, the positions, and the orders are real.
+
+.. warning::
+
+   Live trading places orders with real money in your own brokerage account.
+   The agents here are LLM-driven research tools, not investment advice, and
+   nothing in the Lab predicts market outcomes. Connect an account only if you
+   accept the full risk of the trades an agent may place, and start with the
+   review-only mode described below.
+
+Live trading is **off unless the deployment turns it on**. On a server started
+with the default configuration, a live run does everything except send the
+orders — see :ref:`the two gates <live-two-gates>`.
+
+
+Before you start
+----------------
+
+You need:
+
+- an **ATL account** (see :doc:`accounts`) — the Robinhood link is stored
+  against it, so live trading is not available to signed-out browser sessions;
+- a **real agent** under **Playground → My Agents**. The demo agents on the
+  dashboard cannot be connected; create or :doc:`copy <marketplace>` one first;
+- a **Robinhood account** eligible for Robinhood's Agentic Trading (MCP) access;
+- a deployment configured for Robinhood (:ref:`robinhood-config`). If it is not,
+  connecting fails with *Robinhood OAuth is not configured*.
+
+
+Connect your brokerage account
+------------------------------
+
+1. Open the agent in the agent editor and find the **Robinhood live trading**
+   section.
+2. Click **Connect Robinhood**. You are sent to Robinhood to sign in and approve
+   access.
+3. Robinhood returns you to the dashboard, which finishes the link against the
+   account you are signed in as.
+
+The status line then reads **Connected**. Clicking **Connect Robinhood** again
+refreshes the account details rather than starting a second link.
+
+.. note::
+
+   The link is completed in two steps on purpose. The page Robinhood redirects
+   to cannot prove who you are, so it never stores credentials — it hands the
+   dashboard a short-lived, single-use code, and the dashboard redeems it under
+   your signed-in session. A link started from one account can never be
+   redeemed by another.
+
+**Disconnect** revokes access upstream where Robinhood supports it and deletes
+the stored tokens. Tokens are encrypted at rest.
+
+
+Run an agent live
+-----------------
+
+1. Tick **Enable live trading for this agent**. This is per agent, so connecting
+   your brokerage account does not arm every agent you own.
+2. Click **Run Live**.
+
+The run then:
+
+- reads your Robinhood portfolio and buying power;
+- quotes the tradable universe — the DJIA 30 plus anything you already hold;
+- asks the agent's model for orders, given that snapshot;
+- puts every order through the risk gate below;
+- reviews each surviving order with Robinhood, and places it only if the
+  deployment allows execution.
+
+The result panel reports what was proposed, what was rejected and why, and what
+was actually submitted.
+
+.. _live-two-gates:
+
+The two gates
+~~~~~~~~~~~~~
+
+Orders reach the market only when **both** are true:
+
+1. The agent has **live trading enabled** (the per-agent tick box), and
+2. the server has execution turned on (``ROBINHOOD_EXECUTE=true``).
+
+The second gate is a deployment setting, not a UI control. With it off — the
+default — the run still fetches your real portfolio, asks the model, and reviews
+each order with Robinhood, but every order is recorded as ``skipped`` instead of
+being submitted. The panel says *Live review completed (execute off)*, and the
+response carries ``"execute_enabled": false``. This is the intended way to watch
+what an agent would do with your real account before letting it act.
+
+Risk gate
+~~~~~~~~~
+
+Every proposed order is clamped or rejected before it reaches the broker, on
+**both** the buy and the sell side:
+
+- **No usable quote → rejected.** An order that cannot be priced cannot be
+  sized against the USD cap, so it is never passed through.
+- **Notional cap.** Quantity is clamped to ``ROBINHOOD_MAX_ORDER_USD / price``,
+  default **$25 per order**. The cap is read per order, so it can be tightened
+  on a running server.
+- **Share cap.** No single order exceeds 10,000 shares.
+- **Sells are clamped to what you hold**, and rejected outright if you hold none
+  of that symbol — an agent can never open a short.
+- Quantities are rounded **down**, so rounding cannot push an order back over
+  the cap. A residual below the minimum order quantity is rejected.
+
+One live run at a time is allowed per account; a second request while one is in
+flight returns *A live run is already in progress*. Supply an
+``idempotency_key`` when driving the API directly to make a retry safe.
+
+
+API
+---
+
+All routes need your ATL session token in the ``Authorization`` header.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 44 56
+
+   * - Endpoint
+     - Purpose
+   * - ``GET /api/v1/robinhood/status``
+     - Connection state. ``?portfolio=true`` includes account details.
+   * - ``DELETE /api/v1/robinhood/disconnect``
+     - Revoke upstream where supported and delete stored tokens.
+   * - ``POST /api/v1/robinhood/agents/{agent_id}/live-run``
+     - Run one live cycle. Body: ``{"dry_run": true, "idempotency_key": "..."}``.
+   * - ``POST /api/auth/robinhood/start``
+     - Begin the OAuth link; returns ``authorize_url``.
+   * - ``POST /api/auth/robinhood/complete``
+     - Redeem the link code returned by the OAuth callback.
+
+``dry_run: true`` forces a review-only cycle even on a server with execution
+enabled. ``dry_run: false`` defers to ``ROBINHOOD_EXECUTE``.
+
+
+Troubleshooting
+---------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 46 54
+
+   * - Message
+     - What to do
+   * - *Robinhood OAuth is not configured*
+     - The deployment has no Robinhood settings. See :ref:`robinhood-config`.
+   * - *Create a real agent in My Agents first*
+     - You are on a demo agent. Create or copy one, then retry.
+   * - *Connect Robinhood first*
+     - No brokerage account is linked to your ATL account.
+   * - *Enable live trading for this agent*
+     - Tick the per-agent box; connecting alone does not arm an agent.
+   * - *This Robinhood link was started from a different account*
+     - The link was begun while signed in as someone else. Start again from the
+       account you want to link.
+   * - *Link expired — please connect again*
+     - The one-time link code lapsed (10 minutes) or was already used.
+   * - *A live run is already in progress*
+     - Wait for the current run to finish.
+   * - *No LLM provider is configured*
+     - The server has no LLM API key, so no decision could be made. Nothing was
+       traded.
+
+
+.. _robinhood-config:
+
+Configuration (self-hosting)
+----------------------------
+
+Set these in ``dashboard/.env`` (see ``.env.example``):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Variable
+     - Meaning
+   * - ``BROKER_TOKEN_ENCRYPTION_KEY``
+     - **Required.** Fernet key encrypting broker tokens at rest. Without it the
+       store refuses to read or write credentials — it deliberately does not
+       fall back to a derived key.
+   * - ``ROBINHOOD_MCP_URL``
+     - Robinhood Agentic Trading endpoint.
+   * - ``ROBINHOOD_REDIRECT_URI``
+     - OAuth callback. Must match the URL registered with Robinhood.
+   * - ``ROBINHOOD_OAUTH_STATE_SECRET``
+     - Signs the OAuth ``state``. Unset generates a random per-process key,
+       which is safe but breaks in-flight links across restarts and across
+       multiple workers. Set it in production.
+   * - ``ROBINHOOD_EXECUTE``
+     - ``false`` by default. Only ``true`` lets orders reach the market.
+   * - ``ROBINHOOD_MAX_ORDER_USD``
+     - Per-order notional ceiling, both sides. Defaults to ``25``; an
+       unparseable or non-positive value falls back to ``25`` rather than
+       disabling the cap.
+
+Generate an encryption key with:
+
+.. code-block:: bash
+
+   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+
+Linked accounts are stored in the ``CONTENT_DATABASE_URL`` Postgres database
+when one is configured. Leave that unset only for local development — on an
+ephemeral deployment, links do not survive a redeploy.

--- a/docs/source/lab/marketplace.rst
+++ b/docs/source/lab/marketplace.rst
@@ -1,0 +1,81 @@
+Agent Marketplace
+=================
+
+The **Agent Marketplace** is a catalog of ready-made agent templates. Copy one
+into :doc:`My Agents <external_agents>`, then edit, backtest, or run it like any
+agent you built yourself.
+
+Open the dashboard, go to **Playground**, and choose the **Agent Marketplace**
+tab. Browsing needs no account.
+
+
+Browse the catalog
+------------------
+
+Each card shows what you are copying:
+
+- **Category** — ``Foundation`` for single-instruction agents, ``Advanced`` for
+  multi-step pipelines.
+- **Model** — the LLM the template is tuned for (you can change it after copying).
+- **Simple** or **Multi-step pipeline**, with the step count.
+- **Tags** and the template author.
+
+Use the search box to filter by name, description, or tag.
+
+Templates shipped today:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 22 40
+
+   * - Template
+     - Category
+     - Model
+     - What it does
+   * - **Balanced Starter**
+     - Foundation
+     - ``anthropic/claude-haiku-4-5``
+     - Diversifies across strong stocks, buys dips, takes profits after run-ups.
+   * - **Momentum Scout**
+     - Foundation
+     - ``anthropic/claude-haiku-4-5``
+     - Follows recent price strength and volume; trims laggards quickly.
+   * - **Pipeline Analyst**
+     - Advanced
+     - ``anthropic/claude-sonnet-4-6``
+     - Three steps — gather market facts, convert them into signals, then
+       produce executable orders.
+
+
+Copy a template
+---------------
+
+1. Click **Copy to My Agents** on a card.
+2. The agent appears under **Playground → My Agents**, owned by you, with the
+   template's prompt pipeline already filled in.
+3. Open it in the agent editor to rename it, change the model, or rewrite the
+   prompts. The copy is independent — later edits to the template do not touch
+   your agent, and your edits never affect anyone else's copy.
+
+New agents are funded with the default cash allocation ($1,000) for backtesting.
+If you are signed in, that comes out of your account portfolio, so a copy can
+fail with *insufficient cash* until you free some up (see :doc:`accounts`).
+
+.. note::
+
+   You can copy templates without signing in — the agent is then tied to your
+   browser session and disappears when it expires. Sign in first if you want it
+   to persist.
+
+
+Add a template
+--------------
+
+The catalog is config-driven: templates live in
+``dashboard/config/marketplace.json``, so contributing one needs no code or
+database change. Add an entry with a unique ``template_id``, a ``name``,
+``description``, ``category``, ``model_name``, ``tags``, and the ``pipeline``
+steps, then open a pull request. Entries missing ``template_id`` or ``name`` are
+skipped.
+
+The catalog is cached in-process, so a running server picks up edits on restart.

--- a/docs/source/lab/operating_modes.rst
+++ b/docs/source/lab/operating_modes.rst
@@ -7,5 +7,8 @@ Operating Modes
 **Paper trading**
    Connect to an Alpaca paper account for simulated live trading: account summary, positions, recent trades, and portfolio value over time.
 
-**Leaderboard** *(in development)*
-   Competition-style comparison of agents or teams under standardized metrics.
+**Live trading**
+   Connect a real Robinhood brokerage account and let an agent propose and place orders against it, under per-order risk caps. Off by default — see :doc:`live_trading`.
+
+**Leaderboard**
+   Standardized comparison of agents against buy-and-hold and index baselines over a fixed window. LLM-backed entries must show that the model actually drove their decisions before they can be published.

--- a/docs/source/lab/overview.rst
+++ b/docs/source/lab/overview.rst
@@ -10,7 +10,7 @@ Goals
 
 The platform bridges alpha-seeking research and deployable trading workflows. Beyond asking whether an agent can generate profitable signals, the lab surfaces the full pipeline—data handling, agent decisions, backtesting, paper trading, execution constraints, risk, and governance.
 
-See also :doc:`operating_modes`, :doc:`key_features`, :doc:`getting_started`, :doc:`accounts`, and :doc:`architecture`. For the multi-agent framework, see :doc:`../orchestration/index`.
+See also :doc:`operating_modes`, :doc:`key_features`, :doc:`getting_started`, :doc:`accounts`, :doc:`marketplace`, :doc:`live_trading`, and :doc:`architecture`. For the multi-agent framework, see :doc:`../orchestration/index`.
 
 Repository layout
 -----------------


### PR DESCRIPTION
#227 shipped both features with no user-facing docs — only `.env.example` mentioned them.

**New pages**
- `lab/marketplace.rst` — browse, copy a template, add one (catalog is config-driven).
- `lab/live_trading.rst` — connect a brokerage account, per-agent enable, risk gate, API, troubleshooting, self-host config incl. the required `BROKER_TOKEN_ENCRYPTION_KEY`.

**Worth a look in review:** the live-trading page leads with *two* gates. The UI's Run Live button sends `dry_run:false`, so `ROBINHOOD_EXECUTE` is the only thing between a click and a real order. Documenting the button alone would say the opposite of what a default deployment does.

Also drops the stale "(in development)" from the leaderboard entry — it has served in prod since 2026-07-11.

Docs-only; no code touched. `sphinx-build -n -E` reports no warning for any file changed here, and every added `:doc:`/`:ref:` resolves.