### PR TITLE
docs: clarify paper trading status

### DIFF
--- a/docs/source/lab/getting_started.rst
+++ b/docs/source/lab/getting_started.rst
@@ -43,6 +43,19 @@ but they are different kinds of money and have their own limits:
    Allocated Capital. A backtest never spends real portfolio cash and never
    changes it. Minimum **$1**, maximum **$10,000**.
 
+Paper trading is not switched on yet, so the first of those two currently has
+nothing to spend. **Run Paper Trading** sits beside **Run Backtest** on every
+agent card but is permanently disabled (*Paper trading is coming soon*), and the
+**Playground → Paper Trading** tab is a read-only view of a connected Alpaca
+paper account rather than somewhere your agent runs. Backtesting is the only way
+to run an agent today.
+
+The reservation is real in the meantime: Paper Trading Allocated Capital leaves
+**My Portfolio** the moment you set it and reduces the cash available to your
+other agents. You can drop it to **$0** on an agent you only plan to backtest —
+give that agent its own **Backtesting** amount first, though, or its backtests
+fall back to $1,000 along with it.
+
 Start from a template
 ---------------------
 

--- a/docs/source/lab/operating_modes.rst
+++ b/docs/source/lab/operating_modes.rst
@@ -5,7 +5,7 @@ Operating Modes
    Evaluate agents on historical market data and compare results to market baselines (buy-and-hold, index).
 
 **Paper trading**
-   Connect to an Alpaca paper account for simulated live trading: account summary, positions, recent trades, and portfolio value over time.
+   Connect to an Alpaca paper account for simulated live trading: account summary, positions, recent trades, and portfolio value over time. Monitoring only for now — an agent cannot yet trade this account, so **Run Paper Trading** on an agent card is disabled even though its :ref:`Paper Trading Allocated Capital <allocated-capital>` is already reserved.
 
 **Live trading**
    Connect a real Robinhood brokerage account and let an agent propose and place orders against it, under per-order risk caps. Off by default — see :doc:`live_trading`.


### PR DESCRIPTION
Follow-up to #259. Both pages described paper trading as if an agent could already run it.

- **`getting_started.rst`** — the Allocated Capital section documented a **Paper Trading** sleeve without saying it currently has nothing to spend. Now notes that **Run Paper Trading** is disabled on every agent card, that backtesting is the only way to run an agent today, and that the sleeve is still reserved from **My Portfolio**. Dropping it to $0 frees that cash — but pin the agent's **Backtesting** amount first, or its backtests fall back to $1,000 with it.
- **`operating_modes.rst`** — the Paper trading entry read as monitoring *plus* execution, especially next to the Live trading entry below it. Now says monitoring only, cross-linked to the capital section.

Verified against code rather than the spec:

- `app.js::renderAgentCardActions` renders the disabled button for every agent; the "Open Agent" branch needs `is_live`/`deployment_status`, which appear in **zero** backend files (only one hardcoded mock agent) — so "disabled" is not state-dependent.
- `execution/paper_backend.py` is a Phase B stub raising `NotImplementedError`.
- `resolveBacktestCapital` takes the first of `[backtest_allocation, cash_allocation]` that is `> 0`, else `$1,000` — hence the coupling warning on zeroing a sleeve.
- `domain/portfolios/service.py`: `cash_available = equity - sum(agent.cash_allocation)`, reconciled on every read — so zeroing a sleeve does free the cash.
- **Live trading is deliberately left as-is** — `execution/robinhood_live_service.py` has a real order path (order building, risk gating, audit trail), so that entry is accurate.

`sphinx-build -n -E` is clean for both files. Note **nothing in CI builds `docs/`** and these pages publish to RTD ~2 min after merge, so please build locally if you reword anything.