### PR TITLE
fix(ui): make dark-theme model select options readable

### DIFF
--- a/dashboard/backend/tests/test_frontend_account_page.py
+++ b/dashboard/backend/tests/test_frontend_account_page.py
@@ -134,5 +134,5 @@ def test_cache_bust_versions_were_bumped():
     styles_version = int(re.search(r"styles\.css\?v=(\d+)", html).group(1))
     app_version = int(re.search(r"app\.js\?v=(\d+)", html).group(1))
 
-    assert styles_version >= 68
+    assert styles_version >= 69
     assert app_version >= 51

--- a/dashboard/backend/tests/test_frontend_select_contrast.py
+++ b/dashboard/backend/tests/test_frontend_select_contrast.py
@@ -1,0 +1,131 @@
+"""Guards for dark-theme readability of native form controls.
+
+A ``<select>`` popup is drawn by the browser, not by us: the list panel is
+painted from the UA's *color scheme*, while the text inherits our
+``--text-primary`` (#e5e7eb). With no ``color-scheme`` declared, the UA defaults
+to light -- near-white text on a white panel, i.e. an unreadable menu. The fix
+is ``color-scheme: dark`` on the control (plus explicit ``option`` colors, which
+is what Firefox actually honours).
+
+None of this is observable from Python, and the frontend has no JS test harness,
+so -- following the convention of the other ``test_frontend_*`` modules here --
+these contracts are asserted against the shipped stylesheet directly.
+
+The picker-indicator case is the subtle one, and it is a regression that shipped
+inside the very PR that added ``color-scheme`` (#265): ``color-scheme`` is
+declared on the *shared* ``.date-input, .control-select`` rule, so it also
+changed how the UA draws the date field's calendar glyph -- from dark (which the
+old ``filter: invert(0.8)`` hack existed to flip *light*) to light. The invert
+then ran backwards and made the button near-black on --bg-input. Any invert()
+hack over a native control's internals is coupled to color-scheme this way.
+"""
+
+import re
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_HTML = _FRONTEND / "app.html"
+_STYLES_CSS = _FRONTEND / "styles.css"
+
+# Selectors that style a <select>. Each must opt into the dark UA scheme.
+_SELECT_SELECTORS = (
+    ".auth-field select",
+    ".control-select",
+    ".filter-select",
+    ".agent-editor-model-select",
+)
+
+# Classes whose rule carries `color-scheme: dark`, keyed by how markup spells
+# them. `.auth-field select` is a descendant rule and so has no class of its own.
+_COVERED_CLASSES = {"control-select", "filter-select", "agent-editor-model-select"}
+
+# Visible <select>s covered by a descendant rule rather than their own class.
+_DESCENDANT_COVERED_IDS = {
+    "builtinAgentModel",  # inside <label class="auth-field"> -> `.auth-field select`
+}
+
+_RULE_RE = re.compile(r"(?P<sel>[^{}]+)\{(?P<body>[^{}]*)\}", re.S)
+_COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
+_SELECT_TAG_RE = re.compile(r"<select\b[^>]*>", re.S)
+# `hidden` as a standalone attribute -- the lookbehind keeps aria-hidden out.
+_HIDDEN_ATTR_RE = re.compile(r"(?<![-\w])hidden(?=[\s>=])")
+
+
+def _rule_bodies(selector: str) -> list[str]:
+    """Bodies of rules that declare `selector` as a whole item of their list.
+
+    Matching on list items rather than substrings keeps `.control-select:focus`
+    from masquerading as `.control-select`.
+
+    Comments are stripped first: these assertions are about declarations, and a
+    rule's own prose explaining `invert()` or `color-scheme` must neither
+    satisfy nor break them.
+    """
+    css = _COMMENT_RE.sub("", _STYLES_CSS.read_text(encoding="utf-8"))
+    bodies = []
+    for match in _RULE_RE.finditer(css):
+        items = [item.strip() for item in match.group("sel").split(",")]
+        if selector in items:
+            bodies.append(match.group("body"))
+    return bodies
+
+
+def test_every_styled_select_declares_the_dark_ua_scheme():
+    for selector in _SELECT_SELECTORS:
+        bodies = _rule_bodies(selector)
+        assert bodies, f"no rule declares {selector} in styles.css"
+        assert any("color-scheme: dark" in body for body in bodies), (
+            f"{selector} has no `color-scheme: dark`; its popup will render as "
+            "light-on-white in the dark dashboard"
+        )
+
+
+def test_every_styled_select_colors_its_options():
+    """Firefox ignores color-scheme for option paint; these rules are what it uses."""
+    for selector in _SELECT_SELECTORS:
+        bodies = _rule_bodies(f"{selector} option")
+        assert bodies, f"no `{selector} option` rule in styles.css"
+        assert any("var(--bg-card)" in body for body in bodies), (
+            f"`{selector} option` must set an explicit dark background"
+        )
+
+
+def test_calendar_picker_indicator_is_not_inverted():
+    """Regression guard -- see this module's docstring.
+
+    `.date-input` shares its rule with `.control-select`, so it inherits
+    `color-scheme: dark` and the UA already draws this glyph light. Re-adding an
+    invert() would turn it near-black on --bg-input and hide the picker button.
+    """
+    bodies = _rule_bodies(".date-input::-webkit-calendar-picker-indicator")
+    assert bodies, "the calendar picker indicator rule vanished from styles.css"
+    for body in bodies:
+        assert "invert(" not in body, (
+            "the calendar glyph is already light under `color-scheme: dark`; "
+            "inverting it makes the date picker button invisible"
+        )
+
+
+def test_no_visible_select_ships_without_dark_coverage():
+    """A new <select> that nobody styled is exactly how #265's bug got in.
+
+    Hidden ones are exempt: `#modelSelect` and `#backtestAgentSelect` are
+    JS-side state holders that are never painted.
+    """
+    html = _APP_HTML.read_text(encoding="utf-8")
+
+    uncovered = []
+    for tag in _SELECT_TAG_RE.findall(html):
+        if _HIDDEN_ATTR_RE.search(tag):
+            continue
+        element_id = (re.search(r'id="([^"]*)"', tag) or [None, ""])[1]
+        if element_id in _DESCENDANT_COVERED_IDS:
+            continue
+        classes = set((re.search(r'class="([^"]*)"', tag) or [None, ""])[1].split())
+        if not classes & _COVERED_CLASSES:
+            uncovered.append(element_id or tag)
+
+    assert not uncovered, (
+        f"visible <select>s with no dark-scheme rule: {uncovered}. Give each a "
+        f"class from {sorted(_COVERED_CLASSES)}, or add a rule and list it here."
+    )

--- a/dashboard/backend/tests/test_frontend_select_contrast.py
+++ b/dashboard/backend/tests/test_frontend_select_contrast.py
@@ -39,16 +39,21 @@ _SELECT_SELECTORS = (
 # them. `.auth-field select` is a descendant rule and so has no class of its own.
 _COVERED_CLASSES = {"control-select", "filter-select", "agent-editor-model-select"}
 
-# Visible <select>s covered by a descendant rule rather than their own class.
+# <select>s covered by a descendant rule rather than their own class.
 _DESCENDANT_COVERED_IDS = {
     "builtinAgentModel",  # inside <label class="auth-field"> -> `.auth-field select`
 }
 
+# The only <select> that is never rendered: no code path clears its `hidden`
+# attribute, so it is pure JS-side state. Do NOT extend this set just because an
+# element ships `hidden` in the markup -- `#modelSelect` (app.js: `modelSelect
+# .hidden = !isIFind`) and `#backtestRunSelect` both start hidden and are later
+# revealed, which is precisely the case this guard has to keep covering.
+_NEVER_RENDERED_IDS = {"backtestAgentSelect"}
+
 _RULE_RE = re.compile(r"(?P<sel>[^{}]+)\{(?P<body>[^{}]*)\}", re.S)
 _COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
 _SELECT_TAG_RE = re.compile(r"<select\b[^>]*>", re.S)
-# `hidden` as a standalone attribute -- the lookbehind keeps aria-hidden out.
-_HIDDEN_ATTR_RE = re.compile(r"(?<![-\w])hidden(?=[\s>=])")
 
 
 def _rule_bodies(selector: str) -> list[str]:
@@ -106,26 +111,27 @@ def test_calendar_picker_indicator_is_not_inverted():
         )
 
 
-def test_no_visible_select_ships_without_dark_coverage():
+def test_no_select_ships_without_dark_coverage():
     """A new <select> that nobody styled is exactly how #265's bug got in.
 
-    Hidden ones are exempt: `#modelSelect` and `#backtestAgentSelect` are
-    JS-side state holders that are never painted.
+    Every <select> is checked, including the ones that ship `hidden`. Exempting
+    those would be the tempting shortcut and it is wrong: `#modelSelect` and
+    `#backtestRunSelect` are both hidden in the markup and both revealed by
+    app.js later, so a hidden-skip would wave through the exact elements whose
+    popup a user does eventually open.
     """
     html = _APP_HTML.read_text(encoding="utf-8")
 
     uncovered = []
     for tag in _SELECT_TAG_RE.findall(html):
-        if _HIDDEN_ATTR_RE.search(tag):
-            continue
         element_id = (re.search(r'id="([^"]*)"', tag) or [None, ""])[1]
-        if element_id in _DESCENDANT_COVERED_IDS:
+        if element_id in _DESCENDANT_COVERED_IDS or element_id in _NEVER_RENDERED_IDS:
             continue
         classes = set((re.search(r'class="([^"]*)"', tag) or [None, ""])[1].split())
         if not classes & _COVERED_CLASSES:
             uncovered.append(element_id or tag)
 
     assert not uncovered, (
-        f"visible <select>s with no dark-scheme rule: {uncovered}. Give each a "
-        f"class from {sorted(_COVERED_CLASSES)}, or add a rule and list it here."
+        f"<select>s with no dark-scheme rule: {uncovered}. Give each a class "
+        f"from {sorted(_COVERED_CLASSES)}, or add a rule and list it here."
     )

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=68">
+    <link rel="stylesheet" href="styles.css?v=69">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -778,7 +778,7 @@
                 </label>
                 <label class="auth-field">
                     <span>Model</span>
-                    <select id="builtinAgentModel" class="auth-input">
+                    <select id="builtinAgentModel">
                         <option value="anthropic/claude-haiku-4-5">Claude Haiku 4.5</option>
                         <option value="anthropic/claude-sonnet-4-6">Claude Sonnet 4.6</option>
                         <option value="openai/gpt-5.5">GPT-5.5</option>

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -487,6 +487,10 @@ a.header-brand:hover .title-section h1 {
     border-radius: 4px;
     background: var(--bg-primary);
     color: var(--text-primary);
+    /* Native <select> menus are painted from the UA's color scheme, not ours;
+       without this the inherited light text lands on a light OS panel.
+       Intentionally on the shared rule: the text inputs want dark autofill,
+       spinners and scrollbars for the same reason. */
     color-scheme: dark;
 }
 
@@ -937,6 +941,10 @@ a.header-brand:hover .title-section h1 {
     font-family: var(--font-mono);
     height: 24px;
     line-height: 1;
+    /* Native <select> menus and date pickers are painted from the UA's color
+       scheme, not ours; without this the inherited light text lands on a light
+       OS panel. Applies to .date-input too -- see the picker-indicator rule
+       below, which must not re-invert the now-light glyph. */
     color-scheme: dark;
 }
 
@@ -955,7 +963,10 @@ a.header-brand:hover .title-section h1 {
     width: 16px;
     height: 16px;
     margin-right: 5px;
-    filter: invert(0.8);
+    /* Deliberately no invert() filter. The UA draws this glyph from the
+       element's color-scheme, so under `color-scheme: dark` above it is
+       already light; inverting would turn it near-black on --bg-input and
+       make the picker button invisible. */
 }
 
 .date-input::-webkit-calendar-picker-indicator:hover {
@@ -1755,6 +1766,12 @@ a.header-brand:hover .title-section h1 {
     color: var(--text-primary);
     font-size: 12px;
     cursor: pointer;
+    color-scheme: dark;
+}
+
+.filter-select option {
+    background-color: var(--bg-card);
+    color: var(--text-primary);
 }
 
 .filter-btn {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -487,6 +487,12 @@ a.header-brand:hover .title-section h1 {
     border-radius: 4px;
     background: var(--bg-primary);
     color: var(--text-primary);
+    color-scheme: dark;
+}
+
+.auth-field select option {
+    background-color: var(--bg-card);
+    color: var(--text-primary);
 }
 
 .auth-error {
@@ -931,6 +937,12 @@ a.header-brand:hover .title-section h1 {
     font-family: var(--font-mono);
     height: 24px;
     line-height: 1;
+    color-scheme: dark;
+}
+
+.control-select option {
+    background-color: var(--bg-card);
+    color: var(--text-primary);
 }
 
 .date-input {
@@ -9244,12 +9256,19 @@ body.agent-editor-open {
     color: var(--text-secondary);
 }
 .agent-editor-model-select {
-    background: transparent;
+    background: var(--bg-input);
     border: 1px solid var(--border-color);
     border-radius: 6px;
     color: var(--text-primary);
     font-size: 0.85rem;
     padding: 4px 8px;
+    /* Native <select> menus often paint a light OS panel; without this the
+       inherited light text becomes unreadable on white. */
+    color-scheme: dark;
+}
+.agent-editor-model-select option {
+    background-color: var(--bg-card);
+    color: var(--text-primary);
 }
 .agent-editor-simple textarea {
     width: 100%;


### PR DESCRIPTION
## Summary
- Fix Agent Configure Model dropdown contrast: native `<select>` menus were light-backed with inherited light text
- Apply the same dark `color-scheme` / option styling to Create Agent and shared `control-select` pickers
- Bump `styles.css` cache-bust to `v=69`

## Test plan
- [ ] Open an agent Configure page → expand Model dropdown → all options are readable (not light-on-white)
- [ ] Create Built-in Agent modal → Model dropdown is readable
- [ ] Hard-refresh to pick up `styles.css?v=69`


Made with [Cursor](https://cursor.com)