### PR TITLE
chore: clear py/import-and-import-from in tests

### DIFF
--- a/dashboard/backend/tests/llm/test_backtest_harness.py
+++ b/dashboard/backend/tests/llm/test_backtest_harness.py
@@ -14,7 +14,6 @@ from dashboard.backend.domain.backtesting import (
     portfolio_manager as portfolio_manager_module,
 )
 import dashboard.backend.infrastructure.llm.backtest_harness as harness
-from dashboard.backend.infrastructure.llm.backtest_harness import request_trading_decision
 from dashboard.scripts import backtest_hourly_agent as bha
 
 
@@ -119,7 +118,7 @@ def test_request_uses_market_aware_a_share_system_prompt():
         "paper_backtest": True,
     }
 
-    request_trading_decision(
+    harness.request_trading_decision(
         client,
         prompt="HELLO",
         market_context=market_context,

--- a/dashboard/backend/tests/test_agent_runs_metadata.py
+++ b/dashboard/backend/tests/test_agent_runs_metadata.py
@@ -131,9 +131,8 @@ def test_engine_llm_run_metadata_snapshot(monkeypatch):
     """The engine's agent run records the EFFECTIVE cap (whatever the env
     parse produced), while every run records data provenance."""
     import dashboard.backend.domain.backtesting.engine as engine_mod
-    from dashboard.backend.domain.backtesting.engine import HourlyBacktester
 
-    backtester = HourlyBacktester.__new__(HourlyBacktester)  # skip creds init
+    backtester = engine_mod.HourlyBacktester.__new__(engine_mod.HourlyBacktester)  # skip creds init
     # _agent_run_metadata() also reads the post-trade/pipeline attrs (added in the
     # post-trade-analysis work); __init__ sets them, but __new__ skips it, so set
     # the no-pipeline defaults here to keep this a pure llm_max_output_tokens test.
@@ -170,9 +169,8 @@ def test_baseline_metadata_is_provenance_only(monkeypatch):
     a shared metadata builder silently stamps the agent's LLM config and a copy
     of its pipeline onto Buy & Hold and DJIA rows."""
     import dashboard.backend.domain.backtesting.engine as engine_mod
-    from dashboard.backend.domain.backtesting.engine import HourlyBacktester
 
-    backtester = HourlyBacktester.__new__(HourlyBacktester)  # skip creds init
+    backtester = engine_mod.HourlyBacktester.__new__(engine_mod.HourlyBacktester)  # skip creds init
     backtester.data_source = "vnpy_simulation"
     backtester.symbols = ["AAPL"]
     monkeypatch.setattr(engine_mod.llm_harness, "DEFAULT_MAX_OUTPUT_TOKENS", 777)

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -107,10 +107,10 @@ def test_unreachable_postgres_agent_store_raises_instead_of_falling_back():
     """
     import psycopg
 
-    from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore
+    import dashboard.backend.domain.agents.repository_postgres as repo_pg
 
     with pytest.raises(psycopg.OperationalError):
-        PostgresAgentStore("postgresql://u:p@127.0.0.1:1/nope?connect_timeout=2")
+        repo_pg.PostgresAgentStore("postgresql://u:p@127.0.0.1:1/nope?connect_timeout=2")
 
 
 def test_malformed_url_is_rejected_before_psycopg_can_echo_it():
@@ -123,10 +123,10 @@ def test_malformed_url_is_rejected_before_psycopg_can_echo_it():
     into __init__ -- testing the helper alone would not catch it being dropped
     from the constructor.
     """
-    from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore
+    import dashboard.backend.domain.agents.repository_postgres as repo_pg
 
     with pytest.raises(ValueError) as excinfo:
-        PostgresAgentStore('"postgresql://u:sup3r-s3cret@ep-x.neon.tech/atl"')
+        repo_pg.PostgresAgentStore('"postgresql://u:sup3r-s3cret@ep-x.neon.tech/atl"')
     assert "sup3r-s3cret" not in str(excinfo.value)
 
 
@@ -135,9 +135,9 @@ def test_malformed_url_is_rejected_before_psycopg_can_echo_it():
 @pytest.fixture
 def pg_agent_store():
     require_local_postgres_url(TEST_POSTGRES_URL)
-    from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore
+    import dashboard.backend.domain.agents.repository_postgres as repo_pg
 
-    store = PostgresAgentStore(TEST_POSTGRES_URL)
+    store = repo_pg.PostgresAgentStore(TEST_POSTGRES_URL)
     with store._get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute("DELETE FROM external_agents")
@@ -392,8 +392,8 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
     written today; the ADDING A COLUMN LATER? comment in repository_postgres.py is
     what guards that, and it is the thing to keep alive.
     """
-    from dashboard.backend.domain.agents.repository import DEFAULT_SCOPES
-    from dashboard.backend.domain.agents.repository_postgres import PostgresAgentStore
+    import dashboard.backend.domain.agents.repository as repo_module
+    import dashboard.backend.domain.agents.repository_postgres as repo_pg
 
     with pg_agent_store._get_connection() as conn:
         with conn.cursor() as cur:
@@ -425,7 +425,7 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
             )
 
     # A redeploy re-runs _init_schema() against the existing "old" table.
-    PostgresAgentStore(TEST_POSTGRES_URL)
+    repo_pg.PostgresAgentStore(TEST_POSTGRES_URL)
 
     with pg_agent_store._get_connection() as conn:
         with conn.cursor() as cur:
@@ -454,7 +454,7 @@ def test_agent_schema_lazily_migrates_an_old_table_postgres(pg_agent_store):
     } <= columns
     # The pre-existing row was backfilled with the column defaults, not NULL.
     assert legacy["agent_type"] == "external"
-    assert legacy["scopes"] == DEFAULT_SCOPES
+    assert legacy["scopes"] == repo_module.DEFAULT_SCOPES
 
     # The store is actually usable after the migration: a real registration
     # writes every migrated column, and the scopes column default applies.
@@ -500,7 +500,7 @@ def test_create_agent_stores_default_scopes_verbatim_postgres(pg_agent_store):
     masked back to DEFAULT_SCOPES in the public view -- only the stored value
     proves the column default itself is right.
     """
-    from dashboard.backend.domain.agents.repository import DEFAULT_SCOPES
+    import dashboard.backend.domain.agents.repository as repo_module
 
     created = pg_agent_store.create_agent(name="Scoped")  # no scopes passed
     with pg_agent_store._get_connection() as conn:
@@ -510,7 +510,7 @@ def test_create_agent_stores_default_scopes_verbatim_postgres(pg_agent_store):
                 (created["agent_id"],),
             )
             raw = cur.fetchone()["scopes"]
-    assert raw == DEFAULT_SCOPES
+    assert raw == repo_module.DEFAULT_SCOPES
 
 
 @pg_only
@@ -630,22 +630,18 @@ def test_unreachable_postgres_version_store_raises_instead_of_falling_back():
     """Fail loud — see the agent-store twin of this test above."""
     import psycopg
 
-    from dashboard.backend.domain.agents.version_repository_postgres import (
-        PostgresAgentVersionStore,
-    )
+    import dashboard.backend.domain.agents.version_repository_postgres as vrepo_pg
 
     with pytest.raises(psycopg.OperationalError):
-        PostgresAgentVersionStore("postgresql://u:p@127.0.0.1:1/nope?connect_timeout=2")
+        vrepo_pg.PostgresAgentVersionStore("postgresql://u:p@127.0.0.1:1/nope?connect_timeout=2")
 
 
 def test_malformed_url_is_rejected_before_psycopg_can_echo_it_version_store():
     """See the agent-store twin of this test above."""
-    from dashboard.backend.domain.agents.version_repository_postgres import (
-        PostgresAgentVersionStore,
-    )
+    import dashboard.backend.domain.agents.version_repository_postgres as vrepo_pg
 
     with pytest.raises(ValueError) as excinfo:
-        PostgresAgentVersionStore('"postgresql://u:sup3r-s3cret@ep-x.neon.tech/atl"')
+        vrepo_pg.PostgresAgentVersionStore('"postgresql://u:sup3r-s3cret@ep-x.neon.tech/atl"')
     assert "sup3r-s3cret" not in str(excinfo.value)
 
 
@@ -654,11 +650,9 @@ def test_malformed_url_is_rejected_before_psycopg_can_echo_it_version_store():
 @pytest.fixture
 def pg_version_store():
     require_local_postgres_url(TEST_POSTGRES_URL)
-    from dashboard.backend.domain.agents.version_repository_postgres import (
-        PostgresAgentVersionStore,
-    )
+    import dashboard.backend.domain.agents.version_repository_postgres as vrepo_pg
 
-    store = PostgresAgentVersionStore(TEST_POSTGRES_URL)
+    store = vrepo_pg.PostgresAgentVersionStore(TEST_POSTGRES_URL)
     with store._get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute("DELETE FROM agent_versions")

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -6,7 +6,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from dashboard.backend.app import app
-from dashboard.backend.domain.agents.repository import AgentStore
 
 
 @pytest.fixture
@@ -16,7 +15,7 @@ def client(tmp_path, monkeypatch):
     import dashboard.backend.database as db_module
 
     db_path = tmp_path / "test.db"
-    test_agents = AgentStore(db_path=db_path)
+    test_agents = agent_store_module.AgentStore(db_path=db_path)
     test_db = db_module.BacktestDatabase(db_path=db_path)
     monkeypatch.setattr(agent_store_module, "agent_store", test_agents)
     monkeypatch.setattr(agents_api.agent_service, "agents", test_agents)

--- a/dashboard/backend/tests/test_external_backtest_api.py
+++ b/dashboard/backend/tests/test_external_backtest_api.py
@@ -7,28 +7,20 @@ import dashboard.backend.app as app_module
 import dashboard.backend.database as db_module
 import dashboard.backend.domain.backtesting.external_run_service as svc
 
-from dashboard.backend.app import app
-from dashboard.backend.database import BacktestDatabase
-from dashboard.backend.domain.backtesting.external_run_service import (
-    _sessions,
-    get_decision_format,
-    parse_actions_payload,
-)
-
 
 @pytest.fixture
 def client(temp_db, monkeypatch):
     monkeypatch.setattr(app_module, "db", temp_db)
     monkeypatch.setattr(db_module, "db", temp_db)
     monkeypatch.setattr(svc, "db", temp_db)
-    _sessions.clear()
-    return TestClient(app)
+    svc._sessions.clear()
+    return TestClient(app_module.app)
 
 
 @pytest.fixture
 def temp_db(tmp_path, monkeypatch):
     db_path = tmp_path / "test.db"
-    test_db = BacktestDatabase(db_path=db_path)
+    test_db = db_module.BacktestDatabase(db_path=db_path)
     yield test_db
 
 
@@ -59,13 +51,13 @@ def test_parse_actions_payload_valid():
             "position_size": 0,
         }]
     }
-    decisions, err = parse_actions_payload(payload)
+    decisions, err = svc.parse_actions_payload(payload)
     assert err is None
     assert len(decisions) == 1
 
 
 def test_get_decision_format():
-    fmt = get_decision_format()
+    fmt = svc.get_decision_format()
     assert "actions" in fmt
 
 
@@ -109,7 +101,7 @@ def test_insert_trades_legacy_schema(tmp_path):
     conn.commit()
     conn.close()
 
-    legacy_db = BacktestDatabase(db_path=db_path)
+    legacy_db = db_module.BacktestDatabase(db_path=db_path)
     legacy_db.insert_trades("ext_test", [{
         "timestamp": "2026-04-15T14:00:00",
         "symbol": "AAPL",

--- a/dashboard/backend/tests/test_protocol_api.py
+++ b/dashboard/backend/tests/test_protocol_api.py
@@ -1067,7 +1067,7 @@ def test_repeat_poll_does_not_rewrite_step_row(client, monkeypatch):
     """steps/next is polled in a loop; re-awaiting an unchanged step must not
     pay a synchronous SQLite write per poll."""
     import dashboard.backend.domain.runs.service as run_service
-    from dashboard.backend.domain.runs.repository import run_store
+    import dashboard.backend.domain.runs.repository as run_store_module
 
     agent_id, key, _ = _new_agent(client)
     version_id = _new_version(client, agent_id, key)
@@ -1075,6 +1075,7 @@ def test_repeat_poll_does_not_rewrite_step_row(client, monkeypatch):
     _wait_for_step(client, run_id, key)
 
     calls = []
+    run_store = run_store_module.run_store
     real = run_store.save_step
     monkeypatch.setattr(
         run_store, "save_step",

--- a/dashboard/backend/tests/test_run_lifecycle_unification.py
+++ b/dashboard/backend/tests/test_run_lifecycle_unification.py
@@ -26,7 +26,6 @@ import dashboard.backend.domain.runs.repository as run_store_module
 import dashboard.backend.domain.runs.service as run_service
 from dashboard.backend.app import app
 from dashboard.backend.database import db
-from dashboard.backend.domain.runs.repository import RunStore
 from dashboard.backend.execution.backtest_backend import ArchivedBacktestBackend
 from dashboard.backend.tests._v2_fakes import FakeBackend
 
@@ -325,7 +324,7 @@ def test_v2_rehydration_is_not_an_existence_oracle(monkeypatch):
 
 
 def test_create_run_stamps_instance_and_heartbeat(tmp_path):
-    store = RunStore(tmp_path / "hb.db")
+    store = run_store_module.RunStore(tmp_path / "hb.db")
     rec = store.create_run(
         agent_id="ag_hb", agent_version_id=None, session_id="sess",
         environment_id=None, environment_type="backtest", config={},
@@ -342,7 +341,7 @@ def test_create_run_stamps_instance_and_heartbeat(tmp_path):
 
 
 def test_fail_stale_runs_spares_fresh_heartbeats(tmp_path):
-    store = RunStore(tmp_path / "stale.db")
+    store = run_store_module.RunStore(tmp_path / "stale.db")
     fresh = store.create_run(
         agent_id="ag_live", agent_version_id=None, session_id="s",
         environment_id=None, environment_type="backtest", config={},
@@ -371,7 +370,7 @@ def test_fail_stale_runs_spares_fresh_heartbeats(tmp_path):
 def test_fail_stale_runs_treats_legacy_null_heartbeat_as_stale(tmp_path):
     """Rows written before the heartbeat column existed must still be
     recoverable — fall back to updated_at for staleness."""
-    store = RunStore(tmp_path / "legacy.db")
+    store = run_store_module.RunStore(tmp_path / "legacy.db")
     rec = store.create_run(
         agent_id="ag_legacy", agent_version_id=None, session_id="s",
         environment_id=None, environment_type="backtest", config={},
@@ -419,7 +418,7 @@ def test_runstore_migrates_legacy_schema(tmp_path):
     conn.commit()
     conn.close()
 
-    store = RunStore(path)  # must migrate, not crash
+    store = run_store_module.RunStore(path)  # must migrate, not crash
     conn = sqlite3.connect(str(path))
     cols = {row[1] for row in conn.execute("PRAGMA table_info(protocol_runs)")}
     conn.close()
@@ -598,7 +597,7 @@ def test_runstore_survives_partially_migrated_schema(tmp_path):
     conn.commit()
     conn.close()
 
-    RunStore(path)  # must add only heartbeat_at, without crashing
+    run_store_module.RunStore(path)  # must add only heartbeat_at, without crashing
     conn = sqlite3.connect(str(path))
     cols = {row[1] for row in conn.execute("PRAGMA table_info(protocol_runs)")}
     conn.close()
@@ -609,7 +608,7 @@ def test_runstore_migration_tolerates_losing_the_alter_race(tmp_path):
     """Two workers can both probe (columns missing) and both ALTER; the loser
     gets 'duplicate column name'. That means the column exists — the goal —
     so it must be swallowed, not crash the process at startup."""
-    store = RunStore(tmp_path / "race.db")  # columns already exist
+    store = run_store_module.RunStore(tmp_path / "race.db")  # columns already exist
     conn = sqlite3.connect(str(store.db_path))
     try:
         # Simulate the raced probe: a stale 'nothing exists yet' snapshot.


### PR DESCRIPTION
Clears 18 CodeQL `py/import-and-import-from` alerts by standardising 7 test modules onto `import X as mod` + attribute access. No behaviour change — attribute access resolves at call time, which is if anything closer to what these monkeypatch seams intend.

Verified:
- CI ran the `@pg_only` tier (skips collapsed 64 → 7, **2000 passed**), so the 16 edits that skip locally are actually exercised.
- An AST re-implementation of the rule now reports **0** files under `dashboard/backend/tests/` importing a module both ways.
- pyflakes clean across all 7 files (no undefined names in the skipped bodies).

Out of scope: the 19th alert of this rule is in `domain/backtesting/engine.py:55` — source, not a test, so left alone.