### PR TITLE
feat(backtest): enforce T+1 for iFinD A-shares

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -26,7 +26,7 @@ import pytz
 from datetime import datetime
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 # matplotlib is imported and configured (headless Agg backend) once at module
 # import, not per request: the plot endpoint previously re-imported it and
@@ -248,7 +248,20 @@ class RunMetadata(BaseModel):
     fx_start_rate: Optional[float] = None
     fx_end_rate: Optional[float] = None
     t_plus_one_enabled: Optional[bool] = None
-    rejected_orders: List[Dict[str, Any]] = Field(default_factory=list)
+    # Scalars only. The rejected-order records themselves are unbounded per-step
+    # audit data and this model is the response_model for two *list* routes
+    # (/api/backtest/runs and the public, unpaginated /runs), so shipping them
+    # inline would multiply a multi-megabyte array by the run count on a payload
+    # the dashboard fetches on every load. The records are served per run by
+    # GET /runs/{run_id}/rejected-orders instead, mirroring /runs/{run_id}/trades.
+    # None (not 0) for runs that predate the feature, matching t_plus_one_enabled.
+    rejected_orders_count: Optional[int] = None
+    rejected_orders_truncated: Optional[int] = None
+    # How hard T+1 actually bound: symbol-days on which the agent wanted to exit
+    # more than it could, and the total shares that deferred. Scalars for the
+    # same reason as above — the records live on the detail endpoint.
+    t1_deferred_events: Optional[int] = None
+    t1_deferred_shares: Optional[float] = None
 
 
 class EquityCurve(BaseModel):
@@ -302,7 +315,10 @@ def _run_metadata_response(run: Dict[str, Any]) -> RunMetadata:
             "fx_start_rate",
             "fx_end_rate",
             "t_plus_one_enabled",
-            "rejected_orders",
+            "rejected_orders_count",
+            "rejected_orders_truncated",
+            "t1_deferred_events",
+            "t1_deferred_shares",
         ):
             if field in metadata:
                 payload[field] = metadata[field]
@@ -1539,6 +1555,46 @@ async def get_run_trades(run_id: str, request: Request):
         raise HTTPException(status_code=404, detail="Run not found or not yours")
     trades = db.get_trades(run_id)
     return {"run_id": run_id, "trades": trades, "count": len(trades)}
+
+
+@router.get("/runs/{run_id}/rejected-orders")
+async def get_run_rejected_orders(run_id: str, request: Request):
+    """Rejected / partially-filled order records for a run owned by this session.
+
+    Served here rather than on RunMetadata because these are per-step audit
+    records — a T+1 A-share run can emit thousands — and RunMetadata is the
+    response_model for two list routes the dashboard fetches on every load.
+
+    ``count`` is the run's true total; ``returned`` is how many this response
+    carries. They differ when the engine capped the persisted sample, in which
+    case ``truncated`` says by how much.
+
+    ``t1_deferrals`` answers the complementary question. A rejected order means
+    the agent *submitted* something unfillable; a deferral means it wanted to
+    exit and sized down because it could not. The built-in agents now do the
+    latter, so for them this list — not ``rejected_orders`` — is where T+1's
+    effect on strategy shows up.
+    """
+    session_id = request.state.session_id
+    run = db.get_run_with_session(run_id, session_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found or not yours")
+    metadata = run.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    records = metadata.get("rejected_orders") or []
+    deferrals = metadata.get("t1_deferrals") or []
+    return {
+        "run_id": run_id,
+        "rejected_orders": records,
+        "count": metadata.get("rejected_orders_count", len(records)),
+        "returned": len(records),
+        "truncated": metadata.get("rejected_orders_truncated", 0),
+        "t1_deferrals": deferrals,
+        "t1_deferred_events": metadata.get("t1_deferred_events", len(deferrals)),
+        "t1_deferred_shares": metadata.get("t1_deferred_shares", 0),
+        "t1_deferrals_truncated": metadata.get("t1_deferrals_truncated", 0),
+    }
 
 
 @router.get("/runs/{run_id}/plot.png", include_in_schema=False)

--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -26,7 +26,7 @@ import pytz
 from datetime import datetime
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # matplotlib is imported and configured (headless Agg backend) once at module
 # import, not per request: the plot endpoint previously re-imported it and
@@ -247,6 +247,8 @@ class RunMetadata(BaseModel):
     fx_policy: Optional[str] = None
     fx_start_rate: Optional[float] = None
     fx_end_rate: Optional[float] = None
+    t_plus_one_enabled: Optional[bool] = None
+    rejected_orders: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class EquityCurve(BaseModel):
@@ -299,6 +301,8 @@ def _run_metadata_response(run: Dict[str, Any]) -> RunMetadata:
             "fx_policy",
             "fx_start_rate",
             "fx_end_rate",
+            "t_plus_one_enabled",
+            "rejected_orders",
         ):
             if field in metadata:
                 payload[field] = metadata[field]

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -146,6 +146,7 @@ class HourlyBacktester:
             json.loads(json.dumps(self.pipeline)) if self.pipeline else None
         )
         self.prompt_adaptations: List[Dict] = []
+        self.rejected_orders: List[Dict] = []
         # Model id; defaults to the gateway-appropriate slug (CommonStack vs native).
         self.model = model or default_model_name()
         self.live_run_id = (live_run_id or "").strip() or None
@@ -284,6 +285,25 @@ class HourlyBacktester:
             serialized.append(record)
         return serialized
 
+    @staticmethod
+    def _serialize_rejected_orders(rejected_orders: List[Dict]) -> List[Dict]:
+        serialized = []
+        for item in rejected_orders:
+            record = dict(item)
+            timestamp = record.get("timestamp")
+            if hasattr(timestamp, "isoformat"):
+                record["timestamp"] = timestamp.isoformat()
+            for field in (
+                "requested_shares",
+                "executed_shares",
+                "unfilled_shares",
+            ):
+                value = record.get(field)
+                if hasattr(value, "item"):
+                    record[field] = value.item()
+            serialized.append(record)
+        return serialized
+
     def _publish_live_progress(self, step: int, total_steps: int, manager) -> None:
         """Write incremental equity curve snapshots for live dashboard charting."""
         if not self.progress_file:
@@ -320,6 +340,9 @@ class HourlyBacktester:
             "total_steps": total_steps,
             "equity_curve": serialized,
             "trades": self._serialize_trades(manager.trades),
+            "rejected_orders": self._serialize_rejected_orders(
+                manager.rejected_orders
+            ),
         }
         try:
             Path(self.progress_file).write_text(json.dumps(payload), encoding="utf-8")
@@ -483,6 +506,7 @@ class HourlyBacktester:
                     # with the decision source they actually resolved.
                     "decision_source": RULE_BASED_DECISION_SOURCE,
                     "benchmark": profile.benchmark,
+                    "t_plus_one_enabled": profile.t_plus_one_enabled,
                 }
             )
             context = self._require_currency_context()
@@ -527,6 +551,10 @@ class HourlyBacktester:
             meta["initial_pipeline"] = self.initial_pipeline
         if self.pipeline is not None:
             meta["final_pipeline"] = self.pipeline
+        if self.data_source == IFIND_ASHARE:
+            meta["rejected_orders"] = list(
+                getattr(self, "rejected_orders", []) or []
+            )
         runtime_type = getattr(self, "runtime_type", PIPELINE_RUNTIME_TYPE)
         if runtime_type != PIPELINE_RUNTIME_TYPE:
             meta["runtime_type"] = runtime_type
@@ -649,6 +677,7 @@ class HourlyBacktester:
         manager = PortfolioManager(
             initial_capital=self.native_initial_capital,
             allowed_symbols=self.symbols,
+            t_plus_one_enabled=self.profile.t_plus_one_enabled,
         )
         _decision_steps, post_trade_steps = split_pipeline(self.pipeline)
         if post_trade_steps:
@@ -895,6 +924,9 @@ class HourlyBacktester:
             llm_model, manager.input_tokens, manager.output_tokens
         )
 
+        self.rejected_orders = self._serialize_rejected_orders(
+            manager.rejected_orders
+        )
         db.insert_run(
             run_id=run_id,
             session_id=self.session_id,

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -86,6 +86,20 @@ from dashboard.backend.infrastructure.llm.pipeline_runner import (
 HOSTED_RUNTIME_MAX_FAILURE_RATIO = 0.2
 HOSTED_RUNTIME_MIN_FAILURE_BUDGET = 2
 
+# Rejected-order audit records are per-step, unbounded, and land in the
+# agent_runs.metadata JSON cell -- which for a run-history Postgres deployment
+# is a row in the free-tier ATL-runs-main project. A 20-symbol A-share run can
+# emit thousands. Persist a bounded head sample plus the true total, the same
+# shape runtime_step_failures already uses below, so the cap is never silent.
+# Head rather than tail, matching runtime_step_failure_samples: the T+1 pattern
+# repeats, so the earliest records characterise it and the count carries scale.
+# Also bounds the (already much smaller) t1_deferrals sample.
+REJECTED_ORDER_SAMPLE_LIMIT = 200
+# The live-progress file is rewritten in full on every step, so embedding the
+# whole growing list makes write volume quadratic in the run length. The live
+# view only ever shows the latest activity, so carry a tail window.
+LIVE_PROGRESS_REJECTED_ORDER_LIMIT = 50
+
 
 def _prior_market_date_by_decision_date(
     timestamps,
@@ -147,6 +161,7 @@ class HourlyBacktester:
         )
         self.prompt_adaptations: List[Dict] = []
         self.rejected_orders: List[Dict] = []
+        self.t1_deferrals: List[Dict] = []
         # Model id; defaults to the gateway-appropriate slug (CommonStack vs native).
         self.model = model or default_model_name()
         self.live_run_id = (live_run_id or "").strip() or None
@@ -287,6 +302,14 @@ class HourlyBacktester:
 
     @staticmethod
     def _serialize_rejected_orders(rejected_orders: List[Dict]) -> List[Dict]:
+        """JSON-safe rejected-order records.
+
+        Static where the sibling ``_serialize_trades`` is an instance method,
+        and deliberately so: trades carry prices and values that must be
+        converted through ``self._require_currency_context()``, while a rejected
+        order records only share counts, which are currency-free. Taking ``self``
+        here just to look symmetric would imply a conversion that does not exist.
+        """
         serialized = []
         for item in rejected_orders:
             record = dict(item)
@@ -302,6 +325,34 @@ class HourlyBacktester:
                 if hasattr(value, "item"):
                     record[field] = value.item()
             serialized.append(record)
+        return serialized
+
+    @staticmethod
+    def _serialize_t1_deferrals(t1_deferrals: Dict) -> List[Dict]:
+        """JSON-safe T+1 deferral records, oldest symbol-day first.
+
+        Static for the same reason as ``_serialize_rejected_orders``: share
+        counts carry no currency. Sorted so the persisted sample is a stable
+        prefix of the run rather than dict-insertion order.
+        """
+        serialized = []
+        for record in sorted(
+            t1_deferrals.values(),
+            key=lambda item: (item["date"], item["symbol"]),
+        ):
+            item = dict(record)
+            date_value = item.get("date")
+            if hasattr(date_value, "isoformat"):
+                item["date"] = date_value.isoformat()
+            for field in (
+                "requested_shares",
+                "sellable_shares",
+                "deferred_shares",
+            ):
+                value = item.get(field)
+                if hasattr(value, "item"):
+                    item[field] = value.item()
+            serialized.append(item)
         return serialized
 
     def _publish_live_progress(self, step: int, total_steps: int, manager) -> None:
@@ -341,8 +392,9 @@ class HourlyBacktester:
             "equity_curve": serialized,
             "trades": self._serialize_trades(manager.trades),
             "rejected_orders": self._serialize_rejected_orders(
-                manager.rejected_orders
+                manager.rejected_orders[-LIVE_PROGRESS_REJECTED_ORDER_LIMIT:]
             ),
+            "rejected_orders_count": len(manager.rejected_orders),
         }
         try:
             Path(self.progress_file).write_text(json.dumps(payload), encoding="utf-8")
@@ -506,6 +558,12 @@ class HourlyBacktester:
                     # with the decision source they actually resolved.
                     "decision_source": RULE_BASED_DECISION_SOURCE,
                     "benchmark": profile.benchmark,
+                    # Market provenance, not execution provenance: this records
+                    # that the run's market settles T+1, which is true of the
+                    # buy-and-hold baseline rows too even though they never
+                    # build a T+1 PortfolioManager (they never sell, so the
+                    # rule cannot bind). Read it as "which market", not "which
+                    # executor ran".
                     "t_plus_one_enabled": profile.t_plus_one_enabled,
                 }
             )
@@ -552,9 +610,28 @@ class HourlyBacktester:
         if self.pipeline is not None:
             meta["final_pipeline"] = self.pipeline
         if self.data_source == IFIND_ASHARE:
-            meta["rejected_orders"] = list(
-                getattr(self, "rejected_orders", []) or []
-            )
+            rejected = list(getattr(self, "rejected_orders", []) or [])
+            if rejected:
+                # Count first, sample second: a consumer must be able to tell
+                # "3 rejections" from "the first 200 of 7,000".
+                meta["rejected_orders_count"] = len(rejected)
+                meta["rejected_orders"] = rejected[:REJECTED_ORDER_SAMPLE_LIMIT]
+                truncated = len(rejected) - REJECTED_ORDER_SAMPLE_LIMIT
+                if truncated > 0:
+                    meta["rejected_orders_truncated"] = truncated
+            deferrals = list(getattr(self, "t1_deferrals", []) or [])
+            if deferrals:
+                # "How often did T+1 stop this agent exiting?" — the question a
+                # capped order can no longer answer, because it fills exactly
+                # and leaves the executor nothing to audit.
+                meta["t1_deferred_events"] = len(deferrals)
+                meta["t1_deferred_shares"] = sum(
+                    item["deferred_shares"] for item in deferrals
+                )
+                meta["t1_deferrals"] = deferrals[:REJECTED_ORDER_SAMPLE_LIMIT]
+                deferrals_truncated = len(deferrals) - REJECTED_ORDER_SAMPLE_LIMIT
+                if deferrals_truncated > 0:
+                    meta["t1_deferrals_truncated"] = deferrals_truncated
         runtime_type = getattr(self, "runtime_type", PIPELINE_RUNTIME_TYPE)
         if runtime_type != PIPELINE_RUNTIME_TYPE:
             meta["runtime_type"] = runtime_type
@@ -582,6 +659,16 @@ class HourlyBacktester:
             "native_currency": self.profile.native_currency,
             "reporting_currency": self.profile.reporting_currency,
         }
+        if self.profile.t_plus_one_enabled:
+            # A bare `sellable_shares` number in each holding is not
+            # self-explanatory. Name the rule that produces it, or the model has
+            # to infer a settlement regime from an unlabelled integer.
+            result["settlement"] = "T+1"
+            result["settlement_note"] = (
+                "Shares bought today cannot be sold until the next trading day. "
+                "Each holding reports sellable_shares; a sell above that amount "
+                "is truncated to it."
+            )
         if context.requires_conversion:
             result["fx_pair"] = context.fx_pair
             result["fx_source"] = "iFinD Historical Conversion Rate"
@@ -924,6 +1011,7 @@ class HourlyBacktester:
             llm_model, manager.input_tokens, manager.output_tokens
         )
 
+        self.t1_deferrals = self._serialize_t1_deferrals(manager.t1_deferrals)
         self.rejected_orders = self._serialize_rejected_orders(
             manager.rejected_orders
         )

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -39,6 +39,10 @@ from dashboard.backend.domain.backtesting.metrics import (
 )
 from dashboard.backend.domain.backtesting.portfolio_manager import PortfolioManager
 from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
+from dashboard.backend.infrastructure.market_data.profiles import (
+    ALPACA,
+    get_market_profile,
+)
 
 from dashboard.backend.domain.backtesting import (
     baseline_worker,
@@ -169,7 +173,18 @@ class ExternalBacktestSession:
         self.context_ref_by_step: Dict[int, str] = {}
 
         self.initial_capital = resolve_initial_capital(initial_capital)
-        self.manager = PortfolioManager(initial_capital=self.initial_capital)
+        # This service is Alpaca-only by construction (it loads bars through
+        # AlpacaDataLoader and neither /api/v1 nor /api/v2 accepts a
+        # data_source). Resolve execution rules from the profile registry
+        # anyway, so wiring a second data source here carries its settlement
+        # semantics with it. Defaulting the flag instead would make a future
+        # A-share run silently execute with US same-day settlement — no error,
+        # no log, just wrong fills.
+        self.profile = get_market_profile(ALPACA)
+        self.manager = PortfolioManager(
+            initial_capital=self.initial_capital,
+            t_plus_one_enabled=self.profile.t_plus_one_enabled,
+        )
         self.all_data: Dict[str, pd.DataFrame] = {}
         self.timestamps: List[Any] = []
         self.price_cache: Dict[str, Dict[Any, float]] = {}

--- a/dashboard/backend/domain/backtesting/portfolio_manager.py
+++ b/dashboard/backend/domain/backtesting/portfolio_manager.py
@@ -78,12 +78,17 @@ class PortfolioManager:
         self,
         initial_capital: float = INITIAL_CAPITAL,
         allowed_symbols: Optional[List[str]] = None,
+        t_plus_one_enabled: bool = False,
     ):
         self.initial_capital = initial_capital
         self.cash = initial_capital
         self.positions = {}  # {symbol: num_shares}
         self.entry_prices = {}  # {symbol: entry_price}
         self.trades = []
+        self.t_plus_one_enabled = t_plus_one_enabled
+        self.available_positions = {}
+        self.frozen_lots = {}
+        self.rejected_orders = []
         self.equity_history = []
         # Real LLM token usage (server-side calls report actual counts)
         self.llm_calls = 0        # billed API calls (any response with usage)
@@ -622,6 +627,10 @@ class PortfolioManager:
             positions=self.positions,
             entry_prices=self.entry_prices,
             trades=self.trades,
+            t_plus_one_enabled=self.t_plus_one_enabled,
+            available_positions=self.available_positions,
+            frozen_lots=self.frozen_lots,
+            rejected_orders=self.rejected_orders,
         )
     
     def update_equity(self, market_data: Dict, price_cache: Dict = None, timestamp = None):

--- a/dashboard/backend/domain/backtesting/portfolio_manager.py
+++ b/dashboard/backend/domain/backtesting/portfolio_manager.py
@@ -25,7 +25,8 @@ This module is domain-level orchestration: it must NOT import dashboard scripts,
 import json
 import os
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional
+from types import MappingProxyType
+from typing import Dict, List, Mapping, Optional
 
 import pandas as pd
 
@@ -89,6 +90,10 @@ class PortfolioManager:
         self.available_positions = {}
         self.frozen_lots = {}
         self.rejected_orders = []
+        # {(symbol, trading_date): record} — one entry per symbol-day on which
+        # T+1 shrank an intended exit. Deduped by key rather than appended per
+        # bar, so it is bounded by symbols x trading days by construction.
+        self.t1_deferrals = {}
         self.equity_history = []
         # Real LLM token usage (server-side calls report actual counts)
         self.llm_calls = 0        # billed API calls (any response with usage)
@@ -107,6 +112,65 @@ class PortfolioManager:
         symbols = allowed_symbols if allowed_symbols is not None else DJIA_30
         self.allowed_symbols = [str(s).strip().upper() for s in symbols if s]
         self._allowed_set = set(self.allowed_symbols)
+    @property
+    def sellable_positions(self) -> Optional[Mapping]:
+        """The T+1 sellable balance, or ``None`` when settlement is immediate.
+
+        ``None`` rather than ``self.positions`` on purpose: it is the sentinel
+        every downstream helper uses to keep the pre-T+1 schema and behavior
+        byte-identical for non-A-share runs.
+
+        Returned as a read-only view. It reads like a query but would otherwise
+        hand out the live ledger, so a consumer could rebalance the portfolio
+        through it by accident. The view still tracks later mutations; execution
+        writes through ``self.available_positions`` directly.
+        """
+        if not self.t_plus_one_enabled:
+            return None
+        return MappingProxyType(self.available_positions)
+
+    def sellable_shares(self, symbol: str) -> float:
+        """Shares of ``symbol`` an order submitted right now could actually fill."""
+        held = self.positions.get(symbol, 0)
+        if not self.t_plus_one_enabled:
+            return held
+        return min(self.available_positions.get(symbol, 0), held)
+
+    def record_t1_deferral(
+        self,
+        symbol: str,
+        requested_shares: float,
+        sellable_shares: float,
+    ) -> None:
+        """Note that T+1 shrank an intended exit, once per symbol-trading-day.
+
+        The trading date is read off the symbol's own frozen lots rather than a
+        clock: a lot is only still frozen on the date it was bought (the release
+        sweep moves every earlier lot out), so ``max(buy_date)`` *is* today
+        whenever anything is blocking. That keeps this callable from the
+        rule-based path, which is handed no timestamp.
+
+        Keeping the largest deferral per symbol-day rather than the first means
+        the record reflects the worst the constraint bound that day.
+        """
+        deferred = requested_shares - sellable_shares
+        if deferred <= 0:
+            return
+        lots = self.frozen_lots.get(symbol) or []
+        trading_date = max((lot["buy_date"] for lot in lots), default=None)
+        if trading_date is None:
+            return
+        key = (symbol, trading_date)
+        prior = self.t1_deferrals.get(key)
+        if prior is None or deferred > prior["deferred_shares"]:
+            self.t1_deferrals[key] = {
+                "date": trading_date,
+                "symbol": symbol,
+                "requested_shares": requested_shares,
+                "sellable_shares": sellable_shares,
+                "deferred_shares": deferred,
+            }
+
     def get_portfolio_state(self, market_data: Dict[str, pd.Series], price_cache: Dict = None, timestamp = None) -> Dict:
         """Get current portfolio state with market indicators.
 
@@ -119,6 +183,7 @@ class PortfolioManager:
             market_data,
             price_cache,
             timestamp,
+            self.sellable_positions,
         )
 
     def make_trading_decision(self, portfolio_state: Dict) -> Dict:
@@ -133,11 +198,21 @@ class PortfolioManager:
         Returns:
             {"actions": [{"symbol": "AAPL", "action": "buy", "shares": 10}, ...]}
         """
-        return _make_rule_based_decision(
+        decision = _make_rule_based_decision(
             portfolio_state=portfolio_state,
             positions=self.positions,
             cash=self.cash,
+            available_positions=self.sellable_positions,
         )
+        # Drain into the run-level ledger and pop, so the returned shape stays
+        # exactly {"actions": [...]} for every existing caller.
+        for deferral in decision.pop("t1_deferrals", ()):
+            self.record_t1_deferral(
+                deferral["symbol"],
+                deferral["requested_shares"],
+                deferral["sellable_shares"],
+            )
+        return decision
     
     def make_trading_decision_with_llm(
         self,
@@ -189,13 +264,21 @@ class PortfolioManager:
             # Extract current holdings for LLM decision-making
             holdings = {}
             for position in portfolio_state["positions"]:
-                holdings[position["symbol"]] = {
+                holding = {
                     "shares": position["shares"],
                     "entry_price": round(position["entry_price"], 2),
                     "current_price": round(position["current_price"], 2),
                     "position_value": round(position["position_value"], 2),
                     "pnl_pct": round(position["pnl_pct"], 2)
                 }
+                # Present only on T+1 markets, so non-A-share prompts are
+                # byte-identical. Without forwarding it the model cannot see the
+                # settlement rule at all -- its order would still be capped
+                # downstream, but it would reason as though it could exit in
+                # full and never learn otherwise.
+                if "sellable_shares" in position:
+                    holding["sellable_shares"] = position["sellable_shares"]
+                holdings[position["symbol"]] = holding
             
             # Extract recent trade history (last 24 hours) for LLM memory
             # This prevents LLM from re-entering stocks too soon
@@ -544,15 +627,29 @@ class PortfolioManager:
                         print(f"      ⚠️  BUY {symbol}: Skip (insufficient cash: need ${shares*price:,.0f}, have ${self.cash:,.0f})")
                 
                 elif action_type == "sell":
-                    if symbol in self.positions and self.positions[symbol] > 0:
-                        actions.append({
+                    # Size at the sellable quantity, not the held one: under T+1
+                    # they differ, and the difference is unfillable.
+                    held = self.positions.get(symbol, 0)
+                    sellable = self.sellable_shares(symbol)
+                    if sellable < held:
+                        self.record_t1_deferral(symbol, held, sellable)
+                    if sellable > 0:
+                        action = {
                             "symbol": symbol,
                             "action": "sell",
-                            "shares": self.positions[symbol],
+                            "shares": sellable,
                             "reason": f"[LLM] {reasoning} (confidence: {confidence:.0%})",
                             "confidence": confidence
-                        })
-                        print(f"      ✅ SELL {symbol}: {self.positions[symbol]} shares @ ${price:.2f} (conf: {confidence:.0%})")
+                        }
+                        if sellable < held:
+                            # The reason string still carries the model's own
+                            # words ("exit the full position"); without this the
+                            # log would read as though it asked for `sellable`.
+                            action["requested_shares"] = held
+                        actions.append(action)
+                        print(f"      ✅ SELL {symbol}: {sellable} shares @ ${price:.2f} (conf: {confidence:.0%})")
+                    elif symbol in self.positions and self.positions[symbol] > 0:
+                        print(f"      ⚠️  SELL {symbol}: Skip (T+1 frozen, {self.positions[symbol]} shares settle next trading day)")
                     else:
                         print(f"      ⚠️  SELL {symbol}: Skip (not in portfolio, only owns: {list(self.positions.keys())})")
                 

--- a/dashboard/backend/domain/backtesting/reference_agent.py
+++ b/dashboard/backend/domain/backtesting/reference_agent.py
@@ -23,11 +23,25 @@ Behavior is byte-for-byte identical to the original method. In particular:
 No thresholds, formulas, strings, or default quantities are changed. The LLM
 decision workflow is intentionally NOT extracted here.
 
+The one addition is the optional ``available_positions`` argument (T+1 markets).
+Left ``None`` — every non-A-share run — the held quantity *is* the sellable
+quantity and the emitted actions are unchanged. Supplied, the SELL size is
+capped at what would actually fill, and a fully-frozen holding emits no action
+at all. Without that cap the agent re-proposes an unfillable full-holding sell
+on every bar of the buy date, and each one becomes a ``t1_frozen`` audit record
+for a constraint the agent was never shown.
+
+The cap alone would trade a too-loud audit for a silent one: a capped order
+fills exactly, so the executor sees nothing to record, and "how often did T+1
+stop this agent exiting?" becomes unanswerable. So a capped SELL also reports
+the discarded intent — as ``t1_deferrals`` on the return value (the caller
+dedupes it per trading day) and as ``requested_shares`` on the action itself.
+
 This module is domain-only: it must not import Anthropic, Alpaca, the database,
 FastAPI, API routers, or scripts.
 """
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import pandas as pd
 
@@ -37,16 +51,20 @@ def make_rule_based_decision(
     portfolio_state: Dict,
     positions: Dict,
     cash: float,
+    available_positions: Optional[Dict] = None,
 ) -> Dict:
     """Produce rule-based trading actions for the given portfolio state.
 
     ``portfolio_state`` must provide ``total_equity`` and ``market_signals`` (a
     mapping of symbol -> indicator dict). ``positions`` and ``cash`` reflect the
-    current holdings and available cash. Inputs are read only, never mutated.
-    Returns ``{"actions": [...]}`` with the same action dictionaries the original
-    method produced.
+    current holdings and available cash. ``available_positions`` is the T+1
+    sellable balance, or ``None`` when settlement is immediate. Inputs are read
+    only, never mutated. Returns ``{"actions": [...]}`` with the same action
+    dictionaries the original method produced, plus a ``t1_deferrals`` key that
+    appears **only** when the T+1 cap actually shrank an intended exit.
     """
     actions: List[Dict] = []
+    deferrals: List[Dict] = []
 
     # Calculate total portfolio equity for consistent position sizing
     total_equity = portfolio_state["total_equity"]
@@ -78,11 +96,41 @@ def make_rule_based_decision(
 
         # SELL logic: RSI > 70 (overbought) or price above SMA50
         elif has_position and (rsi > 70 or (sma50 and price > sma50 * 1.02)):
-            actions.append({
-                "symbol": symbol,
-                "action": "sell",
-                "shares": positions[symbol],
-                "reason": f"RSI overbought ({rsi:.0f})" if rsi > 70 else "Price above MA50"
-            })
+            # Under T+1 the held quantity is not necessarily the sellable one.
+            # Proposing more than that would only mint rejection records.
+            sellable = (
+                positions[symbol]
+                if available_positions is None
+                else min(available_positions.get(symbol, 0), positions[symbol])
+            )
+            reason = (
+                f"RSI overbought ({rsi:.0f})" if rsi > 70 else "Price above MA50"
+            )
+            if sellable < positions[symbol]:
+                # Report the intent the cap discarded. Capping alone would make
+                # "T+1 stopped this agent exiting" unobservable: the order fills
+                # exactly, so the executor has nothing to audit.
+                deferrals.append({
+                    "symbol": symbol,
+                    "requested_shares": positions[symbol],
+                    "sellable_shares": sellable,
+                })
+            if sellable > 0:
+                action = {
+                    "symbol": symbol,
+                    "action": "sell",
+                    "shares": sellable,
+                    "reason": reason,
+                }
+                if sellable < positions[symbol]:
+                    # Keep the untruncated intent on the action so the decision
+                    # log does not read as though the agent asked for `sellable`.
+                    action["requested_shares"] = positions[symbol]
+                actions.append(action)
 
-    return {"actions": actions}
+    result: Dict = {"actions": actions}
+    if deferrals:
+        # Only present when T+1 actually bound, so the returned shape is
+        # unchanged for every non-A-share caller.
+        result["t1_deferrals"] = deferrals
+    return result

--- a/dashboard/backend/domain/leaderboard/strategies/llm_agent.py
+++ b/dashboard/backend/domain/leaderboard/strategies/llm_agent.py
@@ -19,6 +19,10 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from dashboard.backend.infrastructure.llm.validator import DJIA_30
+from dashboard.backend.infrastructure.market_data.profiles import (
+    ALPACA,
+    get_market_profile,
+)
 from dashboard.backend.domain.backtesting.features import TechnicalIndicators
 from dashboard.backend.domain.backtesting.portfolio_manager import PortfolioManager
 from dashboard.backend.infrastructure.llm.backtest_harness import (
@@ -141,7 +145,15 @@ class LLMAgentStrategy(BaselineStrategy):
         # rejects.
         model_id = self.model_id or default_model_name(self.integration)
 
-        manager = PortfolioManager(initial_capital=initial_capital)
+        # Contest entries replay the hourly DJIA window over Alpaca bars, so the
+        # execution rules come from that profile rather than a constructor
+        # default — a leaderboard curve must never be produced under settlement
+        # semantics its market does not have.
+        profile = get_market_profile(ALPACA)
+        manager = PortfolioManager(
+            initial_capital=initial_capital,
+            t_plus_one_enabled=profile.t_plus_one_enabled,
+        )
         total = len(timestamps)
         integration_label = self.integration or "auto"
         print(

--- a/dashboard/backend/domain/trading/execution.py
+++ b/dashboard/backend/domain/trading/execution.py
@@ -5,7 +5,8 @@ Extracted (Phase 2B3) from ``PortfolioManager.execute_actions`` in
 execution logic over explicit state (cash, positions, entry prices, trades). The
 legacy method now delegates here.
 
-Behavior is byte-for-byte identical to the original method. In particular:
+With ``t_plus_one_enabled=False`` (the default), behavior remains identical to
+the original method. In particular:
 
 * action fields are read with ``action.get("symbol")``, ``action.get("action")``,
   ``action.get("shares", 0)``, ``action.get("reason", "")``;
@@ -24,15 +25,77 @@ Behavior is byte-for-byte identical to the original method. In particular:
 * ``positions``, ``entry_prices`` and ``trades`` are mutated in place; ``cash`` is
   a scalar and is returned so the caller can reassign it.
 
-No "improvements", normalization, or new guards are added: any pre-existing edge
-behavior (e.g. zero/negative quantities) is preserved exactly.
+The optional T+1 path adds an available-position balance, date-stamped frozen
+buy lots, partial fills, and rejected-order audit records. It is enabled only by
+the iFinD A-share market profiles.
 
 This module is domain-only: it must not import FastAPI, Anthropic, Alpaca
 clients, the database singleton, API routers, or scripts.
 """
 
-from datetime import datetime
-from typing import Dict, List
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional
+
+
+def _trading_date(timestamp: Any) -> date:
+    """Return the market date carried by one backtest timestamp."""
+    if isinstance(timestamp, datetime):
+        return timestamp.date()
+    if isinstance(timestamp, date):
+        return timestamp
+    date_method = getattr(timestamp, "date", None)
+    if callable(date_method):
+        value = date_method()
+        if isinstance(value, date):
+            return value
+    raise TypeError("T+1 execution requires a date-like timestamp")
+
+
+def _release_frozen_lots(
+    *,
+    current_date: date,
+    available_positions: Dict,
+    frozen_lots: Dict,
+) -> None:
+    """Move every prior-date buy lot into the sellable balance."""
+    for symbol, lots in list(frozen_lots.items()):
+        remaining = []
+        released = 0
+        for lot in lots:
+            if lot["buy_date"] < current_date:
+                released += lot["quantity"]
+            else:
+                remaining.append(lot)
+        if released:
+            available_positions[symbol] = (
+                available_positions.get(symbol, 0) + released
+            )
+        if remaining:
+            frozen_lots[symbol] = remaining
+        else:
+            frozen_lots.pop(symbol, None)
+
+
+def _append_rejection(
+    rejected_orders: List[Dict],
+    *,
+    timestamp: Any,
+    symbol: str,
+    requested_shares: float,
+    executed_shares: float,
+    unfilled_shares: float,
+    reason: str,
+) -> None:
+    rejected_orders.append({
+        "timestamp": timestamp,
+        "symbol": symbol,
+        "action": "sell",
+        "requested_shares": requested_shares,
+        "executed_shares": executed_shares,
+        "unfilled_shares": unfilled_shares,
+        "status": "partial" if executed_shares > 0 else "rejected",
+        "reason": reason,
+    })
 
 
 def execute_actions(
@@ -44,6 +107,10 @@ def execute_actions(
     positions: Dict,
     entry_prices: Dict,
     trades: List[Dict],
+    t_plus_one_enabled: bool = False,
+    available_positions: Optional[Dict] = None,
+    frozen_lots: Optional[Dict] = None,
+    rejected_orders: Optional[List[Dict]] = None,
 ) -> float:
     """Apply ``actions`` to the given portfolio state in place.
 
@@ -52,6 +119,24 @@ def execute_actions(
     reassign it. The return value is the new cash balance, matching the original
     method's mutation of ``self.cash``.
     """
+    current_date = None
+    if t_plus_one_enabled:
+        if (
+            available_positions is None
+            or frozen_lots is None
+            or rejected_orders is None
+        ):
+            raise ValueError(
+                "T+1 execution requires available positions, frozen lots, "
+                "and rejected-order state"
+            )
+        current_date = _trading_date(timestamp)
+        _release_frozen_lots(
+            current_date=current_date,
+            available_positions=available_positions,
+            frozen_lots=frozen_lots,
+        )
+
     for action in actions:
         symbol = action.get("symbol")
         action_type = action.get("action")
@@ -69,6 +154,11 @@ def execute_actions(
                 cash -= cost
                 positions[symbol] = positions.get(symbol, 0) + shares
                 entry_prices[symbol] = price
+                if t_plus_one_enabled:
+                    frozen_lots.setdefault(symbol, []).append({
+                        "quantity": shares,
+                        "buy_date": current_date,
+                    })
                 trades.append({
                     "timestamp": timestamp,
                     "symbol": symbol,
@@ -78,6 +168,63 @@ def execute_actions(
                     "cost": cost,
                     "reason": reason
                 })
+
+        elif action_type == "sell" and t_plus_one_enabled:
+            if shares <= 0:
+                continue
+            held_shares = positions.get(symbol, 0)
+            sellable_shares = min(
+                available_positions.get(symbol, 0),
+                held_shares,
+            )
+            sell_shares = min(shares, sellable_shares)
+
+            if sell_shares > 0:
+                proceeds = sell_shares * price
+                cash += proceeds
+                positions[symbol] -= sell_shares
+                available_positions[symbol] -= sell_shares
+                if available_positions[symbol] == 0:
+                    available_positions.pop(symbol, None)
+                if positions[symbol] == 0:
+                    positions.pop(symbol, None)
+                    entry_prices.pop(symbol, None)
+                trades.append({
+                    "timestamp": timestamp,
+                    "symbol": symbol,
+                    "side": "SELL",
+                    "shares": sell_shares,
+                    "price": price,
+                    "proceeds": proceeds,
+                    "reason": reason,
+                })
+
+            unfilled_shares = shares - sell_shares
+            if unfilled_shares <= 0:
+                continue
+            frozen_shares = max(held_shares - sellable_shares, 0)
+            t1_unfilled = min(unfilled_shares, frozen_shares)
+            if t1_unfilled > 0:
+                _append_rejection(
+                    rejected_orders,
+                    timestamp=timestamp,
+                    symbol=symbol,
+                    requested_shares=shares,
+                    executed_shares=sell_shares,
+                    unfilled_shares=t1_unfilled,
+                    reason="t1_frozen",
+                )
+            insufficient_shares = unfilled_shares - t1_unfilled
+            if insufficient_shares > 0:
+                _append_rejection(
+                    rejected_orders,
+                    timestamp=timestamp,
+                    symbol=symbol,
+                    requested_shares=shares,
+                    executed_shares=sell_shares,
+                    unfilled_shares=insufficient_shares,
+                    reason="insufficient_position",
+                )
 
         elif action_type == "sell":
             if symbol in positions and positions[symbol] > 0:

--- a/dashboard/backend/domain/trading/execution.py
+++ b/dashboard/backend/domain/trading/execution.py
@@ -29,12 +29,32 @@ The optional T+1 path adds an available-position balance, date-stamped frozen
 buy lots, partial fills, and rejected-order audit records. It is enabled only by
 the iFinD A-share market profiles.
 
+The T+1 SELL branch is a rewrite rather than a wrapper, so it also diverges from
+the legacy branch in two ways that are NOT T+1 semantics. Both are deliberate;
+neither can reach a run with ``t_plus_one_enabled=False``:
+
+* it guards ``shares <= 0`` and skips. The legacy branch does not: a sell of
+  ``-5`` evaluates ``min(-5, 100) == -5``, which *adds* 5 shares to the position
+  and *subtracts* the "proceeds" from cash. That is a latent bug, kept only
+  because the legacy path is frozen;
+* a sell of a symbol that is not held emits an ``insufficient_position`` audit
+  record, where the legacy branch skips silently. The audit trail is the point
+  of the T+1 path, so "the agent asked for something impossible" is recorded
+  rather than dropped.
+
 This module is domain-only: it must not import FastAPI, Anthropic, Alpaca
 clients, the database singleton, API routers, or scripts.
 """
 
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
+
+
+# Share quantities are integral for A-shares, but the ledger arithmetic is
+# float, so a fully-filled sell can leave residue on the order of 1e-17
+# (0.3 - 0.1 - 0.2). Without a tolerance that residue is "unfilled" and mints a
+# rejection record for ~0 shares, which reads as a real constraint violation.
+_SHARE_EPSILON = 1e-9
 
 
 def _trading_date(timestamp: Any) -> date:
@@ -200,11 +220,11 @@ def execute_actions(
                 })
 
             unfilled_shares = shares - sell_shares
-            if unfilled_shares <= 0:
+            if unfilled_shares <= _SHARE_EPSILON:
                 continue
             frozen_shares = max(held_shares - sellable_shares, 0)
             t1_unfilled = min(unfilled_shares, frozen_shares)
-            if t1_unfilled > 0:
+            if t1_unfilled > _SHARE_EPSILON:
                 _append_rejection(
                     rejected_orders,
                     timestamp=timestamp,
@@ -215,7 +235,7 @@ def execute_actions(
                     reason="t1_frozen",
                 )
             insufficient_shares = unfilled_shares - t1_unfilled
-            if insufficient_shares > 0:
+            if insufficient_shares > _SHARE_EPSILON:
                 _append_rejection(
                     rejected_orders,
                     timestamp=timestamp,

--- a/dashboard/backend/domain/trading/portfolio.py
+++ b/dashboard/backend/domain/trading/portfolio.py
@@ -38,12 +38,24 @@ def resolve_price(symbol, market_data: Dict, price_cache: Optional[Dict] = None,
     return None
 
 
-def build_position_list(positions, entry_prices, market_data, price_cache=None, timestamp=None):
+def build_position_list(
+    positions,
+    entry_prices,
+    market_data,
+    price_cache=None,
+    timestamp=None,
+    available_positions=None,
+):
     """Build the per-position detail list and the aggregate positions value.
 
     Returns ``(position_list, positions_value)``. Symbols without an available
     price are skipped. ``positions_value`` starts at int ``0`` and accumulates
     ``shares * current_price``.
+
+    ``available_positions`` is the T+1 sellable balance. Pass ``None`` (the
+    default) when settlement is immediate and ``shares`` is itself sellable —
+    the position dicts are then byte-identical to the pre-T+1 schema, so
+    non-A-share LLM prompts are unchanged.
     """
     positions_value = 0
     position_list = []
@@ -58,14 +70,19 @@ def build_position_list(positions, entry_prices, market_data, price_cache=None, 
         entry_price = entry_prices.get(symbol, current_price)
         pnl_pct = ((current_price / entry_price) - 1) * 100 if entry_price > 0 else 0
 
-        position_list.append({
+        position = {
             "symbol": symbol,
             "shares": shares,
             "entry_price": entry_price,
             "current_price": current_price,
             "position_value": position_value,
             "pnl_pct": pnl_pct,
-        })
+        }
+        if available_positions is not None:
+            position["sellable_shares"] = min(
+                available_positions.get(symbol, 0), shares
+            )
+        position_list.append(position)
 
     return position_list, positions_value
 
@@ -87,10 +104,28 @@ def build_market_signals(market_data):
     return market_signals
 
 
-def build_portfolio_state(cash, positions, entry_prices, market_data, price_cache=None, timestamp=None) -> Dict:
-    """Assemble the full portfolio-state snapshot dictionary."""
+def build_portfolio_state(
+    cash,
+    positions,
+    entry_prices,
+    market_data,
+    price_cache=None,
+    timestamp=None,
+    available_positions=None,
+) -> Dict:
+    """Assemble the full portfolio-state snapshot dictionary.
+
+    ``available_positions`` (T+1 only) adds a ``sellable_shares`` key to each
+    position so a decision-maker can see what an order submitted now could
+    actually fill. Left ``None`` the snapshot schema is unchanged.
+    """
     position_list, positions_value = build_position_list(
-        positions, entry_prices, market_data, price_cache, timestamp
+        positions,
+        entry_prices,
+        market_data,
+        price_cache,
+        timestamp,
+        available_positions,
     )
     market_signals = build_market_signals(market_data)
 

--- a/dashboard/backend/infrastructure/market_data/profiles.py
+++ b/dashboard/backend/infrastructure/market_data/profiles.py
@@ -65,6 +65,7 @@ class MarketProfile:
     index_baseline_enabled: bool
     native_currency: str
     reporting_currency: str
+    t_plus_one_enabled: bool
 
     @property
     def decision_source(self) -> str:
@@ -96,6 +97,7 @@ _MARKET_PROFILES = {
         index_baseline_enabled=True,
         native_currency="USD",
         reporting_currency="USD",
+        t_plus_one_enabled=False,
     ),
     (VNPY_SIMULATION, "djia_30"): MarketProfile(
         data_source=VNPY_SIMULATION,
@@ -110,6 +112,7 @@ _MARKET_PROFILES = {
         index_baseline_enabled=True,
         native_currency="USD",
         reporting_currency="USD",
+        t_plus_one_enabled=False,
     ),
     (IFIND_ASHARE, A_SHARE_DEMO_6): MarketProfile(
         data_source=IFIND_ASHARE,
@@ -127,6 +130,7 @@ _MARKET_PROFILES = {
         index_baseline_enabled=False,
         native_currency="CNY",
         reporting_currency="USD",
+        t_plus_one_enabled=True,
     ),
     (IFIND_ASHARE, CSI300_SAMPLE_20_2026H2): MarketProfile(
         data_source=IFIND_ASHARE,
@@ -144,6 +148,7 @@ _MARKET_PROFILES = {
         index_baseline_enabled=False,
         native_currency="CNY",
         reporting_currency="USD",
+        t_plus_one_enabled=True,
     ),
 }
 

--- a/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
+++ b/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
@@ -95,6 +95,101 @@ def make_cn_bars(symbols=A_SHARE_DEMO_6_SYMBOLS, count=60):
     return bars
 
 
+def test_rejected_order_serializer_normalizes_timestamp_and_numpy_numbers():
+    serialized = HourlyBacktester._serialize_rejected_orders([{
+        "timestamp": pd.Timestamp("2026-04-01T10:00:00", tz=CN),
+        "requested_shares": pd.Series([100], dtype="int64").iloc[0],
+        "executed_shares": pd.Series([40], dtype="int64").iloc[0],
+        "unfilled_shares": pd.Series([60], dtype="int64").iloc[0],
+        "reason": "t1_frozen",
+    }])
+
+    assert serialized == [{
+        "timestamp": "2026-04-01T10:00:00+08:00",
+        "requested_shares": 100,
+        "executed_shares": 40,
+        "unfilled_shares": 60,
+        "reason": "t1_frozen",
+    }]
+
+
+@pytest.mark.parametrize(
+    ("decision_source", "wants_llm"),
+    [
+        (RULE_BASED_DECISION_SOURCE, False),
+        (LLM_DECISION_SOURCE, True),
+    ],
+)
+def test_ifind_rule_and_llm_paths_share_t1_execution(
+    monkeypatch,
+    decision_source,
+    wants_llm,
+):
+    provider = RecordingProvider(make_cn_bars())
+    monkeypatch.setattr(
+        engine_module,
+        "create_market_data_provider",
+        lambda _source, universe=None: provider,
+    )
+    monkeypatch.setattr(engine_module, "HAS_ANTHROPIC", True)
+    monkeypatch.setattr(engine_module, "make_llm_client", lambda: object())
+    recording_db = RecordingDB()
+    monkeypatch.setattr(engine_module, "db", recording_db)
+
+    created_managers = []
+    base_manager = engine_module.PortfolioManager
+
+    class ScriptedPortfolioManager(base_manager):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.script_step = 0
+            created_managers.append(self)
+
+        def _scripted_decision(self):
+            self.script_step += 1
+            if self.script_step == 1:
+                return {"actions": [{
+                    "symbol": A_SHARE_DEMO_6_SYMBOLS[0],
+                    "action": "buy",
+                    "shares": 10,
+                }]}
+            if self.script_step == 2:
+                return {"actions": [{
+                    "symbol": A_SHARE_DEMO_6_SYMBOLS[0],
+                    "action": "sell",
+                    "shares": 10,
+                }]}
+            return {"actions": []}
+
+        def make_trading_decision(self, _portfolio_state):
+            return self._scripted_decision()
+
+        def make_trading_decision_with_llm(self, *_args, **_kwargs):
+            return self._scripted_decision()
+
+    monkeypatch.setattr(engine_module, "PortfolioManager", ScriptedPortfolioManager)
+
+    backtester = HourlyBacktester(
+        START,
+        END,
+        session_id=f"ifind-t1-{decision_source}",
+        use_llm=wants_llm,
+        data_source=IFIND_ASHARE,
+        decision_source=decision_source,
+    )
+    backtester.load_data()
+    backtester.calculate_indicators()
+    backtester.run_agent_backtest()
+
+    manager = created_managers[0]
+    assert manager.t_plus_one_enabled is True
+    assert [trade["side"] for trade in manager.trades] == ["BUY"]
+    assert manager.rejected_orders[0]["reason"] == "t1_frozen"
+    assert recording_db.runs[0]["metadata"]["rejected_orders"][0][
+        "reason"
+    ] == "t1_frozen"
+
+
 def test_ifind_engine_uses_profile_symbols_in_explicit_rule_mode(monkeypatch):
     provider = RecordingProvider(make_cn_bars())
     monkeypatch.setattr(engine_module, "create_market_data_provider", lambda _source, universe=None: provider)
@@ -145,6 +240,7 @@ def test_ifind_engine_uses_profile_symbols_in_explicit_rule_mode(monkeypatch):
         "timezone": "Asia/Shanghai",
         "decision_source": "rule_based",
         "benchmark": "equal_weight_buyhold",
+        "t_plus_one_enabled": True,
         "symbols": list(A_SHARE_DEMO_6_SYMBOLS),
         "native_currency": "CNY",
         "reporting_currency": "USD",
@@ -160,6 +256,7 @@ def test_ifind_engine_uses_profile_symbols_in_explicit_rule_mode(monkeypatch):
         "fx_observation_start_date": "2026-03-31",
         "fx_observation_end_date": "2026-04-15",
         "native_initial_capital": 7_000.0,
+        "rejected_orders": [],
     }
     first_equity = recording_db.equity_points[0][1][0]
     assert first_equity["equity"] == pytest.approx(1_000)
@@ -206,6 +303,7 @@ def test_ifind_engine_resolves_csi300_sample20_and_records_provenance(
         "timezone": "Asia/Shanghai",
         "decision_source": "rule_based",
         "benchmark": "equal_weight_buyhold",
+        "t_plus_one_enabled": True,
         "symbols": list(CSI300_SAMPLE_20_2026H2_SYMBOLS),
         "native_currency": "CNY",
         "reporting_currency": "USD",

--- a/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
+++ b/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, time, timedelta
+import json
 import os
 import subprocess
 import sys
@@ -132,7 +133,7 @@ def test_ifind_rule_and_llm_paths_share_t1_execution(
         lambda _source, universe=None: provider,
     )
     monkeypatch.setattr(engine_module, "HAS_ANTHROPIC", True)
-    monkeypatch.setattr(engine_module, "make_llm_client", lambda: object())
+    monkeypatch.setattr(engine_module, "make_llm_client", object)
     recording_db = RecordingDB()
     monkeypatch.setattr(engine_module, "db", recording_db)
 
@@ -256,7 +257,8 @@ def test_ifind_engine_uses_profile_symbols_in_explicit_rule_mode(monkeypatch):
         "fx_observation_start_date": "2026-03-31",
         "fx_observation_end_date": "2026-04-15",
         "native_initial_capital": 7_000.0,
-        "rejected_orders": [],
+        # No rejected_orders* keys at all: a clean run writes nothing rather
+        # than an empty array on every A-share row.
     }
     first_equity = recording_db.equity_points[0][1][0]
     assert first_equity["equity"] == pytest.approx(1_000)
@@ -400,6 +402,15 @@ def test_ifind_registered_universe_runs_explicit_llm_with_strict_market_context(
             "paper_backtest": True,
             "native_currency": "CNY",
             "reporting_currency": "USD",
+            # A_share profiles settle T+1, and the model is told so in words —
+            # a bare sellable_shares integer in each holding is not
+            # self-describing.
+            "settlement": "T+1",
+            "settlement_note": (
+                "Shares bought today cannot be sold until the next trading "
+                "day. Each holding reports sellable_shares; a sell above that "
+                "amount is truncated to it."
+            ),
             "fx_pair": "USD/CNY",
             "fx_source": "iFinD Historical Conversion Rate",
         }
@@ -665,3 +676,128 @@ def test_transport_failure_still_points_at_credentials(monkeypatch):
 
     with pytest.raises(MarketDataUnavailableError, match="permission"):
         backtester.load_data()
+
+
+# ---------------------------------------------------------------------------
+# Rejected-order persistence is bounded, and says so
+# ---------------------------------------------------------------------------
+
+def _metadata_stub(rejected, monkeypatch, data_source=IFIND_ASHARE, deferrals=()):
+    """Run _agent_run_metadata over just the T+1 audit branches."""
+    backtester = object.__new__(HourlyBacktester)
+    backtester.data_source = data_source
+    backtester.rejected_orders = rejected
+    backtester.t1_deferrals = list(deferrals)
+    backtester.use_llm = False
+    backtester.prompt_adaptations = None
+    backtester.initial_pipeline = None
+    backtester.pipeline = None
+    monkeypatch.setattr(HourlyBacktester, "_run_metadata", lambda self: {})
+    return backtester._agent_run_metadata()
+
+
+def test_agent_metadata_omits_rejected_orders_entirely_when_there_are_none(monkeypatch):
+    """A clean run must not write an empty array onto every A-share row."""
+    meta = _metadata_stub([], monkeypatch)
+    assert "rejected_orders" not in meta
+    assert "rejected_orders_count" not in meta
+    assert "rejected_orders_truncated" not in meta
+
+
+def test_agent_metadata_keeps_a_small_rejection_list_whole(monkeypatch):
+    records = [{"reason": "t1_frozen", "seq": i} for i in range(3)]
+    meta = _metadata_stub(records, monkeypatch)
+    assert meta["rejected_orders"] == records
+    assert meta["rejected_orders_count"] == 3
+    assert "rejected_orders_truncated" not in meta
+
+
+def test_agent_metadata_caps_the_sample_and_reports_the_true_total(monkeypatch):
+    """The cap must never be silent.
+
+    A 20-symbol A-share run can emit thousands of records at ~198 bytes each,
+    which would otherwise land whole in one agent_runs.metadata JSON cell.
+    """
+    limit = engine_module.REJECTED_ORDER_SAMPLE_LIMIT
+    records = [{"reason": "t1_frozen", "seq": i} for i in range(limit + 500)]
+    meta = _metadata_stub(records, monkeypatch)
+
+    assert len(meta["rejected_orders"]) == limit
+    assert meta["rejected_orders_count"] == limit + 500
+    assert meta["rejected_orders_truncated"] == 500
+    # Head sample: the first rejections are the diagnostic ones, and the count
+    # above is what tells a reader the list is partial.
+    assert meta["rejected_orders"][0]["seq"] == 0
+
+
+def test_agent_metadata_skips_rejected_orders_for_non_ashare_sources(monkeypatch):
+    meta = _metadata_stub(
+        [{"reason": "t1_frozen"}], monkeypatch, data_source="alpaca"
+    )
+    assert "rejected_orders" not in meta
+    assert "rejected_orders_count" not in meta
+
+
+# ---------------------------------------------------------------------------
+# T+1 deferrals: the "did the rule actually bind?" metric
+# ---------------------------------------------------------------------------
+
+def _deferral(seq, deferred=10):
+    return {
+        "date": f"2026-04-{(seq % 28) + 1:02d}",
+        "symbol": f"60000{seq % 5}.SH",
+        "requested_shares": deferred + 5,
+        "sellable_shares": 5,
+        "deferred_shares": deferred,
+    }
+
+
+def test_agent_metadata_omits_deferrals_when_t1_never_bound(monkeypatch):
+    meta = _metadata_stub([], monkeypatch, deferrals=[])
+    assert "t1_deferrals" not in meta
+    assert "t1_deferred_events" not in meta
+    assert "t1_deferred_shares" not in meta
+
+
+def test_agent_metadata_totals_the_deferred_shares(monkeypatch):
+    records = [_deferral(i, deferred=10) for i in range(3)]
+    meta = _metadata_stub([], monkeypatch, deferrals=records)
+
+    assert meta["t1_deferred_events"] == 3
+    assert meta["t1_deferred_shares"] == 30
+    assert meta["t1_deferrals"] == records
+    assert "t1_deferrals_truncated" not in meta
+
+
+def test_agent_metadata_caps_the_deferral_sample_too(monkeypatch):
+    limit = engine_module.REJECTED_ORDER_SAMPLE_LIMIT
+    records = [_deferral(i) for i in range(limit + 7)]
+    meta = _metadata_stub([], monkeypatch, deferrals=records)
+
+    assert len(meta["t1_deferrals"]) == limit
+    assert meta["t1_deferred_events"] == limit + 7
+    assert meta["t1_deferrals_truncated"] == 7
+    # The total counts every event, not just the persisted sample.
+    assert meta["t1_deferred_shares"] == 10 * (limit + 7)
+
+
+def test_deferral_serializer_sorts_and_isoformats_dates():
+    from datetime import date as _date
+
+    serialized = HourlyBacktester._serialize_t1_deferrals({
+        ("601318.SH", _date(2026, 4, 2)): {
+            "date": _date(2026, 4, 2), "symbol": "601318.SH",
+            "requested_shares": 10, "sellable_shares": 0, "deferred_shares": 10,
+        },
+        ("600519.SH", _date(2026, 4, 1)): {
+            "date": _date(2026, 4, 1), "symbol": "600519.SH",
+            "requested_shares": pd.Series([7], dtype="int64").iloc[0],
+            "sellable_shares": 2, "deferred_shares": 5,
+        },
+    })
+
+    assert [item["date"] for item in serialized] == ["2026-04-01", "2026-04-02"]
+    # numpy scalar unwrapped to a plain int, or json.dumps would reject it.
+    assert serialized[0]["requested_shares"] == 7
+    assert type(serialized[0]["requested_shares"]) is int
+    json.dumps(serialized)

--- a/dashboard/backend/tests/backtesting/test_reference_agent.py
+++ b/dashboard/backend/tests/backtesting/test_reference_agent.py
@@ -268,3 +268,127 @@ def test_subclass_inherits_make_trading_decision():
     assert out["actions"][0]["action"] == "buy"
     assert pm.custom_method() == "ok"
     assert MyPM.make_trading_decision is bha.PortfolioManager.make_trading_decision
+
+
+# ---------------------------------------------------------------------------
+# T+1 sellable cap (available_positions)
+# ---------------------------------------------------------------------------
+
+def _sell_state():
+    """A state whose only signal triggers the SELL rule for MSFT."""
+    return _state(signals={"MSFT": _signal(price=110, rsi=80, sma20=100, sma50=100)})
+
+
+def test_sell_uses_held_quantity_when_settlement_is_immediate():
+    """The default (available_positions=None) must stay byte-identical."""
+    out = _decide(_sell_state(), positions={"MSFT": 10})
+    assert out["actions"] == [
+        {"symbol": "MSFT", "action": "sell", "shares": 10,
+         "reason": "RSI overbought (80)"},
+    ]
+
+
+def test_sell_is_capped_at_the_sellable_quantity():
+    out = make_rule_based_decision(
+        portfolio_state=_sell_state(),
+        positions={"MSFT": 10},
+        cash=100000,
+        available_positions={"MSFT": 4},
+    )
+    assert out["actions"] == [
+        {"symbol": "MSFT", "action": "sell", "shares": 4,
+         "reason": "RSI overbought (80)",
+         # The intent the cap discarded, so the decision log does not read as
+         # though the agent only ever wanted 4.
+         "requested_shares": 10},
+    ]
+    assert out["t1_deferrals"] == [
+        {"symbol": "MSFT", "requested_shares": 10, "sellable_shares": 4},
+    ]
+
+
+def test_uncapped_sell_carries_no_deferral_or_requested_shares():
+    """Nothing is reported when T+1 did not actually bind."""
+    out = make_rule_based_decision(
+        portfolio_state=_sell_state(),
+        positions={"MSFT": 10},
+        cash=100000,
+        available_positions={"MSFT": 10},
+    )
+    assert out == {"actions": [
+        {"symbol": "MSFT", "action": "sell", "shares": 10,
+         "reason": "RSI overbought (80)"},
+    ]}
+
+
+def test_fully_frozen_holding_still_reports_the_deferral():
+    """The case that matters most: no action, so nothing else would record it."""
+    out = make_rule_based_decision(
+        portfolio_state=_sell_state(),
+        positions={"MSFT": 10},
+        cash=100000,
+        available_positions={"MSFT": 0},
+    )
+    assert out["actions"] == []
+    assert out["t1_deferrals"] == [
+        {"symbol": "MSFT", "requested_shares": 10, "sellable_shares": 0},
+    ]
+
+
+def test_fully_frozen_holding_emits_no_action():
+    """The whole point: an unfillable order is not proposed at all.
+
+    Without this the agent re-proposes the full holding on every bar of the buy
+    date, and each one becomes a t1_frozen audit record for a rule it was never
+    shown.
+    """
+    for available in ({"MSFT": 0}, {}):
+        out = make_rule_based_decision(
+            portfolio_state=_sell_state(),
+            positions={"MSFT": 10},
+            cash=100000,
+            available_positions=available,
+        )
+        assert out["actions"] == []
+
+
+def test_empty_available_positions_does_not_disable_selling_outright():
+    """``{}`` means 'nothing settled yet'; ``None`` means 'no T+1 here'.
+
+    Conflating them would silently stop every DJIA run from ever selling.
+    """
+    frozen = make_rule_based_decision(
+        portfolio_state=_sell_state(), positions={"MSFT": 10},
+        cash=100000, available_positions={},
+    )
+    immediate = make_rule_based_decision(
+        portfolio_state=_sell_state(), positions={"MSFT": 10},
+        cash=100000, available_positions=None,
+    )
+    assert frozen["actions"] == []
+    assert immediate["actions"][0]["shares"] == 10
+
+
+def test_sellable_cap_does_not_leak_into_buy_branch():
+    """SELL is an ``elif``; a frozen holding must not fall through to BUY."""
+    state = _state(signals={"MSFT": _signal(price=110, rsi=80, sma20=100, sma50=100)})
+    out = make_rule_based_decision(
+        portfolio_state=state,
+        positions={"MSFT": 10},
+        cash=100000,
+        available_positions={"MSFT": 0},
+    )
+    assert out["actions"] == []
+
+
+def test_inputs_are_not_mutated_by_the_sellable_cap():
+    positions = {"MSFT": 10}
+    available = {"MSFT": 4}
+    positions_before = copy.deepcopy(positions)
+    available_before = copy.deepcopy(available)
+    make_rule_based_decision(
+        portfolio_state=_sell_state(), positions=positions,
+        cash=100000, available_positions=available,
+    )
+    assert positions == positions_before
+    assert available == available_before

--- a/dashboard/backend/tests/domain/trading/test_execution.py
+++ b/dashboard/backend/tests/domain/trading/test_execution.py
@@ -1,10 +1,12 @@
-"""Characterization tests for extracted order execution (Phase 2B3).
+"""Characterization and A-share T+1 tests for order execution.
 
 Locks in the exact behavior of
 ``dashboard.backend.domain.trading.execution.execute_actions`` and the legacy
 ``PortfolioManager.execute_actions`` that delegates to it. Imports use the
 canonical package path; no external services are touched.
 """
+
+from datetime import datetime
 
 import pandas as pd
 
@@ -276,6 +278,146 @@ def test_multiple_symbols():
     ], md)
     assert st["positions"] == {"AAPL": 10, "MSFT": 5}
     assert st["cash"] == 100000 - 2000.0 - 2000.0
+
+
+# ---------------------------------------------------------------------------
+# Optional A-share T+1 execution
+# ---------------------------------------------------------------------------
+
+def _t1_manager(cash=100000):
+    return bha.PortfolioManager(cash, t_plus_one_enabled=True)
+
+
+def test_t1_same_day_buy_then_sell_records_rejection_without_zero_trade():
+    pm = _t1_manager()
+    md = {"600519.SH": _row(100.0)}
+    timestamp = datetime(2026, 4, 1, 10)
+
+    pm.execute_actions([
+        {"symbol": "600519.SH", "action": "buy", "shares": 10},
+        {"symbol": "600519.SH", "action": "sell", "shares": 10},
+    ], md, timestamp)
+
+    assert pm.cash == 99000.0
+    assert pm.positions == {"600519.SH": 10}
+    assert pm.available_positions == {}
+    assert pm.frozen_lots == {
+        "600519.SH": [{"quantity": 10, "buy_date": timestamp.date()}]
+    }
+    assert [(trade["side"], trade["shares"]) for trade in pm.trades] == [
+        ("BUY", 10)
+    ]
+    assert pm.rejected_orders == [{
+        "timestamp": timestamp,
+        "symbol": "600519.SH",
+        "action": "sell",
+        "requested_shares": 10,
+        "executed_shares": 0,
+        "unfilled_shares": 10,
+        "status": "rejected",
+        "reason": "t1_frozen",
+    }]
+
+
+def test_t1_prior_buy_unlocks_on_next_data_trading_date_across_weekend():
+    pm = _t1_manager()
+    md = {"600519.SH": _row(100.0)}
+
+    pm.execute_actions(
+        [{"symbol": "600519.SH", "action": "buy", "shares": 10}],
+        md,
+        datetime(2026, 4, 3, 14),
+    )
+    pm.execute_actions(
+        [{"symbol": "600519.SH", "action": "sell", "shares": 10}],
+        md,
+        datetime(2026, 4, 6, 10),
+    )
+
+    assert pm.cash == 100000
+    assert pm.positions == {}
+    assert pm.available_positions == {}
+    assert pm.frozen_lots == {}
+    assert [trade["side"] for trade in pm.trades] == ["BUY", "SELL"]
+    assert pm.rejected_orders == []
+
+
+def test_t1_sell_above_available_partially_fills_and_audits_frozen_remainder():
+    pm = _t1_manager()
+    pm.positions = {"600519.SH": 100}
+    pm.entry_prices = {"600519.SH": 90.0}
+    pm.available_positions = {"600519.SH": 40}
+    pm.frozen_lots = {
+        "600519.SH": [{"quantity": 60, "buy_date": datetime(2026, 4, 1).date()}]
+    }
+    timestamp = datetime(2026, 4, 1, 14)
+
+    pm.execute_actions(
+        [{"symbol": "600519.SH", "action": "sell", "shares": 100}],
+        {"600519.SH": _row(100.0)},
+        timestamp,
+    )
+
+    assert pm.cash == 104000.0
+    assert pm.positions == {"600519.SH": 60}
+    assert pm.available_positions == {}
+    assert pm.trades[-1]["shares"] == 40
+    assert pm.rejected_orders[-1] == {
+        "timestamp": timestamp,
+        "symbol": "600519.SH",
+        "action": "sell",
+        "requested_shares": 100,
+        "executed_shares": 40,
+        "unfilled_shares": 60,
+        "status": "partial",
+        "reason": "t1_frozen",
+    }
+
+
+def test_t1_multiple_buy_dates_release_only_prior_batches():
+    pm = _t1_manager()
+    md = {"600519.SH": _row(100.0)}
+
+    pm.execute_actions(
+        [{"symbol": "600519.SH", "action": "buy", "shares": 20}],
+        md,
+        datetime(2026, 4, 1, 10),
+    )
+    pm.execute_actions(
+        [{"symbol": "600519.SH", "action": "buy", "shares": 30}],
+        md,
+        datetime(2026, 4, 2, 10),
+    )
+
+    assert pm.positions == {"600519.SH": 50}
+    assert pm.available_positions == {"600519.SH": 20}
+    assert pm.frozen_lots == {
+        "600519.SH": [
+            {"quantity": 30, "buy_date": datetime(2026, 4, 2).date()}
+        ]
+    }
+
+
+def test_t1_request_above_total_splits_frozen_and_insufficient_reasons():
+    pm = _t1_manager()
+    pm.positions = {"600519.SH": 100}
+    pm.entry_prices = {"600519.SH": 90.0}
+    pm.available_positions = {"600519.SH": 40}
+    pm.frozen_lots = {
+        "600519.SH": [{"quantity": 60, "buy_date": datetime(2026, 4, 1).date()}]
+    }
+
+    pm.execute_actions(
+        [{"symbol": "600519.SH", "action": "sell", "shares": 150}],
+        {"600519.SH": _row(100.0)},
+        datetime(2026, 4, 1, 14),
+    )
+
+    assert [item["reason"] for item in pm.rejected_orders] == [
+        "t1_frozen",
+        "insufficient_position",
+    ]
+    assert [item["unfilled_shares"] for item in pm.rejected_orders] == [60, 50]
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/domain/trading/test_execution.py
+++ b/dashboard/backend/tests/domain/trading/test_execution.py
@@ -9,6 +9,7 @@ canonical package path; no external services are touched.
 from datetime import datetime
 
 import pandas as pd
+import pytest
 
 from dashboard.backend.domain.trading.execution import execute_actions
 from dashboard.scripts import backtest_hourly_agent as bha
@@ -420,6 +421,50 @@ def test_t1_request_above_total_splits_frozen_and_insufficient_reasons():
     assert [item["unfilled_shares"] for item in pm.rejected_orders] == [60, 50]
 
 
+def test_t1_float_residue_does_not_mint_a_phantom_rejection():
+    """A fully-filled fractional sell must not audit ~1e-17 unfilled shares.
+
+    0.3 - 0.1 - 0.2 is -2.8e-17 in binary floating point, so an exact fill
+    leaves negative-zero-ish residue that a bare ``> 0`` test reads as a real
+    unfilled quantity — an ``insufficient_position`` record for a constraint
+    that was never violated.
+    """
+    pm = _t1_manager()
+    pm.positions = {"600519.SH": 0.3}
+    pm.entry_prices = {"600519.SH": 90.0}
+    pm.available_positions = {"600519.SH": 0.3}
+
+    for size in (0.1, 0.2):
+        pm.execute_actions(
+            [{"symbol": "600519.SH", "action": "sell", "shares": size}],
+            {"600519.SH": _row(100.0)},
+            datetime(2026, 4, 2, 10),
+        )
+
+    # Both sells fill (the second for the residual balance, itself inexact)…
+    assert len(pm.trades) == 2
+    assert sum(trade["shares"] for trade in pm.trades) == pytest.approx(0.3)
+    # …and neither leaves an audit record behind.
+    assert pm.rejected_orders == []
+
+
+def test_t1_genuine_shortfall_still_audits_above_the_epsilon():
+    """The tolerance must not swallow a real one-share shortfall."""
+    pm = _t1_manager()
+    pm.positions = {"600519.SH": 5}
+    pm.entry_prices = {"600519.SH": 90.0}
+    pm.available_positions = {"600519.SH": 5}
+
+    pm.execute_actions(
+        [{"symbol": "600519.SH", "action": "sell", "shares": 6}],
+        {"600519.SH": _row(100.0)},
+        datetime(2026, 4, 2, 10),
+    )
+
+    assert [item["reason"] for item in pm.rejected_orders] == ["insufficient_position"]
+    assert pm.rejected_orders[0]["unfilled_shares"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Trade records appended in place, earlier records unchanged
 # ---------------------------------------------------------------------------
@@ -528,3 +573,87 @@ def test_subclass_inherits_execute_actions():
     assert pm.custom_method() == "ok"
     # execute_actions resolves through the subclass MRO to the script-defined method
     assert MyPM.execute_actions is bha.PortfolioManager.execute_actions
+
+
+# ---------------------------------------------------------------------------
+# T+1 deferral ledger — the metric a capped order would otherwise erase
+# ---------------------------------------------------------------------------
+
+def test_t1_deferral_is_recorded_once_per_symbol_trading_day():
+    """Four bars of one day that all want out must not be four records."""
+    pm = _t1_manager()
+    day = datetime(2026, 4, 1).date()
+    pm.positions = {"600519.SH": 100}
+    pm.frozen_lots = {"600519.SH": [{"quantity": 100, "buy_date": day}]}
+
+    for _ in range(4):
+        pm.record_t1_deferral("600519.SH", 100, 0)
+
+    assert list(pm.t1_deferrals) == [("600519.SH", day)]
+    assert pm.t1_deferrals[("600519.SH", day)]["deferred_shares"] == 100
+
+
+def test_t1_deferral_keeps_the_worst_of_the_day():
+    pm = _t1_manager()
+    day = datetime(2026, 4, 1).date()
+    pm.frozen_lots = {"600519.SH": [{"quantity": 100, "buy_date": day}]}
+
+    pm.record_t1_deferral("600519.SH", 100, 60)   # 40 deferred
+    pm.record_t1_deferral("600519.SH", 100, 10)   # 90 deferred — worse
+    pm.record_t1_deferral("600519.SH", 100, 80)   # 20 deferred — not worse
+
+    assert pm.t1_deferrals[("600519.SH", day)]["deferred_shares"] == 90
+    assert pm.t1_deferrals[("600519.SH", day)]["sellable_shares"] == 10
+
+
+def test_t1_deferral_separates_symbols_and_days():
+    pm = _t1_manager()
+    d1, d2 = datetime(2026, 4, 1).date(), datetime(2026, 4, 2).date()
+    pm.frozen_lots = {
+        "600519.SH": [{"quantity": 10, "buy_date": d1}],
+        "601318.SH": [{"quantity": 10, "buy_date": d1}],
+    }
+    pm.record_t1_deferral("600519.SH", 10, 0)
+    pm.record_t1_deferral("601318.SH", 10, 0)
+    # Next day: the same symbol blocking again is a distinct event.
+    pm.frozen_lots["600519.SH"] = [{"quantity": 10, "buy_date": d2}]
+    pm.record_t1_deferral("600519.SH", 10, 0)
+
+    assert sorted(pm.t1_deferrals) == [
+        ("600519.SH", d1), ("600519.SH", d2), ("601318.SH", d1),
+    ]
+
+
+def test_t1_deferral_ignores_a_sell_that_was_not_actually_capped():
+    pm = _t1_manager()
+    pm.frozen_lots = {
+        "600519.SH": [{"quantity": 10, "buy_date": datetime(2026, 4, 1).date()}]
+    }
+    pm.record_t1_deferral("600519.SH", 10, 10)
+    assert pm.t1_deferrals == {}
+
+
+def test_t1_deferral_needs_a_frozen_lot_to_date_itself():
+    """No frozen lot means nothing was blocking, so there is no event."""
+    pm = _t1_manager()
+    pm.record_t1_deferral("600519.SH", 10, 0)
+    assert pm.t1_deferrals == {}
+
+
+def test_sellable_positions_is_a_read_only_view():
+    pm = _t1_manager()
+    pm.available_positions = {"600519.SH": 5}
+    view = pm.sellable_positions
+
+    assert view["600519.SH"] == 5
+    with pytest.raises(TypeError):
+        view["600519.SH"] = 999
+    # Still a live view, not a snapshot.
+    pm.available_positions["600519.SH"] = 7
+    assert view["600519.SH"] == 7
+
+
+def test_sellable_positions_is_none_without_t_plus_one():
+    pm = bha.PortfolioManager(100000)
+    pm.available_positions = {"AAPL": 0}
+    assert pm.sellable_positions is None

--- a/dashboard/backend/tests/domain/trading/test_portfolio.py
+++ b/dashboard/backend/tests/domain/trading/test_portfolio.py
@@ -225,3 +225,120 @@ def test_get_equity_curve_is_alias_not_copy():
 
 def test_module_importable():
     assert portfolio is not None
+
+
+# ---------------------------------------------------------------------------
+# T+1 sellable exposure (available_positions)
+# ---------------------------------------------------------------------------
+
+def test_portfolio_state_omits_sellable_shares_when_settlement_is_immediate():
+    """Non-A-share snapshots keep the pre-T+1 schema exactly.
+
+    The position dicts feed the LLM prompt, so an extra key here would change
+    every DJIA prompt and make historical runs non-comparable.
+    """
+    state = build_portfolio_state(
+        100000, {"AAPL": 10}, {"AAPL": 200.0}, {"AAPL": _row(200.0)}
+    )
+    assert "sellable_shares" not in state["positions"][0]
+
+
+def test_portfolio_state_exposes_sellable_shares_under_t_plus_one():
+    state = build_portfolio_state(
+        100000,
+        {"AAPL": 10, "MSFT": 5},
+        {"AAPL": 200.0, "MSFT": 400.0},
+        {"AAPL": _row(200.0), "MSFT": _row(400.0)},
+        available_positions={"AAPL": 4},
+    )
+    by_symbol = {p["symbol"]: p for p in state["positions"]}
+    assert by_symbol["AAPL"]["shares"] == 10
+    assert by_symbol["AAPL"]["sellable_shares"] == 4
+    # Absent from the balance means fully frozen, not "unconstrained".
+    assert by_symbol["MSFT"]["sellable_shares"] == 0
+
+
+def test_sellable_shares_never_exceeds_the_held_quantity():
+    state = build_portfolio_state(
+        100000, {"AAPL": 3}, {"AAPL": 200.0}, {"AAPL": _row(200.0)},
+        available_positions={"AAPL": 99},
+    )
+    assert state["positions"][0]["sellable_shares"] == 3
+
+
+def test_sellable_shares_does_not_disturb_valuation():
+    """Valuation is on the total holding; freezing changes what can be sold."""
+    args = (100000, {"AAPL": 10}, {"AAPL": 200.0}, {"AAPL": _row(200.0)})
+    plain = build_portfolio_state(*args)
+    frozen = build_portfolio_state(*args, available_positions={})
+    assert plain["positions_value"] == frozen["positions_value"] == 2000.0
+    assert plain["total_equity"] == frozen["total_equity"]
+
+
+# ---------------------------------------------------------------------------
+# sellable_shares must reach the model, not just the state dict
+# ---------------------------------------------------------------------------
+
+def _t1_manager_holding(shares, sellable):
+    from dashboard.backend.domain.backtesting.portfolio_manager import (
+        PortfolioManager,
+    )
+
+    manager = PortfolioManager(100000, t_plus_one_enabled=True)
+    manager.positions = {"AAPL": shares}
+    manager.entry_prices = {"AAPL": 200.0}
+    manager.available_positions = {"AAPL": sellable} if sellable else {}
+    return manager
+
+
+def _capture_llm_snapshot(monkeypatch, manager):
+    """Run one LLM decision and return the snapshot handed to create_prompt."""
+    from dashboard.backend.domain.backtesting import portfolio_manager as pm_module
+
+    captured = {}
+
+    def fake_create_prompt(market_snapshot, **_kwargs):
+        captured["snapshot"] = market_snapshot
+        return "prompt"
+
+    monkeypatch.setattr(pm_module, "create_prompt", fake_create_prompt)
+    monkeypatch.setattr(
+        pm_module, "_request_trading_decision",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(pm_module, "_extract_response_text", lambda _r: "{}")
+    monkeypatch.setattr(pm_module, "_extract_token_usage", lambda _r: (0, 0))
+    monkeypatch.setattr(pm_module, "_parse_llm_response", lambda _t: {"decisions": []})
+
+    state = manager.get_portfolio_state({"AAPL": _row(210.0)})
+    manager.make_trading_decision_with_llm(state, llm_client=object())
+    return captured["snapshot"]
+
+
+def test_sellable_shares_is_forwarded_into_the_llm_holdings(monkeypatch):
+    """The state dict carrying the key is not enough — the prompt whitelists.
+
+    Without this the field is write-only: the order still gets capped
+    downstream, but the model reasons as though it can exit in full.
+    """
+    manager = _t1_manager_holding(shares=10, sellable=4)
+    snapshot = _capture_llm_snapshot(monkeypatch, manager)
+
+    holding = snapshot["current_holdings"]["AAPL"]
+    assert holding["shares"] == 10
+    assert holding["sellable_shares"] == 4
+
+
+def test_llm_holdings_are_unchanged_without_t_plus_one(monkeypatch):
+    from dashboard.backend.domain.backtesting.portfolio_manager import (
+        PortfolioManager,
+    )
+
+    manager = PortfolioManager(100000)
+    manager.positions = {"AAPL": 10}
+    manager.entry_prices = {"AAPL": 200.0}
+    snapshot = _capture_llm_snapshot(monkeypatch, manager)
+
+    assert set(snapshot["current_holdings"]["AAPL"]) == {
+        "shares", "entry_price", "current_price", "position_value", "pnl_pct",
+    }

--- a/dashboard/backend/tests/infrastructure/market_data/test_market_profiles.py
+++ b/dashboard/backend/tests/infrastructure/market_data/test_market_profiles.py
@@ -127,6 +127,17 @@ def test_us_profiles_preserve_their_default_decision_behavior():
     assert simulation.llm_enabled is False
 
 
+def test_t_plus_one_is_enabled_only_for_ifind_ashares():
+    assert get_market_profile(ALPACA).t_plus_one_enabled is False
+    assert get_market_profile(VNPY_SIMULATION).t_plus_one_enabled is False
+    assert get_market_profile(IFIND_ASHARE, A_SHARE_DEMO_6).t_plus_one_enabled is True
+    assert (
+        get_market_profile(IFIND_ASHARE, CSI300_SAMPLE_20_2026H2)
+        .t_plus_one_enabled
+        is True
+    )
+
+
 @pytest.mark.parametrize(
     ("universe", "requested", "expected"),
     [

--- a/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
+++ b/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
@@ -529,10 +529,9 @@ def test_ifind_offline_response_reaches_engine_database_and_chart(
         "fx_observation_end_date": "2026-03-31",
         "native_initial_capital": 7_000.0,
     }
-    assert agent_run["metadata"] == {
-        **expected_metadata,
-        "rejected_orders": [],
-    }
+    # A run with nothing rejected writes no rejected_orders* keys at all, so the
+    # agent row matches the baseline row exactly.
+    assert agent_run["metadata"] == expected_metadata
     assert buyhold_run["metadata"] == expected_metadata
     assert agent_run["llm_calls"] == 0
     assert agent_run["baseline_djia_run_id"] is None

--- a/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
+++ b/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
@@ -512,6 +512,7 @@ def test_ifind_offline_response_reaches_engine_database_and_chart(
         "timezone": "Asia/Shanghai",
         "decision_source": "rule_based",
         "benchmark": "equal_weight_buyhold",
+        "t_plus_one_enabled": True,
         "symbols": list(symbols),
         "native_currency": "CNY",
         "reporting_currency": "USD",
@@ -528,7 +529,10 @@ def test_ifind_offline_response_reaches_engine_database_and_chart(
         "fx_observation_end_date": "2026-03-31",
         "native_initial_capital": 7_000.0,
     }
-    assert agent_run["metadata"] == expected_metadata
+    assert agent_run["metadata"] == {
+        **expected_metadata,
+        "rejected_orders": [],
+    }
     assert buyhold_run["metadata"] == expected_metadata
     assert agent_run["llm_calls"] == 0
     assert agent_run["baseline_djia_run_id"] is None

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -47,6 +47,7 @@ EXPECTED_BACKTESTS_ROUTES = {
     ("GET", "/runs/{run_id}", "get_run"),
     ("GET", "/runs/{run_id}/equity", "get_equity_curve"),
     ("GET", "/runs/{run_id}/trades", "get_run_trades"),
+    ("GET", "/runs/{run_id}/rejected-orders", "get_run_rejected_orders"),
     ("GET", "/runs/{run_id}/plot.png", "get_run_plot"),
     ("GET", "/compare", "compare_runs"),
 }
@@ -176,6 +177,7 @@ EXPECTED_FULL_CONTRACT = {
     ("GET", "/runs/{run_id}"),
     ("GET", "/runs/{run_id}/equity"),
     ("GET", "/runs/{run_id}/plot.png"),
+    ("GET", "/runs/{run_id}/rejected-orders"),
     ("GET", "/runs/{run_id}/trades"),
     ("GET", "/strategy"),
     ("GET", "/styles.css"),

--- a/dashboard/backend/tests/test_architecture_boundaries.py
+++ b/dashboard/backend/tests/test_architecture_boundaries.py
@@ -340,3 +340,48 @@ def test_discord_bot_imports_without_secrets():
     proc = _import_clean("dashboard.backend.integrations.discord_bot")
     assert proc.returncode == 0, proc.stderr
     assert "import-ok" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Settlement semantics come from the market profile, never a constructor default
+# ---------------------------------------------------------------------------
+
+def test_portfolio_manager_construction_always_declares_settlement():
+    """Every production PortfolioManager must pass ``t_plus_one_enabled``.
+
+    ``t_plus_one_enabled`` defaults to ``False``, which is correct for US
+    markets and silently wrong for A-shares. A site that omits it therefore
+    fails *closed but invisible*: no error, no log, just same-day settlement on
+    a market that does not have it. Requiring the argument at every call site
+    turns that into a test failure at the moment the site is written.
+
+    Pass ``get_market_profile(...).t_plus_one_enabled`` — resolving it from the
+    registry means wiring a new data source carries its settlement rules along
+    automatically. Hardcoding ``False`` satisfies this test but re-opens the
+    hole, so keep the profile lookup.
+
+    Known limits, so nobody reads a green run as full coverage. The match is by
+    **name**, so a call through an aliased import (``PortfolioManager as PM``)
+    is never inspected; ``**kwargs`` splats pass, since the keyword set is
+    unknowable statically; and a purely positional third argument is *flagged*
+    even though it is correct. The check exists to catch the one form anyone
+    actually writes — the keyword call that simply omits the argument.
+    """
+    offenders = []
+    for path in _production_py_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name != "PortfolioManager":
+                continue
+            passed = {kw.arg for kw in node.keywords}
+            if "t_plus_one_enabled" not in passed and None not in passed:
+                offenders.append(f"{path.relative_to(_REPO_ROOT)}:{node.lineno}")
+
+    assert offenders == [], (
+        "PortfolioManager built without an explicit t_plus_one_enabled at: "
+        + ", ".join(offenders)
+    )

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -153,6 +153,12 @@ def test_run_metadata_response_exposes_complete_ifind_profile():
                 "fx_policy": "daily_implied_median_forward_fill",
                 "fx_start_rate": 7.0,
                 "fx_end_rate": 7.1,
+                "t_plus_one_enabled": True,
+                "rejected_orders": [{
+                    "symbol": "600519.SH",
+                    "reason": "t1_frozen",
+                    "status": "rejected",
+                }],
             }
         )
     )
@@ -172,6 +178,8 @@ def test_run_metadata_response_exposes_complete_ifind_profile():
     assert response.fx_source == "ifind_history_currency_conversion"
     assert response.fx_start_rate == 7.0
     assert response.fx_end_rate == 7.1
+    assert response.t_plus_one_enabled is True
+    assert response.rejected_orders[0]["reason"] == "t1_frozen"
 
 
 def test_run_metadata_response_keeps_new_fields_optional_for_legacy_runs():
@@ -190,6 +198,8 @@ def test_run_metadata_response_keeps_new_fields_optional_for_legacy_runs():
     assert response.fx_pair is None
     assert response.fx_source is None
     assert response.fx_start_rate is None
+    assert response.t_plus_one_enabled is None
+    assert response.rejected_orders == []
 
 
 @pytest.fixture(autouse=True)
@@ -668,6 +678,11 @@ def test_backtest_status_includes_live_progress(tmp_path):
             "price": 150.25,
             "value": 1502.5,
         }],
+        "rejected_orders": [{
+            "symbol": "600519.SH",
+            "reason": "t1_frozen",
+            "status": "rejected",
+        }],
     }), encoding="utf-8")
     bt.backtest_status.update({
         "running": True,
@@ -686,6 +701,7 @@ def test_backtest_status_includes_live_progress(tmp_path):
     assert len(body["progress"]["equity_curve"]) == 1
     assert len(body["progress"]["trades"]) == 1
     assert body["progress"]["trades"][0]["symbol"] == "AAPL"
+    assert body["progress"]["rejected_orders"][0]["reason"] == "t1_frozen"
     assert "step 5/100" in body["message"]
 
 

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -154,11 +154,15 @@ def test_run_metadata_response_exposes_complete_ifind_profile():
                 "fx_start_rate": 7.0,
                 "fx_end_rate": 7.1,
                 "t_plus_one_enabled": True,
+                # The records themselves are deliberately NOT projected onto
+                # RunMetadata (it backs two list routes); only the scalars are.
                 "rejected_orders": [{
                     "symbol": "600519.SH",
                     "reason": "t1_frozen",
                     "status": "rejected",
                 }],
+                "rejected_orders_count": 7200,
+                "rejected_orders_truncated": 7000,
             }
         )
     )
@@ -179,7 +183,11 @@ def test_run_metadata_response_exposes_complete_ifind_profile():
     assert response.fx_start_rate == 7.0
     assert response.fx_end_rate == 7.1
     assert response.t_plus_one_enabled is True
-    assert response.rejected_orders[0]["reason"] == "t1_frozen"
+    assert response.rejected_orders_count == 7200
+    assert response.rejected_orders_truncated == 7000
+    # The unbounded array must never reach a list-route payload.
+    assert not hasattr(response, "rejected_orders")
+    assert "rejected_orders" not in response.model_dump()
 
 
 def test_run_metadata_response_keeps_new_fields_optional_for_legacy_runs():
@@ -199,7 +207,10 @@ def test_run_metadata_response_keeps_new_fields_optional_for_legacy_runs():
     assert response.fx_source is None
     assert response.fx_start_rate is None
     assert response.t_plus_one_enabled is None
-    assert response.rejected_orders == []
+    # None, not 0: a legacy run predates the feature, it did not record zero
+    # rejections. Same convention as t_plus_one_enabled above.
+    assert response.rejected_orders_count is None
+    assert response.rejected_orders_truncated is None
 
 
 @pytest.fixture(autouse=True)
@@ -737,6 +748,82 @@ def test_get_run_trades_endpoint(client, monkeypatch):
     assert body["trades"][0]["symbol"] == "MSFT"
 
 
+def _rejected_orders_run(monkeypatch, run_id, session_id, metadata):
+    def fake_get_run_with_session(rid, sid):
+        if rid == run_id and sid == session_id:
+            return {
+                "run_id": run_id,
+                "agent_name": "Agent",
+                "mode": "backtest",
+                "metadata": metadata,
+            }
+        return None
+
+    monkeypatch.setattr(bt.db, "get_run_with_session", fake_get_run_with_session)
+
+
+def test_get_run_rejected_orders_endpoint(client, monkeypatch):
+    session_id = str(uuid.uuid4())
+    run_id = "agent_test_rejections"
+    _rejected_orders_run(monkeypatch, run_id, session_id, {
+        "rejected_orders": [{"symbol": "600519.SH", "reason": "t1_frozen"}],
+        "rejected_orders_count": 1,
+    })
+
+    resp = client.get(
+        f"/runs/{run_id}/rejected-orders", headers={"X-Session-Id": session_id}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_id"] == run_id
+    assert body["count"] == 1
+    assert body["returned"] == 1
+    assert body["truncated"] == 0
+    assert body["rejected_orders"][0]["reason"] == "t1_frozen"
+
+
+def test_get_run_rejected_orders_reports_the_cap_it_applied(client, monkeypatch):
+    """A capped sample must never read as the run's full rejection history."""
+    session_id = str(uuid.uuid4())
+    run_id = "agent_test_rejections_capped"
+    _rejected_orders_run(monkeypatch, run_id, session_id, {
+        "rejected_orders": [{"symbol": "600519.SH", "reason": "t1_frozen"}] * 200,
+        "rejected_orders_count": 7_200,
+        "rejected_orders_truncated": 7_000,
+    })
+
+    body = client.get(
+        f"/runs/{run_id}/rejected-orders", headers={"X-Session-Id": session_id}
+    ).json()
+    assert body["count"] == 7_200      # what the run actually produced
+    assert body["returned"] == 200     # what this response carries
+    assert body["truncated"] == 7_000  # the difference, stated outright
+
+
+def test_get_run_rejected_orders_is_session_scoped(client, monkeypatch):
+    session_id = str(uuid.uuid4())
+    _rejected_orders_run(monkeypatch, "agent_owned", session_id, {})
+
+    resp = client.get(
+        "/runs/agent_owned/rejected-orders",
+        headers={"X-Session-Id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404
+
+
+def test_get_run_rejected_orders_tolerates_legacy_runs(client, monkeypatch):
+    """Runs predating the feature have no metadata dict at all."""
+    session_id = str(uuid.uuid4())
+    _rejected_orders_run(monkeypatch, "agent_legacy", session_id, None)
+
+    body = client.get(
+        "/runs/agent_legacy/rejected-orders", headers={"X-Session-Id": session_id}
+    ).json()
+    assert body["rejected_orders"] == []
+    assert body["count"] == 0
+    assert body["truncated"] == 0
+
+
 def test_backtest_run_rate_limited_per_client(monkeypatch):
     now = [0.0]
     monkeypatch.setattr(
@@ -855,3 +942,53 @@ def test_error_summary_stays_bounded(monkeypatch):
 
     assert len(summary) == 500
     assert "super-secret-token" not in summary
+
+
+def test_rejected_orders_endpoint_reports_t1_deferrals(client, monkeypatch):
+    """Built-in agents size down instead of over-asking, so deferrals -- not
+    rejections -- are where T+1's effect on strategy shows up."""
+    session_id = str(uuid.uuid4())
+    run_id = "agent_test_deferrals"
+    _rejected_orders_run(monkeypatch, run_id, session_id, {
+        "t1_deferrals": [{
+            "date": "2026-04-01", "symbol": "600519.SH",
+            "requested_shares": 100, "sellable_shares": 40,
+            "deferred_shares": 60,
+        }],
+        "t1_deferred_events": 12,
+        "t1_deferred_shares": 640,
+        "t1_deferrals_truncated": 11,
+    })
+
+    body = client.get(
+        f"/runs/{run_id}/rejected-orders", headers={"X-Session-Id": session_id}
+    ).json()
+    assert body["t1_deferred_events"] == 12
+    assert body["t1_deferred_shares"] == 640
+    assert body["t1_deferrals_truncated"] == 11
+    assert body["t1_deferrals"][0]["deferred_shares"] == 60
+    # A clean run on the rejection side must not read as missing data.
+    assert body["rejected_orders"] == []
+    assert body["count"] == 0
+
+
+def test_run_metadata_exposes_deferral_scalars(client, monkeypatch):
+    response = bt._run_metadata_response(
+        _run_record(metadata={
+            "data_source": "ifind_ashare",
+            "t_plus_one_enabled": True,
+            "t1_deferred_events": 12,
+            "t1_deferred_shares": 640,
+            "t1_deferrals": [{"symbol": "600519.SH"}] * 200,
+        })
+    )
+    assert response.t1_deferred_events == 12
+    assert response.t1_deferred_shares == 640
+    # Scalars only: the records stay off the list-route model.
+    assert "t1_deferrals" not in response.model_dump()
+
+
+def test_run_metadata_deferral_scalars_are_none_for_legacy_runs():
+    response = bt._run_metadata_response(_run_record())
+    assert response.t1_deferred_events is None
+    assert response.t1_deferred_shares is None

--- a/docs/superpowers/specs/2026-08-01-ifind-ashare-t1-design.md
+++ b/docs/superpowers/specs/2026-08-01-ifind-ashare-t1-design.md
@@ -1,0 +1,189 @@
+# iFinD A 股回测 T+1 执行语义设计
+
+## 1. 背景
+
+ATL 已经可以使用 iFinD 的 A 股 60 分钟历史行情运行模拟回测。当前回测执行器只保存每个股票的总持仓，买入后没有区分“当天买入、暂时不可卖出”的数量，因此当天买入的 A 股可能在同一交易日再次卖出。
+
+本设计为两个 iFinD A 股股票池补上模拟回测中的 T+1 规则：
+
+- `A-Share Demo 6`
+- `CSI 300 Sample 20`
+
+Rule-based 和 LLM 两种决策来源都使用同一套执行语义。Alpaca 美股和 vn.py 模拟数据保持现有行为。
+
+## 2. 目标与非目标
+
+### 目标
+
+1. A 股当天买入的数量当天不可卖出。
+2. 按回测数据中出现的下一个不同交易日期解冻，不调用固定周末或节假日表。
+3. 卖出请求超过可卖数量时允许部分成交，并明确记录未成交原因。
+4. 冻结数量不进入成交数、收益、现金变化或权益曲线。
+5. 保持现有成交接口、数据库交易记录和非 A 股数据源的兼容性。
+
+### 非目标
+
+本轮不实现以下 A 股制度：
+
+- 100 股整手限制；
+- 涨跌停撮合；
+- 停牌处理；
+- 印花税、佣金或其他费用；
+- 真实券商下单或实盘交易；
+- Alpaca 或 vn.py 的 T+1 改造。
+
+## 3. 选择的方案
+
+采用方案 A：在现有总持仓之上增加可卖持仓和冻结批次账本。
+
+选择理由：
+
+- 保留 `positions[symbol]`，现有组合估值、前端和 API 不需要改成批次持仓模型；
+- 用买入日期记录冻结批次，可以正确处理多个交易日分批买入和部分卖出；
+- T+1 只由 iFinD A 股市场配置打开，其他市场默认关闭；
+- 执行规则集中在领域执行器，Rule-based、LLM 和外部 Agent 回测共用。
+
+## 4. 状态模型
+
+PortfolioManager 保留现有状态，并增加以下状态：
+
+```python
+positions: Dict[str, int]
+available_positions: Dict[str, int]
+frozen_lots: Dict[str, List[Dict[str, Any]]]
+rejected_orders: List[Dict[str, Any]]
+```
+
+其中：
+
+- `positions[symbol]` 是总持仓，继续供估值和现有 UI 使用；
+- `available_positions[symbol]` 是当前可卖数量；
+- `frozen_lots[symbol]` 是当天买入的批次，每批至少包含 `quantity` 和 `buy_date`；
+- `rejected_orders` 只保存未完全成交的订单审计，不计入 `trades`。
+
+非 T+1 市场可以继续使用原有总持仓执行路径，不创建冻结批次。
+
+### 4.1 交易日期推进
+
+执行器保存当前已处理的回测交易日期。遇到新的日期时，释放该股票所有 `buy_date < current_date` 的冻结批次：
+
+```text
+买入日 2026-04-01：批次保持冻结
+下一个回测数据日期 2026-04-02：批次转入 available_positions
+```
+
+解冻只发生在回测数据实际出现的日期。数据没有出现的周末或节假日不会触发步骤，因此自然会跳到下一个有效交易日。
+
+## 5. 执行流程
+
+### 5.1 BUY
+
+在现金足够且数量为正时：
+
+1. 扣除买入成本；
+2. 增加 `positions[symbol]`；
+3. 追加一个 `frozen_lots[symbol]` 批次；
+4. 当天不增加 `available_positions[symbol]`；
+5. 向 `trades` 写入真实 BUY 成交。
+
+同一根 K 线内后续的 SELL 不能使用刚刚买入的批次。
+
+### 5.2 SELL
+
+1. 读取当前 `available_positions[symbol]`；
+2. 实际成交数量为 `min(requested_shares, available_shares)`；
+3. 只从可卖数量和总持仓中扣除实际成交数量；
+4. 实际成交数量大于 0 时，向 `trades` 写入 SELL 成交并增加现金；
+5. 未成交部分不改变现金和收益，并写入 `rejected_orders`。
+
+当总持仓为 100 股、其中 40 股可卖、60 股冻结，Agent 请求卖 100 股时：
+
+```text
+实际成交：40 股
+未成交：60 股，reason = t1_frozen
+```
+
+如果请求量同时超过总持仓和冻结数量，未成交部分按原因拆分为 `t1_frozen` 和 `insufficient_position`，避免把普通持仓不足误报为 T+1。
+
+## 6. 审计和 API 合同
+
+### 6.1 成交记录
+
+现有 `trades` 只表示真实成交：
+
+- 数量始终大于 0；
+- 继续写入现有 trades 表；
+- 继续用于交易数、收益、权益曲线和现有交易日志。
+
+### 6.2 未成交审计
+
+新增 `rejected_orders` 结果字段，并在运行元数据中持久化完整列表。记录至少包含：
+
+```json
+{
+  "timestamp": "2026-04-01T10:00:00",
+  "symbol": "600519.SH",
+  "action": "sell",
+  "requested_shares": 100,
+  "executed_shares": 40,
+  "unfilled_shares": 60,
+  "status": "partial",
+  "reason": "t1_frozen"
+}
+```
+
+完全不能卖时，`status` 为 `rejected`，`executed_shares` 为 0，但该对象不是 `trades` 中的 0 股成交。
+
+`rejected_orders` 作为可选字段加入回测结果和 live progress：
+
+- 旧客户端忽略该字段即可继续工作；
+- 现有 `/runs/{run_id}/trades` 仍然只返回成交；
+- 回测结果读取接口同时返回 `rejected_orders`，便于诊断 T+1 行为；
+- 现有 Alpaca/vn.py 结果返回空列表。
+
+所有面向用户的新增文案使用英文；不增加凭证输入或打印任何凭证。
+
+## 7. 测试方案
+
+### 7.1 执行器单元测试
+
+覆盖：
+
+1. 同日买入后卖出，卖出被 `t1_frozen` 拒绝；
+2. 下一有效交易日卖出成功；
+3. 周末和缺失节假日日期被跳过；
+4. 可卖 40 股、请求 100 股时部分成交 40 股；
+5. 全部数量冻结时没有成交记录和现金变化；
+6. 多个交易日分批买入时，旧批次先解冻、新批次继续冻结；
+7. 同一决策内先买后卖时，刚买数量不可卖。
+
+### 7.2 回测集成测试
+
+使用确定性模拟 OHLCV 数据验证：
+
+- 两个 iFinD A 股股票池都打开 T+1；
+- Rule-based 和 LLM/外部 Agent 两条路径都传递同一 T+1 配置；
+- 回测结果包含 `rejected_orders`；
+- 成交数、收益、权益曲线排除冻结部分。
+
+### 7.3 回归测试
+
+运行现有 backtesting、execution、iFinD、vn.py 和 Alpaca 测试，确认：
+
+- 非 A 股数据源的成交结果不变；
+- 旧 `trades` API 字段和语义不变；
+- 旧回测结果没有 `rejected_orders` 时按空列表兼容。
+
+## 8. 验收标准
+
+功能完成必须同时满足：
+
+1. iFinD A 股当天买入的股票当天无法卖出；
+2. 下一个回测数据交易日可以卖出；
+3. 超出可卖数量时能部分成交；
+4. `t1_frozen` 原因可从回测结果读取；
+5. 冻结部分不进入成交数、收益和现金；
+6. 两个 A 股股票池、Rule-based 和 LLM 路径均通过测试；
+7. Alpaca 和 vn.py 回归测试通过；
+8. 代码、测试和日志不包含任何 API 凭证。
+

--- a/docs/superpowers/specs/2026-08-01-ifind-ashare-t1-design.zh-CN.md
+++ b/docs/superpowers/specs/2026-08-01-ifind-ashare-t1-design.zh-CN.md
@@ -20,6 +20,26 @@ Rule-based 和 LLM 两种决策来源都使用同一套执行语义。Alpaca 美
 3. 卖出请求超过可卖数量时允许部分成交，并明确记录未成交原因。
 4. 冻结数量不进入成交数、收益、现金变化或权益曲线。
 5. 保持现有成交接口、数据库交易记录和非 A 股数据源的兼容性。
+6. **决策方可以观察到该约束**：`portfolio_state` 的每个持仓在 T+1 市场下带
+   `sellable_shares`，并**转发进 LLM 提示词的 `current_holdings`**（提示词按
+   白名单取字段，不转发等于该字段只写不读），同时 `market_context` 用
+   `settlement` / `settlement_note` 明确说明规则——否则模型只看到一个无标注的
+   整数。内置 Rule-based 和 LLM 两条路径都按可卖数量下单。否则 Agent 只能被动
+   挨罚：它每根 K 线都会重复提交同一笔不可能成交的全仓卖出，每一笔都变成一条
+   `t1_frozen` 审计记录，而它从未被告知这条规则。审计日志应记录真实违规
+   （外部 Agent、模型幻觉），而不是自己制造的噪声。
+7. **约束的约束力本身可观测。** 只做第 6 点会把"过吵的审计"换成"完全沉默的
+   审计"：下单量被裁剪后订单恰好全部成交，执行器无事可记，于是
+   **"T+1 到底多少次挡住了这个 Agent 离场"无法回答**——而这恰恰是 A 股回测最
+   值得问的问题。因此裁剪时同时记录被丢弃的意图：
+   - 按 `(symbol, 交易日)` 去重的 `t1_deferrals` 账本（因此天然有上限 =
+     标的数 × 交易日数，而不是按 K 线增长），同一天保留最严重的一次；
+   - 动作上的 `requested_shares`，使决策日志不会显示成 Agent 本来就只想卖这么多
+     （LLM 的 `reason` 仍是模型原话）；
+   - 运行元数据中的 `t1_deferred_events` / `t1_deferred_shares` 标量，以及有上限
+     的 `t1_deferrals` 样本（超出时写 `t1_deferrals_truncated`）。
+   交易日直接取该标的冻结批次的 `max(buy_date)`——批次只在买入当日仍处于冻结状态
+   （更早的批次已被解冻扫描移出），所以无需向 Rule-based 路径传入时间戳。
 
 ### 非目标
 
@@ -41,7 +61,13 @@ Rule-based 和 LLM 两种决策来源都使用同一套执行语义。Alpaca 美
 - 保留 `positions[symbol]`，现有组合估值、前端和 API 不需要改成批次持仓模型；
 - 用买入日期记录冻结批次，可以正确处理多个交易日分批买入和部分卖出；
 - T+1 只由 iFinD A 股市场配置打开，其他市场默认关闭；
-- 执行规则集中在领域执行器，Rule-based、LLM 和外部 Agent 回测共用。
+- 执行规则集中在领域执行器，Rule-based 和 LLM 两条回测路径共用。
+- 外部 Agent 回测（`external_run_service`）暂不在范围内：`/api/v1` 和 `/api/v2`
+  都不接受 `data_source`，该服务通过 `AlpacaDataLoader` 取数，结构上只支持
+  Alpaca。它仍然从 profile 注册表解析 `t_plus_one_enabled`（而不是依赖构造函数
+  默认值），因此将来接入 iFinD 时会自动带上对应的结算规则。
+  `test_portfolio_manager_construction_always_declares_settlement` 强制所有
+  构造点显式声明结算方式。
 
 ## 4. 状态模型
 
@@ -117,7 +143,8 @@ rejected_orders: List[Dict[str, Any]]
 
 ### 6.2 未成交审计
 
-新增 `rejected_orders` 结果字段，并在运行元数据中持久化完整列表。记录至少包含：
+新增 `rejected_orders` 结果字段，在运行元数据中持久化**有上限的样本**加真实总数。
+记录至少包含：
 
 ```json
 {
@@ -134,12 +161,27 @@ rejected_orders: List[Dict[str, Any]]
 
 完全不能卖时，`status` 为 `rejected`，`executed_shares` 为 0，但该对象不是 `trades` 中的 0 股成交。
 
-`rejected_orders` 作为可选字段加入回测结果和 live progress：
+**容量约束。** 这是逐步（per-step）审计数据，20 只股票的 A 股回测可产生数千条，
+每条约 198 字节。因此：
 
-- 旧客户端忽略该字段即可继续工作；
+- 元数据只持久化前 `REJECTED_ORDER_SAMPLE_LIMIT`（200）条，并同时写入
+  `rejected_orders_count`（真实总数）与 `rejected_orders_truncated`（被截断条数）。
+  截断必须可见——只截不报等于谎报"一共就这些"；
+- live progress 文件每步整体重写，因此只携带最近
+  `LIVE_PROGRESS_REJECTED_ORDER_LIMIT`（50）条，避免写入量随步数呈平方增长；
+- 完全没有拒单时不写入任何 `rejected_orders*` 键，而不是写空数组。
+
+**接口划分。** 记录本身通过独立接口返回，不进入列表接口：
+
+- 新增 `GET /runs/{run_id}/rejected-orders`，与现有 `/runs/{run_id}/trades` 对称，
+  返回 `rejected_orders` / `count`（总数）/ `returned`（本次返回数）/ `truncated`；
+- `RunMetadata` **只**携带 `rejected_orders_count` 和 `rejected_orders_truncated`
+  两个标量。该模型是 `/api/backtest/runs` 和公开且不分页的 `/runs` 两个**列表**
+  接口的 response_model，内联数组会把兆字节级负载乘以运行数量；
+- 旧客户端忽略新字段即可继续工作；
 - 现有 `/runs/{run_id}/trades` 仍然只返回成交；
-- 回测结果读取接口同时返回 `rejected_orders`，便于诊断 T+1 行为；
-- 现有 Alpaca/vn.py 结果返回空列表。
+- 旧运行（功能上线前）两个标量都是 `null` 而不是 `0`——"没有拒单"和"没有记录过"
+  必须可区分，与 `t_plus_one_enabled` 的约定一致。
 
 所有面向用户的新增文案使用英文；不增加凭证输入或打印任何凭证。
 
@@ -162,8 +204,9 @@ rejected_orders: List[Dict[str, Any]]
 使用确定性模拟 OHLCV 数据验证：
 
 - 两个 iFinD A 股股票池都打开 T+1；
-- Rule-based 和 LLM/外部 Agent 两条路径都传递同一 T+1 配置；
-- 回测结果包含 `rejected_orders`；
+- Rule-based 和 LLM 两条路径都传递同一 T+1 配置；
+- 所有 `PortfolioManager` 构造点都从 profile 解析结算规则（AST 守卫测试）；
+- `/runs/{run_id}/rejected-orders` 返回审计记录，并在样本被截断时如实报告；
 - 成交数、收益、权益曲线排除冻结部分。
 
 ### 7.3 回归测试
@@ -172,7 +215,9 @@ rejected_orders: List[Dict[str, Any]]
 
 - 非 A 股数据源的成交结果不变；
 - 旧 `trades` API 字段和语义不变；
-- 旧回测结果没有 `rejected_orders` 时按空列表兼容。
+- 旧回测结果的 `rejected_orders_count` / `rejected_orders_truncated` 为 `null`；
+- 非 T+1 市场的 `portfolio_state` 不含 `sellable_shares` 键（该快照进入 LLM
+  提示词，多一个键会改变每一次 DJIA 提示，使历史运行不可比）。
 
 ## 8. 验收标准
 


### PR DESCRIPTION
## Summary

- enforce A-share T+1 settlement for both iFinD universes in rule-based and LLM backtests
- track sellable positions and date-stamped frozen buy lots, including partial fills and explicit t1_frozen audit records
- expose T+1 provenance and rejected orders without adding zero-share trades or changing Alpaca/vn.py behavior

## Behavior

- same-day A-share buys remain frozen until the next distinct trading date present in the backtest data
- sell requests execute up to the available quantity; frozen and insufficient remainders are audited separately
- rejected quantities do not affect cash, equity, return, or trade counts

## Testing

- 2051 backend tests passed, 63 skipped
- 54 vn.py integration tests passed, 2 skipped
- focused T+1, iFinD, API, frontend-contract, and compatibility suites passed

No real brokerage execution or credentials are introduced.