### PR TITLE
chore: sweep the fixable CodeQL quality alerts

### DIFF
--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse
 from pathlib import Path
 
-from dashboard.backend.database import db, DB_PATH
+import dashboard.backend.database as _database
 from dashboard.backend.paths import FRONTEND_DIR
 from dashboard.backend.middleware import SessionMiddleware, CSPHeaderMiddleware
 from dashboard.backend.api.router import api_router
@@ -25,6 +25,16 @@ from dashboard.backend.api.routers.market import router as market_router
 from dashboard.backend.api.routers.admin import router as admin_router
 from dashboard.backend.api.v2.errors import ApiError, api_error_handler, validation_error_handler
 from dashboard.backend.domain.backtesting.baselines.paper import create_paper_baselines_if_not_exists
+
+# Re-exported from database.py. ``DB_PATH`` is used below; ``db`` is not
+# referenced in this module at all -- it exists so tests can swap the shared
+# connection with `monkeypatch.setattr(app_module, "db", temp_db)`
+# (test_external_backtest_api.py, test_backtest_isolation.py). That reference
+# is a *string*, so neither grep nor AST analysis sees it, and dropping the
+# name as an "unused import" errors 9 tests. Bound explicitly so the
+# re-export reads as deliberate rather than as a stale import.
+db = _database.db
+DB_PATH = _database.DB_PATH
 
 # Load .env from project root (ANTHROPIC_API_KEY, ALPACA_*)
 _env_path = Path(__file__).resolve().parent.parent / ".env"

--- a/dashboard/backend/tests/domain/backtesting/test_algo_service_move.py
+++ b/dashboard/backend/tests/domain/backtesting/test_algo_service_move.py
@@ -136,7 +136,7 @@ def test_execute_algo_writes_config_and_forwards(monkeypatch, tmp_path):
         captured["args"] = kwargs.get("args")
 
         class _T:
-            def start(self_inner):
+            def start(self):
                 captured["started"] = True
 
         return _T()

--- a/dashboard/backend/tests/test_env_isolation.py
+++ b/dashboard/backend/tests/test_env_isolation.py
@@ -67,7 +67,7 @@ def test_the_pop_survives_a_hostile_ambient_environment():
             "-m",
             "pytest",
             "dashboard/backend/tests/test_env_isolation.py::"
-            "test_content_database_url_is_stripped_for_the_suite",
+            + "test_content_database_url_is_stripped_for_the_suite",
             "-q",
             "-p",
             "no:cacheprovider",

--- a/dashboard/backend/tests/test_frontend_xss_guards.py
+++ b/dashboard/backend/tests/test_frontend_xss_guards.py
@@ -107,7 +107,7 @@ def test_escape_html_neutralizes_markup():
         "&lt;img src=x onerror=alert(1)&gt;",
         "Error: &lt;script&gt;alert(document.cookie)&lt;/script&gt;",
         "Backtest failed (code 1): Traceback ... team "
-        "&quot;&lt;svg onload=alert(1)&gt;&quot;",
+        + "&quot;&lt;svg onload=alert(1)&gt;&quot;",
     ]
 
 

--- a/dashboard/backend/tests/test_v2_runs.py
+++ b/dashboard/backend/tests/test_v2_runs.py
@@ -11,7 +11,7 @@ def _register_fake(run_id="run_unit_1", session_id="sess_unit_1"):
 
 
 def test_lifecycle_create_context_decide_result():
-    backend = _register_fake()
+    _register_fake()  # registers the run; the backend handle is not needed here
     # context
     ctx = runs_mod._context_for("run_unit_1", "sess_unit_1")
     assert ctx["status"] == "waiting_decision"


### PR DESCRIPTION
Triaged all 63 open CodeQL alerts. All are quality-tier — **zero security severity**, zero Dependabot alerts. 58 are false positives or deliberate; the 5 changed here are the ones that alter no behaviour.

Fixed:
- `app.py` — bind `db`/`DB_PATH` explicitly rather than importing `db` unused. `db` is a re-export that tests monkeypatch **by string name** (`monkeypatch.setattr(app_module, "db", temp_db)`), so it is invisible to grep and to AST analysis; deleting it as an "unused import" errors 9 tests. Verified by doing exactly that first.
- `test_v2_runs` — drop an unused local (the call's side effect is the point)
- `test_algo_service_move` — name a method's first parameter `self`
- `test_env_isolation`, `test_frontend_xss_guards` — explicit `+` for two string concatenations, which is what the rule asks for

Left open, with reasons, so the next sweep doesn't re-litigate them:

| Rule | n | Why |
|---|---|---|
| `py/unused-import` | 10 | Deliberate re-exports — `backtest_hourly_agent.py` says so in its own comments; `test_service_move.py` asserts on the leaderboard one; `from anthropic import Anthropic` **is** the optional-SDK probe behind `HAS_ANTHROPIC`; `test_module_identity` imports to populate `sys.modules` |
| `py/import-and-import-from` | 19 | Tests need the module object for `monkeypatch.setattr` plus names for use |
| `py/empty-except` | 17 | Best-effort cleanup, optional-dep imports, rollbacks that re-raise |
| `py/cyclic-import` | 7 | The SQLite/Postgres store factory; the function-local import is the mitigation |
| `py/print-during-import` | 3 | Operator-facing optional-dep warning — `logging` emits nothing under the deployed uvicorn config, so `print` is the convention here |
| `py/ineffectual-statement` | 1 | `...` as a Protocol method body |

Independent of #248 (no overlapping files, so no conflict). Suite green: 1848 passed; the one `test_ifind_engine_resolves_csi300_sample20` failure is the known order-dependent flake that also fails on `main` and passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)