### PR TITLE
feat: simple-only agent Configure + seeded starter prompt

### DIFF
--- a/dashboard/backend/domain/agents/defaults.py
+++ b/dashboard/backend/domain/agents/defaults.py
@@ -1,0 +1,48 @@
+"""Canonical starter configuration for newly created built-in agents.
+
+The agent Configure screen has a single mode: one plain-language trading
+instruction, stored as a **one-step pipeline** whose ``presetKey`` is
+``simple_instruction``. There is no separate "simple" storage format.
+
+These constants are mirrored in ``dashboard/frontend/app.js`` (the browser needs
+them to recognise a server-seeded pipeline as the editable simple kind). The two
+copies are pinned together by ``tests/test_agent_starter_defaults.py`` — if they
+drift, ``isSimplePipeline()`` stops matching and every default agent renders the
+"saving replaces your custom pipeline" warning it should never show.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+SIMPLE_INSTRUCTION_PRESET_KEY = "simple_instruction"
+
+# The trading-actions contract every simple-mode agent emits.
+SIMPLE_INSTRUCTION_OUTPUT_FORMAT = (
+    'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", '
+    '"qty": number, "order_type": "market|limit", "limit_price": number|null, '
+    '"reason": "..." }] }'
+)
+
+SIMPLE_INSTRUCTION_LABEL = "Trading instruction"
+
+# Seeded into every new built-in agent so a user can sign up and immediately run
+# a meaningful backtest without opening Configure first.
+DEFAULT_STARTER_INSTRUCTION = (
+    "Spread the money across a few of the strongest available stocks. Buy on "
+    "meaningful dips, take profits after strong run-ups, and never put "
+    "everything into one stock."
+)
+
+
+def default_starter_pipeline() -> List[Dict[str, Any]]:
+    """The one-step pipeline a new built-in agent starts with."""
+    return [
+        {
+            "id": "sub_starter",
+            "presetKey": SIMPLE_INSTRUCTION_PRESET_KEY,
+            "label": SIMPLE_INSTRUCTION_LABEL,
+            "prompt": DEFAULT_STARTER_INSTRUCTION,
+            "outputFormat": SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
+        }
+    ]

--- a/dashboard/backend/domain/agents/defaults.py
+++ b/dashboard/backend/domain/agents/defaults.py
@@ -13,6 +13,7 @@ drift, ``isSimplePipeline()`` stops matching and every default agent renders the
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Dict, List
 
 SIMPLE_INSTRUCTION_PRESET_KEY = "simple_instruction"
@@ -39,7 +40,7 @@ def default_starter_pipeline() -> List[Dict[str, Any]]:
     """The one-step pipeline a new built-in agent starts with."""
     return [
         {
-            "id": "sub_starter",
+            "id": f"sub_starter_{uuid.uuid4().hex[:8]}",
             "presetKey": SIMPLE_INSTRUCTION_PRESET_KEY,
             "label": SIMPLE_INSTRUCTION_LABEL,
             "prompt": DEFAULT_STARTER_INSTRUCTION,

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from dashboard.backend.domain.agents.repository import agent_store, _UNSET
 from dashboard.backend.domain.agents import auth_cache
+from dashboard.backend.domain.agents.defaults import default_starter_pipeline
 from dashboard.backend.domain.agents.version_repository import (
     VALID_EXECUTION_MODES,
     VALID_VERIFICATION_LEVELS,
@@ -278,14 +279,24 @@ class AgentService:
         agent_type: str = "external",
         description: Optional[str] = None,
         cash_allocation: Optional[float] = None,
+        seed_default_pipeline: bool = True,
     ) -> Dict[str, Any]:
+        """Register an agent.
+
+        Built-in agents are seeded with the default starter instruction so a new
+        user can run a backtest straight from My Agents without opening
+        Configure. Callers that immediately write their own pipeline (the
+        marketplace clone) pass ``seed_default_pipeline=False`` to skip the
+        write they are about to overwrite. External agents are driven by the
+        protocol API and never use the editor pipeline, so they are not seeded.
+        """
         from dashboard.backend.domain.backtesting.constants import (
             DEFAULT_AGENT_CASH_ALLOCATION,
         )
 
         if cash_allocation is None:
             cash_allocation = float(DEFAULT_AGENT_CASH_ALLOCATION)
-        return self.agents.create_agent(
+        agent = self.agents.create_agent(
             name=name,
             model_name=model_name,
             owner_user_id=owner_user_id,
@@ -294,6 +305,14 @@ class AgentService:
             description=description,
             cash_allocation=cash_allocation,
         )
+        if seed_default_pipeline and agent_type == "builtin":
+            # Merge rather than reassign: create_agent's dict carries the
+            # one-time plaintext ``api_key`` that the route pops and shows once,
+            # and update_agent re-reads the row (which only stores the hash).
+            pipeline = default_starter_pipeline()
+            self.agents.update_agent(agent["agent_id"], pipeline=pipeline)
+            agent["pipeline"] = pipeline
+        return agent
 
     def clone_marketplace_template(
         self,
@@ -311,6 +330,8 @@ class AgentService:
             raise MarketplaceTemplateNotFoundError()
 
         resolved_name = (name or template.get("name") or "Marketplace Agent").strip()
+        pipeline = template.get("pipeline")
+        has_own_pipeline = isinstance(pipeline, list) and bool(pipeline)
         agent = self.create_agent(
             name=resolved_name,
             model_name=str(template.get("model_name") or "local-model").strip() or "local-model",
@@ -318,9 +339,12 @@ class AgentService:
             owner_browser_session=owner_browser_session,
             agent_type="builtin",
             description=template.get("description"),
+            # A template carrying its own pipeline overwrites the seed below, so
+            # skip that write. A template WITHOUT one still needs the starter
+            # instruction, or the clone lands with an empty Configure screen.
+            seed_default_pipeline=not has_own_pipeline,
         )
-        pipeline = template.get("pipeline")
-        if isinstance(pipeline, list) and pipeline:
+        if has_own_pipeline:
             agent = self.agents.update_agent(agent["agent_id"], pipeline=pipeline) or agent
         return self.attach_equity_sparklines([self.agent_with_stats(agent)])[0]
 

--- a/dashboard/backend/tests/test_agent_starter_defaults.py
+++ b/dashboard/backend/tests/test_agent_starter_defaults.py
@@ -25,12 +25,15 @@ import pytest
 from fastapi.testclient import TestClient
 
 from dashboard.backend.app import app
-from dashboard.backend.domain.agents.repository import AgentStore
+import dashboard.backend.domain.agents.repository as agent_store_module
+import dashboard.backend.domain.agents.marketplace as marketplace_module
 from dashboard.backend.domain.agents.defaults import (
     DEFAULT_STARTER_INSTRUCTION,
     SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
     SIMPLE_INSTRUCTION_PRESET_KEY,
 )
+
+AgentStore = agent_store_module.AgentStore
 
 _FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
 _APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
@@ -40,7 +43,6 @@ _EDITOR_JS = (_FRONTEND / "js" / "agent-editor.js").read_text(encoding="utf-8")
 
 @pytest.fixture
 def client(tmp_path, monkeypatch):
-    import dashboard.backend.domain.agents.repository as agent_store_module
     import dashboard.backend.api.routers.agents as agents_api
     import dashboard.backend.database as db_module
 
@@ -125,6 +127,36 @@ def test_marketplace_clone_keeps_its_own_pipeline(client):
         "info_to_signal",
         "signal_to_execution",
     ]
+
+
+def test_marketplace_clone_without_a_pipeline_gets_the_starter_seed(client, monkeypatch):
+    """A template that ships no pipeline of its own must still land usable.
+
+    Every real template in marketplace.json currently carries a pipeline, so this
+    branch of clone_marketplace_template (seed_default_pipeline=True) is otherwise
+    untested. Fake the catalog lookup rather than editing the real config.
+    """
+    fake_template = {
+        "template_id": "no-pipeline-template",
+        "name": "No Pipeline Template",
+        "model_name": "local-model",
+        "description": "A template with no pipeline of its own.",
+    }
+    monkeypatch.setattr(
+        marketplace_module,
+        "get_marketplace_template",
+        lambda template_id: fake_template if template_id == "no-pipeline-template" else None,
+    )
+    cloned = client.post(
+        "/api/v1/agents/marketplace/no-pipeline-template/clone",
+        json={},
+        headers={"X-Session-Id": str(uuid.uuid4())},
+    )
+    assert cloned.status_code == 200, cloned.text
+    pipeline = cloned.json()["agent"]["pipeline"]
+    assert len(pipeline) == 1
+    assert pipeline[0]["presetKey"] == SIMPLE_INSTRUCTION_PRESET_KEY
+    assert pipeline[0]["prompt"] == DEFAULT_STARTER_INSTRUCTION
 
 
 # --------------------------------------------------------------------------

--- a/dashboard/backend/tests/test_agent_starter_defaults.py
+++ b/dashboard/backend/tests/test_agent_starter_defaults.py
@@ -1,0 +1,209 @@
+"""Starter-instruction seeding and the simple-only Configure screen.
+
+Two things are guarded here.
+
+**Seeding.** The starter instruction used to be applied by a follow-up ``PATCH``
+issued from ``app.js`` after the agent was created, wrapped in a
+``catch { console.warn }``. ``PATCH`` was missing from the CORS ``allow_methods``
+(fixed in #245), so in production that preflight 400'd and the seed silently did
+nothing -- every default agent shipped with an empty pipeline and quietly fell
+back to the generic hourly prompt at backtest time. Seeding now happens inside
+``AgentService.create_agent``, in the same call that creates the row.
+
+**Contract sync.** The preset key and output format are duplicated in
+``dashboard/frontend/app.js`` because the browser has to recognise a
+server-seeded pipeline as the editable simple kind. If the two copies drift,
+``isSimplePipeline()`` stops matching and every default agent renders the
+"saving replaces your custom pipeline" warning it should never show.
+"""
+
+import re
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+from dashboard.backend.domain.agents.repository import AgentStore
+from dashboard.backend.domain.agents.defaults import (
+    DEFAULT_STARTER_INSTRUCTION,
+    SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
+    SIMPLE_INSTRUCTION_PRESET_KEY,
+)
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+_APP_HTML = (_FRONTEND / "app.html").read_text(encoding="utf-8")
+_EDITOR_JS = (_FRONTEND / "js" / "agent-editor.js").read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import dashboard.backend.domain.agents.repository as agent_store_module
+    import dashboard.backend.api.routers.agents as agents_api
+    import dashboard.backend.database as db_module
+
+    db_path = tmp_path / "test.db"
+    test_agents = AgentStore(db_path=db_path)
+    test_db = db_module.BacktestDatabase(db_path=db_path)
+    monkeypatch.setattr(agent_store_module, "agent_store", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "agents", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "db", test_db)
+    monkeypatch.setattr(db_module, "db", test_db)
+    return TestClient(app)
+
+
+def _create(client, **overrides):
+    """Create an agent; returns (body, owner headers) so callers can re-read it."""
+    payload = {"name": "seeded", "model_name": "deepseek/deepseek-v4-pro"}
+    payload.update(overrides)
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    response = client.post("/api/v1/agents", json=payload, headers=headers)
+    assert response.status_code == 200, response.text
+    return response.json(), headers
+
+
+# --------------------------------------------------------------------------
+# Server-side seeding
+# --------------------------------------------------------------------------
+
+
+def test_new_builtin_agent_is_seeded_with_the_starter_instruction(client):
+    agent = _create(client, agent_type="builtin")[0]["agent"]
+
+    pipeline = agent.get("pipeline")
+    assert pipeline, "a built-in agent must be usable without opening Configure"
+    assert len(pipeline) == 1
+    assert pipeline[0]["presetKey"] == SIMPLE_INSTRUCTION_PRESET_KEY
+    assert pipeline[0]["prompt"] == DEFAULT_STARTER_INSTRUCTION
+    assert pipeline[0]["outputFormat"] == SIMPLE_INSTRUCTION_OUTPUT_FORMAT
+
+
+def test_seeded_pipeline_survives_a_reread(client):
+    """The seed is persisted, not just decorated onto the create response."""
+    created, headers = _create(client, agent_type="builtin")
+    created = created["agent"]
+
+    fetched = client.get(f"/api/v1/agents/{created['agent_id']}", headers=headers)
+    assert fetched.status_code == 200
+    pipeline = fetched.json()["agent"]["pipeline"]
+    assert pipeline[0]["prompt"] == DEFAULT_STARTER_INSTRUCTION
+
+
+def test_external_agents_are_not_seeded(client):
+    """External agents are driven by the protocol API and never use the editor."""
+    agent = _create(client, agent_type="external")[0]["agent"]
+    assert not agent.get("pipeline")
+
+
+def test_create_still_returns_the_one_time_api_key(client):
+    """Seeding must not clobber the create response.
+
+    ``create_agent``'s dict carries the plaintext ``api_key`` that the route pops
+    and shows exactly once; it is never recoverable afterwards. ``update_agent``
+    re-reads the row, which stores only the hash -- so seeding by reassigning the
+    agent dict would drop the key and 500 the request.
+    """
+    body, _ = _create(client, agent_type="builtin")
+    assert body["api_key"].startswith("ag_")
+    assert body["session_id"]
+
+
+def test_marketplace_clone_keeps_its_own_pipeline(client):
+    """A template with its own pipeline must not be overwritten by the seed."""
+    cloned = client.post(
+        "/api/v1/agents/marketplace/pipeline-analyst/clone",
+        json={},
+        headers={"X-Session-Id": str(uuid.uuid4())},
+    )
+    assert cloned.status_code == 200, cloned.text
+    pipeline = cloned.json()["agent"]["pipeline"]
+    assert len(pipeline) == 3
+    assert [step["presetKey"] for step in pipeline] == [
+        "info_gather",
+        "info_to_signal",
+        "signal_to_execution",
+    ]
+
+
+# --------------------------------------------------------------------------
+# JS <-> Python contract sync
+# --------------------------------------------------------------------------
+
+
+def _js_const(name: str) -> str:
+    """Read a single-quoted JS string constant out of app.js."""
+    match = re.search(rf"const\s+{name}\s*=\s*\n?\s*'((?:[^'\\]|\\.)*)'", _APP_JS)
+    assert match, f"{name} is no longer a single-quoted const in app.js"
+    return match.group(1).replace("\\'", "'")
+
+
+def test_the_js_constants_are_still_matched():
+    """Guard the guard: a rename must fail loudly rather than pass vacuously."""
+    for name in (
+        "SIMPLE_INSTRUCTION_PRESET_KEY",
+        "SIMPLE_INSTRUCTION_OUTPUT_FORMAT",
+        "DEFAULT_STARTER_INSTRUCTION",
+    ):
+        assert _js_const(name)
+
+
+def test_preset_key_matches_the_frontend():
+    assert _js_const("SIMPLE_INSTRUCTION_PRESET_KEY") == SIMPLE_INSTRUCTION_PRESET_KEY
+
+
+def test_output_format_matches_the_frontend():
+    assert (
+        _js_const("SIMPLE_INSTRUCTION_OUTPUT_FORMAT") == SIMPLE_INSTRUCTION_OUTPUT_FORMAT
+    )
+
+
+def test_starter_instruction_matches_the_frontend():
+    assert _js_const("DEFAULT_STARTER_INSTRUCTION") == DEFAULT_STARTER_INSTRUCTION
+
+
+def test_the_editor_can_read_the_starter_instruction():
+    """agent-editor.js backfills from window, so app.js must publish the value."""
+    assert "window.DEFAULT_STARTER_INSTRUCTION = DEFAULT_STARTER_INSTRUCTION" in _APP_JS
+    assert "window.DEFAULT_STARTER_INSTRUCTION" in _EDITOR_JS
+
+
+def test_app_js_no_longer_seeds_the_pipeline_over_the_network():
+    """The fail-open seed PATCH is the bug; it must not come back."""
+    assert "Starter instruction seed failed" not in _APP_JS
+
+
+# --------------------------------------------------------------------------
+# Advanced mode is gone
+# --------------------------------------------------------------------------
+
+
+ADVANCED_MARKUP = [
+    "agentEditorModeSimple",
+    "agentEditorModeAdvanced",
+    "agentEditorAdvancedPanel",
+    "agentEditorPipeline",
+    "agentEditorAddSelect",
+    "agentEditorAddBtn",
+    "agentEditorResetBtn",
+    "agentEditorStepCount",
+    "agentEditorCustomName",
+]
+
+
+@pytest.mark.parametrize("marker", ADVANCED_MARKUP)
+def test_configure_screen_has_no_advanced_mode_markup(marker):
+    assert marker not in _APP_HTML
+
+
+@pytest.mark.parametrize("symbol", ["setEditorMode", "editorMode", "SUB_AGENT_PRESETS"])
+def test_agent_editor_has_no_mode_switching_code(symbol):
+    assert symbol not in _EDITOR_JS
+
+
+def test_the_simple_panel_is_always_visible():
+    """It is the only panel now, so it must not ship with a `hidden` attribute."""
+    match = re.search(r'<div id="agentEditorSimplePanel"[^>]*>', _APP_HTML)
+    assert match, "the simple panel is missing from app.html"
+    assert "hidden" not in match.group(0)

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=65">
+    <link rel="stylesheet" href="styles.css?v=66">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -955,12 +955,7 @@
                 </div>
             </div>
             <div class="agent-editor-header-actions">
-                <div class="agent-editor-mode-toggle" role="group" aria-label="Editor mode">
-                    <button id="agentEditorModeSimple" class="agent-editor-mode-btn" type="button" aria-pressed="true">Simple</button>
-                    <button id="agentEditorModeAdvanced" class="agent-editor-mode-btn" type="button" aria-pressed="false">Advanced</button>
-                </div>
                 <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>
-                <button id="agentEditorResetBtn" class="home-btn home-btn-secondary agent-editor-reset-btn" type="button">Reset pipeline</button>
                 <button id="agentEditorRunBacktestBtn" class="home-btn home-btn-secondary" type="button">Run Backtest</button>
                 <button id="agentEditorSaveBtn" class="home-btn home-btn-primary" type="button">Save</button>
             </div>
@@ -968,36 +963,14 @@
         <div class="agent-editor-body">
             <div class="agent-editor-layout">
                 <div class="agent-editor-main">
-                    <div id="agentEditorSimplePanel" class="agent-editor-simple section-card compact" hidden>
+                    <div id="agentEditorSimplePanel" class="agent-editor-simple section-card compact">
                         <h3 class="agent-editor-intro-title">Trading instruction</h3>
                         <p class="agent-editor-intro-text">Tell the agent how to trade in plain language. Each market hour it sees prices and its portfolio, follows your instruction, and decides what to buy or sell.</p>
                         <textarea id="agentEditorSimpleInstruction" rows="6" maxlength="8000" placeholder="e.g. Spread the money across a few of the strongest available stocks. Buy on meaningful dips and take profits after strong run-ups." aria-label="Trading instruction"></textarea>
-                        <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note" hidden>This agent currently uses a custom pipeline. Saving in Simple mode replaces it with this one instruction.</p>
-                    </div>
-                    <div id="agentEditorAdvancedPanel">
-                        <div class="agent-editor-intro section-card compact">
-                            <div class="agent-editor-intro-head">
-                                <div>
-                                    <h3 class="agent-editor-intro-title">Sub-agent pipeline</h3>
-                                    <p class="agent-editor-intro-text">Configure sub-agents in order. Each step defines a task prompt and the output format passed to the next model.</p>
-                                </div>
-                                <span id="agentEditorStepCount" class="agent-editor-step-count">0 steps</span>
-                            </div>
-                        </div>
-                        <div id="agentEditorPipeline" class="agent-editor-pipeline" role="list"></div>
-                        <div class="agent-editor-add-row section-card compact">
-                            <label class="agent-editor-add-label" for="agentEditorAddSelect">Add sub-agent</label>
-                            <div class="agent-editor-add-controls">
-                                <select id="agentEditorAddSelect" class="agent-editor-add-select" aria-label="Select sub-agent type to add">
-                                    <option value="">— Select type —</option>
-                                </select>
-                                <input id="agentEditorCustomName" class="agent-editor-custom-name" type="text" maxlength="80" placeholder="Custom name (optional)" hidden aria-label="Custom sub-agent name">
-                                <button id="agentEditorAddBtn" class="home-btn home-btn-secondary" type="button">+ Add</button>
-                            </div>
-                        </div>
+                        <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note" hidden>This agent currently uses a custom multi-step pipeline. Saving this instruction replaces it.</p>
                     </div>
                     <p id="agentEditorSaveStatus" class="agent-editor-save-status" hidden></p>
-                    <p class="agent-editor-hint">Tip: use ↑↓ to reorder steps. Press <kbd>Ctrl</kbd>+<kbd>S</kbd> to save.</p>
+                    <p class="agent-editor-hint">Tip: press <kbd>Ctrl</kbd>+<kbd>S</kbd> to save.</p>
                 </div>
                 <aside class="agent-editor-history" aria-label="Backtest history">
                     <div class="agent-editor-history-card section-card compact">
@@ -1632,8 +1605,8 @@
     <script src="market-events/MarketEventCard.js"></script>
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
-    <script src="js/agent-editor.js?v=13"></script>
-    <script src="app.js?v=48"></script>
+    <script src="js/agent-editor.js?v=14"></script>
+    <script src="app.js?v=49"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -176,8 +176,13 @@ const SIMPLE_INSTRUCTION_OUTPUT_FORMAT =
 // same preset key + output format at call time instead of keeping its own copy.
 window.SIMPLE_INSTRUCTION_PRESET_KEY = SIMPLE_INSTRUCTION_PRESET_KEY;
 window.SIMPLE_INSTRUCTION_OUTPUT_FORMAT = SIMPLE_INSTRUCTION_OUTPUT_FORMAT;
+// Mirrors DEFAULT_STARTER_INSTRUCTION in dashboard/backend/domain/agents/defaults.py,
+// which is what actually seeds new agents. The copy here is the editor's backfill
+// for agents created before server-side seeding existed (their pipeline is empty).
+// tests/test_agent_starter_defaults.py pins the two copies together.
 const DEFAULT_STARTER_INSTRUCTION =
   'Spread the money across a few of the strongest available stocks. Buy on meaningful dips, take profits after strong run-ups, and never put everything into one stock.';
+window.DEFAULT_STARTER_INSTRUCTION = DEFAULT_STARTER_INSTRUCTION;
 
 function defaultAgentProvisionGuardKey() {
   // Prefer the signed-in account so a brand-new user on a browser that already
@@ -1415,22 +1420,12 @@ async function ensureDefaultFoundationAgent(agents) {
       const agent = data?.agent;
       if (!agent?.agent_id) return false;
       localStorage.setItem(guardKey, agent.agent_id);
-      try {
-        await API.patch(`${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}`, {
-          pipeline: [
-            {
-              id: `sub_starter_${agent.agent_id}`,
-              presetKey: SIMPLE_INSTRUCTION_PRESET_KEY,
-              label: 'Trading instruction',
-              prompt: DEFAULT_STARTER_INSTRUCTION,
-              outputFormat: SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
-            },
-          ],
-        });
-      } catch (seedError) {
-        // Non-fatal: the agent exists; the editor just opens with a blank instruction.
-        console.warn('Starter instruction seed failed:', seedError.message);
-      }
+      // The starter instruction is seeded server-side by AgentService.create_agent
+      // for every builtin agent. It used to be a follow-up PATCH from here, which
+      // failed silently in prod for months (PATCH was missing from the CORS
+      // allow_methods, so the preflight 400'd) and left every default agent with
+      // an empty pipeline. Seeding in the same call that creates the row means it
+      // cannot half-succeed.
       if (!getDefaultAgentId()) setDefaultAgentId(agent.agent_id);
       return true;
     } catch (error) {

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -1,8 +1,14 @@
 /**
  * agent-editor.js — Fullscreen agent Configure screen.
- * Simple mode: capital + one plain-language instruction (stored as a 1-step
- * pipeline) + model. Advanced mode: the multi-step sub-agent chain.
- * Agent fields: PATCH /api/v1/agents/{id}. Pipeline cache: localStorage.
+ * One mode only: capital + one plain-language instruction (stored as a 1-step
+ * pipeline) + model. Agent fields: PATCH /api/v1/agents/{id}.
+ *
+ * The multi-step "Advanced" sub-agent editor was removed. Multi-step pipelines
+ * still EXECUTE server-side (infrastructure/llm/pipeline_runner.py) and the
+ * marketplace still ships a 3-step template, so an agent may legitimately hold a
+ * pipeline this screen cannot author. Such a pipeline is carried opaquely in
+ * `subAgents` and re-sent untouched unless the user types an instruction — see
+ * `sendPipeline` in getEditorState().
  */
 (function () {
   'use strict';
@@ -19,9 +25,9 @@
       ? window.location.origin
       : 'https://agentictrading.onrender.com';
 
-  // The Simple-mode contract (preset key + trading-actions output format) has a
-  // single source of truth in app.js, published on `window`. app.js loads AFTER
-  // this file, so read lazily at call time — every use below is inside an
+  // The simple-instruction contract (preset key + trading-actions output format)
+  // has a single source of truth in app.js, published on `window`. app.js loads
+  // AFTER this file, so read lazily at call time — every use below is inside an
   // event-driven function, by which point window.* is populated. The fallbacks
   // only matter if app.js somehow failed to load (whole app is broken anyway).
   function simplePresetKey() {
@@ -35,6 +41,9 @@
       (typeof window !== 'undefined' && window.SIMPLE_INSTRUCTION_OUTPUT_FORMAT) || ''
     );
   }
+  function defaultStarterInstruction() {
+    return (typeof window !== 'undefined' && window.DEFAULT_STARTER_INSTRUCTION) || '';
+  }
 
   // Demo/mock agents (see MOCK_AGENTS in app.js) only exist in the frontend —
   // they have no database row, so PATCH would 404. We persist their edits
@@ -43,71 +52,11 @@
     return typeof agentId === 'string' && agentId.startsWith('mock-');
   }
 
-  const SUB_AGENT_PRESETS = [
-    {
-      presetKey: 'info_gather',
-      label: 'Information Gathering',
-      defaultPrompt:
-        'You are the information-gathering sub-agent. Collect key facts relevant to trading decisions from market data, news, and macro events. Filter noise and keep high-confidence facts and indicator changes.',
-      defaultOutputFormat:
-        'JSON: { "timestamp": "ISO8601", "symbols": ["..."], "facts": [{ "source": "...", "summary": "...", "impact": "bullish|bearish|neutral" }], "confidence": 0.0-1.0 }',
-    },
-    {
-      presetKey: 'info_to_signal',
-      label: 'Information to Signal',
-      defaultPrompt:
-        'You are the signal-generation sub-agent. Based on upstream information-gathering output, convert facts and indicators into executable trading signals (direction, strength, time horizon).',
-      defaultOutputFormat:
-        'JSON: { "signals": [{ "symbol": "...", "direction": "long|short|flat", "strength": 0.0-1.0, "horizon": "1h|4h|1d", "rationale": "..." }] }',
-    },
-    {
-      presetKey: 'signal_to_execution',
-      label: 'Signal to Execution',
-      defaultPrompt:
-        'You are the trade-execution sub-agent. Turn signals into concrete order instructions, respecting position limits, liquidity, and slippage. Output a submit-ready buy/sell plan.',
-      defaultOutputFormat:
-        'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }',
-    },
-    {
-      presetKey: 'global_strategy',
-      label: 'Global Trading Strategy',
-      defaultPrompt:
-        'You are the global strategy sub-agent. Coordinate asset allocation, risk budget, and conflicting signals so the overall portfolio stays within strategy constraints and target return/risk profile.',
-      defaultOutputFormat:
-        'JSON: { "portfolio_targets": [{ "symbol": "...", "target_weight": 0.0-1.0 }], "risk_budget": { "max_drawdown": number, "max_single_position": number }, "strategy_notes": "..." }',
-    },
-    {
-      presetKey: 'stop_loss_take_profit',
-      label: 'Stop Loss / Take Profit',
-      defaultPrompt:
-        'You are the risk-management sub-agent. Set stop-loss and take-profit rules for open positions, monitor unrealized P/L, and output close or reduce instructions when triggers fire.',
-      defaultOutputFormat:
-        'JSON: { "risk_actions": [{ "symbol": "...", "action": "stop_loss|take_profit|trail|hold", "trigger_price": number, "size_pct": 0.0-1.0, "reason": "..." }] }',
-    },
-    {
-      presetKey: 'post_trade_analysis',
-      label: 'Post-trade Analysis',
-      defaultPrompt:
-        'You are the post-trade analysis sub-agent. Once per trading day, review that day\'s trades, equity change, and the current decision-step prompts. Identify what went wrong in those prompts (missed risk, bad signal rules, weak execution constraints). Then propose revised prompts for the upstream sub-agents so the next trading day can improve. Do not invent market facts beyond the episode context you are given.',
-      defaultOutputFormat:
-        'JSON: { "summary": "...", "prompt_problems": [{ "step_id": "...", "presetKey": "...", "issue": "..." }], "prompt_patches": [{ "step_id": "...", "presetKey": "...", "new_prompt": "...", "change_rationale": "..." }] }',
-    },
-    {
-      presetKey: 'custom',
-      label: 'Custom Sub-agent',
-      defaultPrompt: 'Describe this sub-agent\'s responsibilities and decision boundaries.',
-      defaultOutputFormat: 'JSON: { "output": "..." }',
-    },
-  ];
-
-  const presetByKey = Object.fromEntries(SUB_AGENT_PRESETS.map((p) => [p.presetKey, p]));
-
   let currentAgent = null;
   let subAgents = [];
   let saveStatusTimer = null;
   let isDirty = false;
   let savedSnapshot = '';
-  let editorMode = 'simple';
 
   function escapeHtml(value) {
     return String(value ?? '')
@@ -125,52 +74,16 @@
     return `sub_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   }
 
-  function createSubAgentFromPreset(presetKey, customLabel) {
-    const preset = presetByKey[presetKey] || presetByKey.custom;
-    const label =
-      presetKey === 'custom' && customLabel
-        ? customLabel.trim()
-        : preset.label;
-    return {
-      id: newSubAgentId(),
-      presetKey,
-      label,
-      prompt: preset.defaultPrompt,
-      outputFormat: preset.defaultOutputFormat,
-    };
-  }
-
-  function defaultPipeline() {
-    return SUB_AGENT_PRESETS.filter((p) => p.presetKey !== 'custom').map((preset) => ({
-      id: newSubAgentId(),
-      presetKey: preset.presetKey,
-      label: preset.label,
-      prompt: preset.defaultPrompt,
-      outputFormat: preset.defaultOutputFormat,
-    }));
-  }
-
+  // Structural only: this screen no longer knows about sub-agent presets, it
+  // just round-trips whatever shape is already stored.
   function normalizeLoadedSubAgent(item) {
-    const presetKey = item.presetKey || 'custom';
-    const preset = presetByKey[presetKey];
-    const isCustom = presetKey === 'custom' || !preset;
     return {
       id: item.id || newSubAgentId(),
-      presetKey,
-      label: isCustom ? (item.label || 'Sub-agent') : preset.label,
-      prompt: item.prompt || (preset ? preset.defaultPrompt : ''),
-      outputFormat: item.outputFormat || (preset ? preset.defaultOutputFormat : ''),
+      presetKey: item.presetKey || 'custom',
+      label: item.label || 'Sub-agent',
+      prompt: item.prompt || '',
+      outputFormat: item.outputFormat || '',
     };
-  }
-
-  // For real agents the backend-stored pipeline is the source of truth; fall
-  // back to any locally cached / default pipeline when the agent has none yet.
-  // Demo (mock) agents have no backend row, so they always use localStorage.
-  function resolvePipeline(agent) {
-    if (!isDemoAgent(agent.agent_id) && Array.isArray(agent.pipeline) && agent.pipeline.length) {
-      return agent.pipeline.map(normalizeLoadedSubAgent);
-    }
-    return loadPipeline(agent.agent_id);
   }
 
   function isSimplePipeline(pipeline) {
@@ -181,9 +94,9 @@
     );
   }
 
-  // The pipeline the agent ACTUALLY has (backend row, then local cache) — with
-  // NO default-5-step substitution, so a fresh agent opens in Simple mode.
-  // Demo agents keep resolvePipeline's default behavior.
+  // The pipeline the agent ACTUALLY has (backend row, then local cache). Returns
+  // [] when it has none, which is what triggers the starter-instruction backfill
+  // in open() for agents created before server-side seeding existed.
   function loadStoredPipeline(agent) {
     if (Array.isArray(agent.pipeline) && agent.pipeline.length) {
       return agent.pipeline.map(normalizeLoadedSubAgent);
@@ -200,20 +113,6 @@
       /* fall through to empty */
     }
     return [];
-  }
-
-  function loadPipeline(agentId) {
-    try {
-      const raw = localStorage.getItem(storageKey(agentId));
-      if (!raw) return defaultPipeline();
-      const parsed = JSON.parse(raw);
-      if (!Array.isArray(parsed.subAgents) || !parsed.subAgents.length) {
-        return defaultPipeline();
-      }
-      return parsed.subAgents.map(normalizeLoadedSubAgent);
-    } catch {
-      return defaultPipeline();
-    }
   }
 
   function savePipelineLocal(agentId, agents) {
@@ -516,36 +415,33 @@
       cash_allocation = 1000;
     }
     const modelSelect = document.getElementById('agentEditorModelSelect');
+    const instruction = (
+      document.getElementById('agentEditorSimpleInstruction')?.value || ''
+    ).trim();
     let subAgentsOut;
     let sendPipeline;
-    if (editorMode === 'simple') {
-      const instruction = (
-        document.getElementById('agentEditorSimpleInstruction')?.value || ''
-      ).trim();
-      if (instruction) {
-        const existing =
-          subAgents.length === 1 && subAgents[0].presetKey === simplePresetKey()
-            ? subAgents[0]
-            : null;
-        subAgentsOut = [
-          {
-            id: existing ? existing.id : newSubAgentId(),
-            presetKey: simplePresetKey(),
-            label: 'Trading instruction',
-            prompt: instruction,
-            outputFormat: simpleOutputFormat(),
-          },
-        ];
-        sendPipeline = true;
-      } else {
-        // Empty instruction never touches the stored pipeline: not sent to the
-        // server, not cached locally, not folded into currentAgent.
-        subAgentsOut = subAgents;
-        sendPipeline = false;
-      }
-    } else {
-      subAgentsOut = collectPipelineFromDom();
+    if (instruction) {
+      const existing =
+        subAgents.length === 1 && subAgents[0].presetKey === simplePresetKey()
+          ? subAgents[0]
+          : null;
+      subAgentsOut = [
+        {
+          id: existing ? existing.id : newSubAgentId(),
+          presetKey: simplePresetKey(),
+          label: 'Trading instruction',
+          prompt: instruction,
+          outputFormat: simpleOutputFormat(),
+        },
+      ];
       sendPipeline = true;
+    } else {
+      // Empty instruction never touches the stored pipeline: not sent to the
+      // server, not cached locally, not folded into currentAgent. This is what
+      // stops a rename-only save from destroying a multi-step pipeline this
+      // screen cannot display.
+      subAgentsOut = subAgents;
+      sendPipeline = false;
     }
     const liveToggle = document.getElementById('agentEditorLiveTradingEnabled');
     return {
@@ -578,25 +474,6 @@
     setDirty(false);
   }
 
-  function collectPipelineFromDom() {
-    const pipeline = document.getElementById('agentEditorPipeline');
-    if (!pipeline) return subAgents;
-
-    return subAgents.map((sub) => {
-      const card = pipeline.querySelector(`[data-sub-id="${sub.id}"]`);
-      if (!card) return sub;
-      const labelInput = card.querySelector('[data-field="label"]');
-      const promptInput = card.querySelector('[data-field="prompt"]');
-      const outputInput = card.querySelector('[data-field="outputFormat"]');
-      return {
-        ...sub,
-        label: labelInput ? labelInput.value.trim() || sub.label : sub.label,
-        prompt: promptInput ? promptInput.value : sub.prompt,
-        outputFormat: outputInput ? outputInput.value : sub.outputFormat,
-      };
-    });
-  }
-
   function showSaveStatus(message, isError) {
     const el = document.getElementById('agentEditorSaveStatus');
     if (!el) return;
@@ -609,204 +486,11 @@
     }, 3000);
   }
 
-  function updateStepCount() {
-    const el = document.getElementById('agentEditorStepCount');
-    if (!el) return;
-    const n = subAgents.length;
-    el.textContent = `${n} step${n === 1 ? '' : 's'}`;
-  }
-
-  function refreshAddSelect() {
-    const select = document.getElementById('agentEditorAddSelect');
-    const customName = document.getElementById('agentEditorCustomName');
-    if (!select) return;
-
-    const usedPresetKeys = new Set(
-      subAgents.filter((s) => s.presetKey !== 'custom').map((s) => s.presetKey)
-    );
-
-    select.innerHTML = '<option value="">— Select type —</option>';
-    SUB_AGENT_PRESETS.forEach((preset) => {
-      if (preset.presetKey !== 'custom' && usedPresetKeys.has(preset.presetKey)) return;
-      const opt = document.createElement('option');
-      opt.value = preset.presetKey;
-      opt.textContent = preset.label;
-      select.appendChild(opt);
-    });
-
-    const customOpt = document.createElement('option');
-    customOpt.value = 'custom';
-    customOpt.textContent = 'Custom Sub-agent';
-    select.appendChild(customOpt);
-
-    if (customName) {
-      customName.hidden = select.value !== 'custom';
-    }
-  }
-
-  function moveSubAgent(index, delta) {
-    const next = index + delta;
-    if (next < 0 || next >= subAgents.length) return;
-    subAgents = collectPipelineFromDom();
-    const tmp = subAgents[index];
-    subAgents[index] = subAgents[next];
-    subAgents[next] = tmp;
-    renderPipeline();
-    markDirtyFromInput();
-  }
-
-  function duplicateSubAgent(subId) {
-    subAgents = collectPipelineFromDom();
-    const idx = subAgents.findIndex((s) => s.id === subId);
-    if (idx < 0) return;
-    const src = subAgents[idx];
-    const copy = {
-      ...src,
-      id: newSubAgentId(),
-      presetKey: 'custom',
-      label: `${src.label} (copy)`,
-    };
-    subAgents.splice(idx + 1, 0, copy);
-    renderPipeline();
-    markDirtyFromInput();
-    showSaveStatus('Sub-agent duplicated');
-  }
-
-  function restoreSubAgentDefaults(subId) {
-    subAgents = collectPipelineFromDom();
-    const sub = subAgents.find((s) => s.id === subId);
-    if (!sub) return;
-    const preset = presetByKey[sub.presetKey];
-    if (!preset || sub.presetKey === 'custom') return;
-    sub.prompt = preset.defaultPrompt;
-    sub.outputFormat = preset.defaultOutputFormat;
-    renderPipeline();
-    markDirtyFromInput();
-    showSaveStatus('Restored default prompt for this step');
-  }
-
-  function renderPipeline() {
-    const pipeline = document.getElementById('agentEditorPipeline');
-    if (!pipeline) return;
-
-    pipeline.innerHTML = '';
-    updateStepCount();
-
-    subAgents.forEach((sub, index) => {
-      const card = document.createElement('article');
-      card.className = 'section-card agent-sub-card';
-      card.setAttribute('role', 'listitem');
-      card.dataset.subId = sub.id;
-
-      const isCustom = sub.presetKey === 'custom';
-      const isFirst = index === 0;
-      const isLast = index === subAgents.length - 1;
-      const canRestore = !isCustom && presetByKey[sub.presetKey];
-
-      const isPostTrade = sub.presetKey === 'post_trade_analysis';
-      const nextIsPostTrade =
-        !isLast && subAgents[index + 1] && subAgents[index + 1].presetKey === 'post_trade_analysis';
-      const labelField = isCustom
-        ? `<input class="agent-sub-label-input" type="text" data-field="label" value="${escapeHtml(sub.label)}" placeholder="Sub-agent name" aria-label="Sub-agent name">`
-        : `<span class="agent-sub-preset-label">${escapeHtml(sub.label)}${
-            isPostTrade
-              ? '<span class="agent-sub-freq-badge" title="Runs once per trading day after trades">daily after trades</span>'
-              : ''
-          }</span>`;
-
-      card.innerHTML = `
-        <div class="agent-sub-head">
-          <div class="agent-sub-head-left">
-            <span class="agent-sub-index" aria-hidden="true">${index + 1}</span>
-            ${labelField}
-          </div>
-          <div class="agent-sub-actions">
-            <div class="agent-sub-reorder" role="group" aria-label="Reorder sub-agent">
-              <button class="agent-sub-move-btn" type="button" data-action="up" data-sub-id="${escapeHtml(sub.id)}" aria-label="Move up" ${isFirst ? 'disabled' : ''}>↑</button>
-              <button class="agent-sub-move-btn" type="button" data-action="down" data-sub-id="${escapeHtml(sub.id)}" aria-label="Move down" ${isLast ? 'disabled' : ''}>↓</button>
-            </div>
-            <button class="agent-sub-icon-btn" type="button" data-action="duplicate" data-sub-id="${escapeHtml(sub.id)}" title="Duplicate">⧉</button>
-            ${canRestore ? `<button class="agent-sub-icon-btn" type="button" data-action="restore" data-sub-id="${escapeHtml(sub.id)}" title="Restore defaults">↺</button>` : ''}
-            <button class="agent-sub-remove-btn" type="button" data-action="remove" data-sub-id="${escapeHtml(sub.id)}" aria-label="Remove sub-agent">Remove</button>
-          </div>
-        </div>
-        <div class="agent-sub-fields">
-          <label class="agent-sub-field">
-            <span class="agent-sub-field-label">Task prompt</span>
-            <span class="agent-sub-field-hint">What this sub-agent should do</span>
-            <textarea data-field="prompt" rows="5" placeholder="Describe this sub-agent's role…">${escapeHtml(sub.prompt)}</textarea>
-          </label>
-          <label class="agent-sub-field">
-            <span class="agent-sub-field-label">Output format</span>
-            <span class="agent-sub-field-hint">Structure passed to the next model</span>
-            <textarea data-field="outputFormat" rows="4" placeholder="JSON or structured text…">${escapeHtml(sub.outputFormat)}</textarea>
-          </label>
-        </div>
-        ${
-          !isLast
-            ? `<div class="agent-sub-connector" aria-hidden="true"><span>${
-                nextIsPostTrade
-                  ? '↓ Then post-trade analysis (once per day)'
-                  : '↓ Output to next sub-agent'
-              }</span></div>`
-            : ''
-        }
-      `;
-
-      pipeline.appendChild(card);
-    });
-
-    pipeline.querySelectorAll('[data-action]').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const action = btn.dataset.action;
-        const subId = btn.dataset.subId;
-        const idx = subAgents.findIndex((s) => s.id === subId);
-        if (action === 'up') moveSubAgent(idx, -1);
-        else if (action === 'down') moveSubAgent(idx, 1);
-        else if (action === 'duplicate') duplicateSubAgent(subId);
-        else if (action === 'restore') restoreSubAgentDefaults(subId);
-        else if (action === 'remove') {
-          if (subAgents.length <= 1) {
-            showSaveStatus('Keep at least one sub-agent', true);
-            return;
-          }
-          subAgents = collectPipelineFromDom().filter((s) => s.id !== subId);
-          renderPipeline();
-          refreshAddSelect();
-          markDirtyFromInput();
-        }
-      });
-    });
-
-    refreshAddSelect();
-  }
-
+  // Warn only when the agent holds a pipeline this screen cannot author, since
+  // saving an instruction would replace it.
   function updateSimpleReplaceNote() {
     const note = document.getElementById('agentEditorSimpleReplaceNote');
-    if (note) note.hidden = !(editorMode === 'simple' && !isSimplePipeline(subAgents));
-  }
-
-  function setEditorMode(mode) {
-    editorMode = mode === 'advanced' ? 'advanced' : 'simple';
-    const simplePanel = document.getElementById('agentEditorSimplePanel');
-    const advancedPanel = document.getElementById('agentEditorAdvancedPanel');
-    const resetBtn = document.getElementById('agentEditorResetBtn');
-    if (simplePanel) simplePanel.hidden = editorMode !== 'simple';
-    if (advancedPanel) advancedPanel.hidden = editorMode !== 'advanced';
-    if (resetBtn) resetBtn.hidden = editorMode !== 'advanced';
-    const modeSimpleBtn = document.getElementById('agentEditorModeSimple');
-    const modeAdvancedBtn = document.getElementById('agentEditorModeAdvanced');
-    modeSimpleBtn?.classList.toggle('active', editorMode === 'simple');
-    modeAdvancedBtn?.classList.toggle('active', editorMode === 'advanced');
-    modeSimpleBtn?.setAttribute('aria-pressed', editorMode === 'simple' ? 'true' : 'false');
-    modeAdvancedBtn?.setAttribute('aria-pressed', editorMode === 'advanced' ? 'true' : 'false');
-    if (editorMode === 'advanced' && subAgents.length === 0) {
-      // First look at Advanced on a fresh agent: start from the default chain.
-      subAgents = defaultPipeline();
-      renderPipeline();
-    }
-    updateSimpleReplaceNote();
-    markDirtyFromInput();
+    if (note) note.hidden = isSimplePipeline(subAgents);
   }
 
   function fillHeader(agent) {
@@ -1022,23 +706,17 @@
     if (!agent || !agent.agent_id) return;
 
     currentAgent = { ...agent };
-    if (isDemoAgent(agent.agent_id)) {
-      subAgents = resolvePipeline(agent); // demo agents keep the legacy default chain
-    } else {
-      subAgents = loadStoredPipeline(agent);
-    }
+    subAgents = loadStoredPipeline(agent);
     fillHeader(agent);
     populateModelSelect(agent);
+
     const instructionEl = document.getElementById('agentEditorSimpleInstruction');
-    if (instructionEl) {
-      const simpleStep =
-        subAgents.length === 1 && subAgents[0].presetKey === simplePresetKey()
-          ? subAgents[0]
-          : null;
-      instructionEl.value = simpleStep ? simpleStep.prompt : '';
-    }
-    renderPipeline();
-    setEditorMode(isSimplePipeline(subAgents) ? 'simple' : 'advanced');
+    const simpleStep =
+      subAgents.length === 1 && subAgents[0].presetKey === simplePresetKey()
+        ? subAgents[0]
+        : null;
+    if (instructionEl) instructionEl.value = simpleStep ? simpleStep.prompt : '';
+    updateSimpleReplaceNote();
     refreshRunHistory(currentAgent);
     refreshRobinhoodStatus();
 
@@ -1051,7 +729,18 @@
     const playgroundView = document.getElementById('playgroundView');
     if (playgroundView) playgroundView.setAttribute('aria-hidden', 'true');
 
+    // Baseline the STORED state first, then backfill — capturing the snapshot
+    // after the injection would re-baseline it and the default would never be
+    // recognised as an unsaved change.
     captureSavedSnapshot();
+    if (!subAgents.length && instructionEl && defaultStarterInstruction()) {
+      // Agent predates server-side seeding (its pipeline is empty). Offer the
+      // starter instruction so Configure is never a blank box, and mark it dirty
+      // so a Save persists it.
+      instructionEl.value = defaultStarterInstruction();
+      markDirtyFromInput();
+    }
+
     document.getElementById('agentEditorNameInput')?.focus();
   }
 
@@ -1059,8 +748,6 @@
     if (!force && isDirty) {
       if (!window.confirm('Discard unsaved changes?')) return;
     }
-
-    subAgents = collectPipelineFromDom();
 
     const view = document.getElementById('agentEditorView');
     if (view) view.hidden = true;
@@ -1091,7 +778,6 @@
     }
 
     subAgents = state.subAgents;
-    renderPipeline();
     updateSimpleReplaceNote();
     const saveBtn = document.getElementById('agentEditorSaveBtn');
     if (saveBtn) {
@@ -1186,56 +872,9 @@
     }
   }
 
-  function resetPipeline() {
-    if (!window.confirm('Reset the pipeline to the default 5 sub-agents? Unsaved prompt edits will be lost.')) {
-      return;
-    }
-    subAgents = defaultPipeline();
-    renderPipeline();
-    markDirtyFromInput();
-    showSaveStatus('Pipeline reset to defaults');
-  }
-
-  function addSubAgent() {
-    const select = document.getElementById('agentEditorAddSelect');
-    const customNameEl = document.getElementById('agentEditorCustomName');
-    const presetKey = select ? select.value : '';
-    if (!presetKey) {
-      showSaveStatus('Select a sub-agent type to add', true);
-      return;
-    }
-
-    subAgents = collectPipelineFromDom();
-
-    let customLabel = null;
-    if (presetKey === 'custom' && customNameEl) {
-      customLabel = customNameEl.value.trim() || 'Custom Sub-agent';
-    }
-
-    subAgents.push(createSubAgentFromPreset(presetKey, customLabel));
-    renderPipeline();
-    markDirtyFromInput();
-    showSaveStatus('Sub-agent added');
-
-    if (select) select.value = '';
-    if (customNameEl) {
-      customNameEl.value = '';
-      customNameEl.hidden = true;
-    }
-
-    const pipeline = document.getElementById('agentEditorPipeline');
-    if (pipeline && pipeline.lastElementChild) {
-      pipeline.lastElementChild.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-    }
-  }
-
   function bindEvents() {
     document.getElementById('agentEditorBackBtn')?.addEventListener('click', () => close(false));
     document.getElementById('agentEditorSaveBtn')?.addEventListener('click', () => save());
-    document.getElementById('agentEditorAddBtn')?.addEventListener('click', addSubAgent);
-    document.getElementById('agentEditorResetBtn')?.addEventListener('click', resetPipeline);
-    document.getElementById('agentEditorModeSimple')?.addEventListener('click', () => setEditorMode('simple'));
-    document.getElementById('agentEditorModeAdvanced')?.addEventListener('click', () => setEditorMode('advanced'));
     document.getElementById('agentEditorConnectRobinhoodBtn')?.addEventListener('click', connectRobinhood);
     document.getElementById('agentEditorDisconnectRobinhoodBtn')?.addEventListener('click', disconnectRobinhood);
     document.getElementById('agentEditorRunLiveBtn')?.addEventListener('click', runLive);
@@ -1244,11 +883,6 @@
       if (typeof window.openRunBacktestModal === 'function') {
         window.openRunBacktestModal(currentAgent);
       }
-    });
-
-    document.getElementById('agentEditorAddSelect')?.addEventListener('change', (e) => {
-      const customName = document.getElementById('agentEditorCustomName');
-      if (customName) customName.hidden = e.target.value !== 'custom';
     });
 
     const body = document.getElementById('agentEditorView');
@@ -1278,5 +912,5 @@
 
   bindEvents();
 
-  window.AgentEditor = { open, close, save, loadPipeline };
+  window.AgentEditor = { open, close, save };
 })();

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8561,11 +8561,6 @@ body.agent-editor-open {
     border: 1px solid rgba(251, 191, 36, 0.35);
 }
 
-.agent-editor-reset-btn {
-    font-size: 12px;
-    padding: 8px 12px;
-}
-
 .agent-editor-title {
     margin: 0;
     font-size: 20px;
@@ -8708,24 +8703,6 @@ body.agent-editor-open {
     line-height: 1.3;
 }
 
-.agent-editor-intro-head {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 16px;
-}
-
-.agent-editor-step-count {
-    flex-shrink: 0;
-    font-size: 12px;
-    font-weight: 700;
-    color: var(--home-accent-cyan, #22d3ee);
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(34, 211, 238, 0.1);
-    border: 1px solid rgba(34, 211, 238, 0.25);
-}
-
 .agent-editor-hint {
     margin: 16px 0 0;
     font-size: 12px;
@@ -8740,10 +8717,6 @@ body.agent-editor-open {
     font-size: 11px;
 }
 
-.agent-editor-intro {
-    margin-bottom: 16px;
-}
-
 .agent-editor-intro-title {
     margin: 0 0 6px;
     font-size: 15px;
@@ -8756,261 +8729,6 @@ body.agent-editor-open {
     font-size: 13px;
     color: var(--text-secondary);
     line-height: 1.5;
-}
-
-.agent-editor-pipeline {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-}
-
-.agent-sub-card {
-    padding: 16px 18px;
-    margin-bottom: 0;
-    border-left: 3px solid rgba(34, 211, 238, 0.35);
-}
-
-.agent-sub-actions {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 6px;
-    flex-shrink: 0;
-}
-
-.agent-sub-reorder {
-    display: inline-flex;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    overflow: hidden;
-}
-
-.agent-sub-move-btn {
-    width: 32px;
-    height: 30px;
-    border: none;
-    background: var(--bg-input);
-    color: var(--text-secondary);
-    font-size: 14px;
-    font-weight: 700;
-    cursor: pointer;
-    transition: background 0.15s, color 0.15s;
-}
-
-.agent-sub-move-btn + .agent-sub-move-btn {
-    border-left: 1px solid var(--border-color);
-}
-
-.agent-sub-move-btn:hover:not(:disabled) {
-    background: rgba(34, 211, 238, 0.12);
-    color: var(--home-accent-cyan, #22d3ee);
-}
-
-.agent-sub-move-btn:disabled {
-    opacity: 0.35;
-    cursor: not-allowed;
-}
-
-.agent-sub-icon-btn {
-    width: 30px;
-    height: 30px;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    background: transparent;
-    color: var(--text-secondary);
-    font-size: 14px;
-    cursor: pointer;
-    transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-
-.agent-sub-icon-btn:hover {
-    border-color: rgba(34, 211, 238, 0.4);
-    color: var(--home-accent-cyan, #22d3ee);
-    background: rgba(34, 211, 238, 0.08);
-}
-
-.agent-sub-head {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 12px;
-}
-
-.agent-sub-head-left {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    min-width: 0;
-    flex: 1;
-}
-
-.agent-sub-index {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    border-radius: 50%;
-    background: rgba(34, 211, 238, 0.14);
-    color: var(--home-accent-cyan, #22d3ee);
-    font-size: 12px;
-    font-weight: 700;
-    flex-shrink: 0;
-}
-
-.agent-sub-preset-label {
-    font-size: 15px;
-    font-weight: 700;
-    color: var(--text-primary);
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-}
-
-.agent-sub-freq-badge {
-    font-size: 10px;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-    color: var(--text-secondary, #64748b);
-    border: 1px solid var(--border-color, #cbd5e1);
-    border-radius: 4px;
-    padding: 2px 6px;
-}
-
-.agent-sub-label-input {
-    flex: 1;
-    min-width: 0;
-    padding: 6px 10px;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background: var(--bg-input);
-    color: var(--text-primary);
-    font-size: 14px;
-    font-weight: 600;
-}
-
-.agent-sub-remove-btn {
-    padding: 5px 10px;
-    border: 1px solid rgba(239, 68, 68, 0.35);
-    border-radius: 4px;
-    background: transparent;
-    color: #f87171;
-    font-size: 11px;
-    font-weight: 600;
-    cursor: pointer;
-    flex-shrink: 0;
-    transition: background 0.15s;
-}
-
-.agent-sub-remove-btn:hover {
-    background: rgba(239, 68, 68, 0.12);
-}
-
-.agent-sub-fields {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 14px;
-}
-
-.agent-sub-field {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.agent-sub-field-label {
-    font-size: 12px;
-    font-weight: 700;
-    color: var(--text-primary);
-}
-
-.agent-sub-field-hint {
-    font-size: 11px;
-    color: var(--text-muted);
-    margin-bottom: 2px;
-}
-
-.agent-sub-field textarea {
-    width: 100%;
-    box-sizing: border-box;
-    padding: 10px 12px;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    background: var(--bg-input);
-    color: var(--text-primary);
-    font-size: 13px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    line-height: 1.45;
-    resize: vertical;
-    min-height: 72px;
-}
-
-.agent-sub-field textarea:focus {
-    outline: none;
-    border-color: rgba(34, 211, 238, 0.5);
-    box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.12);
-}
-
-.agent-sub-connector {
-    display: flex;
-    justify-content: center;
-    padding: 8px 0 12px;
-    color: var(--text-muted);
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-}
-
-.agent-sub-connector span {
-    padding: 4px 12px;
-    border-radius: 999px;
-    background: rgba(148, 163, 184, 0.08);
-    border: 1px dashed rgba(148, 163, 184, 0.2);
-}
-
-.agent-editor-add-row {
-    margin-top: 16px;
-}
-
-.agent-editor-add-label {
-    display: block;
-    margin-bottom: 8px;
-    font-size: 12px;
-    font-weight: 700;
-    color: var(--text-primary);
-}
-
-.agent-editor-add-controls {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    align-items: center;
-}
-
-.agent-editor-custom-name {
-    flex: 1;
-    min-width: 160px;
-    padding: 8px 12px;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    background: var(--bg-input);
-    color: var(--text-primary);
-    font-size: 13px;
-}
-
-.agent-editor-add-select {
-    flex: 1;
-    min-width: 200px;
-    padding: 8px 12px;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    background: var(--bg-input);
-    color: var(--text-primary);
-    font-size: 13px;
 }
 
 .agent-editor-save-status {
@@ -9043,12 +8761,6 @@ body.agent-editor-open {
     }
 }
 
-@media (max-width: 900px) {
-    .agent-sub-fields {
-        grid-template-columns: 1fr;
-    }
-}
-
 @media (max-width: 640px) {
     .agent-editor-header {
         flex-wrap: wrap;
@@ -9066,24 +8778,6 @@ body.agent-editor-open {
 
     .agent-editor-body {
         padding: 12px;
-    }
-
-    .agent-editor-intro-head {
-        flex-direction: column;
-    }
-
-    .agent-editor-add-controls {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .agent-sub-head {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .agent-sub-actions {
-        justify-content: flex-start;
     }
 }
 
@@ -9379,26 +9073,7 @@ body.agent-editor-open {
     white-space: nowrap;
 }
 
-/* Agent editor — Simple/Advanced modes (Demo 1) */
-.agent-editor-mode-toggle {
-    display: inline-flex;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    overflow: hidden;
-}
-.agent-editor-mode-btn {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    font-size: 0.8rem;
-    font-weight: 600;
-    padding: 6px 14px;
-    cursor: pointer;
-}
-.agent-editor-mode-btn.active {
-    background: var(--border-color);
-    color: var(--text-primary);
-}
+/* Agent editor — model picker (Demo 1) */
 .agent-editor-model-field {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Removes Advanced mode from the agent Configure screen and makes the default agent usable without opening it.

**Advanced mode removed.** Mode toggle, sub-agent pipeline builder, "Reset pipeline", and the dead `.agent-sub-*` CSS. Simple mode is now the only mode.

Multi-step pipelines still execute server-side (`pipeline_runner.py`) and the marketplace still ships the 3-step `pipeline-analyst`, so an agent can hold a pipeline this screen cannot author. That pipeline is carried opaquely and re-sent untouched unless the user types an instruction — a rename-only save cannot destroy it.

**Starter prompt seeded server-side.** `AgentService.create_agent` now seeds built-in agents with the default instruction, replacing a follow-up `PATCH` from `app.js` wrapped in `catch { console.warn }`. `PATCH` was absent from the CORS `allow_methods` until #245, so that preflight 400'd in prod and every default agent shipped with an **empty pipeline**, silently falling back to the generic hourly prompt at backtest time. The editor backfills the same default for agents created before this change.

Net −442 lines. Backend contract, `marketplace.json`, and `pipeline_runner.py` unchanged.

### Verification
- `pytest dashboard/backend/tests/` — 1847 passed, 43 skipped.
- One pre-existing failure (`test_ifind_ashare_engine`, suite-ordering pollution) reproduces identically on `main`; passes in isolation on both.
- Live uvicorn smoke: create returns a 1-step `simple_instruction` pipeline **and** still returns the one-time `api_key`; `/app` serves 0 advanced-mode elements.
- 24 new tests: seeding, marketplace-clone precedence, JS↔Python contract sync, advanced-markup absence.

### Note for reviewers
Cache-busters bumped (`styles.css` 65→66, `agent-editor.js` 13→14, `app.js` 48→49) — `js/*.js` has no no-cache override in `vercel.json`, and stale JS against new markup renders a blank Configure screen.