### PR TITLE
fix: re-land flow clarity + refresh docs

### DIFF
--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -221,7 +221,7 @@
         <div class="auth-modal-panel run-backtest-modal-panel" role="dialog" aria-labelledby="runBacktestModalTitle">
             <button id="runBacktestModalClose" class="auth-modal-close" type="button" aria-label="Close">×</button>
             <h2 id="runBacktestModalTitle" class="auth-modal-title">Run Backtest</h2>
-            <p class="auth-modal-subtitle">Simulation settings for this agent. Does not change allocated capital.</p>
+            <p class="auth-modal-subtitle">Simulation settings for this agent. Does not change its Paper Trading Allocated Capital.</p>
 
             <div class="run-backtest-modal-body">
                 <div class="control-group">
@@ -230,12 +230,13 @@
                 </div>
 
                 <div class="control-group" id="runBacktestPromptGroup" hidden>
-                    <label>Prompt</label>
+                    <label>Trading instruction</label>
                     <pre id="runBacktestPromptPreview" class="run-backtest-prompt-preview"></pre>
                 </div>
 
                 <div class="control-group">
                     <label>Period</label>
+                    <p class="control-helper">Pre-filled with a recent window that has full market data. Change it to any range you have data for.</p>
                     <div class="date-range-inputs">
                         <div class="date-input-wrapper">
                             <input type="date" id="startDate" value="2026-04-15" class="date-input">
@@ -317,8 +318,8 @@
                 </div>
 
                 <div class="control-group">
-                    <label for="backtestInitialCapital">Initial Capital</label>
-                    <p class="control-helper">Simulation starting cash for this backtest only (max $10,000). Independent of portfolio allocation and paper trading.</p>
+                    <label for="backtestInitialCapital">Backtest Allocated Capital</label>
+                    <p class="control-helper">Simulated starting cash for this run only (max $10,000). Defaults to this agent's Paper Trading Allocated Capital, and spends no real portfolio cash.</p>
                     <input
                         class="control-select"
                         id="backtestInitialCapital"
@@ -327,15 +328,16 @@
                         max="10000"
                         step="1"
                         value="1000"
-                        aria-label="Backtest initial capital"
+                        aria-label="Backtest allocated capital"
                     >
-                    <p id="runBacktestCapitalHint" class="control-helper">Does not change Allocated Capital.</p>
+                    <p id="runBacktestCapitalHint" class="control-helper">Does not change Paper Trading Allocated Capital.</p>
                 </div>
 
                 <div class="control-group">
                     <label for="modelSelect">Model</label>
-                    <p id="modelSelectHint" class="control-helper">Defaults to this agent’s model. Changing it here is temporary and is not saved to the agent.</p>
-                    <select class="control-select" id="modelSelect">
+                    <p id="runBacktestModelReadonly" class="run-backtest-readonly" hidden>—</p>
+                    <p id="modelSelectHint" class="control-helper">Set on the agent in Configure — this backtest always runs the agent's saved model.</p>
+                    <select class="control-select" id="modelSelect" hidden>
                         <option value="claude-haiku-4.5">Claude Haiku 4.5</option>
                         <option value="claude-sonnet-4.6">Claude Sonnet 4.6</option>
                         <option value="claude-opus-4.7">Claude Opus 4.7</option>
@@ -749,10 +751,10 @@
                     <input id="externalAgentModel" type="text" maxlength="100" placeholder="gpt-4 / rule-based" autocomplete="off">
                 </label>
                 <label class="auth-field">
-                    <span>Allocated capital (max $3,000)</span>
+                    <span>Paper Trading Allocated Capital (max $3,000)</span>
                     <input id="externalAgentCashAllocation" type="number" min="0" max="3000" step="100" value="1000" required aria-describedby="externalAgentCashHint">
                 </label>
-                <p id="externalAgentCashHint" class="credential-hint">Starting capital budget for this agent's backtests and trading sessions.</p>
+                <p id="externalAgentCashHint" class="credential-hint">Cash reserved from My Portfolio for this agent's paper trading. Backtests start from this amount by default but never spend it.</p>
                 <p id="createExternalAgentError" class="auth-error" hidden></p>
                 <button id="createExternalAgentSubmit" class="auth-submit-btn" type="submit">Create agent</button>
             </form>
@@ -786,10 +788,10 @@
                     <input id="builtinAgentDescription" type="text" maxlength="280" placeholder="What is this agent's edge?" autocomplete="off">
                 </label>
                 <label class="auth-field">
-                    <span>Allocated capital (max $3,000)</span>
+                    <span>Paper Trading Allocated Capital (max $3,000)</span>
                     <input id="builtinAgentCashAllocation" type="number" min="0" max="3000" step="100" value="1000" required aria-describedby="builtinAgentCashHint">
                 </label>
-                <p id="builtinAgentCashHint" class="credential-hint">Starting capital budget for this agent's backtests and trading sessions.</p>
+                <p id="builtinAgentCashHint" class="credential-hint">Cash reserved from My Portfolio for this agent's paper trading. Backtests start from this amount by default but never spend it.</p>
                 <p id="createBuiltinAgentError" class="auth-error" hidden></p>
                 <button id="createBuiltinAgentSubmit" class="auth-submit-btn" type="submit">Create built-in agent</button>
             </form>
@@ -877,7 +879,7 @@
                 <div id="agentsCategories">
                     <section class="agents-category" data-category="builtin">
                         <div class="agents-category-head">
-                            <h3 class="agents-category-title">Foundation Models</h3>
+                            <h3 class="agents-category-title">Foundation Agents</h3>
                             <p class="agents-category-sub">A prompting game — give it money, an instruction, and a model, then backtest.</p>
                         </div>
                         <div id="agentsGridBuiltin" class="agents-grid"></div>
@@ -932,8 +934,8 @@
                 </label>
                 <textarea id="agentEditorDescription" class="agent-editor-description" rows="2" maxlength="280" placeholder="Optional description for this agent…" aria-label="Agent description"></textarea>
                 <label class="agent-editor-cash-field" for="agentEditorCashAllocation">
-                    <span class="agent-editor-cash-label">Allocated capital (paper, max $3,000)</span>
-                    <input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="3000" step="100" placeholder="0" aria-label="Allocated capital for paper trading">
+                    <span class="agent-editor-cash-label">Paper Trading Allocated Capital (max $3,000)</span>
+                    <input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="3000" step="100" placeholder="1000" aria-label="Paper Trading Allocated Capital">
                 </label>
                 <div id="agentEditorBrokerPanel" class="agent-editor-broker section-card compact">
                     <div class="agent-editor-broker-head">

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -141,6 +141,8 @@ function formatTokenCount(value) {
 // ============================================================================
 const MAX_AGENT_CASH_ALLOCATION = 3000;
 const DEFAULT_AGENT_CASH_ALLOCATION = 1000;
+/** Simulated cash ceiling for a single backtest run — unrelated to the paper sleeve above. */
+const MAX_BACKTEST_ALLOCATED_CAPITAL = 10000;
 const DEFAULT_PORTFOLIO_EQUITY = 10000;
 const AGENT_CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
 
@@ -227,10 +229,10 @@ function parseAgentCashAllocationInput(raw) {
   }
   const value = Number(raw);
   if (!Number.isFinite(value) || value < 0) {
-    throw new Error(`Allocated capital must be between $0 and $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
+    throw new Error(`Paper Trading Allocated Capital must be between $0 and $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
   }
   if (value > MAX_AGENT_CASH_ALLOCATION) {
-    throw new Error(`Allocated capital cannot exceed $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
+    throw new Error(`Paper Trading Allocated Capital cannot exceed $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
   }
   return Math.round(value);
 }
@@ -450,9 +452,11 @@ function resolveAgentStatusBadge(agent) {
   }
   const runCount = Number(agent.run_count) || (Array.isArray(agent.runs) ? agent.runs.length : 0);
   if (runCount > 0 || agent.latest_run?.run_id || agent.latest_run?.total_return != null) {
-    return { key: 'backtested', label: 'IDLE', className: 'idle' };
+    return { key: 'backtested', label: 'BACKTESTED', className: 'idle' };
   }
-  return { key: 'draft', label: 'DRAFT', className: 'draft' };
+  // Not "DRAFT": the agent is saved and its capital is already reserved from
+  // My Portfolio. The only thing missing is a run.
+  return { key: 'draft', label: 'READY', className: 'draft' };
 }
 
 function formatAgentMoney(value, { cents = true } = {}) {
@@ -736,7 +740,7 @@ function renderAgentAllocatedCapitalHero(agent) {
   return `
     <div class="agent-card-hero agent-card-hero--draft">
       <div class="agent-card-hero-text">
-        <span class="agent-card-metric-label">Allocated Capital</span>
+        <span class="agent-card-metric-label">Paper Trading Allocated Capital</span>
         <p class="agent-card-metric-value">${escapeHtml(capital)}</p>
         <p class="agent-card-capital-note">From My Portfolio</p>
       </div>
@@ -755,7 +759,7 @@ function renderAgentCardBody(agent, statusKey) {
           : '';
       changeHtml = `<p class="agent-card-change ${positive ? 'is-pos' : 'is-neg'}">${escapeHtml(formatSignedMoney(m.dayPnl))}${escapeHtml(pct)} today</p>`;
     } else if (!m.hasLive) {
-      changeHtml = `<p class="agent-card-change is-muted">Allocated capital · paper session not live yet</p>`;
+      changeHtml = `<p class="agent-card-change is-muted">Paper Trading Allocated Capital · session not live yet</p>`;
     }
     const activity = m.lastActivity
       ? escapeHtml(m.lastActivity)
@@ -819,7 +823,7 @@ function renderAgentCardBody(agent, statusKey) {
           ${renderAgentSparkline(agent, m.positive, m)}
         </div>
         <p class="agent-card-latest-meta">${escapeHtml(metaParts.join(' · '))}</p>
-        <p class="agent-card-latest-note">Separate from allocated capital.</p>
+        <p class="agent-card-latest-note">Simulated — separate from Paper Trading Allocated Capital.</p>
         ${renderAgentRunsLink(agent)}
       </div>`;
   }
@@ -1324,13 +1328,41 @@ function findBacktestModelOption(modelSelect, modelName) {
   ) || null;
 }
 
+/**
+ * The picker is a live control only for iFinD A-share, where it doubles as the
+ * rule-based-vs-LLM decision source. Everywhere else the run uses the agent's
+ * saved model, so the picker is hidden behind a read-only echo of it.
+ */
+function backtestModelPickerIsLiveControl() {
+  return document.getElementById('marketDataSourceSelect')?.value === IFIND_ASHARE_SOURCE;
+}
+
 function resolveBacktestModelRequest(modelSelect, agent) {
   const selectedModel = modelSelect?.value || '';
   const agentOption = findBacktestModelOption(modelSelect, agent?.model_name);
   if (agentOption?.value === selectedModel && agent?.model_name) {
     return agent.model_name;
   }
+  // A model the nine-option list cannot represent still belongs to the agent:
+  // without this the run submits whatever value a previous agent left behind.
+  if (agent?.model_name && !backtestModelPickerIsLiveControl()) {
+    return agent.model_name;
+  }
   return selectedModel || agent?.model_name || 'claude-haiku-4.5';
+}
+
+/** Show the picker only where it is a real control; otherwise echo the agent's model. */
+function syncBacktestModelFieldMode() {
+  const modelSelect = document.getElementById('modelSelect');
+  const readonly = document.getElementById('runBacktestModelReadonly');
+  const source = document.getElementById('marketDataSourceSelect')?.value || 'alpaca';
+  const isIFind = source === IFIND_ASHARE_SOURCE;
+  if (modelSelect) modelSelect.hidden = !isIFind;
+  if (!readonly) return;
+  readonly.hidden = isIFind;
+  readonly.textContent = source === 'vnpy_simulation'
+    ? 'Rule-based — vn.py simulation makes no LLM calls'
+    : formatAgentModelLabel(runBacktestModalAgent?.model_name);
 }
 
 function syncModelSelectFromAgent(agent) {
@@ -2016,10 +2048,11 @@ function syncMarketDataSourceUI(options = {}) {
   if (modelSelectHint && !isIFind) {
     modelSelectHint.textContent = isSimulation
       ? 'vn.py simulation uses rule-based decisions.'
-      : 'Defaults to this agent’s model. Changing it here is temporary and is not saved to the agent.';
+      : 'Set on the agent in Configure — this backtest always runs the agent’s saved model.';
   }
   if (notice) notice.hidden = !isSimulation;
   if (ifindNotice) ifindNotice.hidden = !isIFind;
+  syncBacktestModelFieldMode();
 }
 
 function renderBacktestDataSourceBadge(run) {
@@ -5064,8 +5097,19 @@ function openRunBacktestModal(agent) {
     const hint = document.getElementById('runBacktestCapitalHint');
     if (hint) {
         hint.textContent = Number.isFinite(sleeve)
-            ? `Does not change Allocated Capital ($${sleeve.toLocaleString()}).`
-            : 'Does not change Allocated Capital.';
+            ? `Does not change Paper Trading Allocated Capital ($${sleeve.toLocaleString()}).`
+            : 'Does not change Paper Trading Allocated Capital.';
+    }
+
+    // Reseed on every open. The field is per-run, so leaving the previous
+    // agent's number in place silently backtests this one at the wrong size.
+    const capitalInput = document.getElementById('backtestInitialCapital');
+    if (capitalInput) {
+        capitalInput.value = String(
+            Number.isFinite(sleeve) && sleeve > 0
+                ? Math.min(Math.round(sleeve), MAX_BACKTEST_ALLOCATED_CAPITAL)
+                : DEFAULT_AGENT_CASH_ALLOCATION,
+        );
     }
 
     syncModelSelectFromAgent(agent);
@@ -5156,24 +5200,21 @@ async function runBacktest() {
     }
 
     await activateAgent(activeAgent);
-    if (!isIFind) {
-        syncModelSelectFromAgent(activeAgent);
-    }
     const pipeline = isRuleBasedDecision ? null : loadAgentPipelineForBacktest(activeAgent);
     const model = isRuleBasedDecision
         ? null
         : resolveBacktestModelRequest(modelSelect, activeAgent);
 
     const capitalInput = document.getElementById('backtestInitialCapital');
-    let initialCapital = 1000;
+    let initialCapital = DEFAULT_AGENT_CASH_ALLOCATION;
     if (capitalInput && capitalInput.value !== '') {
         const parsed = Number(capitalInput.value);
         if (!Number.isFinite(parsed) || parsed <= 0) {
-            alert('Initial capital must be greater than 0.');
+            alert('Backtest Allocated Capital must be greater than 0.');
             return;
         }
-        if (parsed > 10000) {
-            alert('Initial capital cannot exceed $10,000.');
+        if (parsed > MAX_BACKTEST_ALLOCATED_CAPITAL) {
+            alert(`Backtest Allocated Capital cannot exceed $${MAX_BACKTEST_ALLOCATED_CAPITAL.toLocaleString()}.`);
             return;
         }
         initialCapital = Math.round(parsed);

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -148,6 +148,20 @@
     return fetch(url, { ...options, signal: controller.signal }).finally(() => clearTimeout(timer));
   }
 
+  /**
+   * Run Live is the loudest button on the screen, so it must not look ready
+   * while the broker it needs is unconnected — demote it until then.
+   */
+  function setRunLiveProminence(connected) {
+    const runLiveBtn = document.getElementById('agentEditorRunLiveBtn');
+    if (!runLiveBtn) return;
+    runLiveBtn.disabled = !connected;
+    runLiveBtn.className = connected
+      ? 'home-btn home-btn-primary'
+      : 'home-btn home-btn-secondary';
+    runLiveBtn.title = connected ? '' : 'Connect Robinhood first';
+  }
+
   async function refreshRobinhoodStatus() {
     const statusEl = document.getElementById('agentEditorRobinhoodStatus');
     const metaEl = document.getElementById('agentEditorRobinhoodMeta');
@@ -168,6 +182,7 @@
       }
       if (disconnectBtn) disconnectBtn.hidden = true;
       if (metaEl) metaEl.hidden = true;
+      setRunLiveProminence(false);
       setBrokerMessage('Log in to your ATL account, then click Connect Robinhood.', true);
       return;
     }
@@ -205,6 +220,7 @@
         connectBtn.textContent = 'Connect Robinhood';
       }
       if (disconnectBtn) disconnectBtn.hidden = !connected;
+      setRunLiveProminence(connected);
       if (metaEl) {
         if (connected) {
           metaEl.hidden = false;
@@ -234,6 +250,7 @@
         connectBtn.textContent = 'Connect Robinhood';
       }
       if (disconnectBtn) disconnectBtn.hidden = true;
+      setRunLiveProminence(false);
       setBrokerMessage(
         timedOut
           ? 'Status check timed out. You can still click Connect Robinhood.'
@@ -405,10 +422,10 @@
     if (cashInput && cashInput.value !== '') {
       const value = Number(cashInput.value);
       if (!Number.isFinite(value) || value < 0) {
-        throw new Error('Allocated capital must be zero or greater.');
+        throw new Error('Paper Trading Allocated Capital must be zero or greater.');
       }
       if (value > 3000) {
-        throw new Error('Allocated capital cannot exceed $3,000.');
+        throw new Error('Paper Trading Allocated Capital cannot exceed $3,000.');
       }
       cash_allocation = Math.round(value);
     } else {
@@ -880,6 +897,12 @@
     document.getElementById('agentEditorRunLiveBtn')?.addEventListener('click', runLive);
     document.getElementById('agentEditorRunBacktestBtn')?.addEventListener('click', () => {
       if (!currentAgent) return;
+      // The modal reads the last-saved agent, so an unsaved edit would run the
+      // old instruction while the preview shows the new one. Same guard as Run Live.
+      if (isDirty) {
+        showSaveStatus('Save changes before Run Backtest', true);
+        return;
+      }
       if (typeof window.openRunBacktestModal === 'function') {
         window.openRunBacktestModal(currentAgent);
       }

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -6065,6 +6065,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s;
 }
 .home-btn[hidden] { display: none !important; }
+.home-btn:disabled, .home-btn:disabled:hover { cursor: not-allowed; opacity: 0.5; box-shadow: none; filter: none; }
 .home-btn-primary { background: var(--home-accent-cyan); color: #041018; border-color: var(--home-accent-cyan); box-shadow: 0 6px 24px rgba(34,211,238,0.24); }
 .home-btn-primary:hover { filter: brightness(1.05); }
 .home-btn-secondary { background: rgba(8,18,40,0.55); color: var(--text-primary); border-color: rgba(148,163,184,0.22); }
@@ -7197,10 +7198,12 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     border: 1px solid rgba(34, 211, 238, 0.28);
 }
 
+/* Slate, matching AVAILABLE_SLICE_COLOR in portfolio.js — the donut beside this
+   card shows the same quantity, and two colours for it read as two concepts. */
 .pf-overview-pill--avail {
-    color: #f59e0b;
-    background: rgba(245, 158, 11, 0.12);
-    border: 1px solid rgba(245, 158, 11, 0.28);
+    color: #94a3b8;
+    background: rgba(100, 116, 139, 0.14);
+    border: 1px solid rgba(100, 116, 139, 0.32);
 }
 
 .pf-overview-bar {
@@ -7219,7 +7222,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .pf-overview-bar-avail {
     height: 100%;
-    background: #f59e0b;
+    background: #64748b;
 }
 
 .pf-allocation-card {

--- a/docs/source/lab/getting_started.rst
+++ b/docs/source/lab/getting_started.rst
@@ -4,12 +4,34 @@ Getting Started
 Run a backtest in the dashboard
 --------------------------------
 
-1. Open `agentic-trading-lab.vercel.app <https://agentic-trading-lab.vercel.app/>`_ or `http://localhost:8000/ <http://localhost:8000/>`_ when running locally. Stay on the **Backtest** tab.
-2. Set the date range, assets, and model in the left sidebar.
-3. Click **Run Backtest**.
+1. Open `agentic-trading-lab.vercel.app <https://agentic-trading-lab.vercel.app/>`_ or `http://localhost:8000/ <http://localhost:8000/>`_ when running locally, then go to the **My Agents** tab.
+2. On an agent's card click **Run Backtest**. Use one of the **Foundation Agents**, or click **Add Agent +** to create your own.
+3. In the dialog set the **Period**, **Asset Universe**, and **Backtest Allocated Capital**, then click **Run Backtest**.
 4. Wait for completion—the UI polls ``/backtest/status`` and reloads equity charts when done.
 
 Results appear in **Trading Performance** (agent vs. buy-and-hold vs. DJIA).
+
+The backtest always runs the model saved on the agent; change it from the
+agent's **Configure** screen rather than at run time. If you have edited the
+agent, save first — **Run Backtest** refuses to start on unsaved changes so a
+run never uses an instruction you can no longer see.
+
+.. _allocated-capital:
+
+Two kinds of allocated capital
+------------------------------
+
+The dashboard keeps these separate, and they have their own limits:
+
+**Paper Trading Allocated Capital**
+   Cash reserved from **My Portfolio** for one agent's paper trading, set when
+   you create the agent and editable in **Configure**. Maximum **$3,000**.
+
+**Backtest Allocated Capital**
+   Simulated starting cash for a single backtest, set in the **Run Backtest**
+   dialog. It defaults to that agent's Paper Trading Allocated Capital, but a
+   backtest never spends real portfolio cash and never changes it. Maximum
+   **$10,000**.
 
 Start from a template
 ---------------------

--- a/docs/source/lab/live_trading.rst
+++ b/docs/source/lab/live_trading.rst
@@ -63,7 +63,8 @@ Run an agent live
 
 1. Tick **Enable live trading for this agent**. This is per agent, so connecting
    your brokerage account does not arm every agent you own.
-2. Click **Run Live**.
+2. Click **Run Live**. The button stays disabled until a Robinhood account is
+   connected, so it never looks ready before the broker behind it is.
 
 The run then:
 

--- a/docs/source/lab/marketplace.rst
+++ b/docs/source/lab/marketplace.rst
@@ -57,9 +57,11 @@ Copy a template
    prompts. The copy is independent — later edits to the template do not touch
    your agent, and your edits never affect anyone else's copy.
 
-New agents are funded with the default cash allocation ($1,000) for backtesting.
-If you are signed in, that comes out of your account portfolio, so a copy can
-fail with *insufficient cash* until you free some up (see :doc:`accounts`).
+New agents get the default **Paper Trading Allocated Capital** ($1,000), and a
+backtest starts from that amount unless you change it in the **Run Backtest**
+dialog — see :ref:`allocated-capital`. If you are signed in, the $1,000 is
+reserved from your account portfolio, so a copy can fail with *insufficient
+cash* until you free some up.
 
 .. note::
 


### PR DESCRIPTION
#251 merged into `fix/my-agents-ui-polish` 15s after #250 merged that branch into main, so GitHub's auto-retarget never fired and the work orphaned — none of it reached main. Commit 1 re-applies it unchanged.

Commit 2 updates the docs it made stale: Getting Started still described a "Backtest" tab and a left sidebar that no longer exist, and told users to set the model at run time. Adds one definition of Paper Trading vs Backtest Allocated Capital, referenced from the marketplace page.

Frontend guard tests 27/27. `sphinx-build -n -E` clean — 49 warnings, identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)