### PR TITLE
chore(codeql): fix the 3 new bulk_create_agents.py alerts

### DIFF
--- a/dashboard/scripts/bulk_create_agents.py
+++ b/dashboard/scripts/bulk_create_agents.py
@@ -32,7 +32,6 @@ Use --dry-run to print the plan without creating anything.
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 import time
 import uuid
@@ -115,7 +114,7 @@ def create_agent(
         try:
             detail = resp.json().get("detail", detail)
         except Exception:
-            pass
+            pass  # non-JSON body -- keep the raw-text fallback set above
         raise RuntimeError(f"HTTP {resp.status_code}: {detail}")
     return resp.json()
 
@@ -198,7 +197,7 @@ def main() -> int:
         existing = list_agents(args.base_url, token, browser_id)
         print(f"Existing agents: {len(existing)}")
     except SystemExit:
-        existing = []
+        pass  # informational only -- listing failure shouldn't block creation
 
     if args.dry_run:
         print("\n[dry-run] No agents created.")


### PR DESCRIPTION
Follow-up to the #235 review. Of the 4 CodeQL alerts that appeared since PR #216's quality sweep (which deliberately left 60+8 other alerts open with documented reasoning), 3 were genuinely new and untriaged:

- `#1129` unused `json` import — removed, confirmed zero uses.
- `#1130` empty `except Exception: pass` (JSON-body-parsing fallback) — commented, no logging added (consistent with the logging-invisible-in-prod convention already established for this repo).
- `#1131` unused local variable `existing` in an `except SystemExit:` branch — it was never read after assignment; replaced with `pass`.

The 4th, `#1137` (`backtests.py:490`), is the identical best-effort temp-file-cleanup pattern as the two open-by-design siblings `#144`/`#145` in the same function — dismissed via the code-scanning API as `won't fix`, referencing that precedent, without touching the code (so the 60+8 already-documented PR #216 decisions stay untouched).

## Test plan
- [x] `pytest dashboard/backend/tests/` green (one pre-existing order-dependent flake in `test_ifind_ashare_engine.py`, confirmed unrelated — passes standalone)
- [x] `python dashboard/scripts/bulk_create_agents.py --help` still works