### PR TITLE
docs: refresh My Agents capital and instruction docs

### DIFF
--- a/docs/source/lab/external_agents.rst
+++ b/docs/source/lab/external_agents.rst
@@ -372,10 +372,12 @@ submit → result sequence you can port to any language.
 Viewing results
 ----------------
 
-- **Dashboard:** open **My Agents** and, on your agent's card, click
-  **View All Runs** to open its latest backtest in the Playground — equity
-  curve, trades, and the hour-by-hour reasoning log, no console needed. (Before
-  the first run the card shows **Run Backtest** instead.)
+- **Dashboard:** open **My Agents** and, on your agent's card, click the
+  **N backtests** link to open its latest run in the Playground — equity curve,
+  trades, and the hour-by-hour reasoning log, no console needed. (Before the
+  first run the card shows *No backtests yet* in place of that link.) The
+  card's **Configure** screen lists the same runs under **Backtest history**;
+  clicking any one of them opens it the same way.
 - **API:** ``GET /api/v1/backtest/runs/{run_id}/result`` (full result),
   ``.../trades``, and ``.../decisions``.
 - **Leaderboard:** registered agents are ranked against baselines.

--- a/docs/source/lab/getting_started.rst
+++ b/docs/source/lab/getting_started.rst
@@ -6,32 +6,42 @@ Run a backtest in the dashboard
 
 1. Open `agentic-trading-lab.vercel.app <https://agentic-trading-lab.vercel.app/>`_ or `http://localhost:8000/ <http://localhost:8000/>`_ when running locally, then go to the **My Agents** tab.
 2. On an agent's card click **Run Backtest**. Use one of the **Foundation Agents**, or click **Add Agent +** to create your own.
-3. In the dialog set the **Period**, **Asset Universe**, and **Backtest Allocated Capital**, then click **Run Backtest**.
-4. Wait for completion—the UI polls ``/backtest/status`` and reloads equity charts when done.
+3. In the dialog set the **Period** and **Asset Universe**, then click **Run Backtest**. **Allocated Capital** is shown read-only — it is a saved setting on the agent; **Edit in Configure** opens the editor to change it.
+4. You stay on **My Agents**. The agent's card switches to a live ``Backtesting…`` state with an elapsed timer, and flips to the finished result when the run ends.
 
-Results appear in **Trading Performance** (agent vs. buy-and-hold vs. DJIA).
+Open the **Backtest** tab for the full run — **Trading Performance** charts the
+agent against buy-and-hold and DJIA, next to the trades and the hour-by-hour
+decision log.
 
-The backtest always runs the model saved on the agent; change it from the
-agent's **Configure** screen rather than at run time. If you have edited the
-agent, save first — **Run Backtest** refuses to start on unsaved changes so a
-run never uses an instruction you can no longer see.
+The backtest always runs the model and the capital saved on the agent; change
+either from the agent's **Configure** screen rather than at run time. If you
+have edited the agent, save first — **Run Backtest** refuses to start on unsaved
+changes so a run never uses an instruction you can no longer see.
+
+Leaving **Trading instruction** empty in **Configure** is a supported state, not
+an error: the agent then trades on the platform's built-in default strategy.
+Expand **See the default instruction** in the editor to read exactly what that
+is. Clearing the box on an agent that uses a custom multi-step pipeline asks for
+confirmation first, because saving replaces that pipeline.
 
 .. _allocated-capital:
 
 Two kinds of allocated capital
 ------------------------------
 
-The dashboard keeps these separate, and they have their own limits:
+Both live in the **Allocated Capital** card on an agent's **Configure** screen,
+but they are different kinds of money and have their own limits:
 
-**Paper Trading Allocated Capital**
-   Cash reserved from **My Portfolio** for one agent's paper trading, set when
-   you create the agent and editable in **Configure**. Maximum **$3,000**.
+**Paper Trading Allocated Capital** (the card's *Paper Trading* field)
+   Real cash reserved from **My Portfolio** for that one agent's paper trading,
+   set when you create the agent and editable afterwards. Maximum **$3,000**.
 
-**Backtest Allocated Capital**
-   Simulated starting cash for a single backtest, set in the **Run Backtest**
-   dialog. It defaults to that agent's Paper Trading Allocated Capital, but a
-   backtest never spends real portfolio cash and never changes it. Maximum
-   **$10,000**.
+**Backtest Allocated Capital** (the card's *Backtesting* field)
+   Simulated starting cash for that agent's backtests. It is a saved per-agent
+   setting rather than a per-run choice, so the **Run Backtest** dialog shows it
+   read-only. Leave the field blank and it follows the agent's Paper Trading
+   Allocated Capital. A backtest never spends real portfolio cash and never
+   changes it. Minimum **$1**, maximum **$10,000**.
 
 Start from a template
 ---------------------

--- a/docs/source/lab/marketplace.rst
+++ b/docs/source/lab/marketplace.rst
@@ -51,17 +51,19 @@ Add one to My Agents
 --------------------
 
 1. Click **Add to My Agents** on a card.
-2. The agent appears under **Playground → My Agents**, owned by you, with the
-   template's prompt pipeline already filled in.
-3. Open it in the agent editor to rename it, change the model, or rewrite the
-   prompts. Your agent is an independent copy — later edits to the template do
-   not touch it, and your edits never affect anyone else's.
+2. You land on **Playground → My Agents** and the new agent's **Configure**
+   screen opens straight away — owned by you, with the template's prompt
+   pipeline already filled in.
+3. Rename it, change the model, set its capital, or rewrite the instruction,
+   then close the editor to find the agent waiting on your **My Agents** grid.
+   Your agent is an independent copy — later edits to the template do not touch
+   it, and your edits never affect anyone else's.
 
-New agents get the default **Paper Trading Allocated Capital** ($1,000), and a
-backtest starts from that amount unless you change it in the **Run Backtest**
-dialog — see :ref:`allocated-capital`. If you are signed in, the $1,000 is
-reserved from your account portfolio, so adding an agent can fail with
-*insufficient cash* until you free some up.
+New agents get the default **Paper Trading Allocated Capital** ($1,000), and
+backtests start from that amount until you set a separate **Backtesting** amount
+in the added agent's **Configure** screen — see :ref:`allocated-capital`. If you
+are signed in, the $1,000 is reserved from your account portfolio, so adding an
+agent can fail with *insufficient cash* until you free some up.
 
 .. note::
 


### PR DESCRIPTION
Closes the docs followup catalogued in `docs/superpowers/specs/2026-07-29-my-agents-capital-instruction-running-design.md` §278, deferred out of #254/#255.

**`getting_started.rst`**
- Run Backtest dialog no longer takes a capital amount — read-only, with **Edit in Configure**.
- After launching you stay on **My Agents** with a live `Backtesting…` card; the Backtest tab is now opened deliberately.
- Empty **Trading instruction** documented as a supported state (runs the platform default), incl. the multi-step-pipeline confirm.
- Capital section reframed around the one Configure card; adds the previously undocumented **$1 minimum**.

**`marketplace.rst`** — backtest capital is changed in Configure, not the Run Backtest dialog. Add-flow steps corrected: the editor opens automatically.

**`external_agents.rst`** — the card's runs link is labelled **"N backtests"**, not "View All Runs"; adds the Configure → Backtest history path. The old parenthetical claimed the card shows Run Backtest only before the first run — it renders in both states.

Every claim checked against shipped code rather than the spec. One divergence found and followed: `agent-editor.js:447-455` resolves a blank Backtesting field client-side, so the docs describe field-level behaviour, not the backend NULL fallback.

Docs-only. `sphinx-build -n -E` succeeds; zero warnings in the three edited files (48 pre-existing, all in `orchestration/`). Worth running locally — nothing in CI builds `docs/`, and these pages publish to RTD ~2 min after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxdWcdBCuL4taRb49qdthP