### PR TITLE
fix(deploy): build AI Hedge Fund venv on Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,20 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Keep virattt/ai-hedge-fund and its LangChain graph isolated from ATL's main
 # dependency set. The adapter invokes this interpreter over a JSON subprocess
 # boundary; marketplace users never clone or install the upstream project.
-RUN python -m venv /opt/ai-hedge-fund-venv \
-    && /opt/ai-hedge-fund-venv/bin/pip install --no-cache-dir \
-       -r requirements-ai-hedge-fund.txt
+#
+# Upstream pins numpy^1.24 (<2). numpy 1.26.x has no cp313 wheels, and
+# python:*-slim has no C compiler to build from source — so the isolated
+# venv must run on 3.12 even though ATL itself stays on 3.13. uv installs
+# a managed 3.12 under /opt/uv-python; the venv keeps an absolute reference
+# to it, so uninstalling the uv build tool afterwards is safe.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
+RUN pip install --no-cache-dir uv \
+    && uv python install 3.12 \
+    && uv venv --python 3.12 /opt/ai-hedge-fund-venv \
+    && uv pip install --python /opt/ai-hedge-fund-venv \
+       -r requirements-ai-hedge-fund.txt \
+    && /opt/ai-hedge-fund-venv/bin/python -c "from src.main import run_hedge_fund" \
+    && pip uninstall -y uv
 
 # Copy dashboard application
 COPY dashboard ./dashboard

--- a/render.yaml
+++ b/render.yaml
@@ -5,8 +5,11 @@ services:
     region: oregon
     plan: standard
     
-    # Build and run from repository root (dashboard lives under dashboard/)
-    buildCommand: pip install -r requirements.txt && python -m venv .ai-hedge-fund-venv && .ai-hedge-fund-venv/bin/pip install -r requirements-ai-hedge-fund.txt
+    # Build and run from repository root (dashboard lives under dashboard/).
+    # Prod deploys via Dockerfile (ATL on 3.13, AI Hedge Fund venv on 3.12 via
+    # uv). This native buildCommand is documentation — upstream numpy^1.24 has
+    # no cp313 wheels, so the isolated venv must use 3.12.
+    buildCommand: pip install -r requirements.txt && pip install uv && uv python install 3.12 && uv venv --python 3.12 .ai-hedge-fund-venv && uv pip install --python .ai-hedge-fund-venv -r requirements-ai-hedge-fund.txt
     
     # Start command (canonical ASGI package target; runs via Render's shell,
     # which expands $PORT). No import-path workarounds needed.

--- a/requirements-ai-hedge-fund.txt
+++ b/requirements-ai-hedge-fund.txt
@@ -1,4 +1,8 @@
 # Installed only into the dedicated AI Hedge Fund virtual environment.
 # Pin the reviewed upstream source; never install these dependencies into ATL's
 # main environment because its LangChain/Pydantic constraints are independent.
+#
+# Install with Python 3.11 or 3.12 only. Upstream pins numpy^1.24 (<2); the
+# 1.26.x line has no cp313 wheels, so a 3.13 venv tries (and fails) to build
+# numpy from source. The Dockerfile uses uv to provision 3.12 for this reason.
 ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz


### PR DESCRIPTION
## Summary
- Fixes the Render Docker deploy failure introduced by #261 (`feat(marketplace): integrate AI Hedge Fund hosted runtime`).
- Upstream `ai-hedge-fund` pins `numpy^1.24` (<2), which resolves to 1.26.x with **no cp313 wheels**. On `python:3.13-slim` (no C compiler) pip tries to build numpy from source and fails with `Unknown compiler(s): cc/gcc/clang/...`.
- Keep ATL on Python 3.13; provision the isolated `/opt/ai-hedge-fund-venv` with a managed **Python 3.12** via `uv`, then smoke-import `from src.main import run_hedge_fund` during the image build. Mirror the same 3.12 path in `render.yaml`'s documented `buildCommand`.

## Test plan
- [ ] Confirm Render Docker build succeeds past the `ai-hedge-fund-venv` install step
- [ ] Confirm container has `AI_HEDGE_FUND_PYTHON=/opt/ai-hedge-fund-venv/bin/python` and that interpreter reports 3.12.x
- [ ] Confirm `/opt/ai-hedge-fund-venv/bin/python -c "from src.main import run_hedge_fund"` works in the built image
- [ ] Spot-check ATL app still starts on 3.13 (`uvicorn dashboard.backend.app:app`)

## Render failure log (reference)

Prod Docker build after #261 (`2026-08-01T01:50Z`). Key lines: `Collecting numpy<2.0.0,>=1.24.0` → `Downloading numpy-1.26.4.tar.gz` → meson `Unknown compiler(s)` on `python:3.13-slim`.

<details>
<summary>Full Render log excerpt</summary>

```
#11 3.956   Downloading fastapi_cli-0.0.7-py3-none-any.whl.metadata (6.2 kB)
#11 3.993 Collecting fastapi<0.105.0,>=0.104.0 (from fastapi[standard]<0.105.0,>=0.104.0->ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.004   Downloading fastapi-0.104.1-py3-none-any.whl.metadata (24 kB)
#11 4.023 Collecting httpx<0.28.0,>=0.27.0 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.032   Downloading httpx-0.27.2-py3-none-any.whl.metadata (7.1 kB)
#11 4.084 Collecting langchain<0.4.0,>=0.3.7 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.096   Downloading langchain-0.3.30-py3-none-any.whl.metadata (6.4 kB)
#11 4.115 Collecting langchain-anthropic==0.3.5 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.126   Downloading langchain_anthropic-0.3.5-py3-none-any.whl.metadata (2.3 kB)
#11 4.202 Collecting langchain-deepseek<0.2.0,>=0.1.2 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.211   Downloading langchain_deepseek-0.1.4-py3-none-any.whl.metadata (1.1 kB)
#11 4.288 Collecting langchain-gigachat<0.4.0,>=0.3.12 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.298   Downloading langchain_gigachat-0.3.12-py3-none-any.whl.metadata (3.0 kB)
#11 4.314 Collecting langchain-google-genai<3.0.0,>=2.0.11 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.323   Downloading langchain_google_genai-2.1.12-py3-none-any.whl.metadata (7.1 kB)
#11 4.337 Collecting langchain-groq==0.2.3 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.346   Downloading langchain_groq-0.2.3-py3-none-any.whl.metadata (3.0 kB)
#11 4.360 Collecting langchain-ollama==0.3.6 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.434   Downloading langchain_ollama-0.3.6-py3-none-any.whl.metadata (2.1 kB)
#11 4.453 Collecting langchain-openai<0.4.0,>=0.3.5 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.465   Downloading langchain_openai-0.3.35-py3-none-any.whl.metadata (2.4 kB)
#11 4.476 Collecting langchain-xai<0.3.0,>=0.2.5 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.490   Downloading langchain_xai-0.2.5-py3-none-any.whl.metadata (1.1 kB)
#11 4.515 Collecting langgraph==0.2.56 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.525   Downloading langgraph-0.2.56-py3-none-any.whl.metadata (15 kB)
#11 4.606 Collecting matplotlib<4.0.0,>=3.9.2 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.622   Downloading matplotlib-3.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (80 kB)
#11 4.744 Collecting numpy<2.0.0,>=1.24.0 (from ai-hedge-fund @ https://github.com/virattt/ai-hedge-fund/archive/9557e64273e212635a4a28cbd8128df22f166c07.tar.gz->-r requirements-ai-hedge-fund.txt (line 4))
#11 4.753   Downloading numpy-1.26.4.tar.gz (15.8 MB)
#11 4.854      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 15.8/15.8 MB 180.7 MB/s  0:00:00
#11 5.976   Installing build dependencies: started
#11 6.793   Installing build dependencies: finished with status 'done'
#11 6.793   Getting requirements to build wheel: started
#11 6.923   Getting requirements to build wheel: finished with status 'done'
#11 6.924   Installing backend dependencies: started
#11 7.397   Installing backend dependencies: finished with status 'done'
#11 7.397   Preparing metadata (pyproject.toml): started
#11 8.191   Preparing metadata (pyproject.toml): finished with status 'error'
#11 8.194   error: subprocess-exited-with-error
#11 8.194
#11 8.194   × Preparing metadata (pyproject.toml) did not run successfully.
#11 8.194   │ exit code: 1
#11 8.194   ╰─> [20 lines of output]
#11 8.194       + /opt/ai-hedge-fund-venv/bin/python /tmp/pip-install-iqxa5wg_/numpy_fe087e463e034ff392087381ec5ec6d4/vendored-meson/meson/meson.py setup /tmp/pip-install-iqxa5wg_/numpy_fe087e463e034ff392087381ec5ec6d4 /tmp/pip-install-iqxa5wg_/numpy_fe087e463e034ff392087381ec5ec6d4/.mesonpy-n_ajisju -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/tmp/pip-install-iqxa5wg_/numpy_fe087e463e034ff392087381ec5ec6d4/.mesonpy-n_ajisju/meson-python-native-file.ini
#11 8.194       The Meson build system
#11 8.194       Version: 1.2.99
#11 8.194       Source dir: /tmp/pip-install-iqxa5wg_/numpy_fe087e463e034ff392087381ec5ec6d4
#11 8.194       Build dir: /tmp/pip-install-iqxa5wg_/numpy_fe087e463e034ff392087381ec5ec6d4/.mesonpy-n_ajisju
#11 8.194       Build type: native build
#11 8.194       Project name: NumPy
#11 8.194       Project version: 1.26.4
#11 8.194
#11 8.194       ../meson.build:1:0: ERROR: Unknown compiler(s): [['cc'], ['gcc'], ['clang'], ['nvc'], ['pgcc'], ['icc'], ['icx']]
#11 8.194       The following exception(s) were encountered:
#11 8.194       Running `cc --version` gave "[Errno 2] No such file or directory: 'cc'"
#11 8.194       Running `gcc --version` gave "[Errno 2] No such file or directory: 'gcc'"
#11 8.194       Running `clang --version` gave "[Errno 2] No such file or directory: 'clang'"
#11 8.194       Running `nvc --version` gave "[Errno 2] No such file or directory: 'nvc'"
#11 8.194       Running `pgcc --version` gave "[Errno 2] No such file or directory: 'pgcc'"
#11 8.194       Running `icc --version` gave "[Errno 2] No such file or directory: 'icc'"
#11 8.194       Running `icx --version` gave "[Errno 2] No such file or directory: 'icx'"
#11 8.194
#11 8.194       A full log can be found at /tmp/pip-install-iqxa5wg_/numpy_fe087e463e034ff392087381ec5ec6d4/.mesonpy-n_ajisju/meson-logs/meson-log.txt
#11 8.194       [end of output]
#11 8.194
#11 8.194   note: This error originates from a subprocess, and is likely not a problem with pip.
#11 8.195
#11 8.195 [notice] A new release of pip is available: 26.1.2 -> 26.2
#11 8.195 [notice] To update, run: /opt/ai-hedge-fund-venv/bin/python -m pip install --upgrade pip
#11 8.196 error: metadata-generation-failed
#11 8.196
#11 8.196 × Encountered error while generating package metadata.
#11 8.196 ╰─> numpy
#11 8.196
#11 8.196 note: This is an issue with the package mentioned above, not pip.
#11 8.196 hint: See above for details.
#11 ERROR: process "/bin/sh -c python -m venv /opt/ai-hedge-fund-venv     && /opt/ai-hedge-fund-venv/bin/pip install --no-cache-dir        -r requirements-ai-hedge-fund.txt" did not complete successfully: exit code: 1
------
 > [5/6] RUN python -m venv /opt/ai-hedge-fund-venv     && /opt/ai-hedge-fund-venv/bin/pip install --no-cache-dir        -r requirements-ai-hedge-fund.txt:
8.195
8.195 [notice] A new release of pip is available: 26.1.2 -> 26.2
8.195 [notice] To update, run: /opt/ai-hedge-fund-venv/bin/python -m pip install --upgrade pip
8.196 error: metadata-generation-failed
8.196
8.196 × Encountered error while generating package metadata.
8.196 ╰─> numpy
8.196
8.196 note: This is an issue with the package mentioned above, not pip.
8.196 hint: See above for details.
------
Dockerfile:14
--------------------
  13 |     # boundary; marketplace users never clone or install the upstream project.
  14 | >>> RUN python -m venv /opt/ai-hedge-fund-venv \
  15 | >>>     && /opt/ai-hedge-fund-venv/bin/pip install --no-cache-dir \
  16 | >>>        -r requirements-ai-hedge-fund.txt
  17 |
--------------------
error: failed to solve: process "/bin/sh -c python -m venv /opt/ai-hedge-fund-venv     && /opt/ai-hedge-fund-venv/bin/pip install --no-cache-dir        -r requirements-ai-hedge-fund.txt" did not complete successfully: exit code: 1
error: exit status 1
```

</details>
