### PR TITLE
fix(ui): move marketplace to Community and tidy account profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Start with a market question or trading idea, then turn it into an agent you can
 - **Create trading agents your way**  
 Choose a model, data source, and trading prompt, or connect your own agent through our API.
 - **Start from a template**  
-Copy a ready-made agent out of the Agent Marketplace, then customize its prompts and backtest it.
+Add a ready-made agent from the Agent Marketplace, then customize its prompts and backtest it.
 - **Build an agent-powered portfolio**  
 Give multiple agents simulated capital and manage them as your own virtual trading team.
 - **Test before using real capital**  

--- a/dashboard/backend/tests/test_frontend_account_page.py
+++ b/dashboard/backend/tests/test_frontend_account_page.py
@@ -134,5 +134,5 @@ def test_cache_bust_versions_were_bumped():
     styles_version = int(re.search(r"styles\.css\?v=(\d+)", html).group(1))
     app_version = int(re.search(r"app\.js\?v=(\d+)", html).group(1))
 
-    assert styles_version >= 65
-    assert app_version >= 48
+    assert styles_version >= 67
+    assert app_version >= 50

--- a/dashboard/backend/tests/test_frontend_account_page.py
+++ b/dashboard/backend/tests/test_frontend_account_page.py
@@ -134,5 +134,5 @@ def test_cache_bust_versions_were_bumped():
     styles_version = int(re.search(r"styles\.css\?v=(\d+)", html).group(1))
     app_version = int(re.search(r"app\.js\?v=(\d+)", html).group(1))
 
-    assert styles_version >= 67
-    assert app_version >= 50
+    assert styles_version >= 68
+    assert app_version >= 51

--- a/dashboard/backend/tests/test_frontend_marketplace_placement.py
+++ b/dashboard/backend/tests/test_frontend_marketplace_placement.py
@@ -1,0 +1,158 @@
+"""Guards for the Agent Marketplace living on the Community page.
+
+The marketplace moved out of Playground (where it was a subtab) and became a
+section of Community. Nothing about that move is enforceable at runtime -- the
+frontend has no JS test harness -- so, following the convention of the other
+test_frontend_* files here, these contracts are asserted against the shipped
+source directly.
+
+What they are really protecting is the *anti-FOUC* pair: app.html's boot script
+decides which page the CSS paints before app.js loads, and app.js decides which
+page it renders. If those two ever disagree about where the marketplace lives,
+the dashboard paints one page and renders another -- a flash bug no other test
+in this repo can see.
+"""
+
+import re
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_HTML = _FRONTEND / "app.html"
+_APP_JS = _FRONTEND / "app.js"
+_STYLES_CSS = _FRONTEND / "styles.css"
+
+
+def _community_view() -> str:
+    html = _APP_HTML.read_text(encoding="utf-8")
+    start = html.index('<div id="communityView"')
+    end = html.index('<div id="accountView"')
+    assert start < end, "communityView must precede accountView in app.html"
+    return html[start:end]
+
+
+def test_marketplace_markup_lives_inside_the_community_view():
+    view = _community_view()
+    for marker in (
+        'id="marketplaceGrid"',
+        'id="marketplaceSearchInput"',
+        'id="marketplaceEmptyState"',
+        'id="marketplaceErrorState"',
+    ):
+        assert marker in view, f"{marker} is not inside #communityView"
+
+    # ...and nowhere else. A duplicate id would make document.getElementById
+    # return whichever copy came first, silently wiring the search box and the
+    # grid to different sections.
+    html = _APP_HTML.read_text(encoding="utf-8")
+    assert html.count('id="marketplaceGrid"') == 1
+
+
+def test_the_playground_marketplace_subtab_is_gone():
+    html = _APP_HTML.read_text(encoding="utf-8")
+    assert "playgroundMarketplacePanel" not in html
+    assert 'data-playground-tab="marketplace"' not in html
+    # app.js must not reference the removed panel either -- a leftover
+    # getElementById would be a silent null, not an error.
+    assert "playgroundMarketplacePanel" not in _APP_JS.read_text(encoding="utf-8")
+
+
+def test_nav_view_map_sends_the_marketplace_slug_to_community():
+    """?view=marketplace and #marketplace are load-bearing: they are in shipped
+    docs and in any URL a user bookmarked before the move."""
+    html = _APP_HTML.read_text(encoding="utf-8")
+    match = re.search(r"marketplace:\s*\{([^}]*)\}", html)
+    assert match, "NAV_VIEW_MAP has no 'marketplace' key"
+    entry = match.group(1)
+    assert "page: 'community'" in entry
+    # No playgroundTab: leaving one behind would set the module-level tab to a
+    # subtab that no longer exists.
+    assert "playgroundTab" not in entry
+
+
+def test_boot_css_reveals_the_community_view():
+    """The boot stylesheet is what makes the move flash-free. Without this rule
+    a saved 'community' nav state paints nothing until app.js runs."""
+    html = _APP_HTML.read_text(encoding="utf-8")
+    assert (
+        'html[data-nav-boot][data-nav-page="community"] #communityView'
+        in html
+    )
+
+
+def test_the_saved_state_migration_is_defined_once_and_shared():
+    """Both files restore the SAME localStorage blob.
+
+    Two hand-written copies of the rewrite rule is exactly the divergence the
+    NAV_VIEW_MAP comment warns about, so app.html owns it and app.js reads it
+    back off `window`.
+    """
+    html = _APP_HTML.read_text(encoding="utf-8")
+    js = _APP_JS.read_text(encoding="utf-8")
+
+    assert "window.migrateSavedNavState = migrateSavedNavState;" in html
+    assert "window.migrateSavedNavState" in js
+    # app.js must not re-implement it: the boot copy inspects the parsed blob's
+    # own playgroundTab, so that expression appearing here means a second copy.
+    assert "saved.playgroundTab" not in js
+
+
+def test_navigating_to_the_retired_subtab_lands_on_community():
+    js = _APP_JS.read_text(encoding="utf-8")
+    start = js.index("function navigateToPage")
+    guard = js[start : start + 1800]
+    assert "=== 'marketplace'" in guard, "navigateToPage lost its marketplace redirect"
+    assert "page = 'community'" in guard
+
+
+def test_view_param_never_emits_the_marketplace_alias():
+    """viewParamForNavState is NAV_VIEW_MAP's hand-maintained inverse. Emitting
+    'marketplace' would write a URL naming a page that no longer exists."""
+    js = _APP_JS.read_text(encoding="utf-8")
+    start = js.index("function viewParamForNavState")
+    body = js[start : js.index("function buildNavigationUrl")]
+    assert "return 'marketplace'" not in body
+    assert "return 'community'" in body
+
+
+def test_community_page_header_matches_the_nav_button():
+    """The nav says one word and the page must say the same word.
+
+    Before this guard the button read "Community" while the page it opened was
+    titled "Agent Marketplace" and held nothing else.
+    """
+    html = _APP_HTML.read_text(encoding="utf-8")
+    nav = re.search(r'<button[^>]*data-mode="community"[^>]*>([^<]+)</button>', html)
+    assert nav, "no primary-nav button for the community page"
+    label = nav.group(1).strip()
+
+    view = _community_view()
+    title = re.search(r'<h2 class="page-title">([^<]+)</h2>', view)
+    assert title, "#communityView has no page title"
+    assert title.group(1).strip() == label
+
+    # The marketplace is a section *within* that page, so it must not also claim
+    # the page-level heading.
+    assert 'class="marketplace-section-title">Agent Marketplace<' in view
+    assert view.count('class="page-title"') == 1
+
+
+def test_marketplace_section_title_is_styled():
+    """A heading class with no rule renders at the browser default h3 size,
+    which is larger than the .page-title above it."""
+    css = _STYLES_CSS.read_text(encoding="utf-8")
+    assert ".marketplace-section-title {" in css
+
+
+def test_repeat_visits_do_not_refetch_the_catalog():
+    """Community is a top-level page now, so loadMarketplace runs on every nav
+    click, every popstate and the initial boot -- not once per session as it did
+    behind the Playground subtab."""
+    js = _APP_JS.read_text(encoding="utf-8")
+    start = js.index("async function loadMarketplace")
+    body = js[start : js.index("async function cloneMarketplaceTemplate")]
+
+    assert "if (marketplaceTemplates.length)" in body, "no cache short-circuit"
+    assert "marketplaceLoadInFlight" in body, "no in-flight dedup"
+    # The cache must be cleared on failure, or one flaky GET pins the error
+    # state for the rest of the session.
+    assert "marketplaceTemplates = [];" in body

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=66">
+    <link rel="stylesheet" href="styles.css?v=67">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -25,7 +25,7 @@
             backtest: { page: 'playground', playgroundTab: 'backtest' },
             paper: { page: 'playground', playgroundTab: 'paper' },
             agents: { page: 'playground', playgroundTab: 'agents' },
-            marketplace: { page: 'playground', playgroundTab: 'marketplace' },
+            marketplace: { page: 'community' },
             playground: { page: 'playground', playgroundTab: 'agents' },
             'my-algo': { page: 'playground', playgroundTab: 'agents' },
             contest: { page: 'competition', competitionTab: 'daily' },
@@ -57,7 +57,13 @@
             try {
                 var saved = JSON.parse(localStorage.getItem(NAV_STATE_KEY) || 'null');
                 var valid = ['home', 'playground', 'competition', 'community', 'account'];
-                if (saved && valid.indexOf(saved.page) !== -1) return saved;
+                if (saved && valid.indexOf(saved.page) !== -1) {
+                    // Marketplace moved from Playground → Community.
+                    if (saved.page === 'playground' && saved.playgroundTab === 'marketplace') {
+                        return { page: 'community' };
+                    }
+                    return saved;
+                }
             } catch (e) { /* ignore */ }
             return { page: 'home' };
         }
@@ -82,13 +88,10 @@
     html[data-nav-boot][data-nav-page="community"] .primary-nav [data-mode="community"] { background-color: var(--info-color); color: white; }
     html[data-nav-boot][data-nav-page="playground"] .playground-subtabs .subtab-btn.active { background: transparent; color: var(--text-secondary); }
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="agents"] .playground-subtabs [data-playground-tab="agents"],
-    html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="marketplace"] .playground-subtabs [data-playground-tab="marketplace"],
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="backtest"] .playground-subtabs [data-playground-tab="backtest"],
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="paper"] .playground-subtabs [data-playground-tab="paper"] { background: var(--info-color); color: white; }
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="backtest"] #playgroundAgentsPanel,
-    html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="marketplace"] #playgroundAgentsPanel,
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="paper"] #playgroundAgentsPanel { display: none !important; }
-    html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="marketplace"] #playgroundMarketplacePanel { display: block !important; }
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="backtest"] .main-container.playground-backtest-panel { display: grid !important; }
     html[data-nav-boot][data-nav-page="playground"][data-nav-playground-tab="paper"] #paperTradingView { display: block !important; }
     html[data-nav-boot][data-nav-page="competition"] .competition-subtabs .subtab-btn.active { background: transparent; color: var(--text-secondary); }
@@ -180,7 +183,6 @@
                             <span id="accountMenuEmail" class="account-menu-email"></span>
                         </div>
                         <button id="accountMenuAccountBtn" class="account-menu-item" type="button">Account</button>
-                        <a id="accountMenuLandingLink" class="account-menu-item" href="/?stay=1">Visit Landing Page</a>
                         <button id="accountMenuLogoutBtn" class="account-menu-item account-menu-item--danger" type="button">Log out</button>
                     </div>
                 </div>
@@ -822,7 +824,6 @@
     <div id="playgroundView" class="page-view playground-view" style="display: none;">
         <div class="subtab-bar playground-subtabs">
             <button class="subtab-btn active" data-playground-tab="agents">My Agents</button>
-            <button class="subtab-btn" data-playground-tab="marketplace">Agent Marketplace</button>
             <button class="subtab-btn" data-playground-tab="backtest">Backtest</button>
             <button class="subtab-btn" data-playground-tab="paper">Paper Trading</button>
         </div>
@@ -897,23 +898,6 @@
                     </section>
                 </div>
                 <p id="agentsErrorState" class="control-helper" hidden style="color:#f87171;">Couldn't reach the server to load agents. Check your connection and try again.</p>
-            </div>
-        </div>
-        <div id="playgroundMarketplacePanel" class="playground-panel" style="display: none;">
-            <div class="marketplace-section">
-                <div class="marketplace-section-head">
-                    <div>
-                        <h2 class="page-title">Agent Marketplace</h2>
-                        <p class="marketplace-section-sub">Browse open agent templates and copy them into My Agents to customize and backtest.</p>
-                    </div>
-                    <div class="agent-toolbar-search marketplace-search">
-                        <svg class="agent-toolbar-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-                        <input id="marketplaceSearchInput" type="search" placeholder="Search templates..." aria-label="Search marketplace templates">
-                    </div>
-                </div>
-                <div id="marketplaceGrid" class="agents-grid marketplace-grid"></div>
-                <p id="marketplaceEmptyState" class="control-helper" hidden>No templates match your search.</p>
-                <p id="marketplaceErrorState" class="control-helper" hidden style="color:#f87171;">Couldn't load the marketplace. Check your connection and try again.</p>
             </div>
         </div>
     </div>
@@ -1492,12 +1476,22 @@
         </div>
     </div>
 
-    <!-- Community -->
+    <!-- Community (Agent Marketplace) -->
     <div id="communityView" class="page-view community-view" style="display: none;">
-        <div class="page-header">
-            <div>
-                <h2 class="page-title">Community</h2>
+        <div class="marketplace-section">
+            <div class="marketplace-section-head">
+                <div>
+                    <h2 class="page-title">Agent Marketplace</h2>
+                    <p class="marketplace-section-sub">Browse open agent templates and select them into My Agents to customize and backtest.</p>
+                </div>
+                <div class="agent-toolbar-search marketplace-search">
+                    <svg class="agent-toolbar-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                    <input id="marketplaceSearchInput" type="search" placeholder="Search templates..." aria-label="Search marketplace templates">
+                </div>
             </div>
+            <div id="marketplaceGrid" class="agents-grid marketplace-grid"></div>
+            <p id="marketplaceEmptyState" class="control-helper" hidden>No templates match your search.</p>
+            <p id="marketplaceErrorState" class="control-helper" hidden style="color:#f87171;">Couldn't load the marketplace. Check your connection and try again.</p>
         </div>
     </div>
 
@@ -1530,7 +1524,7 @@
                 </form>
             </div>
             <div class="account-section">
-                <h3 class="account-section-title">Email address</h3>
+                <h3 class="account-section-title">Change email address</h3>
                 <form id="accountEmailForm" class="auth-form account-password-form">
                     <div id="emailChangeIdle">
                         <label class="auth-field">
@@ -1608,7 +1602,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
     <script src="js/agent-editor.js?v=14"></script>
-    <script src="app.js?v=49"></script>
+    <script src="app.js?v=50"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=67">
+    <link rel="stylesheet" href="styles.css?v=68">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -36,6 +36,17 @@
             about: { page: 'competition', competitionTab: 'about' },
         };
         window.NAV_VIEW_MAP = NAV_VIEW_MAP;
+        // Saved nav state written before the marketplace moved out of Playground.
+        // Exported for the same reason NAV_VIEW_MAP is: the boot below and app.js
+        // read the SAME localStorage blob, so a second hand-written copy of this
+        // rule could paint Playground while app.js renders Community.
+        function migrateSavedNavState(saved) {
+            if (saved && saved.page === 'playground' && saved.playgroundTab === 'marketplace') {
+                return { page: 'community' };
+            }
+            return saved;
+        }
+        window.migrateSavedNavState = migrateSavedNavState;
         function resolveBootNavigation() {
             var params = new URLSearchParams(window.location.search);
             var view = params.get('view') || params.get('mode');
@@ -55,13 +66,11 @@
                 };
             }
             try {
-                var saved = JSON.parse(localStorage.getItem(NAV_STATE_KEY) || 'null');
+                var saved = migrateSavedNavState(
+                    JSON.parse(localStorage.getItem(NAV_STATE_KEY) || 'null'),
+                );
                 var valid = ['home', 'playground', 'competition', 'community', 'account'];
                 if (saved && valid.indexOf(saved.page) !== -1) {
-                    // Marketplace moved from Playground → Community.
-                    if (saved.page === 'playground' && saved.playgroundTab === 'marketplace') {
-                        return { page: 'community' };
-                    }
                     return saved;
                 }
             } catch (e) { /* ignore */ }
@@ -1476,13 +1485,20 @@
         </div>
     </div>
 
-    <!-- Community (Agent Marketplace) -->
+    <!-- Community -- Agent Marketplace is its first section, not the whole page:
+         the nav button says "Community", so the page has to say it too. -->
     <div id="communityView" class="page-view community-view" style="display: none;">
+        <div class="page-header">
+            <div>
+                <h2 class="page-title">Community</h2>
+                <p class="page-description">Agent templates shared by the Agentic Trading Lab community.</p>
+            </div>
+        </div>
         <div class="marketplace-section">
             <div class="marketplace-section-head">
                 <div>
-                    <h2 class="page-title">Agent Marketplace</h2>
-                    <p class="marketplace-section-sub">Browse open agent templates and select them into My Agents to customize and backtest.</p>
+                    <h3 class="marketplace-section-title">Agent Marketplace</h3>
+                    <p class="marketplace-section-sub">Browse open agent templates and add them to My Agents to customize and backtest.</p>
                 </div>
                 <div class="agent-toolbar-search marketplace-search">
                     <svg class="agent-toolbar-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
@@ -1602,7 +1618,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
     <script src="js/agent-editor.js?v=14"></script>
-    <script src="app.js?v=50"></script>
+    <script src="app.js?v=51"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1623,7 +1623,7 @@ function renderMarketplaceGrid() {
         ${tags ? `<div class="marketplace-tag-row">${tags}</div>` : ''}
       </div>
       <div class="agent-card-actions agent-card-actions--status">
-        <button class="agent-card-cta marketplace-clone-btn" type="button" data-template-id="${escapeHtml(template.template_id)}">Copy to My Agents</button>
+        <button class="agent-card-cta marketplace-clone-btn" type="button" data-template-id="${escapeHtml(template.template_id)}">Select to My Agents</button>
       </div>`;
     grid.appendChild(card);
   });
@@ -1636,11 +1636,11 @@ function renderMarketplaceGrid() {
       marketplaceCloneInFlight = true;
       btn.disabled = true;
       const prevLabel = btn.textContent;
-      btn.textContent = 'Copying…';
+      btn.textContent = 'Selecting…';
       try {
         await cloneMarketplaceTemplate(template);
       } catch (error) {
-        alert(error.message || 'Failed to copy template');
+        alert(error.message || 'Failed to select template');
       } finally {
         marketplaceCloneInFlight = false;
         btn.disabled = false;
@@ -1678,7 +1678,7 @@ async function cloneMarketplaceTemplate(template) {
   );
   const agent = data?.agent;
   if (!agent?.agent_id) {
-    throw new Error('Copy failed — no agent returned');
+    throw new Error('Select failed — no agent returned');
   }
   applyActiveAgent(agent);
   await loadAgents();
@@ -3064,9 +3064,6 @@ function initAuthUI(options = {}) {
   document.getElementById('accountMenuAccountBtn')?.addEventListener('click', () => {
     closeAccountMenu();
     navigateToPage('account');
-  });
-  document.getElementById('accountMenuLandingLink')?.addEventListener('click', () => {
-    closeAccountMenu();
   });
   document.getElementById('accountMenuLogoutBtn')?.addEventListener('click', () => {
     closeAccountMenu();
@@ -5439,7 +5436,6 @@ function viewParamForNavState(state) {
     if (state.page === 'playground') {
         if (state.playgroundTab === 'backtest') return 'backtest';
         if (state.playgroundTab === 'paper') return 'paper';
-        if (state.playgroundTab === 'marketplace') return 'marketplace';
         return 'agents';
     }
     if (state.page === 'competition') {
@@ -5525,6 +5521,10 @@ function resolveInitialNavigation() {
         const saved = JSON.parse(localStorage.getItem(NAV_STATE_KEY) || 'null');
         const validPages = ['home', 'playground', 'competition', 'community', 'account'];
         if (saved && validPages.includes(saved.page)) {
+            // Marketplace moved from Playground → Community.
+            if (saved.page === 'playground' && saved.playgroundTab === 'marketplace') {
+                return { page: 'community' };
+            }
             return saved;
         }
     } catch (error) {
@@ -5678,17 +5678,21 @@ function updateCompetitionSubtabs() {
 }
 
 function showPlaygroundPanel(tab) {
+    // Legacy: marketplace used to be a Playground subtab.
+    if (tab === 'marketplace') {
+        navigateToPage('community');
+        return;
+    }
+
     playgroundTab = tab;
     updatePlaygroundSubtabs();
 
     const agents = document.getElementById('playgroundAgentsPanel');
-    const marketplace = document.getElementById('playgroundMarketplacePanel');
     const backtest = document.querySelector('.playground-backtest-panel')
       || document.querySelector('.main-container');
     const paper = document.getElementById('paperTradingView');
 
     if (agents) agents.style.display = tab === 'agents' ? 'block' : 'none';
-    if (marketplace) marketplace.style.display = tab === 'marketplace' ? 'block' : 'none';
     if (backtest) backtest.style.display = tab === 'backtest' ? 'grid' : 'none';
     if (paper) paper.style.display = tab === 'paper' ? 'block' : 'none';
 
@@ -5701,9 +5705,6 @@ function showPlaygroundPanel(tab) {
     } else if (tab === 'paper') {
         currentMode = 'paper';
         loadPaperTradingData();
-    } else if (tab === 'marketplace') {
-        currentMode = 'marketplace';
-        loadMarketplace();
     } else {
         currentMode = 'agents';
         // Cache-only repaint so the panel is not blank while agents load;
@@ -5748,6 +5749,11 @@ function navigateToPage(page, options = {}) {
         page = 'playground';
         options = { ...options, playgroundTab: options.playgroundTab || 'agents' };
     }
+    // Marketplace moved from Playground → Community.
+    if (page === 'playground' && options.playgroundTab === 'marketplace') {
+        page = 'community';
+        options = { ...options, playgroundTab: undefined };
+    }
 
     const historyMode = options.history || 'push';
     const prevState = getNavigationState();
@@ -5791,7 +5797,6 @@ function navigateToPage(page, options = {}) {
     hide(myAlgoView);
     hide(leaderboardView);
     hide(document.getElementById('playgroundAgentsPanel'));
-    hide(document.getElementById('playgroundMarketplacePanel'));
     hide(document.getElementById('competitionParticipantsPanel'));
     hide(document.getElementById('competitionAboutPanel'));
 
@@ -5808,7 +5813,9 @@ function navigateToPage(page, options = {}) {
             if (competitionView) competitionView.style.display = 'block';
             showCompetitionPanel(competitionTab);
         } else if (page === 'community') {
+            currentMode = 'community';
             if (communityView) communityView.style.display = 'block';
+            loadMarketplace();
         } else if (page === 'account') {
             currentMode = 'account';
             if (accountView) accountView.style.display = 'block';

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1556,6 +1556,7 @@ async function loadAgents() {
 
 let marketplaceTemplates = [];
 let marketplaceCloneInFlight = false;
+let marketplaceLoadInFlight = null;
 
 function getFilteredMarketplaceTemplates() {
   const query = (document.getElementById('marketplaceSearchInput')?.value || '').trim().toLowerCase();
@@ -1623,7 +1624,7 @@ function renderMarketplaceGrid() {
         ${tags ? `<div class="marketplace-tag-row">${tags}</div>` : ''}
       </div>
       <div class="agent-card-actions agent-card-actions--status">
-        <button class="agent-card-cta marketplace-clone-btn" type="button" data-template-id="${escapeHtml(template.template_id)}">Select to My Agents</button>
+        <button class="agent-card-cta marketplace-clone-btn" type="button" data-template-id="${escapeHtml(template.template_id)}">Add to My Agents</button>
       </div>`;
     grid.appendChild(card);
   });
@@ -1636,11 +1637,11 @@ function renderMarketplaceGrid() {
       marketplaceCloneInFlight = true;
       btn.disabled = true;
       const prevLabel = btn.textContent;
-      btn.textContent = 'Selecting…';
+      btn.textContent = 'Adding…';
       try {
         await cloneMarketplaceTemplate(template);
       } catch (error) {
-        alert(error.message || 'Failed to select template');
+        alert(error.message || 'Failed to add template');
       } finally {
         marketplaceCloneInFlight = false;
         btn.disabled = false;
@@ -1659,16 +1660,37 @@ function renderMarketplaceError() {
   if (errorEl) errorEl.hidden = false;
 }
 
+/**
+ * Fetch the template catalog, at most once per page load.
+ *
+ * Community is a top-level page now, so this runs on every nav click, every
+ * Back/Forward and the initial boot -- where it used to run once, when the
+ * Playground marketplace subtab was opened. The catalog is static config the
+ * server already caches in-process, so repeat visits repaint from memory and
+ * skip the network entirely. A failure clears the cache, so the next visit
+ * retries rather than showing the error forever.
+ */
 async function loadMarketplace() {
-  try {
-    const data = await API.get(`${API_BASE}/api/v1/agents/marketplace`);
-    marketplaceTemplates = data.templates || [];
+  if (marketplaceTemplates.length) {
     renderMarketplaceGrid();
-  } catch (error) {
-    console.warn('Failed to load marketplace:', error.message);
-    marketplaceTemplates = [];
-    renderMarketplaceError();
+    return;
   }
+  // Concurrent callers share one request (boot + a fast nav click can overlap).
+  if (marketplaceLoadInFlight) return marketplaceLoadInFlight;
+  marketplaceLoadInFlight = (async () => {
+    try {
+      const data = await API.get(`${API_BASE}/api/v1/agents/marketplace`);
+      marketplaceTemplates = data.templates || [];
+      renderMarketplaceGrid();
+    } catch (error) {
+      console.warn('Failed to load marketplace:', error.message);
+      marketplaceTemplates = [];
+      renderMarketplaceError();
+    } finally {
+      marketplaceLoadInFlight = null;
+    }
+  })();
+  return marketplaceLoadInFlight;
 }
 
 async function cloneMarketplaceTemplate(template) {
@@ -1678,7 +1700,7 @@ async function cloneMarketplaceTemplate(template) {
   );
   const agent = data?.agent;
   if (!agent?.agent_id) {
-    throw new Error('Select failed — no agent returned');
+    throw new Error('Add failed — no agent returned');
   }
   applyActiveAgent(agent);
   await loadAgents();
@@ -5388,6 +5410,9 @@ function getSelectedSymbols() {
 // A divergence would paint one page and render another — a flash bug no test
 // in this repo can catch, so there is deliberately only ever one object.
 const NAV_VIEW_MAP = window.NAV_VIEW_MAP;
+// Same deal, same reason: both files restore the same saved nav blob, so the
+// rule that rewrites a pre-move one lives in exactly one place.
+const migrateSavedNavState = window.migrateSavedNavState;
 
 // Persist the current tab so a page refresh restores it instead of going home.
 function persistNavigation() {
@@ -5426,8 +5451,10 @@ function navigationStatesEqual(a, b) {
  * hand-maintained inverses — change one, check the other.
  *
  * Several NAV_VIEW_MAP keys are read-only aliases that this never emits
- * ('contest', 'competition', 'playground', 'my-algo'); old links keep working,
- * new URLs get the canonical slug.
+ * ('contest', 'competition', 'playground', 'my-algo', 'marketplace'); old links
+ * keep working, new URLs get the canonical slug. 'marketplace' joined that list
+ * when the catalog moved to Community: ?view=marketplace still opens it, but a
+ * URL written from that page now says ?view=community.
  */
 function viewParamForNavState(state) {
     if (state.page === 'home') return 'home';
@@ -5518,13 +5545,16 @@ function resolveInitialNavigation() {
 
     // Otherwise restore the last visited tab across refreshes.
     try {
-        const saved = JSON.parse(localStorage.getItem(NAV_STATE_KEY) || 'null');
+        // Migrated here as well as in navigateToPage's redirect: this function
+        // is documented to return a *current* nav state, and popstate reads it
+        // directly. Returning a page/subtab pair that no longer exists would be
+        // a live trap for the next caller that does not route through
+        // navigateToPage.
+        const saved = migrateSavedNavState(
+            JSON.parse(localStorage.getItem(NAV_STATE_KEY) || 'null'),
+        );
         const validPages = ['home', 'playground', 'competition', 'community', 'account'];
         if (saved && validPages.includes(saved.page)) {
-            // Marketplace moved from Playground → Community.
-            if (saved.page === 'playground' && saved.playgroundTab === 'marketplace') {
-                return { page: 'community' };
-            }
             return saved;
         }
     } catch (error) {
@@ -5678,7 +5708,11 @@ function updateCompetitionSubtabs() {
 }
 
 function showPlaygroundPanel(tab) {
-    // Legacy: marketplace used to be a Playground subtab.
+    // Belt and braces: navigateToPage already redirects the retired subtab, so
+    // nothing in-tree reaches this. It stays because this function is also the
+    // direct target of the subtab click handler, where a stray
+    // data-playground-tab="marketplace" would otherwise blank the page -- every
+    // panel hidden and none shown.
     if (tab === 'marketplace') {
         navigateToPage('community');
         return;
@@ -5749,10 +5783,15 @@ function navigateToPage(page, options = {}) {
         page = 'playground';
         options = { ...options, playgroundTab: options.playgroundTab || 'agents' };
     }
-    // Marketplace moved from Playground → Community.
-    if (page === 'playground' && options.playgroundTab === 'marketplace') {
+    // Marketplace moved from Playground → Community. This is the choke point
+    // every navigation funnels through, so the redirect belongs here rather than
+    // at each call site. Reads the module-level playgroundTab too, so a session
+    // that entered this page load holding the retired subtab cannot land back on
+    // it, and rewrites the tab to 'agents' rather than clearing it -- leaving it
+    // set to 'marketplace' would bounce the *next* Playground visit as well.
+    if (page === 'playground' && (options.playgroundTab || playgroundTab) === 'marketplace') {
         page = 'community';
-        options = { ...options, playgroundTab: undefined };
+        options = { ...options, playgroundTab: 'agents' };
     }
 
     const historyMode = options.history || 'push';

--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -158,7 +158,7 @@
           window.location.replace(APP_URL);
         }
 
-        // Account menu "Visit Landing Page" uses ?stay=1 so logged-in users can view marketing.
+        // Optional ?stay=1 keeps signed-in users on the marketing page.
         var stayOnLanding = false;
         try {
           stayOnLanding = new URLSearchParams(window.location.search).get('stay') === '1';

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8896,6 +8896,11 @@ body.agent-editor-open {
     max-width: 360px;
 }
 
+/* The class is on all three account forms, but `>` is deliberate and narrows
+   this to two buttons: Save name and Update password, the only submits that are
+   direct children of a form. The email form's pair is nested in
+   .account-email-actions and sized by that rule instead -- the child combinator
+   is what keeps the two from fighting over the same buttons. */
 .account-password-form > .auth-btn {
     width: 100%;
 }
@@ -8918,8 +8923,13 @@ body.agent-editor-open {
     color: var(--text-secondary);
 }
 
+/* `1fr auto`, not a single column: Cancel is hidden in the idle state and so
+   generates no grid item, leaving "Send code" spanning the full first track.
+   Once the code step un-hides Cancel it takes the auto track beside it, instead
+   of stacking full-width underneath and reading as an equal-weight action. */
 .account-email-actions {
     display: grid;
+    grid-template-columns: 1fr auto;
     gap: 8px;
     width: 100%;
 }
@@ -9004,6 +9014,15 @@ body.agent-editor-open {
     align-items: flex-end;
     justify-content: space-between;
     gap: 16px;
+}
+
+/* One step down from .page-title (22px): the Community page owns the h2, the
+   marketplace is a section within it. */
+.marketplace-section-title {
+    margin: 0;
+    font-size: 17px;
+    font-weight: 700;
+    color: var(--text-primary);
 }
 
 .marketplace-section-sub {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8896,6 +8896,10 @@ body.agent-editor-open {
     max-width: 360px;
 }
 
+.account-password-form > .auth-btn {
+    width: 100%;
+}
+
 .password-policy-hints {
     margin: 4px 0 0;
     padding-left: 18px;
@@ -8915,9 +8919,13 @@ body.agent-editor-open {
 }
 
 .account-email-actions {
-    display: flex;
+    display: grid;
     gap: 8px;
-    align-items: center;
+    width: 100%;
+}
+
+.account-email-actions .auth-btn {
+    width: 100%;
 }
 
 .auth-avatar--large {

--- a/docs/source/lab/getting_started.rst
+++ b/docs/source/lab/getting_started.rst
@@ -36,8 +36,8 @@ The dashboard keeps these separate, and they have their own limits:
 Start from a template
 ---------------------
 
-Rather than writing an agent from scratch, open **Playground → Agent
-Marketplace** and copy a ready-made template into **My Agents**, then edit its
+Rather than writing an agent from scratch, open **Community → Agent
+Marketplace** and add a ready-made template to **My Agents**, then edit its
 prompts and backtest it. See :doc:`marketplace`.
 
 Accounts (optional)

--- a/docs/source/lab/key_features.rst
+++ b/docs/source/lab/key_features.rst
@@ -5,6 +5,6 @@ Key Features
 - **Educational playground** — Explore trading without wiring up APIs and infrastructure yourself.
 - **Interactive backtesting** — Custom date ranges and assets from the web dashboard.
 - **Performance metrics** — Final portfolio value, cumulative return, max drawdown, Sharpe ratio, and equity-curve comparison views.
-- **Agent Marketplace** — Copy ready-made agent templates into your own workspace and customize them.
+- **Agent Marketplace** — Select ready-made agent templates into your own workspace and customize them.
 - **Live trading** — Connect a real Robinhood account and let an agent propose orders under hard risk caps, with a review-only mode by default.
 - **Optional accounts** — Sign in to persist your agents, attribute leaderboard runs, and link Discord.

--- a/docs/source/lab/key_features.rst
+++ b/docs/source/lab/key_features.rst
@@ -5,6 +5,6 @@ Key Features
 - **Educational playground** — Explore trading without wiring up APIs and infrastructure yourself.
 - **Interactive backtesting** — Custom date ranges and assets from the web dashboard.
 - **Performance metrics** — Final portfolio value, cumulative return, max drawdown, Sharpe ratio, and equity-curve comparison views.
-- **Agent Marketplace** — Select ready-made agent templates into your own workspace and customize them.
+- **Agent Marketplace** — Add ready-made agent templates to your own workspace and customize them.
 - **Live trading** — Connect a real Robinhood account and let an agent propose orders under hard risk caps, with a review-only mode by default.
 - **Optional accounts** — Sign in to persist your agents, attribute leaderboard runs, and link Discord.

--- a/docs/source/lab/live_trading.rst
+++ b/docs/source/lab/live_trading.rst
@@ -27,7 +27,8 @@ You need:
 - an **ATL account** (see :doc:`accounts`) — the Robinhood link is stored
   against it, so live trading is not available to signed-out browser sessions;
 - a **real agent** under **Playground → My Agents**. The demo agents on the
-  dashboard cannot be connected; create or :doc:`copy <marketplace>` one first;
+  dashboard cannot be connected; create one, or add one from the
+  :doc:`Agent Marketplace <marketplace>` first;
 - a **Robinhood account** eligible for Robinhood's Agentic Trading (MCP) access;
 - a deployment configured for Robinhood (:ref:`robinhood-config`). If it is not,
   connecting fails with *Robinhood OAuth is not configured*.
@@ -155,7 +156,8 @@ Troubleshooting
    * - *Robinhood OAuth is not configured*
      - The deployment has no Robinhood settings. See :ref:`robinhood-config`.
    * - *Create a real agent in My Agents first*
-     - You are on a demo agent. Create or copy one, then retry.
+     - You are on a demo agent. Create one, or add one from the marketplace,
+       then retry.
    * - *Connect Robinhood first*
      - No brokerage account is linked to your ATL account.
    * - *Enable live trading for this agent*

--- a/docs/source/lab/marketplace.rst
+++ b/docs/source/lab/marketplace.rst
@@ -1,8 +1,8 @@
 Agent Marketplace
 =================
 
-The **Agent Marketplace** is a catalog of ready-made agent templates. Select one
-into :doc:`My Agents <external_agents>`, then edit, backtest, or run it like any
+The **Agent Marketplace** is a catalog of ready-made agent templates. Add one to
+:doc:`My Agents <external_agents>`, then edit, backtest, or run it like any
 agent you built yourself.
 
 Open the dashboard, go to **Community**, and use the **Agent Marketplace**.
@@ -12,11 +12,11 @@ Browsing needs no account.
 Browse the catalog
 ------------------
 
-Each card shows what you are selecting:
+Each card shows what you are adding:
 
 - **Category** — ``Foundation`` for single-instruction agents, ``Advanced`` for
   multi-step pipelines.
-- **Model** — the LLM the template is tuned for (you can change it after selecting).
+- **Model** — the LLM the template is tuned for (you can change it afterwards).
 - **Simple** or **Multi-step pipeline**, with the step count.
 - **Tags** and the template author.
 
@@ -47,31 +47,31 @@ Templates shipped today:
        produce executable orders.
 
 
-Select a template
------------------
+Add one to My Agents
+--------------------
 
-1. Click **Select to My Agents** on a card.
+1. Click **Add to My Agents** on a card.
 2. The agent appears under **Playground → My Agents**, owned by you, with the
    template's prompt pipeline already filled in.
 3. Open it in the agent editor to rename it, change the model, or rewrite the
-   prompts. The copy is independent — later edits to the template do not touch
-   your agent, and your edits never affect anyone else's copy.
+   prompts. Your agent is an independent copy — later edits to the template do
+   not touch it, and your edits never affect anyone else's.
 
 New agents get the default **Paper Trading Allocated Capital** ($1,000), and a
 backtest starts from that amount unless you change it in the **Run Backtest**
 dialog — see :ref:`allocated-capital`. If you are signed in, the $1,000 is
-reserved from your account portfolio, so a select can fail with *insufficient
-cash* until you free some up.
+reserved from your account portfolio, so adding an agent can fail with
+*insufficient cash* until you free some up.
 
 .. note::
 
-   You can select templates without signing in — the agent is then tied to your
+   You can add templates without signing in — the agent is then tied to your
    browser session and disappears when it expires. Sign in first if you want it
    to persist.
 
 
-Add a template
---------------
+Contribute a template
+---------------------
 
 The catalog is config-driven: templates live in
 ``dashboard/config/marketplace.json``, so contributing one needs no code or

--- a/docs/source/lab/marketplace.rst
+++ b/docs/source/lab/marketplace.rst
@@ -1,22 +1,22 @@
 Agent Marketplace
 =================
 
-The **Agent Marketplace** is a catalog of ready-made agent templates. Copy one
+The **Agent Marketplace** is a catalog of ready-made agent templates. Select one
 into :doc:`My Agents <external_agents>`, then edit, backtest, or run it like any
 agent you built yourself.
 
-Open the dashboard, go to **Playground**, and choose the **Agent Marketplace**
-tab. Browsing needs no account.
+Open the dashboard, go to **Community**, and use the **Agent Marketplace**.
+Browsing needs no account.
 
 
 Browse the catalog
 ------------------
 
-Each card shows what you are copying:
+Each card shows what you are selecting:
 
 - **Category** — ``Foundation`` for single-instruction agents, ``Advanced`` for
   multi-step pipelines.
-- **Model** — the LLM the template is tuned for (you can change it after copying).
+- **Model** — the LLM the template is tuned for (you can change it after selecting).
 - **Simple** or **Multi-step pipeline**, with the step count.
 - **Tags** and the template author.
 
@@ -47,10 +47,10 @@ Templates shipped today:
        produce executable orders.
 
 
-Copy a template
----------------
+Select a template
+-----------------
 
-1. Click **Copy to My Agents** on a card.
+1. Click **Select to My Agents** on a card.
 2. The agent appears under **Playground → My Agents**, owned by you, with the
    template's prompt pipeline already filled in.
 3. Open it in the agent editor to rename it, change the model, or rewrite the
@@ -60,12 +60,12 @@ Copy a template
 New agents get the default **Paper Trading Allocated Capital** ($1,000), and a
 backtest starts from that amount unless you change it in the **Run Backtest**
 dialog — see :ref:`allocated-capital`. If you are signed in, the $1,000 is
-reserved from your account portfolio, so a copy can fail with *insufficient
+reserved from your account portfolio, so a select can fail with *insufficient
 cash* until you free some up.
 
 .. note::
 
-   You can copy templates without signing in — the agent is then tied to your
+   You can select templates without signing in — the agent is then tied to your
    browser session and disappears when it expires. Sign in first if you want it
    to persist.
 


### PR DESCRIPTION
## Summary
- Move Agent Marketplace from Playground into the Community page. Legacy `?view=marketplace`, `#marketplace` and saved nav state all redirect; Community keeps its own page header with the marketplace as its first section.
- Rename the marketplace CTA to **Add to My Agents** (verb *and* noun, so the docs read grammatically), and update `marketplace` / `key_features` / `getting_started` / `live_trading` / README to match.
- Account profile: retitle the email section to **Change email address**, widen the form submit buttons, and remove **Visit Landing Page** from the account dropdown.

## Notes for reviewers
- `.account-password-form > .auth-btn` widens **Save name** and **Update password** — the two submits that are direct children of a form. The email pair is nested in `.account-email-actions` and sized separately; `>` is what keeps the two rules off each other.
- `.account-email-actions` uses `grid-template-columns: 1fr auto`, so **Cancel** sits beside the primary during the code step rather than full-width beneath it.
- `?stay=1` stays supported for shared marketing links; it just no longer has an account-menu entry point.
- `loadMarketplace()` now caches. Community is a top-level page, so it would otherwise re-fetch the static catalog on every nav click, popstate and boot.
- The saved-nav-state migration is defined once in `app.html` and read off `window` by `app.js`, matching how `NAV_VIEW_MAP` already avoids boot/render divergence.

## Test plan
- [ ] Open Community — page header reads **Community**, marketplace catalog loads beneath it; Playground has no Agent Marketplace tab
- [ ] Click **Add to My Agents** on a template — agent lands in My Agents / editor
- [ ] Hard-refresh with old `?view=marketplace` or prior marketplace localStorage — lands on Community
- [ ] Navigate away from Community and back — grid repaints with no second network request
- [ ] Account page: email section title is **Change email address**; start an email change and confirm **Cancel** sits beside the submit
- [ ] Account dropdown shows Account + Log out only (no Visit Landing Page)

`dashboard/backend/tests/test_frontend_marketplace_placement.py` adds 10 structural guards for the move (each one mutation-tested).

Made with [Cursor](https://cursor.com)
