### PR TITLE
fix: keep default Foundation agent after signup + land on Home

### DIFF
--- a/dashboard/backend/domain/agents/repository.py
+++ b/dashboard/backend/domain/agents/repository.py
@@ -321,6 +321,10 @@ class AgentStore:
             )
 
         conn.close()
+        # Each _add_rows call is independently sorted, but the groups are
+        # appended query-by-query, so a recent unclaimed browser agent could
+        # otherwise land after an older owned agent. Re-sort the union once.
+        rows.sort(key=lambda row: row["created_at"], reverse=True)
         return [_public_agent(row) for row in rows]
 
     def list_builtin_agents(self) -> List[Dict[str, Any]]:

--- a/dashboard/backend/domain/agents/repository.py
+++ b/dashboard/backend/domain/agents/repository.py
@@ -286,6 +286,20 @@ class AgentStore:
                 """,
                 (owner_user_id,),
             )
+            # Also surface unclaimed agents created in this browser before
+            # login/claim. Without this, a signed-in list drops the guest
+            # "My Foundation Agent" whenever claim races or is skipped, while
+            # logout (browser-only list) still shows it.
+            if owner_browser_session:
+                _add_rows(
+                    """
+                    SELECT * FROM external_agents
+                    WHERE owner_browser_session = ?
+                      AND owner_user_id IS NULL
+                    ORDER BY created_at DESC
+                    """,
+                    (owner_browser_session,),
+                )
         elif owner_browser_session:
             _add_rows(
                 """

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -248,6 +248,18 @@ class PostgresAgentStore:
                         """,
                         (owner_user_id,),
                     )
+                    # Also surface unclaimed agents created in this browser
+                    # before login/claim (same rationale as the SQLite twin).
+                    if owner_browser_session:
+                        _add_rows(
+                            """
+                            SELECT * FROM external_agents
+                            WHERE owner_browser_session = %s
+                              AND owner_user_id IS NULL
+                            ORDER BY created_at DESC
+                            """,
+                            (owner_browser_session,),
+                        )
                 elif owner_browser_session:
                     _add_rows(
                         """

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -280,6 +280,10 @@ class PostgresAgentStore:
                         (trading_session_id,),
                     )
 
+        # Each _add_rows call is independently sorted, but the groups are
+        # appended query-by-query, so a recent unclaimed browser agent could
+        # otherwise land after an older owned agent. Re-sort the union once.
+        rows.sort(key=lambda row: row["created_at"], reverse=True)
         return [_public_agent(row) for row in rows]
 
     def list_builtin_agents(self) -> List[Dict[str, Any]]:

--- a/dashboard/backend/tests/domain/agents/test_repository_move.py
+++ b/dashboard/backend/tests/domain/agents/test_repository_move.py
@@ -150,6 +150,31 @@ def test_list_agents_signed_in_includes_unclaimed_browser_agents(store):
     assert other_browser["agent_id"] not in ids
 
 
+def test_list_agents_merges_owned_and_unclaimed_by_recency(store, monkeypatch):
+    """The owned-rows and unclaimed-browser-rows groups must merge into one
+    global ORDER BY, not just be independently sorted within each group.
+
+    Without the merge, a browser agent created after every owned agent would
+    still sort last, because list_agents appends the unclaimed-browser group
+    only after the owned group is fully built.
+    """
+    import itertools
+
+    day = itertools.count(1)
+    monkeypatch.setattr(
+        repository, "_utcnow_iso", lambda: f"2020-01-{next(day):02d}T00:00:00+00:00"
+    )
+
+    older_owned = store.create_agent(name="Older Owned", owner_user_id=7, owner_browser_session="b1")
+    newer_unclaimed = store.create_agent(name="Newer Guest", owner_browser_session="b1")
+
+    listed = store.list_agents(owner_user_id=7, owner_browser_session="b1")
+    assert [a["agent_id"] for a in listed] == [
+        newer_unclaimed["agent_id"],
+        older_owned["agent_id"],
+    ]
+
+
 def test_rotate_api_key(store):
     created = store.create_agent(name="A")
     new_key = store.rotate_api_key(created["agent_id"])

--- a/dashboard/backend/tests/domain/agents/test_repository_move.py
+++ b/dashboard/backend/tests/domain/agents/test_repository_move.py
@@ -133,6 +133,23 @@ def test_list_agents_owner_filters(store):
     assert store.list_agents() == []
 
 
+def test_list_agents_signed_in_includes_unclaimed_browser_agents(store):
+    """Signed-in listing must not hide guest-provisioned agents awaiting claim."""
+    owned = store.create_agent(name="Owned", owner_user_id=7, owner_browser_session="b1")
+    unclaimed = store.create_agent(name="Guest", owner_browser_session="b1")
+    other_user = store.create_agent(
+        name="Other", owner_user_id=99, owner_browser_session="b1"
+    )
+    other_browser = store.create_agent(name="Elsewhere", owner_browser_session="b2")
+
+    listed = store.list_agents(owner_user_id=7, owner_browser_session="b1")
+    ids = {a["agent_id"] for a in listed}
+    assert owned["agent_id"] in ids
+    assert unclaimed["agent_id"] in ids
+    assert other_user["agent_id"] not in ids
+    assert other_browser["agent_id"] not in ids
+
+
 def test_rotate_api_key(store):
     created = store.create_agent(name="A")
     new_key = store.rotate_api_key(created["agent_id"])

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -183,6 +183,69 @@ def test_browser_claim_and_ownership_postgres(pg_agent_store):
 
 
 @pg_only
+def test_list_agents_signed_in_includes_unclaimed_browser_agents_postgres(
+    pg_agent_store,
+):
+    """Postgres mirror of the SQLite regression test in test_repository_move.py.
+
+    #235 added an unclaimed-browser-session fallback to list_agents so a
+    signed-in user still sees a guest-provisioned agent whose claim hasn't
+    landed yet. The SQLite twin had a test for the exclusion boundaries
+    (other user's claimed agent, other browser's agent); this store's twin
+    -- the one CONTENT_DATABASE_URL actually points prod at -- had none.
+    """
+    owned = pg_agent_store.create_agent(
+        name="Owned", owner_user_id=7, owner_browser_session="b1"
+    )
+    unclaimed = pg_agent_store.create_agent(name="Guest", owner_browser_session="b1")
+    other_user = pg_agent_store.create_agent(
+        name="Other", owner_user_id=99, owner_browser_session="b1"
+    )
+    other_browser = pg_agent_store.create_agent(name="Elsewhere", owner_browser_session="b2")
+
+    listed = pg_agent_store.list_agents(owner_user_id=7, owner_browser_session="b1")
+    ids = {a["agent_id"] for a in listed}
+    assert owned["agent_id"] in ids
+    assert unclaimed["agent_id"] in ids
+    assert other_user["agent_id"] not in ids
+    assert other_browser["agent_id"] not in ids
+
+
+@pg_only
+def test_list_agents_merges_owned_and_unclaimed_by_recency_postgres(
+    pg_agent_store, monkeypatch
+):
+    """The owned-rows and unclaimed-browser-rows groups must merge into one
+    global ORDER BY, not just be independently sorted within each group.
+
+    Without the merge, a browser agent created after every owned agent would
+    still sort last, because list_agents appends the unclaimed-browser group
+    only after the owned group is fully built.
+    """
+    import itertools
+
+    import dashboard.backend.domain.agents.repository_postgres as repo_pg
+
+    day = itertools.count(1)
+    monkeypatch.setattr(
+        repo_pg, "_utcnow_iso", lambda: f"2020-01-{next(day):02d}T00:00:00+00:00"
+    )
+
+    older_owned = pg_agent_store.create_agent(
+        name="Older Owned", owner_user_id=7, owner_browser_session="b1"
+    )
+    newer_unclaimed = pg_agent_store.create_agent(
+        name="Newer Guest", owner_browser_session="b1"
+    )
+
+    listed = pg_agent_store.list_agents(owner_user_id=7, owner_browser_session="b1")
+    assert [a["agent_id"] for a in listed] == [
+        newer_unclaimed["agent_id"],
+        older_owned["agent_id"],
+    ]
+
+
+@pg_only
 def test_register_or_get_agent_is_idempotent_postgres(pg_agent_store):
     first = pg_agent_store.register_or_get_agent(session_id="sess-1", name="A")
     again = pg_agent_store.register_or_get_agent(session_id="sess-1", name="A renamed")

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -256,6 +256,7 @@ def test_signed_in_list_includes_unclaimed_browser_foundation_agent(client):
     assert agent_id in ids
     assert any(a.get("name") == "My Foundation Agent" for a in listed.json()["agents"])
 
+
 def test_rotate_api_key(client):
     browser_session = str(uuid.uuid4())
     headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -217,6 +217,45 @@ def test_claim_account_links_browser_agents(client):
     assert listed.json()["agents"][0]["agent_id"] == agent_id
 
 
+def test_signed_in_list_includes_unclaimed_browser_foundation_agent(client):
+    """Regression: logout shows guest starter; signup must still see it pre-claim."""
+    browser_session = str(uuid.uuid4())
+    anon_headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}
+
+    created = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "My Foundation Agent",
+            "model_name": "deepseek/deepseek-v4-pro",
+            "agent_type": "builtin",
+        },
+        headers=anon_headers,
+    )
+    assert created.status_code == 200
+    agent_id = created.json()["agent"]["agent_id"]
+
+    signup = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "foundation-list@example.com",
+            "display_name": "Foundation List",
+            "password": "securepass123",
+        },
+    )
+    assert signup.status_code == 200
+    token = signup.json()["token"]
+    auth_headers = {
+        **anon_headers,
+        "Authorization": f"Bearer {token}",
+    }
+
+    # Before claim-account: signed-in listing must still surface the guest agent.
+    listed = client.get("/api/v1/agents", headers=auth_headers)
+    assert listed.status_code == 200
+    ids = [a["agent_id"] for a in listed.json()["agents"]]
+    assert agent_id in ids
+    assert any(a.get("name") == "My Foundation Agent" for a in listed.json()["agents"])
+
 def test_rotate_api_key(client):
     browser_session = str(uuid.uuid4())
     headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -13,6 +13,8 @@ const ACTIVE_AGENT_NAME_KEY = 'active-agent-name';
 const BROWSER_OWNER_KEY = 'browser-owner-id';
 const HIDDEN_DEMO_AGENTS_KEY = 'hidden-demo-agent-ids';
 const SELECTED_BACKTEST_RUN_KEY = 'selected-backtest-run-id';
+// index.html's goToDashboardLoggedIn() writes this same key as a bare string
+// literal (no build step to share this constant across the landing/app split).
 const NAV_STATE_KEY = 'nav-state';
 const DISCORD_SERVER_URL = 'https://discord.gg/9HnQ6XDG98';
 const BACKTEST_POLL_MAX_SECONDS = 600; // 10 minutes at 1-second polling intervals
@@ -203,6 +205,7 @@ function hasDefaultAgentProvisionGuard() {
     return true; // no storage → cannot guard → do not provision
   }
 }
+
 function formatAgentCashAllocation(value) {
   if (value == null || value === '') return '—';
   return new Intl.NumberFormat('en-US', {
@@ -1367,15 +1370,25 @@ async function ensureDefaultFoundationAgent(agents) {
   if (isDemoMode()) return false;
   const builtins = agents.filter((a) => a.agent_type === 'builtin');
   if (builtins.length) {
-    // Claimed guest starters (or any existing builtin) count as onboarding done
-    // for this identity, so a later delete does not resurrect the default.
-    try {
-      const guardKey = defaultAgentProvisionGuardKey();
-      if (!localStorage.getItem(guardKey)) {
-        localStorage.setItem(guardKey, builtins[0].agent_id);
+    // A builtin visible only via the unclaimed-browser-session fallback (#235)
+    // is not proof claim-account actually landed — owner_user_id is still null
+    // server-side. Stamping the guard against it would permanently mark this
+    // identity "onboarded" for an agent it may never end up owning. Still skip
+    // provisioning either way (never worth creating a duplicate starter), but
+    // only persist the guard once ownership is confirmed.
+    const user = typeof getStoredAuthUser === 'function' ? getStoredAuthUser() : null;
+    const owned = user?.id != null
+      ? builtins.find((a) => a.owner_user_id === user.id)
+      : builtins[0];
+    if (owned) {
+      try {
+        const guardKey = defaultAgentProvisionGuardKey();
+        if (!localStorage.getItem(guardKey)) {
+          localStorage.setItem(guardKey, owned.agent_id);
+        }
+      } catch (e) {
+        /* storage unavailable — delete-guard simply won't persist */
       }
-    } catch (e) {
-      /* storage unavailable — delete-guard simply won't persist */
     }
     return false;
   }

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -177,6 +177,32 @@ window.SIMPLE_INSTRUCTION_OUTPUT_FORMAT = SIMPLE_INSTRUCTION_OUTPUT_FORMAT;
 const DEFAULT_STARTER_INSTRUCTION =
   'Spread the money across a few of the strongest available stocks. Buy on meaningful dips, take profits after strong run-ups, and never put everything into one stock.';
 
+function defaultAgentProvisionGuardKey() {
+  // Prefer the signed-in account so a brand-new user on a browser that already
+  // provisioned (or deleted) a guest starter still gets their own default.
+  // Guests keep the browser-scoped key so logout→login claim can find it.
+  const user = typeof getStoredAuthUser === 'function' ? getStoredAuthUser() : null;
+  if (user?.id != null) {
+    return `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}u:${user.id}`;
+  }
+  return `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}b:${window.BROWSER_OWNER_ID || 'anon'}`;
+}
+
+function hasDefaultAgentProvisionGuard() {
+  try {
+    const key = defaultAgentProvisionGuardKey();
+    if (localStorage.getItem(key)) return true;
+    // Pre-fix legacy key (no u:/b: prefix). Honor it for guests only so we
+    // do not duplicate a starter that was already provisioned; signed-in users
+    // intentionally ignore it so a new account still gets onboarding.
+    const user = typeof getStoredAuthUser === 'function' ? getStoredAuthUser() : null;
+    if (user?.id != null) return false;
+    const legacy = `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}${window.BROWSER_OWNER_ID || 'anon'}`;
+    return Boolean(localStorage.getItem(legacy));
+  } catch (e) {
+    return true; // no storage → cannot guard → do not provision
+  }
+}
 function formatAgentCashAllocation(value) {
   if (value == null || value === '') return '—';
   return new Intl.NumberFormat('en-US', {
@@ -1334,55 +1360,76 @@ async function onBacktestAgentSelectChange() {
 
 // First-visit onboarding: a brand-new owner gets one real Foundation agent so
 // the row is never empty. The guard key means "we provisioned once for this
-// browser identity" — deleting the agent must NOT resurrect it.
-let defaultAgentProvisionInFlight = false;
+// identity" — deleting the agent must NOT resurrect it.
+let defaultAgentProvisionInFlight = null;
 
 async function ensureDefaultFoundationAgent(agents) {
   if (isDemoMode()) return false;
-  if (agents.some((a) => a.agent_type === 'builtin')) return false;
-  const guardKey = `${DEFAULT_AGENT_PROVISION_GUARD_PREFIX}${window.BROWSER_OWNER_ID || 'anon'}`;
-  try {
-    if (localStorage.getItem(guardKey)) return false;
-  } catch (e) {
-    return false; // no storage → cannot guard → do not provision
-  }
-  if (defaultAgentProvisionInFlight) return false;
-  defaultAgentProvisionInFlight = true;
-  try {
-    const data = await API.post(`${API_BASE}/api/v1/agents`, {
-      name: 'My Foundation Agent',
-      model_name: DEFAULT_FOUNDATION_MODEL,
-      agent_type: 'builtin',
-      description: 'Your starter agent — configure it and run a backtest.',
-      cash_allocation: DEFAULT_AGENT_CASH_ALLOCATION,
-    });
-    const agent = data?.agent;
-    if (!agent?.agent_id) return false;
-    localStorage.setItem(guardKey, agent.agent_id);
+  const builtins = agents.filter((a) => a.agent_type === 'builtin');
+  if (builtins.length) {
+    // Claimed guest starters (or any existing builtin) count as onboarding done
+    // for this identity, so a later delete does not resurrect the default.
     try {
-      await API.patch(`${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`, {
-        pipeline: [
-          {
-            id: `sub_starter_${agent.agent_id}`,
-            presetKey: SIMPLE_INSTRUCTION_PRESET_KEY,
-            label: 'Trading instruction',
-            prompt: DEFAULT_STARTER_INSTRUCTION,
-            outputFormat: SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
-          },
-        ],
-      });
-    } catch (seedError) {
-      // Non-fatal: the agent exists; the editor just opens with a blank instruction.
-      console.warn('Starter instruction seed failed:', seedError.message);
+      const guardKey = defaultAgentProvisionGuardKey();
+      if (!localStorage.getItem(guardKey)) {
+        localStorage.setItem(guardKey, builtins[0].agent_id);
+      }
+    } catch (e) {
+      /* storage unavailable — delete-guard simply won't persist */
     }
-    if (!getDefaultAgentId()) setDefaultAgentId(agent.agent_id);
-    return true;
-  } catch (error) {
-    // Non-fatal: the row falls back to its empty state with the Add Agent CTA.
-    console.warn('Default agent provisioning skipped:', error.message);
     return false;
+  }
+  const guardKey = defaultAgentProvisionGuardKey();
+  if (hasDefaultAgentProvisionGuard()) return false;
+  if (defaultAgentProvisionInFlight) {
+    // Another loadAgents is already creating the starter — wait for it so a
+    // signup race does not skip provisioning and leave My Agents empty.
+    try {
+      return await defaultAgentProvisionInFlight;
+    } catch (e) {
+      return false;
+    }
+  }
+  defaultAgentProvisionInFlight = (async () => {
+    try {
+      const data = await API.post(`${API_BASE}/api/v1/agents`, {
+        name: 'My Foundation Agent',
+        model_name: DEFAULT_FOUNDATION_MODEL,
+        agent_type: 'builtin',
+        description: 'Your starter agent — configure it and run a backtest.',
+        cash_allocation: DEFAULT_AGENT_CASH_ALLOCATION,
+      });
+      const agent = data?.agent;
+      if (!agent?.agent_id) return false;
+      localStorage.setItem(guardKey, agent.agent_id);
+      try {
+        await API.patch(`${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`, {
+          pipeline: [
+            {
+              id: `sub_starter_${agent.agent_id}`,
+              presetKey: SIMPLE_INSTRUCTION_PRESET_KEY,
+              label: 'Trading instruction',
+              prompt: DEFAULT_STARTER_INSTRUCTION,
+              outputFormat: SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
+            },
+          ],
+        });
+      } catch (seedError) {
+        // Non-fatal: the agent exists; the editor just opens with a blank instruction.
+        console.warn('Starter instruction seed failed:', seedError.message);
+      }
+      if (!getDefaultAgentId()) setDefaultAgentId(agent.agent_id);
+      return true;
+    } catch (error) {
+      // Non-fatal: the row falls back to its empty state with the Add Agent CTA.
+      console.warn('Default agent provisioning skipped:', error.message);
+      return false;
+    }
+  })();
+  try {
+    return await defaultAgentProvisionInFlight;
   } finally {
-    defaultAgentProvisionInFlight = false;
+    defaultAgentProvisionInFlight = null;
   }
 }
 
@@ -2175,7 +2222,7 @@ function setAuthState(user, token) {
   updateAuthUI();
 }
 
-async function claimAgentsForUser() {
+async function claimAgentsForUser({ reload = true } = {}) {
   const token = localStorage.getItem(AUTH_TOKEN_KEY);
   if (!token) return;
   try {
@@ -2183,7 +2230,9 @@ async function claimAgentsForUser() {
   } catch (error) {
     console.warn('Agent account claim skipped:', error.message);
   }
-  await loadAgents();
+  if (reload) {
+    await loadAgents();
+  }
 }
 
 function clearAuthState() {
@@ -2725,7 +2774,8 @@ async function refreshAuthUser() {
   }
 }
 
-function initAuthUI() {
+function initAuthUI(options = {}) {
+  const { refresh = true } = options;
   const signInBtn = document.getElementById('authSignInBtn');
   const accountBtn = document.getElementById('authAccountBtn');
   const accountSignInBtn = document.getElementById('accountSignInBtn');
@@ -2822,6 +2872,11 @@ function initAuthUI() {
       // post-sign-in housekeeping and must not hold the modal open — a slow or
       // hung backend used to leave the popup up over an already-signed-in UI.
       closeAuthModal();
+      // First-time accounts should greet on Home, not a leftover My Agents tab
+      // from browsing while logged out (nav-state restore).
+      if (authMode === 'signup') {
+        navigateToPage('home');
+      }
       claimAgentsForUser()
         .then(() => {
           // If we arrived here from a Discord deep link that needed this account
@@ -2859,7 +2914,11 @@ function initAuthUI() {
   wireDiscordAccountButtons();
   initChangePasswordForm();
   initAvatarControls();
-  refreshAuthUser();
+  // Boot claims + loads agents itself so landing signup → /app does not race
+  // a fire-and-forget refresh against the first My Agents paint.
+  if (refresh) {
+    refreshAuthUser();
+  }
 }
 
 // Store default run IDs
@@ -2890,9 +2949,18 @@ let defaultConfig = null;
 document.addEventListener('DOMContentLoaded', async () => {
     // Initialize session FIRST (before any API calls)
     initSession();
-    initAuthUI();
+    // Defer refreshAuthUser: claim must finish before the first loadAgents so a
+    // landing signup → /app handoff does not miss the guest Foundation agent.
+    initAuthUI({ refresh: false });
     bindCashStepInputs();
     await restoreActiveAgentSession();
+    if (localStorage.getItem(AUTH_TOKEN_KEY)) {
+        try {
+            await refreshAuthUser();
+        } catch (error) {
+            console.warn('Boot refreshAuthUser failed:', error?.message || error);
+        }
+    }
     // Portfolio overview must not wait on the agents waterfall. Paint any
     // sessionStorage snapshot immediately, kick GET /portfolio in parallel,
     // then show the page while loadAgents continues in the background.
@@ -2914,9 +2982,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             console.warn('Portfolio prefetch failed:', error?.message || error);
         });
     }
-    const agentsReady = loadAgents().catch((error) => {
-        console.warn('Initial loadAgents failed:', error.message);
-    });
+    // refreshAuthUser → claimAgentsForUser already loadAgents when signed in.
+    const agentsReady = localStorage.getItem(AUTH_TOKEN_KEY) && getStoredAuthUser()
+        ? Promise.resolve()
+        : loadAgents().catch((error) => {
+            console.warn('Initial loadAgents failed:', error.message);
+        });
     applyInitialNavigation();
     // Home modules / agent cards catch up once the list lands; do not block
     // first navigation on that wait.

--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -310,6 +310,8 @@
             localStorage.setItem(AUTH_USER_KEY, JSON.stringify(user));
             // New accounts should land on Home, not a leftover My Agents tab
             // from browsing the dashboard while logged out.
+            // 'nav-state' must match app.js's NAV_STATE_KEY -- this landing
+            // page has no build step to share that constant across the split.
             if (options.goHome) {
               localStorage.setItem('nav-state', JSON.stringify({ page: 'home' }));
             }

--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -303,12 +303,18 @@
           return data;
         }
 
-        function goToDashboardLoggedIn(user, token) {
+        function goToDashboardLoggedIn(user, token, options) {
+          options = options || {};
           try {
             localStorage.setItem(AUTH_TOKEN_KEY, token);
             localStorage.setItem(AUTH_USER_KEY, JSON.stringify(user));
+            // New accounts should land on Home, not a leftover My Agents tab
+            // from browsing the dashboard while logged out.
+            if (options.goHome) {
+              localStorage.setItem('nav-state', JSON.stringify({ page: 'home' }));
+            }
           } catch (e) { /* ignore */ }
-          window.location.href = APP_URL;
+          window.location.href = options.goHome ? (APP_URL + '?view=home') : APP_URL;
         }
 
         function initAuthModal() {
@@ -363,7 +369,9 @@
                     email: email,
                     password: password,
                   });
-              goToDashboardLoggedIn(data.user, data.token);
+              goToDashboardLoggedIn(data.user, data.token, {
+                goHome: authMode === 'signup',
+              });
             } catch (error) {
               if (errorEl) {
                 errorEl.textContent = error.message || 'Something went wrong.';


### PR DESCRIPTION
## Summary
- Signed-in `list_agents` now also returns unclaimed browser-owned agents, so a guest-provisioned **My Foundation Agent** stays visible after signup (and claim) instead of disappearing while logout still showed it.
- Provision guard is user-scoped; boot claims before the first My Agents paint; concurrent provision waits instead of skipping.
- New account signup (landing + in-app) navigates to **Home** instead of restoring a leftover My Agents `nav-state`.

## Test plan
- [ ] Logged out: open My Agents → see My Foundation Agent
- [ ] Register a new account on the same browser → My Agents still shows that agent (or a new default)
- [ ] Fresh landing signup → lands on `/app?view=home`, not My Agents
- [ ] In-app signup while on My Agents → switches to Home
- [ ] Returning login still restores last tab
- [ ] `pytest dashboard/backend/tests/domain/agents/test_repository_move.py dashboard/backend/tests/test_agents_api.py -q`


Made with [Cursor](https://cursor.com)