### PR TITLE
feat: persist and expose backtest_allocation

### DIFF
--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from dashboard.backend.domain.backtesting.constants import (
     DEFAULT_AGENT_CASH_ALLOCATION,
     MAX_AGENT_CASH_ALLOCATION,
+    MAX_BACKTEST_INITIAL_CAPITAL,
 )
 from dashboard.backend.domain.agents.repository import _UNSET
 from dashboard.backend.domain.agents.service import (
@@ -44,6 +45,11 @@ class CreateAgentBody(BaseModel):
         ge=0,
         le=MAX_AGENT_CASH_ALLOCATION,
     )
+    backtest_allocation: Optional[float] = Field(
+        default=None,
+        ge=1,
+        le=MAX_BACKTEST_INITIAL_CAPITAL,
+    )
 
 
 class PipelineStep(BaseModel):
@@ -67,6 +73,11 @@ class UpdateAgentBody(BaseModel):
         default=None,
         ge=0,
         le=MAX_AGENT_CASH_ALLOCATION,
+    )
+    backtest_allocation: Optional[float] = Field(
+        default=None,
+        ge=1,
+        le=MAX_BACKTEST_INITIAL_CAPITAL,
     )
     live_trading_enabled: Optional[bool] = None
 
@@ -120,6 +131,7 @@ async def create_agent(
         agent_type=agent_type,
         description=(body.description.strip() if body.description else None),
         cash_allocation=cash,
+        backtest_allocation=body.backtest_allocation,
     )
     if ctx["user_id"]:
         portfolio_service.get_or_create_portfolio(ctx["user_id"])
@@ -320,6 +332,7 @@ async def update_agent(
     fields_set = body.model_fields_set
     pipeline_provided = "pipeline" in fields_set
     cash_allocation_provided = "cash_allocation" in fields_set
+    backtest_allocation_provided = "backtest_allocation" in fields_set
     live_trading_provided = "live_trading_enabled" in fields_set
     if (
         body.name is None
@@ -327,6 +340,7 @@ async def update_agent(
         and body.description is None
         and not pipeline_provided
         and not cash_allocation_provided
+        and not backtest_allocation_provided
         and not live_trading_provided
     ):
         raise HTTPException(status_code=400, detail="No fields to update")
@@ -341,6 +355,9 @@ async def update_agent(
         pipeline_arg = _UNSET
 
     cash_allocation_arg = body.cash_allocation if cash_allocation_provided else _UNSET
+    backtest_allocation_arg = (
+        body.backtest_allocation if backtest_allocation_provided else _UNSET
+    )
     live_trading_arg = body.live_trading_enabled if live_trading_provided else _UNSET
 
     # When a signed-in owner changes cash_allocation, the portfolio ledger has
@@ -373,6 +390,7 @@ async def update_agent(
             description=body.description,
             pipeline=pipeline_arg,
             cash_allocation=cash_allocation_arg,
+            backtest_allocation=backtest_allocation_arg,
             live_trading_enabled=live_trading_arg,
         )
     except AgentNotFoundError:

--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -16,6 +16,7 @@ from dashboard.backend.domain.backtesting.constants import (
     DEFAULT_AGENT_CASH_ALLOCATION,
     MAX_AGENT_CASH_ALLOCATION,
     MAX_BACKTEST_INITIAL_CAPITAL,
+    MIN_BACKTEST_INITIAL_CAPITAL,
 )
 from dashboard.backend.domain.agents.repository import _UNSET
 from dashboard.backend.domain.agents.service import (
@@ -47,7 +48,7 @@ class CreateAgentBody(BaseModel):
     )
     backtest_allocation: Optional[float] = Field(
         default=None,
-        ge=1,
+        ge=MIN_BACKTEST_INITIAL_CAPITAL,
         le=MAX_BACKTEST_INITIAL_CAPITAL,
     )
 
@@ -76,7 +77,7 @@ class UpdateAgentBody(BaseModel):
     )
     backtest_allocation: Optional[float] = Field(
         default=None,
-        ge=1,
+        ge=MIN_BACKTEST_INITIAL_CAPITAL,
         le=MAX_BACKTEST_INITIAL_CAPITAL,
     )
     live_trading_enabled: Optional[bool] = None

--- a/dashboard/backend/domain/agents/repository.py
+++ b/dashboard/backend/domain/agents/repository.py
@@ -65,6 +65,7 @@ def _public_agent(row: sqlite3.Row | Dict[str, Any]) -> Dict[str, Any]:
         "description": data.get("description"),
         "pipeline": _parse_pipeline(data.get("pipeline_config")),
         "cash_allocation": data.get("cash_allocation"),
+        "backtest_allocation": data.get("backtest_allocation"),
         "live_trading_enabled": bool(data.get("live_trading_enabled")),
         "api_key_prefix": data.get("api_key_prefix") or "",
         "owner_user_id": data.get("owner_user_id"),
@@ -142,6 +143,10 @@ class AgentStore:
             cursor.execute(
                 "ALTER TABLE external_agents ADD COLUMN cash_allocation REAL"
             )
+        if "backtest_allocation" not in existing_columns:
+            cursor.execute(
+                "ALTER TABLE external_agents ADD COLUMN backtest_allocation REAL"
+            )
         if "live_trading_enabled" not in existing_columns:
             cursor.execute(
                 "ALTER TABLE external_agents ADD COLUMN live_trading_enabled INTEGER NOT NULL DEFAULT 0"
@@ -172,6 +177,7 @@ class AgentStore:
         agent_type: str = "external",
         description: Optional[str] = None,
         cash_allocation: Optional[float] = None,
+        backtest_allocation: Optional[float] = None,
     ) -> Dict[str, Any]:
         agent_id = f"agent_{uuid.uuid4().hex[:12]}"
         session_id = session_id or str(uuid.uuid4())
@@ -187,8 +193,9 @@ class AgentStore:
             INSERT INTO external_agents (
                 agent_id, name, session_id, api_key_hash, api_key_prefix,
                 model_name, agent_type, description, cash_allocation,
+                backtest_allocation,
                 owner_user_id, owner_browser_session, created_at, last_used_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 agent_id,
@@ -200,6 +207,7 @@ class AgentStore:
                 (agent_type or "external").strip() or "external",
                 (description or None),
                 cash_allocation,
+                backtest_allocation,
                 owner_user_id,
                 owner_browser_session,
                 now,
@@ -486,6 +494,7 @@ class AgentStore:
         description: Optional[str] = None,
         pipeline: Any = _UNSET,
         cash_allocation: Any = _UNSET,
+        backtest_allocation: Any = _UNSET,
         live_trading_enabled: Any = _UNSET,
     ) -> Optional[Dict[str, Any]]:
         """Update display fields for an agent. Returns the updated record or None.
@@ -511,6 +520,9 @@ class AgentStore:
         if cash_allocation is not _UNSET:
             sets.append("cash_allocation = ?")
             params.append(cash_allocation)
+        if backtest_allocation is not _UNSET:
+            sets.append("backtest_allocation = ?")
+            params.append(backtest_allocation)
         if live_trading_enabled is not _UNSET:
             sets.append("live_trading_enabled = ?")
             params.append(1 if live_trading_enabled else 0)

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -81,6 +81,7 @@ class PostgresAgentStore:
                         description TEXT,
                         pipeline_config TEXT,
                         cash_allocation DOUBLE PRECISION,
+                        backtest_allocation DOUBLE PRECISION,
                         live_trading_enabled BOOLEAN NOT NULL DEFAULT FALSE
                     )
                     """
@@ -103,6 +104,10 @@ class PostgresAgentStore:
                 cur.execute(
                     "ALTER TABLE external_agents "
                     "ADD COLUMN IF NOT EXISTS cash_allocation DOUBLE PRECISION"
+                )
+                cur.execute(
+                    "ALTER TABLE external_agents "
+                    "ADD COLUMN IF NOT EXISTS backtest_allocation DOUBLE PRECISION"
                 )
                 cur.execute(
                     "ALTER TABLE external_agents "
@@ -142,6 +147,7 @@ class PostgresAgentStore:
         agent_type: str = "external",
         description: Optional[str] = None,
         cash_allocation: Optional[float] = None,
+        backtest_allocation: Optional[float] = None,
     ) -> Dict[str, Any]:
         agent_id = f"agent_{uuid.uuid4().hex[:12]}"
         session_id = session_id or str(uuid.uuid4())
@@ -157,8 +163,9 @@ class PostgresAgentStore:
                     INSERT INTO external_agents (
                         agent_id, name, session_id, api_key_hash, api_key_prefix,
                         model_name, agent_type, description, cash_allocation,
+                        backtest_allocation,
                         owner_user_id, owner_browser_session, created_at, last_used_at
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     RETURNING *
                     """,
                     (
@@ -171,6 +178,7 @@ class PostgresAgentStore:
                         (agent_type or "external").strip() or "external",
                         (description or None),
                         cash_allocation,
+                        backtest_allocation,
                         owner_user_id,
                         owner_browser_session,
                         now,
@@ -441,6 +449,7 @@ class PostgresAgentStore:
         description: Optional[str] = None,
         pipeline: Any = _UNSET,
         cash_allocation: Any = _UNSET,
+        backtest_allocation: Any = _UNSET,
         live_trading_enabled: Any = _UNSET,
     ) -> Optional[Dict[str, Any]]:
         """Update display fields for an agent. Returns the updated record or None.
@@ -466,6 +475,9 @@ class PostgresAgentStore:
         if cash_allocation is not _UNSET:
             sets.append("cash_allocation = %s")
             params.append(cash_allocation)
+        if backtest_allocation is not _UNSET:
+            sets.append("backtest_allocation = %s")
+            params.append(backtest_allocation)
         if live_trading_enabled is not _UNSET:
             sets.append("live_trading_enabled = %s")
             params.append(bool(live_trading_enabled))

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -49,9 +49,9 @@ class PostgresAgentStore:
         # in tests, and CI's Postgres service container is empty on every run,
         # so the @pg_only tier only ever exercises the CREATE path -- except
         # test_agent_schema_lazily_migrates_an_old_table_postgres, which recreates
-        # the pre-migration table to force the migrate path. The six ALTER ...
-        # ADD COLUMN IF NOT EXISTS statements below re-add the columns the SQLite
-        # store accreted as lazy migrations, so a deployment whose table predates
+        # the pre-migration table to force the migrate path. Every ALTER ...
+        # ADD COLUMN IF NOT EXISTS statement below re-adds a column the SQLite
+        # store accreted as a lazy migration, so a deployment whose table predates
         # them is brought up to shape on the next boot; on a fresh or current
         # table they no-op. Add the next column the same way (Postgres supports
         # ADD COLUMN IF NOT EXISTS natively; users_postgres.py has the pattern).
@@ -87,9 +87,10 @@ class PostgresAgentStore:
                     """
                 )
                 # Lazy migrations for a table created before these columns
-                # existed (mirrors the SQLite store's five post-ship ALTERs).
-                # Each no-ops on a fresh or already-current table. Must run
-                # before idx_external_agents_type, which indexes agent_type.
+                # existed (mirrors every one of the SQLite store's post-ship
+                # ALTERs). Each no-ops on a fresh or already-current table.
+                # Must run before idx_external_agents_type, which indexes
+                # agent_type.
                 cur.execute(
                     "ALTER TABLE external_agents "
                     "ADD COLUMN IF NOT EXISTS agent_type TEXT NOT NULL DEFAULT 'external'"

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -254,6 +254,7 @@ class AgentService:
         description: Optional[str] = None,
         pipeline: Any = _UNSET,
         cash_allocation: Any = _UNSET,
+        backtest_allocation: Any = _UNSET,
         live_trading_enabled: Any = _UNSET,
     ) -> Dict[str, Any]:
         agent = self.agents.update_agent(
@@ -263,6 +264,7 @@ class AgentService:
             description=description,
             pipeline=pipeline,
             cash_allocation=cash_allocation,
+            backtest_allocation=backtest_allocation,
             live_trading_enabled=live_trading_enabled,
         )
         if not agent:
@@ -279,6 +281,7 @@ class AgentService:
         agent_type: str = "external",
         description: Optional[str] = None,
         cash_allocation: Optional[float] = None,
+        backtest_allocation: Optional[float] = None,
         seed_default_pipeline: bool = True,
     ) -> Dict[str, Any]:
         """Register an agent.
@@ -304,6 +307,7 @@ class AgentService:
             agent_type=agent_type,
             description=description,
             cash_allocation=cash_allocation,
+            backtest_allocation=backtest_allocation,
         )
         if seed_default_pipeline and agent_type == "builtin":
             # Merge rather than reassign: create_agent's dict carries the

--- a/dashboard/backend/domain/backtesting/constants.py
+++ b/dashboard/backend/domain/backtesting/constants.py
@@ -29,6 +29,9 @@ from typing import Any, Optional
 # Default starting capital for a backtest when none is requested.
 INITIAL_CAPITAL = 1000
 
+# Hard floor on simulation capital for a single backtest / protocol run.
+MIN_BACKTEST_INITIAL_CAPITAL = 1
+
 # Hard cap on simulation capital for a single backtest / protocol run.
 MAX_BACKTEST_INITIAL_CAPITAL = 10_000
 

--- a/dashboard/backend/tests/domain/agents/test_repository_move.py
+++ b/dashboard/backend/tests/domain/agents/test_repository_move.py
@@ -71,7 +71,8 @@ def test_create_agent_schema(store):
     agent = store.create_agent(name="My Agent", model_name="gpt-x", owner_user_id=7)
     assert set(agent.keys()) == {
         "agent_id", "name", "session_id", "model_name", "agent_type",
-        "description", "pipeline", "cash_allocation", "api_key_prefix", "owner_user_id", "scopes",
+        "description", "pipeline", "cash_allocation", "backtest_allocation",
+        "api_key_prefix", "owner_user_id", "scopes",
         "created_at", "last_used_at", "api_key", "live_trading_enabled",
     }
     assert agent["name"] == "My Agent"

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -11,7 +11,6 @@ portfolio ledger.
 """
 
 import uuid
-from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -142,3 +142,93 @@ def test_backtest_allocation_does_not_change_the_paper_sleeve(client):
 
     assert updated["cash_allocation"] == 1000
     assert updated["backtest_allocation"] == 9000
+
+
+@pytest.fixture
+def authed_client(tmp_path, monkeypatch):
+    """Like ``client``, but signed in: also wires the user + portfolio stores
+    to the same content DB, so a PATCH carrying both cash_allocation and
+    backtest_allocation exercises the real ledger-write branch
+    (``ctx["user_id"]`` is not None) -- the one path where a real-money write
+    and a simulated-money write interleave (api/routers/agents.py:385-404).
+    """
+    import dashboard.backend.api.routers.agents as agents_api
+    import dashboard.backend.domain.portfolios.repository as portfolio_repo
+    import dashboard.backend.domain.portfolios.service as portfolio_service_module
+    import dashboard.backend.users as users_module
+
+    content_db = tmp_path / "content.db"
+    test_agents = AgentStore(db_path=content_db)
+    test_portfolio = portfolio_repo.PortfolioStore(db_path=content_db)
+    test_db = db_module.BacktestDatabase(db_path=content_db)
+    test_users = users_module.UserStore(db_path=tmp_path / "users.db")
+
+    monkeypatch.setattr(agent_store_module, "agent_store", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "agents", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "db", test_db)
+    monkeypatch.setattr(db_module, "db", test_db)
+    monkeypatch.setattr(portfolio_repo, "portfolio_store", test_portfolio)
+    monkeypatch.setattr(portfolio_service_module, "portfolio_store", test_portfolio)
+    monkeypatch.setattr(users_module, "user_store", test_users)
+    return TestClient(app)
+
+
+def _signup(client, email="backtest-alloc@example.com"):
+    resp = client.post(
+        "/api/auth/signup",
+        json={
+            "email": email,
+            "display_name": "Backtest Alloc User",
+            "password": "securepass1",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    return data["token"], data["user"]
+
+
+def _auth_headers(token, browser="browser-backtest-alloc-1"):
+    return {
+        "Authorization": f"Bearer {token}",
+        "X-Browser-Id": browser,
+        "X-Session-Id": browser,
+    }
+
+
+def test_signed_in_combined_patch_moves_only_the_real_sleeve(authed_client):
+    """The one path where a real-money write (cash_allocation) and a
+    simulated-money write (backtest_allocation) interleave: a signed-in owner
+    PATCHing both fields together in one request.
+
+    The route writes backtest_allocation via ``agent_service.update_agent``
+    first (with cash_allocation left ``_UNSET``), then re-reads the row
+    through the ledger write (``portfolio_service.set_agent_allocation`` ->
+    ``_write_sleeve``, which re-reads via ``agent_store.update_agent``) for
+    cash_allocation. Pins that the merged response still carries both values,
+    and that cash_available moves by exactly the sleeve delta.
+    """
+    token, _ = _signup(authed_client)
+    headers = _auth_headers(token)
+
+    created = authed_client.post(
+        "/api/v1/agents",
+        headers=headers,
+        json={"name": "Combo", "model_name": "local-model", "cash_allocation": 1000},
+    )
+    assert created.status_code == 200, created.text
+    agent_id = created.json()["agent"]["agent_id"]
+
+    before = authed_client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
+
+    updated = authed_client.patch(
+        f"/api/v1/agents/{agent_id}",
+        headers=headers,
+        json={"cash_allocation": 2500, "backtest_allocation": 6000},
+    )
+    assert updated.status_code == 200, updated.text
+    agent = updated.json()["agent"]
+    assert agent["cash_allocation"] == 2500
+    assert agent["backtest_allocation"] == 6000
+
+    after = authed_client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
+    assert after["cash_available"] == before["cash_available"] - 1500

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -54,3 +54,92 @@ def test_update_agent_leaves_backtest_allocation_alone_when_omitted(store):
     updated = store.update_agent(agent["agent_id"], name="renamed")
     assert updated["backtest_allocation"] == 2500
     assert updated["name"] == "renamed"
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import dashboard.backend.api.routers.agents as agents_api
+
+    db_path = tmp_path / "test.db"
+    test_agents = AgentStore(db_path=db_path)
+    test_db = db_module.BacktestDatabase(db_path=db_path)
+    monkeypatch.setattr(agent_store_module, "agent_store", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "agents", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "db", test_db)
+    monkeypatch.setattr(db_module, "db", test_db)
+    return TestClient(app)
+
+
+def _headers():
+    return {"X-Session-Id": str(uuid.uuid4())}
+
+
+def test_create_accepts_backtest_allocation(client):
+    headers = _headers()
+    resp = client.post(
+        "/api/v1/agents",
+        json={"name": "alpha", "agent_type": "builtin", "backtest_allocation": 5000},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent"]["backtest_allocation"] == 5000
+
+
+def test_patch_updates_backtest_allocation(client):
+    headers = _headers()
+    created = client.post(
+        "/api/v1/agents", json={"name": "alpha", "agent_type": "builtin"}, headers=headers
+    ).json()["agent"]
+
+    resp = client.patch(
+        f"/api/v1/agents/{created['agent_id']}",
+        json={"backtest_allocation": 7500},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent"]["backtest_allocation"] == 7500
+
+
+def test_patch_backtest_allocation_alone_is_not_no_fields_to_update(client):
+    """It must satisfy the 'at least one field' guard on its own."""
+    headers = _headers()
+    created = client.post(
+        "/api/v1/agents", json={"name": "alpha", "agent_type": "builtin"}, headers=headers
+    ).json()["agent"]
+
+    resp = client.patch(
+        f"/api/v1/agents/{created['agent_id']}",
+        json={"backtest_allocation": 2000},
+        headers=headers,
+    )
+    assert resp.status_code != 400
+
+
+@pytest.mark.parametrize("bad", [0, -100, 10001])
+def test_backtest_allocation_out_of_range_is_rejected(client, bad):
+    headers = _headers()
+    resp = client.post(
+        "/api/v1/agents",
+        json={"name": "alpha", "agent_type": "builtin", "backtest_allocation": bad},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_backtest_allocation_does_not_change_the_paper_sleeve(client):
+    """Simulated money must never move the real sleeve."""
+    headers = _headers()
+    created = client.post(
+        "/api/v1/agents",
+        json={"name": "alpha", "agent_type": "builtin", "cash_allocation": 1000},
+        headers=headers,
+    ).json()["agent"]
+
+    updated = client.patch(
+        f"/api/v1/agents/{created['agent_id']}",
+        json={"backtest_allocation": 9000},
+        headers=headers,
+    ).json()["agent"]
+
+    assert updated["cash_allocation"] == 1000
+    assert updated["backtest_allocation"] == 9000

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -196,16 +196,13 @@ def _auth_headers(token, browser="browser-backtest-alloc-1"):
 
 
 def test_signed_in_combined_patch_moves_only_the_real_sleeve(authed_client):
-    """The one path where a real-money write (cash_allocation) and a
-    simulated-money write (backtest_allocation) interleave: a signed-in owner
-    PATCHing both fields together in one request.
+    """Signed-in round trip: both fields survive a combined PATCH without
+    backtest_allocation being lost to the route's ``_UNSET`` substitution.
 
-    The route writes backtest_allocation via ``agent_service.update_agent``
-    first (with cash_allocation left ``_UNSET``), then re-reads the row
-    through the ledger write (``portfolio_service.set_agent_allocation`` ->
-    ``_write_sleeve``, which re-reads via ``agent_store.update_agent``) for
-    cash_allocation. Pins that the merged response still carries both values,
-    and that cash_available moves by exactly the sleeve delta.
+    Does NOT prove the ledger branch (api/routers/agents.py:369-384) executed:
+    _reconcile derives cash_available from the sum of agent allocations on
+    every read, so the cash_available assertion would pass even if that code
+    were deleted.
     """
     token, _ = _signup(authed_client)
     headers = _auth_headers(token)

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -1,0 +1,56 @@
+"""``backtest_allocation``: a saved per-agent simulated-capital setting.
+
+Backtest capital used to be a per-run value reseeded from the paper sleeve on
+every Run Backtest modal open. Consolidating both capital fields into one
+Configure card (2026-07-29) makes it a stored column, which means it has to
+exist on *both* twins -- see tests/test_store_twin_parity.py for why a
+one-twin column is a prod-only 500.
+
+Unlike ``cash_allocation`` this is simulated money: it must never move the
+portfolio ledger.
+"""
+
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+import dashboard.backend.domain.agents.repository as agent_store_module
+import dashboard.backend.database as db_module
+
+AgentStore = agent_store_module.AgentStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return AgentStore(db_path=tmp_path / "agents.db")
+
+
+def test_backtest_allocation_round_trips_through_create(store):
+    agent = store.create_agent(name="alpha", backtest_allocation=2500)
+    assert agent["backtest_allocation"] == 2500
+
+    reread = store.get_agent(agent["agent_id"])
+    assert reread["backtest_allocation"] == 2500
+
+
+def test_backtest_allocation_defaults_to_none(store):
+    """Existing agents have a NULL column and must keep today's behaviour."""
+    agent = store.create_agent(name="legacy")
+    assert agent["backtest_allocation"] is None
+
+
+def test_update_agent_sets_backtest_allocation(store):
+    agent = store.create_agent(name="alpha")
+    updated = store.update_agent(agent["agent_id"], backtest_allocation=4000)
+    assert updated["backtest_allocation"] == 4000
+
+
+def test_update_agent_leaves_backtest_allocation_alone_when_omitted(store):
+    """The _UNSET sentinel means 'do not touch', not 'set to None'."""
+    agent = store.create_agent(name="alpha", backtest_allocation=2500)
+    updated = store.update_agent(agent["agent_id"], name="renamed")
+    assert updated["backtest_allocation"] == 2500
+    assert updated["name"] == "renamed"

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -367,9 +367,9 @@ def test_builtin_listing_and_delete_postgres(pg_agent_store):
 def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
     """#135: the twin must ADD COLUMN IF NOT EXISTS for post-ship columns.
 
-    Simulate a deployment created before the six lazy-migration columns
-    (agent_type, description, pipeline_config, cash_allocation, scopes,
-    live_trading_enabled) existed:
+    Simulate a deployment created before the seven lazy-migration columns
+    (agent_type, description, pipeline_config, cash_allocation,
+    backtest_allocation, scopes, live_trading_enabled) existed:
     a table with only the original base schema, already holding a real agent row
     that predates those columns. Re-running _init_schema() -- what every redeploy
     does -- must bring it up to the current shape. CREATE TABLE IF NOT EXISTS
@@ -448,6 +448,7 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
         "description",
         "pipeline_config",
         "cash_allocation",
+        "backtest_allocation",
         "scopes",
         "live_trading_enabled",
     } <= columns
@@ -457,8 +458,11 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
 
     # The store is actually usable after the migration: a real registration
     # writes every migrated column, and the scopes column default applies.
-    created = pg_agent_store.create_agent(name="Post-migration", cash_allocation=123.0)
+    created = pg_agent_store.create_agent(
+        name="Post-migration", cash_allocation=123.0, backtest_allocation=123.0
+    )
     assert created["cash_allocation"] == 123.0
+    assert created["backtest_allocation"] == 123.0
 
 
 @pg_only


### PR DESCRIPTION
Backend slice of the My Agents capital/instruction/running-state work. Additive only — nothing consumes the field yet; the UI lands in a follow-up PR.

## Summary
- New `backtest_allocation` column on `external_agents`, mirrored across **both** store twins (SQLite + Postgres).
- `POST /api/v1/agents` and `PATCH /api/v1/agents/{id}` accept it (1–`MAX_BACKTEST_INITIAL_CAPITAL`); every agent payload now carries the key.
- Simulated money: deliberately excluded from the `ledger_new_amount` branch, so it can never move the real portfolio sleeve.
- Omitted stays `NULL` — agents predating the column keep falling back to their paper sleeve.

## Test plan
- [x] `test_agent_backtest_allocation.py` — 10 cases (store round-trip, `_UNSET` semantics, API create/patch, range rejection, sleeve isolation)
- [x] `test_store_twin_parity.py` green (the guard that catches a one-twin column)
- [x] Full backend suite: 1885 passed / 44 skipped / 1 known `iFind csi300` flake (passes in isolation)
- [x] `git diff origin/main -- dashboard/storage/data/backtest.db` empty — prod seed DB untouched

Plan: `docs/superpowers/plans/2026-07-29-my-agents-capital-instruction-running.md` (Tasks 1–2)