### PR TITLE
feat: My Agents capital, instruction, run state

### DIFF
--- a/dashboard/backend/domain/backtesting/constants.py
+++ b/dashboard/backend/domain/backtesting/constants.py
@@ -16,12 +16,17 @@ Capital scale (product):
   ``DEFAULT_AGENT_CASH_ALLOCATION`` ($1,000), max ``MAX_AGENT_CASH_ALLOCATION``
   ($3,000) — also capped by remaining unallocated cash. **Paper trading only**;
   backtests must not read or write this field.
-- Backtest / protocol simulation capital: default ``INITIAL_CAPITAL`` ($1,000),
-  max ``MAX_BACKTEST_INITIAL_CAPITAL`` ($10,000). Chosen per run via
-  ``config.initial_cash`` / ``--initial-capital``, or persisted per agent via
-  the ``backtest_allocation`` field (set from the Configure screen's
-  Allocated Capital card) when a run does not specify one explicitly. Either
-  way it is independent of the account ledger and agent sleeves.
+- Backtest / protocol simulation capital: floor ``MIN_BACKTEST_INITIAL_CAPITAL``
+  ($1), default ``INITIAL_CAPITAL`` ($1,000), max
+  ``MAX_BACKTEST_INITIAL_CAPITAL`` ($10,000). Chosen per run via
+  ``config.initial_cash`` / ``--initial-capital``, resolved by
+  ``resolve_initial_capital()`` below, which only ever looks at the value
+  passed in for *that* run — it does not read the agent row. The per-agent
+  ``backtest_allocation`` field (set from the Configure screen's Allocated
+  Capital card) is stored on the agent and supplied by the dashboard as that
+  requested value when it launches a backtest for the agent; it is not a
+  backend fallback. Either way, backtest capital is independent of the
+  account ledger and agent sleeves.
 """
 
 from __future__ import annotations

--- a/dashboard/backend/domain/backtesting/constants.py
+++ b/dashboard/backend/domain/backtesting/constants.py
@@ -18,8 +18,10 @@ Capital scale (product):
   backtests must not read or write this field.
 - Backtest / protocol simulation capital: default ``INITIAL_CAPITAL`` ($1,000),
   max ``MAX_BACKTEST_INITIAL_CAPITAL`` ($10,000). Chosen per run via
-  ``config.initial_cash`` / ``--initial-capital`` and is independent of the
-  account ledger and agent sleeves.
+  ``config.initial_cash`` / ``--initial-capital``, or persisted per agent via
+  the ``backtest_allocation`` field (set from the Configure screen's
+  Allocated Capital card) when a run does not specify one explicitly. Either
+  way it is independent of the account ledger and agent sleeves.
 """
 
 from __future__ import annotations

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -229,3 +229,25 @@ def test_signed_in_combined_patch_moves_only_the_real_sleeve(authed_client):
 
     after = authed_client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
     assert after["cash_available"] == before["cash_available"] - 1500
+
+
+def test_patch_with_an_empty_pipeline_clears_the_instruction(client):
+    """Empty instruction -> no pipeline -> the backend's default hourly prompt.
+
+    portfolio_manager takes the ``create_prompt`` branch when an agent has no
+    pipeline, so clearing is what "use the default" means end to end.
+    """
+    headers = _headers()
+    created = client.post(
+        "/api/v1/agents", json={"name": "alpha", "agent_type": "builtin"}, headers=headers
+    ).json()["agent"]
+    assert created["pipeline"], "builtin agents are seeded with a starter pipeline"
+
+    resp = client.patch(
+        f"/api/v1/agents/{created['agent_id']}", json={"pipeline": []}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert not resp.json()["agent"]["pipeline"]
+
+    reread = client.get(f"/api/v1/agents/{created['agent_id']}", headers=headers)
+    assert not reread.json()["agent"]["pipeline"]

--- a/dashboard/backend/tests/test_agent_starter_defaults.py
+++ b/dashboard/backend/tests/test_agent_starter_defaults.py
@@ -196,7 +196,12 @@ def test_starter_instruction_matches_the_frontend():
 
 
 def test_the_editor_can_read_the_starter_instruction():
-    """agent-editor.js backfills from window, so app.js must publish the value."""
+    """The editor shows the default in its disclosure, so app.js must publish it.
+
+    (This used to back a *backfill* that injected the text into the textarea;
+    that was removed when an empty instruction became a supported state --
+    see tests/test_my_agents_instruction_ui.py.)
+    """
     assert "window.DEFAULT_STARTER_INSTRUCTION = DEFAULT_STARTER_INSTRUCTION" in _APP_JS
     assert "window.DEFAULT_STARTER_INSTRUCTION" in _EDITOR_JS
 

--- a/dashboard/backend/tests/test_ifind_ashare_frontend.py
+++ b/dashboard/backend/tests/test_ifind_ashare_frontend.py
@@ -206,7 +206,7 @@ def test_ifind_universe_change_preserves_decision_source(js):
     )
 
 
-def test_backtest_default_capital_is_natively_valid(html, js):
+def test_backtest_capital_input_stays_removed_default_unchanged(html, js):
     """Historically pinned native <input min/max/step/value> attributes.
 
     The input was removed in Task 4 (2026-07-29): capital is now set in

--- a/dashboard/backend/tests/test_ifind_ashare_frontend.py
+++ b/dashboard/backend/tests/test_ifind_ashare_frontend.py
@@ -119,13 +119,12 @@ def test_ifind_mode_applies_one_month_dates_without_changing_capital(html, js):
     assert re.search(r"startDateInput\.value\s*=\s*previousStartDate", js)
     assert re.search(r"endDateInput\.value\s*=\s*previousEndDate", js)
 
-    capital_input = re.search(
-        r'<input\b(?=[^>]*id="backtestInitialCapital")[^>]*>',
-        html,
-        re.S,
-    )
-    assert capital_input
-    assert _attr(capital_input.group(0), "value", "1000")
+    # Capital is no longer a per-run input the mode switch could touch (Task 4,
+    # 2026-07-29) — the modal reads it read-only from the agent's saved value.
+    # The invariant this test guards ("switching to iFind mode doesn't perturb
+    # capital") now holds structurally: there is no capital-related identifier
+    # anywhere in the mode-switch path.
+    assert 'id="runBacktestCapitalValue"' in html
     assert "IFIND_ASHARE_INITIAL_CAPITAL" not in js
 
 
@@ -207,19 +206,16 @@ def test_ifind_universe_change_preserves_decision_source(js):
     )
 
 
-def test_backtest_default_capital_is_natively_valid(html):
-    capital_input = re.search(
-        r'<input\b(?=[^>]*id="backtestInitialCapital")[^>]*>',
-        html,
-        re.S,
-    )
+def test_backtest_default_capital_is_natively_valid(html, js):
+    """Historically pinned native <input min/max/step/value> attributes.
 
-    assert capital_input
-    tag = capital_input.group(0)
-    assert _attr(tag, "min", "1")
-    assert _attr(tag, "step", "1")
-    assert _attr(tag, "max", "10000")
-    assert _attr(tag, "value", "1000")
+    The input was removed in Task 4 (2026-07-29): capital is now set in
+    Configure and the modal only reports it via ``resolveBacktestCapital``,
+    so there is nothing left to natively validate. This guards that the old
+    input stays gone and the fallback default is still $1,000.
+    """
+    assert 'id="backtestInitialCapital"' not in html
+    assert re.search(r"DEFAULT_AGENT_CASH_ALLOCATION\s*=\s*1000", js)
 
 
 def test_ifind_model_dropdown_keeps_all_nine_models_available(html):

--- a/dashboard/backend/tests/test_my_agents_capital_ui.py
+++ b/dashboard/backend/tests/test_my_agents_capital_ui.py
@@ -1,0 +1,46 @@
+"""Both allocated-capital fields live in one Configure card (2026-07-29).
+
+Paper-trading capital used to sit in the agent editor's *header* as a 12.5px
+uppercase field while backtest capital was a separate input inside the Run
+Backtest modal, with nothing connecting them. They are now one card in the
+editor's main column, and the modal shows the saved backtest figure read-only.
+
+These are contract guards, not style assertions: they pin *where the inputs
+live* and *that the modal no longer edits capital*, which is the behaviour the
+consolidation delivers.
+"""
+
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_HTML = (_FRONTEND / "app.html").read_text(encoding="utf-8")
+_EDITOR_JS = (_FRONTEND / "js" / "agent-editor.js").read_text(encoding="utf-8")
+
+
+def _slice(text: str, start_marker: str, end_marker: str) -> str:
+    start = text.index(start_marker)
+    end = text.index(end_marker, start)
+    return text[start:end]
+
+
+def test_configure_has_one_allocated_capital_card_with_both_inputs():
+    card = _slice(_APP_HTML, 'class="agent-capital-card', "</div>\n                    <div")
+    assert "Allocated Capital" in card
+    assert 'id="agentEditorCashAllocation"' in card
+    assert 'id="agentEditorBacktestAllocation"' in card
+
+
+def test_capital_inputs_are_no_longer_in_the_editor_header():
+    """The header held a cramped uppercase field; the card replaces it."""
+    header = _slice(_APP_HTML, 'class="agent-editor-title-wrap"', "</header>")
+    assert 'id="agentEditorCashAllocation"' not in header
+    assert 'id="agentEditorBacktestAllocation"' not in header
+
+
+def test_capital_limits_are_stated_next_to_each_field():
+    assert "max $3,000" in _APP_HTML
+    assert "max $10,000" in _APP_HTML
+
+
+def test_editor_state_carries_backtest_allocation():
+    assert "backtest_allocation" in _EDITOR_JS

--- a/dashboard/backend/tests/test_my_agents_capital_ui.py
+++ b/dashboard/backend/tests/test_my_agents_capital_ui.py
@@ -44,3 +44,22 @@ def test_capital_limits_are_stated_next_to_each_field():
 
 def test_editor_state_carries_backtest_allocation():
     assert "backtest_allocation" in _EDITOR_JS
+
+
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+
+
+def test_run_backtest_modal_has_no_editable_capital_input():
+    """Capital is set in Configure now; the modal only reports it."""
+    modal = _slice(_APP_HTML, 'id="runBacktestModal"', 'id="runBacktestModalSubmit"')
+    assert 'id="backtestInitialCapital"' not in modal
+
+
+def test_run_backtest_modal_links_to_configure():
+    modal = _slice(_APP_HTML, 'id="runBacktestModal"', 'id="runBacktestModalSubmit"')
+    assert 'id="runBacktestEditCapitalBtn"' in modal
+    assert "Edit in Configure" in modal
+
+
+def test_backtest_capital_resolution_helper_exists():
+    assert "function resolveBacktestCapital(" in _APP_JS

--- a/dashboard/backend/tests/test_my_agents_card_ui.py
+++ b/dashboard/backend/tests/test_my_agents_card_ui.py
@@ -120,3 +120,31 @@ def test_run_paper_trading_is_absent_from_live_paper_cards():
     head, _, tail = actions.partition("if (statusKey === 'paper')")
     branch, _, rest = tail.partition("} else {")
     assert "Run Paper Trading" not in branch
+
+
+def test_run_backtest_lands_on_my_agents():
+    """The whole point: the user sees the agent they just started."""
+    run_backtest = _extract_function(_APP_JS, "runBacktest")
+    assert "playgroundTab: 'agents'" in run_backtest
+    assert "playgroundTab: 'backtest'" not in run_backtest
+
+
+def test_running_state_survives_a_refresh():
+    assert "sessionStorage" in _APP_JS
+    assert "function markAgentBacktestRunning(" in _APP_JS
+    assert "function clearAgentBacktestRunning(" in _APP_JS
+
+
+def test_running_card_shows_an_indicator_and_elapsed_time():
+    body = _extract_function(_APP_JS, "renderAgentRunningBody")
+    assert "Backtesting" in body
+    assert "agent-card-running-dot" in body
+    assert "agent-card-running-bar" in body
+    assert "formatBacktestElapsed" in body
+
+
+def test_running_animation_respects_reduced_motion():
+    """First continuously-animating element on the page."""
+    css = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+    start = css.index(".agent-card-running-dot")
+    assert "prefers-reduced-motion" in css[start:]

--- a/dashboard/backend/tests/test_my_agents_card_ui.py
+++ b/dashboard/backend/tests/test_my_agents_card_ui.py
@@ -86,6 +86,27 @@ def test_card_backtest_capital_falls_back_to_the_sleeve():
     assert out.count("$2,000") == 2
 
 
+def test_zero_paper_sleeve_displays_as_zero_but_backtest_capital_does_not():
+    """The two capitals deliberately diverge at $0 -- this is not a bug.
+
+    `cash_allocation` is `ge=0` server-side: a $0 paper sleeve is a real,
+    legal state and must be shown honestly, not padded to a default. But
+    `backtest_allocation` is `ge=1` server-side -- a backtest cannot run on
+    $0 -- so `resolveBacktestCapital` treats a non-positive value as absent
+    and falls through to the $1,000 default. Rendering these two the same
+    way would either lie about a user's real (zero) money or hand a $0 into
+    an API call that would 422.
+    """
+    out = _run_node(
+        _harness(
+            "console.log(renderAgentAllocatedCapitalHero("
+            "{cash_allocation: 0, backtest_allocation: null}));"
+        )
+    )
+    assert "$0" in out
+    assert "$1,000" in out
+
+
 def test_run_paper_trading_button_is_disabled_and_explained():
     actions = _extract_function(_APP_JS, "renderAgentCardActions")
     assert "Run Paper Trading" in actions

--- a/dashboard/backend/tests/test_my_agents_card_ui.py
+++ b/dashboard/backend/tests/test_my_agents_card_ui.py
@@ -1,0 +1,101 @@
+"""My Agents card: both capitals, and a signposted paper-trading affordance.
+
+The card showed only the paper sleeve directly above a **Run Backtest** button,
+which implied the figure was what the backtest would use -- it wasn't. Both
+figures are now labelled side by side.
+
+Run Paper Trading ships disabled: execution/paper_backend.py is still a stub
+(Phase B), and a greyed button with no explanation reads as a bug.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+
+def _extract_function(src: str, name: str) -> str:
+    for marker in (f"async function {name}(", f"function {name}("):
+        start = src.find(marker)
+        if start != -1:
+            break
+    else:
+        raise AssertionError(f"{name} not found in app.js")
+    depth = 0
+    i = src.index("{", start)
+    while True:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+
+
+def _run_node(script: str) -> str:
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _harness(body: str) -> str:
+    """Real functions lifted from app.js, with their few dependencies stubbed."""
+    return f"""
+const MAX_BACKTEST_ALLOCATED_CAPITAL = 10000;
+const DEFAULT_AGENT_CASH_ALLOCATION = 1000;
+function escapeHtml(s) {{ return String(s); }}
+function formatAgentCashAllocation(v) {{ return '$' + Number(v).toLocaleString(); }}
+{_extract_function(_APP_JS, "resolveBacktestCapital")}
+{_extract_function(_APP_JS, "renderAgentAllocatedCapitalHero")}
+{body}
+"""
+
+
+def test_card_shows_both_capitals():
+    out = _run_node(
+        _harness(
+            "console.log(renderAgentAllocatedCapitalHero("
+            "{cash_allocation: 1000, backtest_allocation: 5000}));"
+        )
+    )
+    assert "Paper Trading" in out
+    assert "Backtesting" in out
+    assert "$1,000" in out
+    assert "$5,000" in out
+
+
+def test_card_backtest_capital_falls_back_to_the_sleeve():
+    """An agent predating the column must not render a dash."""
+    out = _run_node(
+        _harness(
+            "console.log(renderAgentAllocatedCapitalHero("
+            "{cash_allocation: 2000, backtest_allocation: null}));"
+        )
+    )
+    assert out.count("$2,000") == 2
+
+
+def test_run_paper_trading_button_is_disabled_and_explained():
+    actions = _extract_function(_APP_JS, "renderAgentCardActions")
+    assert "Run Paper Trading" in actions
+    assert "disabled" in actions
+    assert "Paper trading is coming soon" in actions
+
+
+def test_run_paper_trading_is_absent_from_live_paper_cards():
+    """Paper cards show Open Agent; a second paper button would be nonsense."""
+    actions = _extract_function(_APP_JS, "renderAgentCardActions")
+    head, _, tail = actions.partition("if (statusKey === 'paper')")
+    branch, _, rest = tail.partition("} else {")
+    assert "Run Paper Trading" not in branch

--- a/dashboard/backend/tests/test_my_agents_instruction_ui.py
+++ b/dashboard/backend/tests/test_my_agents_instruction_ui.py
@@ -1,0 +1,47 @@
+"""An empty Trading Instruction is a supported state (2026-07-29).
+
+It used to be a silent no-op: ``getEditorState()`` set ``sendPipeline = false``
+on an empty box, so the stored pipeline was never touched and the user got a
+success toast for a save that changed nothing -- with no way to return an agent
+to the platform's default strategy.
+
+Empty now clears the pipeline, which makes the backend take the
+``create_prompt`` branch in portfolio_manager. Two things must hold:
+
+1. The UI says so, and shows what the default actually is.
+2. The starter *backfill* is gone. It re-injected the default text whenever a
+   pipeline-less agent was opened, which under the new semantics would silently
+   undo a deliberate empty save on the next visit.
+"""
+
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_HTML = (_FRONTEND / "app.html").read_text(encoding="utf-8")
+_EDITOR_JS = (_FRONTEND / "js" / "agent-editor.js").read_text(encoding="utf-8")
+
+
+def test_the_empty_state_is_explained_next_to_the_textarea():
+    assert (
+        "Leave this empty and the agent uses the platform's default trading strategy."
+        in _APP_HTML
+    )
+
+
+def test_the_default_instruction_is_inspectable():
+    assert "See the default instruction" in _APP_HTML
+    assert 'id="agentEditorDefaultInstructionText"' in _APP_HTML
+
+
+def test_saving_empty_reports_the_default_was_applied():
+    assert "Saved — using the default trading instruction." in _EDITOR_JS
+
+
+def test_the_starter_backfill_is_gone():
+    """The old backfill fought a deliberate empty save on reopen."""
+    assert "if (!subAgents.length && instructionEl" not in _EDITOR_JS
+
+
+def test_empty_instruction_sends_an_empty_pipeline():
+    """sendPipeline must be true on empty, or the clear never reaches the API."""
+    assert "sendPipeline = false" not in _EDITOR_JS

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -966,6 +966,11 @@
                         <h3 class="agent-editor-intro-title">Trading instruction</h3>
                         <p class="agent-editor-intro-text">Tell the agent how to trade in plain language. Each market hour it sees prices and its portfolio, follows your instruction, and decides what to buy or sell.</p>
                         <textarea id="agentEditorSimpleInstruction" rows="6" maxlength="8000" placeholder="e.g. Spread the money across a few of the strongest available stocks. Buy on meaningful dips and take profits after strong run-ups." aria-label="Trading instruction"></textarea>
+                        <p class="agent-editor-simple-note">Leave this empty and the agent uses the platform's default trading strategy.</p>
+                        <details class="agent-editor-default-details">
+                            <summary>See the default instruction</summary>
+                            <p id="agentEditorDefaultInstructionText" class="agent-editor-default-text"></p>
+                        </details>
                         <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note" hidden>This agent currently uses a custom multi-step pipeline. Saving this instruction replaces it.</p>
                     </div>
                     <p id="agentEditorSaveStatus" class="agent-editor-save-status" hidden></p>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -329,19 +329,12 @@
                 </div>
 
                 <div class="control-group">
-                    <label for="backtestInitialCapital">Backtest Allocated Capital</label>
-                    <p class="control-helper">Simulated starting cash for this run only (max $10,000). Defaults to this agent's Paper Trading Allocated Capital, and spends no real portfolio cash.</p>
-                    <input
-                        class="control-select"
-                        id="backtestInitialCapital"
-                        type="number"
-                        min="1"
-                        max="10000"
-                        step="1"
-                        value="1000"
-                        aria-label="Backtest allocated capital"
-                    >
-                    <p id="runBacktestCapitalHint" class="control-helper">Does not change Paper Trading Allocated Capital.</p>
+                    <label>Allocated Capital</label>
+                    <div class="run-backtest-capital-row">
+                        <p id="runBacktestCapitalValue" class="run-backtest-readonly">—</p>
+                        <button id="runBacktestEditCapitalBtn" class="run-backtest-edit-link" type="button">Edit in Configure</button>
+                    </div>
+                    <p id="runBacktestCapitalHint" class="control-helper">Simulated starting cash. Does not change Paper Trading Allocated Capital.</p>
                 </div>
 
                 <div class="control-group">

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -926,10 +926,6 @@
                     <select id="agentEditorModelSelect" class="agent-editor-model-select" aria-label="Agent model"></select>
                 </label>
                 <textarea id="agentEditorDescription" class="agent-editor-description" rows="2" maxlength="280" placeholder="Optional description for this agent…" aria-label="Agent description"></textarea>
-                <label class="agent-editor-cash-field" for="agentEditorCashAllocation">
-                    <span class="agent-editor-cash-label">Paper Trading Allocated Capital (max $3,000)</span>
-                    <input id="agentEditorCashAllocation" class="agent-editor-cash-input" type="number" min="0" max="3000" step="100" placeholder="1000" aria-label="Paper Trading Allocated Capital">
-                </label>
                 <div id="agentEditorBrokerPanel" class="agent-editor-broker section-card compact">
                     <div class="agent-editor-broker-head">
                         <h3 class="agent-editor-intro-title">Robinhood live trading</h3>
@@ -958,6 +954,21 @@
         <div class="agent-editor-body">
             <div class="agent-editor-layout">
                 <div class="agent-editor-main">
+                    <div class="agent-capital-card section-card compact">
+                        <h3 class="agent-capital-title">Allocated Capital</h3>
+                        <div class="agent-capital-grid">
+                            <label class="agent-capital-field" for="agentEditorCashAllocation">
+                                <span class="agent-capital-label">Paper Trading <span class="agent-capital-max">max $3,000</span></span>
+                                <input id="agentEditorCashAllocation" class="agent-capital-input" type="number" min="0" max="3000" step="100" placeholder="1000" aria-label="Paper Trading Allocated Capital">
+                                <span class="agent-capital-note">Reserved from My Portfolio. Real sleeve.</span>
+                            </label>
+                            <label class="agent-capital-field" for="agentEditorBacktestAllocation">
+                                <span class="agent-capital-label">Backtesting <span class="agent-capital-max">max $10,000</span></span>
+                                <input id="agentEditorBacktestAllocation" class="agent-capital-input" type="number" min="1" max="10000" step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
+                                <span class="agent-capital-note">Simulated only. Never spends real cash.</span>
+                            </label>
+                        </div>
+                    </div>
                     <div id="agentEditorSimplePanel" class="agent-editor-simple section-card compact">
                         <h3 class="agent-editor-intro-title">Trading instruction</h3>
                         <p class="agent-editor-intro-text">Tell the agent how to trade in plain language. Each market hour it sees prices and its portfolio, follows your instruction, and decides what to buy or sell.</p>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -772,6 +772,28 @@ function renderAgentAllocatedCapitalHero(agent) {
     </div>`;
 }
 
+/**
+ * Card body for an agent with a backtest in flight.
+ *
+ * The bar is deliberately indeterminate rather than a percentage: the launch
+ * path has no honest completion estimate, and a fake percentage that stalls is
+ * worse than an animation that only claims "still working".
+ */
+function renderAgentRunningBody(agent, running) {
+  return `
+    <div class="agent-card-running">
+      <div class="agent-card-running-head">
+        <span class="agent-card-running-dot" aria-hidden="true"></span>
+        <span class="agent-card-running-label">Backtesting…</span>
+        <span class="agent-card-running-elapsed">${escapeHtml(formatBacktestElapsed(running.elapsedSeconds))}</span>
+      </div>
+      <div class="agent-card-running-track" role="progressbar" aria-label="Backtest in progress">
+        <div class="agent-card-running-bar"></div>
+      </div>
+    </div>
+    ${renderAgentAllocatedCapitalHero(agent)}`;
+}
+
 function renderAgentCardBody(agent, statusKey) {
   if (statusKey === 'paper') {
     const m = resolvePaperCardMetrics(agent);
@@ -896,6 +918,15 @@ function renderAgentCardActions(agent, statusKey) {
           <button class="agent-menu-item agent-menu-item--danger agent-delete-btn" type="button" data-agent-id="${id}">Delete</button>
         </div>
       </div>
+    </div>`;
+}
+
+function renderAgentRunningActions(agent) {
+  const id = escapeHtml(agent.agent_id);
+  return `
+    <div class="agent-card-actions agent-card-actions--status">
+      <button class="agent-card-cta agent-card-cta--configure agent-card-cta--disabled" type="button" disabled aria-disabled="true" data-agent-id="${id}">Configure</button>
+      <button class="agent-card-cta agent-card-cta--disabled" type="button" disabled aria-disabled="true">Running…</button>
     </div>`;
 }
 
@@ -1093,6 +1124,8 @@ function renderAgentCards(grid, agents, categoryKey) {
     card.className = `section-card agent-card agent-card--status agent-card--${statusBadge.key}${isBuiltin ? ' agent-card-builtin' : ''}`;
     const model = escapeHtml(formatAgentModelLabel(agent.model_name));
     const type = escapeHtml(agentTypeLabel(agent));
+    const running = getAgentBacktestRunning(agent.agent_id);
+    if (running) card.classList.add('agent-card--running');
 
     card.innerHTML = `
       <div class="agent-card-top">
@@ -1105,8 +1138,8 @@ function renderAgentCards(grid, agents, categoryKey) {
         </div>
         <span class="status-badge ${statusBadge.className}"><span class="status-badge-dot" aria-hidden="true"></span>${statusBadge.label}</span>
       </div>
-      ${renderAgentCardBody(agent, statusBadge.key)}
-      ${renderAgentCardActions(agent, statusBadge.key)}
+      ${running ? renderAgentRunningBody(agent, running) : renderAgentCardBody(agent, statusBadge.key)}
+      ${running ? renderAgentRunningActions(agent) : renderAgentCardActions(agent, statusBadge.key)}
     `;
     grid.appendChild(card);
   });
@@ -3253,6 +3286,61 @@ let liveBacktestLaunchPending = false;
 let liveBacktestLaunchError = false;
 /** Active status-poll timer id (so dropdown can re-attach to a running job). */
 let backtestPollTimer = null;
+
+// Which agents have a backtest in flight, so My Agents can show it. Mirrored to
+// sessionStorage: a refresh mid-run must not silently drop the indicator and
+// make a running backtest look like it never started.
+const RUNNING_BACKTESTS_KEY = 'running-backtests';
+
+function readRunningBacktests() {
+    try {
+        const raw = sessionStorage.getItem(RUNNING_BACKTESTS_KEY);
+        const parsed = raw ? JSON.parse(raw) : {};
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (error) {
+        return {};
+    }
+}
+
+function writeRunningBacktests(map) {
+    try {
+        sessionStorage.setItem(RUNNING_BACKTESTS_KEY, JSON.stringify(map));
+    } catch (error) {
+        /* sessionStorage unavailable — the in-page indicator still works */
+    }
+}
+
+function markAgentBacktestRunning(agentId, runId) {
+    if (!agentId) return;
+    const map = readRunningBacktests();
+    map[agentId] = { runId: runId || null, startedAt: Date.now() };
+    writeRunningBacktests(map);
+}
+
+function clearAgentBacktestRunning(agentId) {
+    if (!agentId) return;
+    const map = readRunningBacktests();
+    if (!(agentId in map)) return;
+    delete map[agentId];
+    writeRunningBacktests(map);
+}
+
+/**
+ * Running entry for an agent, or null.
+ *
+ * Entries older than the poll ceiling are discarded: a run that died without a
+ * terminal status would otherwise pin a card to "Backtesting…" forever.
+ */
+function getAgentBacktestRunning(agentId) {
+    const entry = readRunningBacktests()[agentId];
+    if (!entry) return null;
+    const elapsed = (Date.now() - Number(entry.startedAt || 0)) / 1000;
+    if (!Number.isFinite(elapsed) || elapsed > BACKTEST_POLL_MAX_SECONDS) {
+        clearAgentBacktestRunning(agentId);
+        return null;
+    }
+    return { ...entry, elapsedSeconds: Math.floor(elapsed) };
+}
 let liveBacktestChartMeta = { timestamps: [] };
 let tradingLogCache = [];
 let tradingLogFilter = 'all';
@@ -4688,6 +4776,10 @@ function attachToLiveBacktest(runId, progress = null, launchConfig = null) {
 }
 
 function showBacktestLaunchFailure(message, launchConfig) {
+    if (launchConfig?.agentId) {
+        clearAgentBacktestRunning(launchConfig.agentId);
+        renderAgentCategories(allAgents);
+    }
     liveBacktestChartActive = false;
     liveBacktestRunId = null;
     liveBacktestLaunchPending = false;
@@ -4729,6 +4821,11 @@ function ensureBacktestPolling() {
 
             if (status.running) {
                 if (liveId) liveBacktestRunId = liveId;
+                // Repaint the My Agents card even when the user is not on the
+                // Backtest tab — that page is now the landing page after launch.
+                if (playgroundTab === 'agents' && currentPage === 'playground') {
+                    renderAgentCategories(allAgents);
+                }
                 const step = Number(status.progress?.step);
                 const total = Number(status.progress?.total_steps);
                 const stepPct = Number.isFinite(step) && Number.isFinite(total) && total > 0
@@ -4757,6 +4854,10 @@ function ensureBacktestPolling() {
                 liveBacktestChartActive = false;
                 const finishedId = liveBacktestRunId;
                 liveBacktestRunId = null;
+                Object.keys(readRunningBacktests()).forEach(clearAgentBacktestRunning);
+                if (playgroundTab === 'agents' && currentPage === 'playground') {
+                    loadAgents();
+                }
 
                 if (status.error) {
                     if (viewingLive) {
@@ -5311,8 +5412,10 @@ async function runBacktest() {
     // otherwise the async history load paints the previous run over the chart.
     closeRunBacktestModal();
     prepareLiveBacktestView(launchConfigBase);
-    navigateToPage('playground', { playgroundTab: 'backtest' });
+    markAgentBacktestRunning(activeAgent.agent_id, null);
+    navigateToPage('playground', { playgroundTab: 'agents' });
     currentMode = 'backtest';
+    renderAgentCategories(allAgents);
     updateBacktestRunProgress({
         elapsedSeconds: 0,
         message: pipeline?.length
@@ -5366,6 +5469,7 @@ async function runBacktest() {
         const liveRunId = data.live_run_id || data.run_id;
         if (liveRunId) {
             stashBacktestLaunchConfig(liveRunId, launchConfigBase);
+            markAgentBacktestRunning(activeAgent.agent_id, liveRunId);
             attachToLiveBacktest(liveRunId, null, launchConfigBase);
         }
         

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -3358,7 +3358,7 @@ function refreshRunningAgentCards() {
     const key = Object.keys(running).sort().join(',');
     if (key !== lastRenderedRunningKey) {
         lastRenderedRunningKey = key;
-        renderAgentCategories(allAgents);
+        applyAgentFilters(false);
         return;
     }
     Object.keys(running).forEach((agentId) => {
@@ -4809,7 +4809,7 @@ function attachToLiveBacktest(runId, progress = null, launchConfig = null) {
 function showBacktestLaunchFailure(message, launchConfig) {
     if (launchConfig?.agentId) {
         clearAgentBacktestRunning(launchConfig.agentId);
-        renderAgentCategories(allAgents);
+        applyAgentFilters(false);
     }
     liveBacktestChartActive = false;
     liveBacktestRunId = null;
@@ -4820,6 +4820,14 @@ function showBacktestLaunchFailure(message, launchConfig) {
     clearTradingLog('Backtest did not start.');
     showBacktestRunProgress(true, { isError: true });
     updateBacktestRunProgress({ elapsedSeconds: 0, message });
+    // The panel painted above lives under the Backtest tab, which is hidden
+    // when the user is standing on My Agents -- the landing page after a
+    // launch. Surface the failure where they actually are, using this
+    // file's existing alert() convention for launch-time refusals (see
+    // openRunBacktestModal / runBacktest) rather than inventing a new one.
+    if (playgroundTab === 'agents' && currentPage === 'playground') {
+        alert(message);
+    }
 }
 
 function stopBacktestPolling() {
@@ -5453,7 +5461,7 @@ async function runBacktest() {
     try {
         navigateToPage('playground', { playgroundTab: 'agents' });
         currentMode = 'backtest';
-        renderAgentCategories(allAgents);
+        applyAgentFilters(false);
         updateBacktestRunProgress({
             elapsedSeconds: 0,
             message: pipeline?.length
@@ -5908,6 +5916,12 @@ function showPlaygroundPanel(tab) {
             window.repaintPortfolioFromCache(allAgents.map(decorateAgent));
         }
         loadAgents();
+        // A refresh mid-run restores the sessionStorage running marks but
+        // drops the poller that would ever clear them -- reattach it here so
+        // the card doesn't strand at "Backtesting…" for up to
+        // BACKTEST_POLL_MAX_SECONDS. ensureBacktestPolling() is a no-op if a
+        // poller is already attached.
+        if (Object.keys(readRunningBacktests()).length) ensureBacktestPolling();
     }
 
     persistNavigation();

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -785,7 +785,7 @@ function renderAgentRunningBody(agent, running) {
       <div class="agent-card-running-head">
         <span class="agent-card-running-dot" aria-hidden="true"></span>
         <span class="agent-card-running-label">Backtesting…</span>
-        <span class="agent-card-running-elapsed">${escapeHtml(formatBacktestElapsed(running.elapsedSeconds))}</span>
+        <span class="agent-card-running-elapsed" data-running-elapsed="${escapeHtml(agent.agent_id)}">${escapeHtml(formatBacktestElapsed(running.elapsedSeconds))}</span>
       </div>
       <div class="agent-card-running-track" role="progressbar" aria-label="Backtest in progress">
         <div class="agent-card-running-bar"></div>
@@ -3341,6 +3341,37 @@ function getAgentBacktestRunning(agentId) {
     }
     return { ...entry, elapsedSeconds: Math.floor(elapsed) };
 }
+
+let lastRenderedRunningKey = null;
+
+/**
+ * Per-second refresh for running cards.
+ *
+ * Patches the elapsed timer in place rather than re-rendering the grid:
+ * renderAgentCards() starts with `grid.innerHTML = ''`, so doing that once a
+ * second would destroy focus, scroll position and any open card menu for the
+ * whole duration of a run. A full re-render happens only when the set of
+ * running agents changes.
+ */
+function refreshRunningAgentCards() {
+    const running = readRunningBacktests();
+    const key = Object.keys(running).sort().join(',');
+    if (key !== lastRenderedRunningKey) {
+        lastRenderedRunningKey = key;
+        renderAgentCategories(allAgents);
+        return;
+    }
+    Object.keys(running).forEach((agentId) => {
+        const entry = getAgentBacktestRunning(agentId);
+        if (!entry) return;
+        const escaped = (typeof CSS !== 'undefined' && CSS.escape) ? CSS.escape(agentId) : agentId.replace(/"/g, '\\"');
+        document
+            .querySelectorAll(`[data-running-elapsed="${escaped}"]`)
+            .forEach((el) => {
+                el.textContent = formatBacktestElapsed(entry.elapsedSeconds);
+            });
+    });
+}
 let liveBacktestChartMeta = { timestamps: [] };
 let tradingLogCache = [];
 let tradingLogFilter = 'all';
@@ -4823,8 +4854,10 @@ function ensureBacktestPolling() {
                 if (liveId) liveBacktestRunId = liveId;
                 // Repaint the My Agents card even when the user is not on the
                 // Backtest tab — that page is now the landing page after launch.
+                // refreshRunningAgentCards() patches the elapsed timer in place
+                // instead of tearing down the whole grid every second.
                 if (playgroundTab === 'agents' && currentPage === 'playground') {
-                    renderAgentCategories(allAgents);
+                    refreshRunningAgentCards();
                 }
                 const step = Number(status.progress?.step);
                 const total = Number(status.progress?.total_steps);
@@ -5413,16 +5446,25 @@ async function runBacktest() {
     closeRunBacktestModal();
     prepareLiveBacktestView(launchConfigBase);
     markAgentBacktestRunning(activeAgent.agent_id, null);
-    navigateToPage('playground', { playgroundTab: 'agents' });
-    currentMode = 'backtest';
-    renderAgentCategories(allAgents);
-    updateBacktestRunProgress({
-        elapsedSeconds: 0,
-        message: pipeline?.length
-            ? `Running ${pipeline.length}-step agent pipeline…`
-            : 'Starting backtest…',
-    });
-    
+    // A synchronous throw anywhere in here would otherwise leave the agent
+    // marked running with no poller ever attached to clear it — narrow
+    // try/catch (not the outer one below, which governs the API call) so we
+    // can clear the mark and rethrow rather than swallow the failure.
+    try {
+        navigateToPage('playground', { playgroundTab: 'agents' });
+        currentMode = 'backtest';
+        renderAgentCategories(allAgents);
+        updateBacktestRunProgress({
+            elapsedSeconds: 0,
+            message: pipeline?.length
+                ? `Running ${pipeline.length}-step agent pipeline…`
+                : 'Starting backtest…',
+        });
+    } catch (error) {
+        clearAgentBacktestRunning(activeAgent.agent_id);
+        throw error;
+    }
+
     try {
         // Call API with session ID, assets, and model
         const params = new URLSearchParams({

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -3361,15 +3361,17 @@ function refreshRunningAgentCards() {
         applyAgentFilters(false);
         return;
     }
+    // Query by attribute presence and compare values in JS rather than
+    // interpolating an agent id into a selector string: no escaping, no
+    // CSS.escape feature detection, and nothing to get wrong later.
+    const elapsedNodes = document.querySelectorAll('[data-running-elapsed]');
     Object.keys(running).forEach((agentId) => {
         const entry = getAgentBacktestRunning(agentId);
         if (!entry) return;
-        const escaped = (typeof CSS !== 'undefined' && CSS.escape) ? CSS.escape(agentId) : agentId.replace(/"/g, '\\"');
-        document
-            .querySelectorAll(`[data-running-elapsed="${escaped}"]`)
-            .forEach((el) => {
-                el.textContent = formatBacktestElapsed(entry.elapsedSeconds);
-            });
+        elapsedNodes.forEach((el) => {
+            if (el.getAttribute('data-running-elapsed') !== agentId) return;
+            el.textContent = formatBacktestElapsed(entry.elapsedSeconds);
+        });
     });
 }
 let liveBacktestChartMeta = { timestamps: [] };

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -246,7 +246,6 @@ const CASH_STEP_INPUT_IDS = [
   'externalAgentCashAllocation',
   'builtinAgentCashAllocation',
   'agentEditorCashAllocation',
-  'backtestInitialCapital',
 ];
 
 function cashStepMeta(input) {
@@ -729,6 +728,24 @@ function formatSignedReturnPct(frac) {
   if (pct > 0) return `+${body}`;
   if (pct < 0) return `−${body}`;
   return body;
+}
+
+/**
+ * Saved simulated capital for an agent's backtests.
+ *
+ * Mirrors the backend fallback chain exactly: an agent created before
+ * `backtest_allocation` existed has a NULL column and must keep behaving as it
+ * did, i.e. starting from its paper sleeve.
+ */
+function resolveBacktestCapital(agent) {
+  const candidates = [agent?.backtest_allocation, agent?.cash_allocation];
+  for (const raw of candidates) {
+    const value = Number(raw);
+    if (Number.isFinite(value) && value > 0) {
+      return Math.min(Math.round(value), MAX_BACKTEST_ALLOCATED_CAPITAL);
+    }
+  }
+  return DEFAULT_AGENT_CASH_ALLOCATION;
 }
 
 /** Shared top block: portfolio sleeve always leads (draft + backtested cards). */
@@ -3340,6 +3357,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('runBacktestModalSubmit')?.addEventListener('click', () => {
         runBacktest();
     });
+    document.getElementById('runBacktestEditCapitalBtn')?.addEventListener('click', () => {
+        const agent = runBacktestModalAgent;
+        closeRunBacktestModal();
+        if (agent && window.AgentEditor?.open) window.AgentEditor.open(agent);
+    });
     document.addEventListener('keydown', (event) => {
         if (event.key !== 'Escape') return;
         const modal = document.getElementById('runBacktestModal');
@@ -5120,15 +5142,9 @@ function openRunBacktestModal(agent) {
             : 'Does not change Paper Trading Allocated Capital.';
     }
 
-    // Reseed on every open. The field is per-run, so leaving the previous
-    // agent's number in place silently backtests this one at the wrong size.
-    const capitalInput = document.getElementById('backtestInitialCapital');
-    if (capitalInput) {
-        capitalInput.value = String(
-            Number.isFinite(sleeve) && sleeve > 0
-                ? Math.min(Math.round(sleeve), MAX_BACKTEST_ALLOCATED_CAPITAL)
-                : DEFAULT_AGENT_CASH_ALLOCATION,
-        );
+    const capitalValue = document.getElementById('runBacktestCapitalValue');
+    if (capitalValue) {
+        capitalValue.textContent = `$${resolveBacktestCapital(agent).toLocaleString()}`;
     }
 
     syncModelSelectFromAgent(agent);
@@ -5224,21 +5240,7 @@ async function runBacktest() {
         ? null
         : resolveBacktestModelRequest(modelSelect, activeAgent);
 
-    const capitalInput = document.getElementById('backtestInitialCapital');
-    let initialCapital = DEFAULT_AGENT_CASH_ALLOCATION;
-    if (capitalInput && capitalInput.value !== '') {
-        const parsed = Number(capitalInput.value);
-        if (!Number.isFinite(parsed) || parsed <= 0) {
-            alert('Backtest Allocated Capital must be greater than 0.');
-            return;
-        }
-        if (parsed > MAX_BACKTEST_ALLOCATED_CAPITAL) {
-            alert(`Backtest Allocated Capital cannot exceed $${MAX_BACKTEST_ALLOCATED_CAPITAL.toLocaleString()}.`);
-            return;
-        }
-        initialCapital = Math.round(parsed);
-        capitalInput.value = String(initialCapital);
-    }
+    const initialCapital = resolveBacktestCapital(activeAgent);
 
     const promptSummary = formatPromptFromPipeline(pipeline);
     const universeLabel = isIFind

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -750,18 +750,24 @@ function resolveBacktestCapital(agent) {
   return DEFAULT_AGENT_CASH_ALLOCATION;
 }
 
-/** Shared top block: portfolio sleeve always leads (draft + backtested cards). */
+/** Shared top block: both capital figures, equal weight (draft + backtested). */
 function renderAgentAllocatedCapitalHero(agent) {
-  const capital =
+  const paper =
     agent.cash_allocation != null
       ? formatAgentCashAllocation(agent.cash_allocation)
       : '$1,000';
+  const backtest = formatAgentCashAllocation(resolveBacktestCapital(agent));
   return `
-    <div class="agent-card-hero agent-card-hero--draft">
-      <div class="agent-card-hero-text">
-        <span class="agent-card-metric-label">Paper Trading Allocated Capital</span>
-        <p class="agent-card-metric-value">${escapeHtml(capital)}</p>
+    <div class="agent-card-capitals">
+      <div class="agent-card-capital">
+        <span class="agent-card-metric-label">Paper Trading</span>
+        <p class="agent-card-metric-value">${escapeHtml(paper)}</p>
         <p class="agent-card-capital-note">From My Portfolio</p>
+      </div>
+      <div class="agent-card-capital">
+        <span class="agent-card-metric-label">Backtesting</span>
+        <p class="agent-card-metric-value">${escapeHtml(backtest)}</p>
+        <p class="agent-card-capital-note">Simulated</p>
       </div>
     </div>`;
 }
@@ -842,7 +848,6 @@ function renderAgentCardBody(agent, statusKey) {
           ${renderAgentSparkline(agent, m.positive, m)}
         </div>
         <p class="agent-card-latest-meta">${escapeHtml(metaParts.join(' · '))}</p>
-        <p class="agent-card-latest-note">Simulated — separate from Paper Trading Allocated Capital.</p>
         ${renderAgentRunsLink(agent)}
       </div>`;
   }
@@ -864,7 +869,13 @@ function renderAgentCardActions(agent, statusKey) {
   if (statusKey === 'paper') {
     primary = `<button class="agent-card-cta agent-open-btn" type="button" data-agent-id="${id}">Open Agent</button>`;
   } else {
-    primary = `<button class="agent-card-cta agent-run-backtest-btn" type="button" data-agent-id="${id}">Run Backtest</button>`;
+    // Paper trading is Phase B (execution/paper_backend.py is a stub). Ship the
+    // affordance disabled *with a reason* -- an unexplained grey button reads as
+    // a bug, and its absence hides that the two capital figures above map onto
+    // two different things you can eventually run.
+    primary = `
+      <button class="agent-card-cta agent-run-backtest-btn" type="button" data-agent-id="${id}">Run Backtest</button>
+      <button class="agent-card-cta agent-card-cta--disabled" type="button" disabled aria-disabled="true" title="Paper trading is coming soon" aria-label="Run Paper Trading — Paper trading is coming soon">Run Paper Trading</button>`;
   }
   const configure = `<button class="agent-card-cta agent-card-cta--configure agent-configure-btn" type="button" data-agent-id="${id}">Configure</button>`;
   const rotate =

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -179,8 +179,9 @@ const SIMPLE_INSTRUCTION_OUTPUT_FORMAT =
 window.SIMPLE_INSTRUCTION_PRESET_KEY = SIMPLE_INSTRUCTION_PRESET_KEY;
 window.SIMPLE_INSTRUCTION_OUTPUT_FORMAT = SIMPLE_INSTRUCTION_OUTPUT_FORMAT;
 // Mirrors DEFAULT_STARTER_INSTRUCTION in dashboard/backend/domain/agents/defaults.py,
-// which is what actually seeds new agents. The copy here is the editor's backfill
-// for agents created before server-side seeding existed (their pipeline is empty).
+// which is what actually seeds new agents. The copy here populates the
+// "See the default instruction" disclosure in Configure's empty-instruction
+// state, so the editor can show what an agent falls back to without a pipeline.
 // tests/test_agent_starter_defaults.py pins the two copies together.
 const DEFAULT_STARTER_INSTRUCTION =
   'Spread the money across a few of the strongest available stocks. Buy on meaningful dips, take profits after strong run-ups, and never put everything into one stock.';

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -246,6 +246,7 @@ const CASH_STEP_INPUT_IDS = [
   'externalAgentCashAllocation',
   'builtinAgentCashAllocation',
   'agentEditorCashAllocation',
+  'agentEditorBacktestAllocation',
 ];
 
 function cashStepMeta(input) {

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -431,6 +431,26 @@
     } else {
       cash_allocation = 1000;
     }
+    const backtestInput = document.getElementById('agentEditorBacktestAllocation');
+    let backtest_allocation = null;
+    if (backtestInput && backtestInput.value !== '') {
+      const value = Number(backtestInput.value);
+      if (!Number.isFinite(value) || value < 1) {
+        throw new Error('Backtest Allocated Capital must be at least $1.');
+      }
+      if (value > 10000) {
+        throw new Error('Backtest Allocated Capital cannot exceed $10,000.');
+      }
+      backtest_allocation = Math.round(value);
+    } else {
+      // Non-positive counts as absent: cash_allocation is legally 0 (a $0 paper
+      // sleeve), but backtest capital is >= 1 server-side, so 0 must fall
+      // through to the default rather than becoming an unsaveable value.
+      backtest_allocation =
+        Number.isFinite(Number(cash_allocation)) && Number(cash_allocation) > 0
+          ? Math.min(Math.round(Number(cash_allocation)), 10000)
+          : 1000;
+    }
     const modelSelect = document.getElementById('agentEditorModelSelect');
     const instruction = (
       document.getElementById('agentEditorSimpleInstruction')?.value || ''
@@ -465,6 +485,7 @@
       name: nameInput ? nameInput.value.trim() : '',
       description: descInput ? descInput.value.trim() : '',
       cash_allocation,
+      backtest_allocation,
       model_name: modelSelect ? modelSelect.value : '',
       live_trading_enabled: Boolean(liveToggle?.checked),
       subAgents: subAgentsOut,
@@ -521,6 +542,19 @@
     if (cashInput) {
       cashInput.value = agent.cash_allocation != null ? String(agent.cash_allocation) : '';
     }
+    const backtestInput = document.getElementById('agentEditorBacktestAllocation');
+    if (backtestInput) {
+      // Non-positive counts as absent: cash_allocation is legally 0 (a $0 paper
+      // sleeve), but backtest capital is >= 1 server-side, so 0 must fall
+      // through to the default rather than becoming an unsaveable value.
+      const candidates = [agent.backtest_allocation, agent.cash_allocation];
+      let resolved = 1000;
+      for (const raw of candidates) {
+        const value = Number(raw);
+        if (Number.isFinite(value) && value > 0) { resolved = value; break; }
+      }
+      backtestInput.value = String(Math.min(Math.round(resolved), 10000));
+    }
     if (meta) {
       meta.textContent = agent.agent_type === 'builtin' ? 'Built-in agent' : 'External agent';
     }
@@ -564,11 +598,12 @@
     }));
   }
 
-  async function patchAgent(agent, name, description, pipeline, cash_allocation, model_name, live_trading_enabled) {
+  async function patchAgent(agent, name, description, pipeline, cash_allocation, backtest_allocation, model_name, live_trading_enabled) {
     const payload = {
       name,
       description: description || null,
       cash_allocation,
+      backtest_allocation,
       live_trading_enabled: Boolean(live_trading_enabled),
     };
     if (pipeline) payload.pipeline = serializePipeline(pipeline);
@@ -846,6 +881,7 @@
         state.description,
         state.sendPipeline ? subAgents : null,
         state.cash_allocation,
+        state.backtest_allocation,
         state.model_name,
         state.live_trading_enabled
       );

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -95,8 +95,8 @@
   }
 
   // The pipeline the agent ACTUALLY has (backend row, then local cache). Returns
-  // [] when it has none, which is what triggers the starter-instruction backfill
-  // in open() for agents created before server-side seeding existed.
+  // [] when it has none -- an empty pipeline is a supported state (the platform
+  // default), not something open() backfills any more.
   function loadStoredPipeline(agent) {
     if (Array.isArray(agent.pipeline) && agent.pipeline.length) {
       return agent.pipeline.map(normalizeLoadedSubAgent);
@@ -473,12 +473,13 @@
       ];
       sendPipeline = true;
     } else {
-      // Empty instruction never touches the stored pipeline: not sent to the
-      // server, not cached locally, not folded into currentAgent. This is what
-      // stops a rename-only save from destroying a multi-step pipeline this
-      // screen cannot display.
-      subAgentsOut = subAgents;
-      sendPipeline = false;
+      // Empty means "use the platform default": clear the pipeline so the
+      // backend takes its create_prompt branch. The multi-step pipeline this
+      // screen cannot author is protected by a confirm in save(), not by
+      // silently refusing to send -- which used to make an empty save a no-op
+      // that still reported success.
+      subAgentsOut = [];
+      sendPipeline = true;
     }
     const liveToggle = document.getElementById('agentEditorLiveTradingEnabled');
     return {
@@ -763,6 +764,8 @@
     populateModelSelect(agent);
 
     const instructionEl = document.getElementById('agentEditorSimpleInstruction');
+    const defaultText = document.getElementById('agentEditorDefaultInstructionText');
+    if (defaultText) defaultText.textContent = defaultStarterInstruction();
     const simpleStep =
       subAgents.length === 1 && subAgents[0].presetKey === simplePresetKey()
         ? subAgents[0]
@@ -781,17 +784,8 @@
     const playgroundView = document.getElementById('playgroundView');
     if (playgroundView) playgroundView.setAttribute('aria-hidden', 'true');
 
-    // Baseline the STORED state first, then backfill — capturing the snapshot
-    // after the injection would re-baseline it and the default would never be
-    // recognised as an unsaved change.
+    // Baseline the stored state so the dirty badge only fires on real edits.
     captureSavedSnapshot();
-    if (!subAgents.length && instructionEl && defaultStarterInstruction()) {
-      // Agent predates server-side seeding (its pipeline is empty). Offer the
-      // starter instruction so Configure is never a blank box, and mark it dirty
-      // so a Save persists it.
-      instructionEl.value = defaultStarterInstruction();
-      markDirtyFromInput();
-    }
 
     document.getElementById('agentEditorNameInput')?.focus();
   }
@@ -827,6 +821,15 @@
       showSaveStatus('Agent name is required', true);
       document.getElementById('agentEditorNameInput')?.focus();
       return;
+    }
+
+    const clearingToDefault = state.sendPipeline && state.subAgents.length === 0;
+    if (clearingToDefault && !isSimplePipeline(subAgents) && subAgents.length) {
+      const ok = window.confirm(
+        'This agent uses a custom multi-step pipeline. Saving an empty '
+        + 'instruction replaces it with the platform default. Continue?',
+      );
+      if (!ok) return;
     }
 
     subAgents = state.subAgents;
@@ -897,7 +900,11 @@
 
       fillHeader(currentAgent);
       captureSavedSnapshot();
-      showSaveStatus('Saved successfully');
+      showSaveStatus(
+        clearingToDefault
+          ? 'Saved — using the default trading instruction.'
+          : 'Saved successfully',
+      );
       window.dispatchEvent(
         new CustomEvent('agent-editor-saved', { detail: { agent: currentAgent } })
       );

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -7,8 +7,10 @@
  * still EXECUTE server-side (infrastructure/llm/pipeline_runner.py) and the
  * marketplace still ships a 3-step template, so an agent may legitimately hold a
  * pipeline this screen cannot author. Such a pipeline is carried opaquely in
- * `subAgents` and re-sent untouched unless the user types an instruction — see
- * `sendPipeline` in getEditorState().
+ * `subAgents` and re-sent when the user has an instruction; an EMPTY
+ * instruction deliberately clears it instead, so the backend falls back to
+ * its platform default -- save() guards that with a confirm when the
+ * existing pipeline is multi-step. See `sendPipeline` in getEditorState().
  */
 (function () {
   'use strict';

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8106,7 +8106,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 }
 
 .agent-card-cta--disabled:hover {
-    background: inherit;
+    filter: none;
 }
 
 .agent-card-menu {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -8430,37 +8430,63 @@ body.agent-editor-open {
     border-color: rgba(34, 211, 238, 0.4);
 }
 
-.agent-editor-cash-field {
+.agent-capital-card {
+    margin-bottom: 12px;
+}
+
+.agent-capital-title {
+    margin: 0 0 12px;
+    font-size: 17px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.agent-capital-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.agent-capital-field {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    margin-top: 10px;
-    max-width: 220px;
+    min-width: 0;
 }
 
-.agent-editor-cash-label {
-    font-size: 12.5px;
+.agent-capital-label {
+    font-size: 15px;
     font-weight: 600;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    color: var(--text-primary);
 }
 
-.agent-editor-cash-input {
+.agent-capital-max {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-left: 6px;
+}
+
+.agent-capital-input {
     width: 100%;
     box-sizing: border-box;
-    padding: 8px 12px;
+    padding: 9px 12px;
     border: 1px solid var(--border-color);
     border-radius: 6px;
     background: var(--bg-input);
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: 15px;
     font-family: var(--font-mono);
 }
 
-.agent-editor-cash-input:focus {
+.agent-capital-input:focus {
     outline: none;
     border-color: rgba(34, 211, 238, 0.4);
+}
+
+.agent-capital-note {
+    font-size: 13px;
+    color: var(--text-secondary);
 }
 
 .agent-editor-broker {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -7826,12 +7826,6 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     color: var(--text-secondary);
 }
 
-.agent-card-latest-note {
-    margin: 0;
-    font-size: 12.5px;
-    color: var(--text-muted);
-}
-
 .agent-card-latest .agent-card-runs-link {
     padding-top: 4px;
     padding-bottom: 0;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -7774,6 +7774,20 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     color: var(--text-muted);
 }
 
+.agent-card-capitals {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.agent-card-capital {
+    min-width: 0;
+}
+
+.agent-card-capital .agent-card-metric-value {
+    font-size: 22px;
+}
+
 .agent-card-latest {
     display: flex;
     flex-direction: column;
@@ -8022,6 +8036,15 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 .agent-card-cta--outline:hover {
     filter: none;
     background: rgba(34, 211, 238, 0.1);
+}
+
+.agent-card-cta--disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.agent-card-cta--disabled:hover {
+    background: inherit;
 }
 
 .agent-card-menu {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -7996,6 +7996,74 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     max-width: 240px;
 }
 
+.agent-card-running {
+    margin-bottom: 14px;
+}
+
+.agent-card-running-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.agent-card-running-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent-cyan, #22d3ee);
+    animation: agent-card-running-pulse 1.4s ease-in-out infinite;
+}
+
+.agent-card-running-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.agent-card-running-elapsed {
+    margin-left: auto;
+    font-size: 13px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+}
+
+.agent-card-running-track {
+    height: 4px;
+    border-radius: 999px;
+    background: var(--border-color);
+    overflow: hidden;
+}
+
+.agent-card-running-bar {
+    width: 40%;
+    height: 100%;
+    border-radius: 999px;
+    background: var(--accent-cyan, #22d3ee);
+    animation: agent-card-running-slide 1.6s ease-in-out infinite;
+}
+
+@keyframes agent-card-running-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.25; }
+}
+
+@keyframes agent-card-running-slide {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(250%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-card-running-dot,
+    .agent-card-running-bar {
+        animation: none;
+    }
+    .agent-card-running-bar {
+        width: 100%;
+        opacity: 0.5;
+    }
+}
+
 .agent-card-actions--status {
     display: flex;
     align-items: center;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -4455,6 +4455,27 @@ a.header-brand:hover .title-section h1 {
     color: var(--text-primary);
 }
 
+.run-backtest-capital-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.run-backtest-edit-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--accent-cyan, #22d3ee);
+    cursor: pointer;
+}
+
+.run-backtest-edit-link:hover {
+    text-decoration: underline;
+}
+
 .run-backtest-prompt-preview {
     margin: 0;
     max-height: 120px;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9183,3 +9183,22 @@ body.agent-editor-open {
     font-size: 13px;
     color: #fbbf24;
 }
+
+.agent-editor-default-details {
+    margin-top: 8px;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.agent-editor-default-details summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.agent-editor-default-text {
+    margin: 8px 0 0;
+    padding: 10px 12px;
+    border-left: 2px solid var(--border-color);
+    color: var(--text-secondary);
+}


### PR DESCRIPTION
Frontend slice. Backend shipped in #254.

## Summary
- **One Allocated Capital card** in Configure holds both Paper Trading (max $3,000) and Backtesting (max $10,000). The Run Backtest modal shows the saved figure read-only with **Edit in Configure**.
- **An empty Trading Instruction now falls back to the platform default** instead of being a silent no-op that reported success. Destructive clears of a multi-step pipeline are confirmed first; the starter backfill is gone.
- **Launching a backtest lands on My Agents**, and the agent's card goes live — pulsing dot, indeterminate bar, ticking elapsed timer — driven by the existing 1s poller (no new interval).
- Cards show both capital figures; **Run Paper Trading ships disabled** with a reason (`paper_backend.py` is still a Phase B stub).

Paper (`ge=0`) and backtest (`ge=1`) capital resolve differently **on purpose**: a $0 sleeve displays honestly as `$0`, while `0` is not usable backtest capital and falls through to $1,000. Pinned by a regression test.

## Test plan
- [x] Full backend suite: 1918 passed / 44 skipped / 1 documented `iFind csi300` flake (passes alone)
- [x] 4 new guard suites (capital / instruction / card UI) + existing frontend guards green
- [x] `node --check` on `app.js` and `agent-editor.js` — no build step, so syntax is CI-invisible
- [x] Manual 9-point walkthrough against a scratch DB: elapsed timer observed ticking 0:01→0:04, backtest completed and card flipped
- [x] `git diff origin/main -- dashboard/storage/data/backtest.db` empty — prod seed DB untouched

Plan: `docs/superpowers/plans/2026-07-29-my-agents-capital-instruction-running.md` (Tasks 3–8)