### PR TITLE
fix: My Agents UI text size + wrapping

### DIFF
--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1057,7 +1057,7 @@ function renderAgentCards(grid, agents, categoryKey) {
     const statusBadge = resolveAgentStatusBadge(agent);
     const card = document.createElement('div');
     card.className = `section-card agent-card agent-card--status agent-card--${statusBadge.key}${isBuiltin ? ' agent-card-builtin' : ''}`;
-    const model = escapeHtml(agent.model_name || 'local-model');
+    const model = escapeHtml(formatAgentModelLabel(agent.model_name));
     const type = escapeHtml(agentTypeLabel(agent));
 
     card.innerHTML = `

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -461,7 +461,7 @@ a.header-brand:hover .title-section h1 {
 .auth-modal-subtitle {
     margin: 0 0 18px;
     color: var(--text-secondary);
-    font-size: 12px;
+    font-size: 13px;
 }
 
 .auth-form {
@@ -896,7 +896,7 @@ a.header-brand:hover .title-section h1 {
 
 .control-group label {
     display: block;
-    font-size: 11px;
+    font-size: 12.5px;
     font-weight: 700;
     color: var(--text-secondary);
     text-transform: none;
@@ -914,7 +914,7 @@ a.header-brand:hover .title-section h1 {
 .date-input-wrapper {
     position: relative;
     flex: 1;
-    max-width: 100px;
+    max-width: 122px;
     display: flex;
     align-items: center;
 }
@@ -927,7 +927,7 @@ a.header-brand:hover .title-section h1 {
     border: 1px solid var(--border-color);
     border-radius: 3px;
     color: var(--text-primary);
-    font-size: 10px;
+    font-size: 12.5px;
     font-family: var(--font-mono);
     height: 24px;
     line-height: 1;
@@ -969,7 +969,7 @@ a.header-brand:hover .title-section h1 {
     border-left: 2px solid var(--warning-color);
     background: rgba(245, 158, 11, 0.08);
     color: var(--text-secondary);
-    font-size: 10px;
+    font-size: 12px;
     line-height: 1.45;
 }
 
@@ -1052,7 +1052,7 @@ a.header-brand:hover .title-section h1 {
    ============================================================================ */
 
 .control-helper {
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
     margin-bottom: 12px;
     margin-top: -4px;
@@ -1132,7 +1132,7 @@ a.header-brand:hover .title-section h1 {
     border-radius: 3px;
     color: #fda4af;
     font-family: var(--font-mono);
-    font-size: 9px;
+    font-size: 10px;
     font-weight: 700;
 }
 
@@ -1165,14 +1165,14 @@ a.header-brand:hover .title-section h1 {
 .ifind-symbol-item span {
     color: var(--text-primary);
     font-family: var(--font-mono);
-    font-size: 9px;
+    font-size: 10px;
     font-weight: 700;
 }
 
 .ifind-symbol-item small {
     margin-top: 2px;
     color: var(--text-secondary);
-    font-size: 9px;
+    font-size: 10px;
 }
 
 /* Preset Cards */
@@ -1215,7 +1215,7 @@ a.header-brand:hover .title-section h1 {
 }
 
 .preset-desc {
-    font-size: 11px;
+    font-size: 12.5px;
     color: var(--text-secondary);
     margin-bottom: 12px;
 }
@@ -1226,7 +1226,7 @@ a.header-brand:hover .title-section h1 {
     border-radius: 4px;
     background-color: transparent;
     color: var(--text-secondary);
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 500;
     cursor: pointer;
     transition: all 0.15s;
@@ -1258,7 +1258,7 @@ a.header-brand:hover .title-section h1 {
 }
 
 .custom-header {
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 600;
     color: var(--text-primary);
     margin-bottom: 12px;
@@ -1361,7 +1361,7 @@ a.header-brand:hover .title-section h1 {
     background-color: var(--bg-hover);
     border: 1px solid var(--border-color);
     border-radius: 4px;
-    font-size: 11px;
+    font-size: 12.5px;
     color: var(--text-primary);
     font-weight: 500;
     white-space: nowrap;
@@ -1384,7 +1384,7 @@ a.header-brand:hover .title-section h1 {
 }
 
 .chips-helper {
-    font-size: 11px;
+    font-size: 12.5px;
     color: var(--text-muted);
 }
 
@@ -1587,7 +1587,7 @@ a.header-brand:hover .title-section h1 {
     border: none;
     border-radius: 3px;
     color: white;
-    font-size: 11px;
+    font-size: 12.5px;
     font-weight: 700;
     cursor: pointer;
     transition: all 0.15s;
@@ -6064,6 +6064,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     cursor: pointer; text-decoration: none; border: 1px solid transparent;
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s;
 }
+.home-btn[hidden] { display: none !important; }
 .home-btn-primary { background: var(--home-accent-cyan); color: #041018; border-color: var(--home-accent-cyan); box-shadow: 0 6px 24px rgba(34,211,238,0.24); }
 .home-btn-primary:hover { filter: brightness(1.05); }
 .home-btn-secondary { background: rgba(8,18,40,0.55); color: var(--text-primary); border-color: rgba(148,163,184,0.22); }
@@ -6904,12 +6905,12 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     display: flex;
     flex-direction: column;
     gap: 4px;
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
 }
 
 .agent-discord {
-    font-size: 11px;
+    font-size: 12.5px;
     font-weight: 600;
 }
 
@@ -6961,7 +6962,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     border: 1px solid var(--border-color);
     background: var(--bg-input);
     color: var(--text-secondary);
-    font-size: 11px;
+    font-size: 12.5px;
     text-align: left;
     cursor: pointer;
     transition: border-color 0.15s, color 0.15s;
@@ -6975,7 +6976,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-run-secondary {
     color: var(--text-muted);
-    font-size: 10px;
+    font-size: 12px;
     line-height: 1.3;
 }
 
@@ -6996,7 +6997,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     border: 1px solid var(--info-color);
     background: rgba(0, 191, 255, 0.12);
     color: var(--info-color);
-    font-size: 11px;
+    font-size: 12.5px;
     font-weight: 700;
     cursor: pointer;
     text-decoration: none;
@@ -7056,7 +7057,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-description {
     margin: 6px 0 2px;
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
     line-height: 1.4;
 }
@@ -7669,18 +7670,14 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     font-size: 16px;
     font-weight: 700;
     line-height: 1.25;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
 }
 
 .agent-card-submeta {
     margin: 3px 0 0;
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
 }
 
 .agent-card-hero {
@@ -7708,7 +7705,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     align-items: center;
     padding: 2px 7px;
     border-radius: 999px;
-    font-size: 9px;
+    font-size: 10px;
     font-weight: 750;
     letter-spacing: 0.06em;
     text-transform: uppercase;
@@ -7731,7 +7728,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-card-metric-label {
     display: inline;
-    font-size: 11px;
+    font-size: 13px;
     font-weight: 500;
     color: var(--text-muted);
     margin-bottom: 0;
@@ -7748,7 +7745,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-card-capital-note {
     margin: 4px 0 0;
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 500;
     color: var(--text-muted);
 }
@@ -7786,14 +7783,14 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-card-latest-meta {
     margin: 0;
-    font-size: 12.5px;
+    font-size: 13px;
     font-weight: 500;
     color: var(--text-secondary);
 }
 
 .agent-card-latest-note {
     margin: 0;
-    font-size: 11.5px;
+    font-size: 12.5px;
     color: var(--text-muted);
 }
 
@@ -7804,7 +7801,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-card-change {
     margin: 6px 0 0;
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 600;
 }
 
@@ -7817,7 +7814,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-card-period {
     margin: -4px 0 0;
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
 }
 
@@ -7883,7 +7880,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 }
 
 .agent-card-stat-label {
-    font-size: 11px;
+    font-size: 12.5px;
     color: var(--text-muted);
 }
 
@@ -7897,7 +7894,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     display: flex;
     align-items: flex-start;
     gap: 8px;
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
 }
 
@@ -7925,7 +7922,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 }
 
 .agent-card-activity-sub {
-    font-size: 11px;
+    font-size: 12.5px;
     color: var(--text-muted);
 }
 
@@ -7957,14 +7954,14 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-card-empty strong {
     color: var(--text-secondary);
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 650;
 }
 
 .agent-card-empty span {
-    font-size: 12px;
+    font-size: 13px;
     line-height: 1.4;
-    max-width: 220px;
+    max-width: 240px;
 }
 
 .agent-card-actions--status {
@@ -8063,7 +8060,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     border-radius: 6px;
     background: transparent;
     color: var(--text-primary);
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 600;
     text-align: left;
     cursor: pointer;
@@ -8135,7 +8132,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 }
 
 .add-agent-option span {
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
 }
 
@@ -8439,7 +8436,7 @@ body.agent-editor-open {
 }
 
 .agent-editor-cash-label {
-    font-size: 11px;
+    font-size: 12.5px;
     font-weight: 600;
     color: var(--text-muted);
     text-transform: uppercase;
@@ -8478,7 +8475,7 @@ body.agent-editor-open {
 }
 
 .agent-editor-broker-status {
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 700;
     padding: 4px 10px;
     border-radius: 999px;
@@ -8499,7 +8496,7 @@ body.agent-editor-open {
 }
 
 .agent-editor-broker-meta {
-    font-size: 12px;
+    font-size: 13px;
     color: #94a3b8;
 }
 
@@ -8518,7 +8515,7 @@ body.agent-editor-open {
 }
 
 .agent-editor-live-result {
-    font-size: 12px;
+    font-size: 13px;
     color: #cbd5e1;
     margin: 0;
 }
@@ -8573,7 +8570,7 @@ body.agent-editor-open {
 
 .agent-editor-meta {
     margin: 2px 0 0;
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
 }
 
@@ -8628,7 +8625,7 @@ body.agent-editor-open {
 
 .agent-editor-run-count {
     flex-shrink: 0;
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 700;
     color: var(--home-accent-cyan, #22d3ee);
     padding: 4px 10px;
@@ -8639,7 +8636,7 @@ body.agent-editor-open {
 
 .agent-editor-history-hint {
     margin: 0;
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-secondary);
     line-height: 1.45;
 }
@@ -8657,7 +8654,7 @@ body.agent-editor-open {
     padding: 12px;
     border-radius: 6px;
     border: 1px dashed var(--border-color);
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-muted);
     line-height: 1.5;
 }
@@ -8693,19 +8690,19 @@ body.agent-editor-open {
 
 .agent-editor-run-secondary {
     color: var(--text-muted);
-    font-size: 11px;
+    font-size: 12.5px;
     line-height: 1.3;
 }
 
 .agent-editor-run-meta {
     color: var(--text-secondary);
-    font-size: 10px;
+    font-size: 12px;
     line-height: 1.3;
 }
 
 .agent-editor-hint {
     margin: 16px 0 0;
-    font-size: 12px;
+    font-size: 13px;
     color: var(--text-muted);
 }
 
@@ -8714,7 +8711,7 @@ body.agent-editor-open {
     border-radius: 4px;
     border: 1px solid var(--border-color);
     background: var(--bg-input);
-    font-size: 11px;
+    font-size: 12px;
 }
 
 .agent-editor-intro-title {
@@ -8726,14 +8723,14 @@ body.agent-editor-open {
 
 .agent-editor-intro-text {
     margin: 0;
-    font-size: 13px;
+    font-size: 14px;
     color: var(--text-secondary);
     line-height: 1.5;
 }
 
 .agent-editor-save-status {
     margin: 12px 0 0;
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 600;
     color: var(--home-accent-cyan, #22d3ee);
 }
@@ -9081,7 +9078,7 @@ body.agent-editor-open {
     margin-top: 6px;
 }
 .agent-editor-model-label {
-    font-size: 0.8rem;
+    font-size: 13px;
     color: var(--text-secondary);
 }
 .agent-editor-model-select {
@@ -9106,6 +9103,6 @@ body.agent-editor-open {
 }
 .agent-editor-simple-note {
     margin: 10px 0 0;
-    font-size: 0.8rem;
+    font-size: 13px;
     color: #fbbf24;
 }

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -7611,7 +7611,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 /* Status-aware agent cards (PAPER / BACKTESTED / DRAFT) */
 .agents-section .agents-grid:not(.agents-grid--list) {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 16px;
 }
 


### PR DESCRIPTION
Readability pass over My Agents, the agent Configure screen, and the Run Backtest modal:

- Bump 9–12px descriptive/label/box text to 12–14px (chips/badges capped at +1px)
- Agent card name/model now wrap instead of ellipsis-truncating; the External Agents placeholder sentence no longer overflows its card
- `.home-btn[hidden] { display:none !important }` — `display:inline-flex` was defeating the `hidden` attribute, so **Disconnect** rendered on the Robinhood panel while status said "Not connected"
- Agent cards show the human model label (`formatAgentModelLabel`) instead of the raw provider id
- Widen date inputs so the larger font doesn't clip the year

Verified with before/after Playwright screenshots at 1440px; `test_ifind_ashare_frontend.py` (21 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)