### PR TITLE
fix: agent Configure save 404s

### DIFF
--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -53,7 +53,10 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_credentials=False,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    # PATCH backs the agent Configure screen's Save. Frontend and API are
+    # separate origins in prod, so a method absent here fails at the preflight
+    # even though the route exists (test_cors_preflight_allows_every_routed_method).
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["content-type", "authorization", "x-session-id", "x-browser-id", "x-api-key", "accept"],
     # x-ratelimit-*/retry-after: the v2 spec promises these to agent clients;
     # browsers strip headers absent from Access-Control-Expose-Headers.

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -326,6 +326,40 @@ def test_middleware_order_preserved():
     assert names == ["CSPHeaderMiddleware", "SessionMiddleware", "CORSMiddleware"]
 
 
+def test_cors_preflight_allows_every_routed_method():
+    """A routed method missing from ``allow_methods`` is unreachable in prod.
+
+    The frontend (Vercel) and the API (Render) are separate origins, so any
+    request the browser preflights -- PATCH among them -- dies at the preflight
+    when the method is absent, even though the route exists and answers fine to
+    curl. ``PATCH /api/v1/agents/{id}`` shipped that way: the only PATCH route
+    in the app, and the one behind the agent Configure screen's Save.
+    """
+    from fastapi.testclient import TestClient
+
+    routed = {
+        method
+        for route in app.routes
+        for method in (getattr(route, "methods", None) or set())
+    } - {"HEAD", "OPTIONS"}
+    assert "PATCH" in routed, "guard the guard: the PATCH route must still exist"
+
+    client = TestClient(app)
+    for method in sorted(routed):
+        response = client.options(
+            "/api/v1/agents/some-agent",
+            headers={
+                "Origin": "https://agentic-trading-lab.vercel.app",
+                "Access-Control-Request-Method": method,
+            },
+        )
+        assert response.status_code == 200, (
+            f"{method} preflight rejected ({response.status_code}): {response.text}"
+        )
+        allowed = response.headers.get("access-control-allow-methods", "")
+        assert method in allowed, f"{method} missing from allow_methods: {allowed!r}"
+
+
 # ---------------------------------------------------------------------------
 # Boundaries
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/test_frontend_api_base.py
+++ b/dashboard/backend/tests/test_frontend_api_base.py
@@ -33,6 +33,13 @@ _DEFINITION = re.compile(r"(?:const|let|var)\s+(?:API_BASE|API)\s*=\s*([^;]{0,30
 
 _BARE_ORIGIN = re.compile(r"(?:API_BASE|API)\s*=\s*window\.location\.origin\s*;")
 
+# Anchored to the exact quoted literal, not a bare substring: a check like
+# ``"onrender.com" in initializer`` would also pass for a typo'd host such as
+# ``'https://evil.example/onrender.com'`` (CodeQL: py/incomplete-url-substring
+# -sanitization). Quote-delimiting the literal makes the match exact.
+_LOCALHOST_LITERAL = re.compile(r"""['"]localhost['"]""")
+_ONRENDER_HOST_LITERAL = re.compile(r"""['"]https://agentictrading\.onrender\.com['"]""")
+
 
 def _definitions():
     for path in _SOURCES:
@@ -53,10 +60,10 @@ def test_the_known_api_base_definers_are_still_matched():
 
 def test_every_api_base_definition_targets_the_backend_off_localhost():
     for name, initializer in _definitions():
-        assert "localhost" in initializer, (
+        assert _LOCALHOST_LITERAL.search(initializer), (
             f"{name}: the API base must special-case local development"
         )
-        assert "onrender.com" in initializer, (
+        assert _ONRENDER_HOST_LITERAL.search(initializer), (
             f"{name}: the API base must point at the hosted backend when not on "
             "localhost -- the Vercel origin serves no /api routes"
         )

--- a/dashboard/backend/tests/test_frontend_api_base.py
+++ b/dashboard/backend/tests/test_frontend_api_base.py
@@ -1,0 +1,71 @@
+"""Split-origin API-base guard for the static frontend.
+
+In production the frontend and the API live on **different origins** -- Vercel
+serves ``dashboard/frontend`` statically, Render serves the FastAPI app -- so a
+script that resolves its API base to ``window.location.origin`` addresses every
+``/api/...`` call to the static host.  ``vercel.json`` has no ``/api`` rewrite,
+so those requests come back as Vercel's *HTML* 404 page and surface as a JSON
+parse error (``Unexpected token 'T', "The page c"...``) rather than a clean
+404.  That is exactly how ``js/agent-editor.js`` shipped a Configure screen
+whose save silently could not reach the backend.
+
+The contract is on every file that *defines* a base; the files that merely read
+the global ``API_BASE`` from ``app.js`` inherit a correct value.  ``API`` is
+matched too because ``strategy.html`` names its base that.
+"""
+
+import re
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+
+# ``assets/`` is minified Vite output for the landing page -- its identifiers are
+# mangled, so a source-level name scan cannot say anything about it.
+_SOURCES = sorted(
+    path
+    for path in _FRONTEND.rglob("*")
+    if path.suffix in {".js", ".html"}
+    and "assets" not in path.relative_to(_FRONTEND).parts
+)
+
+# Capture the initializer up to its terminating semicolon.
+_DEFINITION = re.compile(r"(?:const|let|var)\s+(?:API_BASE|API)\s*=\s*([^;]{0,300})")
+
+_BARE_ORIGIN = re.compile(r"(?:API_BASE|API)\s*=\s*window\.location\.origin\s*;")
+
+
+def _definitions():
+    for path in _SOURCES:
+        rel = path.relative_to(_FRONTEND).as_posix()
+        for match in _DEFINITION.finditer(path.read_text(encoding="utf-8")):
+            initializer = match.group(1).strip()
+            # ``const API = {`` is app.js's fetch-helper object, not a base URL.
+            if initializer.startswith("{"):
+                continue
+            yield rel, initializer
+
+
+def test_the_known_api_base_definers_are_still_matched():
+    """Guard the guard: a rename must fail loudly rather than pass vacuously."""
+    definers = {name for name, _ in _definitions()}
+    assert {"app.js", "js/agent-editor.js", "index.html", "strategy.html"} <= definers
+
+
+def test_every_api_base_definition_targets_the_backend_off_localhost():
+    for name, initializer in _definitions():
+        assert "localhost" in initializer, (
+            f"{name}: the API base must special-case local development"
+        )
+        assert "onrender.com" in initializer, (
+            f"{name}: the API base must point at the hosted backend when not on "
+            "localhost -- the Vercel origin serves no /api routes"
+        )
+
+
+def test_no_source_uses_a_bare_location_origin_as_its_api_base():
+    offenders = [
+        path.relative_to(_FRONTEND).as_posix()
+        for path in _SOURCES
+        if _BARE_ORIGIN.search(path.read_text(encoding="utf-8"))
+    ]
+    assert not offenders, f"split-origin regression in: {offenders}"

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1632,7 +1632,7 @@
     <script src="market-events/MarketEventCard.js"></script>
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
-    <script src="js/agent-editor.js?v=12"></script>
+    <script src="js/agent-editor.js?v=13"></script>
     <script src="app.js?v=48"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -10,7 +10,14 @@
   const STORAGE_PREFIX = 'agent-pipeline-config:';
   const NAME_OVERRIDE_PREFIX = 'agent-name-override:';
   const CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
-  const API_BASE = window.location.origin;
+  // Match app.js: same-origin locally, hosted backend everywhere else. In
+  // production the static frontend (Vercel) and the API (Render) are different
+  // origins, so a bare location.origin sends every /api call to the static host
+  // -- which answers with an HTML 404 page, not JSON.
+  const API_BASE =
+    window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+      ? window.location.origin
+      : 'https://agentictrading.onrender.com';
 
   // The Simple-mode contract (preset key + trading-actions output format) has a
   // single source of truth in app.js, published on `window`. app.js loads AFTER


### PR DESCRIPTION
Two independent bugs blocked Save on the agent Configure screen. The second was masked by the first, so fixing either alone leaves it broken.

1. `js/agent-editor.js` resolved `API_BASE` to `window.location.origin`. Prod is split-origin (Vercel frontend, Render API) and `vercel.json` has no `/api` rewrite, so every call hit the static host and returned Vercel's HTML 404 — surfacing as `Unexpected token 'T', "The page c"...`. Every other frontend file already uses the hostname ternary; this was the only outlier.
2. `PATCH` was missing from the backend CORS `allow_methods`, so the (now cross-origin) preflight was rejected with `400 Disallowed CORS method`. `PATCH /api/v1/agents/{id}` is the only PATCH route in the app. This also fixes the My Agents rename in `app.js`, which was already broken in prod for the same reason.

Also bumps `agent-editor.js?v=13` — `js/*.js` has no no-cache override in `vercel.json`.

Both regressions are covered by tests written first and observed failing: a source guard on every file that defines an API base, and a real CORS preflight over every routed method.

Backend suite: 1804 passed. The one failure (`test_ifind_engine_resolves_csi300_sample20_and_records_provenance`) is pre-existing — identical on clean `main`, passes in isolation, unrelated to this branch.