### PR TITLE
docs: UX feedback round spec and plan

### DIFF
--- a/docs/superpowers/plans/2026-08-01-user-feedback-ux-round.md
+++ b/docs/superpowers/plans/2026-08-01-user-feedback-ux-round.md
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - **Docs are a non-goal.** No task edits any file under `docs/` except this plan's own checkboxes. Staleness is recorded in the spec, not fixed here.
-- **No paper-trading or real-capital claim** may appear in any user-visible string. `/paper/*` is read-only and `ROBINHOOD_EXECUTE` defaults to `false`.
+- **No paper-trading or real-capital claim** may appear in any user-visible string. The precise, defensible form of the claim: **no order-submission route exists.** `AlpacaPaperTradingClient` has no order method, `PaperTradingSession.add_trade` has zero production callers, `execution/paper_backend.py` raises `NotImplementedError`, and `ROBINHOOD_EXECUTE` defaults to `false`. Use *that* wording in PR bodies — **"`/paper/*` is read-only" is literally false**: `POST /paper/start-session` (`api/routers/paper_trading.py:253`) writes a run row via `db.insert_run(...)`. It places no order and no frontend calls it, so the conclusion holds; the shorthand does not, and a reviewer who greps will find the write.
 - **Run every command from the repo root.** The backend is the `dashboard.backend` package; never run a backend file by path.
 - **Tests:** `pytest dashboard/backend/tests/ -v`. Pytest is not in `requirements.txt` — install separately. The suite is green on `main`; a red test is a real regression.
 - **Never `git add -A`.** Importing a backend module runs lazy `CREATE TABLE`/`ALTER` against the committed `dashboard/storage/data/backtest.db`, which is the real prod seed database. Stage named paths only.
@@ -69,10 +69,17 @@ _STYLES = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
 
 
 def test_toast_container_is_a_polite_live_region():
-    """A success message screen readers never announce is not a confirmation."""
-    assert 'id="appToast"' in _APP_HTML
-    assert 'role="status"' in _APP_HTML
-    assert 'aria-live="polite"' in _APP_HTML
+    """A success message screen readers never announce is not a confirmation.
+
+    Asserted as one whole tag, not three independent substrings: app.html:377
+    (the ticker) already carries role="status" and aria-live="polite", so
+    file-wide substring checks for those two would pass before the toast
+    exists -- two thirds of a vacuous test.
+    """
+    assert (
+        '<div id="appToast" class="app-toast" role="status" aria-live="polite" hidden>'
+        in _APP_HTML
+    )
 
 
 def test_toast_helper_exists():
@@ -93,11 +100,11 @@ def test_toast_animation_has_a_reduced_motion_fallback():
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `pytest dashboard/backend/tests/test_app_toast.py -v`
-Expected: FAIL — `assert 'id="appToast"' in _APP_HTML`
+Expected: FAIL — the container tag is absent from `_APP_HTML`
 
 - [ ] **Step 3: Add the container to `app.html`**
 
-Insert immediately before the closing `</body>` tag:
+Insert immediately before the closing `</body>` tag — **byte-for-byte as written**, since Step 1 pins the whole opening tag (attribute order included):
 
 ```html
 <div id="appToast" class="app-toast" role="status" aria-live="polite" hidden></div>
@@ -338,7 +345,7 @@ In `submitCreateBuiltinAgent`, replace the block from `if (submitBtn) submitBtn.
 }
 ```
 
-`highlightAgentCard` is defined in Task 3. Implement Task 3 before running the browser check in Step 6.
+`highlightAgentCard` is defined in **Task 3**, so this commit alone ships a live `ReferenceError` on the success path — after the toast fires, before `restoreButton`. The source-guard tests are string checks and stay green through it, so nothing will tell you. It is contained only because the PR opens at **phase exit**, never between these two commits: do not browser-test, push, or open a PR until Task 3 is committed.
 
 - [ ] **Step 5: Add the pending spinner style**
 
@@ -413,7 +420,7 @@ def test_highlight_uses_attribute_lookup_not_selector_interpolation():
     server-supplied, so never interpolate one into a selector string."""
     start = _APP_JS.index("function highlightAgentCard(")
     body = _APP_JS[start : start + 900]
-    assert "querySelectorAll('[data-agent-id]')" in body
+    assert "querySelectorAll('.agent-card[data-agent-id]')" in body
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -421,11 +428,20 @@ def test_highlight_uses_attribute_lookup_not_selector_interpolation():
 Run: `pytest dashboard/backend/tests/test_create_agent_feedback.py -v -k highlight`
 Expected: FAIL — `assert "function highlightAgentCard(" in _APP_JS`
 
-- [ ] **Step 3: Confirm the card carries `data-agent-id`**
+- [ ] **Step 3: Tag the card element — and scope the selector to it**
 
-Run: `command grep -n "data-agent-id" dashboard/frontend/app.js | head -5`
+Run: `command grep -n "data-agent-id" dashboard/frontend/app.js`
 
-If the attribute is absent from the card element built in `renderAgentCards` (`app.js:1121`), add `card.setAttribute('data-agent-id', agent.agent_id);` alongside the existing `card.className = ...` assignment. Do not interpolate the id into HTML.
+All ten existing occurrences are **`<button>` elements inside the card** (`:522`, `:892`, `:899`, `:902`, `:906`, `:912`, `:916`, `:918`, `:928`, `:1335` — Open Agent, Run Backtest, Configure, the menu items, the run links). **The outer card element carries no `data-agent-id`.**
+
+Two consequences, both load-bearing:
+
+1. Add it, alongside the existing `card.className = ...` at `app.js:1124` (which already includes the `agent-card` class):
+   ```js
+   card.setAttribute('data-agent-id', agent.agent_id);
+   ```
+   `setAttribute`, not HTML interpolation.
+2. **The selector must be `.agent-card[data-agent-id]`, never the bare `[data-agent-id]`.** The bare form matches the card *and* its 5–8 child buttons, firing `scrollIntoView` six-to-eight times per creation — the smooth-scroll target changes mid-flight and the page visibly jitters. The class narrows it to the one element; marketplace cards (`:1666`) share `.agent-card` but carry no `data-agent-id`, so the conjunction matches exactly one node.
 
 - [ ] **Step 4: Implement**
 
@@ -437,10 +453,13 @@ Add next to `refreshRunningAgentCards` in `app.js`:
  *
  * Attribute lookup then compare in JS -- no escaping, no CSS.escape feature
  * detection -- matching refreshRunningAgentCards() (app.js:3370).
+ *
+ * Scoped to .agent-card: every card also contains 5-8 buttons carrying the same
+ * data-agent-id, and the unscoped selector would scroll to each of them in turn.
  */
 function highlightAgentCard(agentId) {
   if (!agentId) return;
-  document.querySelectorAll('[data-agent-id]').forEach((card) => {
+  document.querySelectorAll('.agent-card[data-agent-id]').forEach((card) => {
     if (card.getAttribute('data-agent-id') !== agentId) return;
     card.scrollIntoView({ behavior: 'smooth', block: 'center' });
     card.classList.add('is-just-created');
@@ -838,6 +857,7 @@ This is the surface the tester was actually standing on. The existing running-st
 - Modify: `dashboard/frontend/app.js:782-795` (`renderAgentRunningBody`)
 - Modify: `dashboard/frontend/app.js:3362-3382` (`refreshRunningAgentCards`)
 - Modify: `dashboard/frontend/app.js:4870-4901` (the `status.running` branch of `ensureBacktestPolling`)
+- Modify: `dashboard/frontend/app.js:4942-4954` (the timeout branch — Step 4b)
 - Modify: `dashboard/frontend/styles.css`
 - Test: `dashboard/backend/tests/test_backtest_progress_card.py` (create)
 
@@ -1049,6 +1069,19 @@ And in the `else` branch (`:4902`, run finished), immediately after `stopBacktes
                 liveBacktestProgress = null;
 ```
 
+- [ ] **Step 4b: Close the timeout path — it is the one that leaks**
+
+The finished branch above already clears every running entry (`Object.keys(readRunningBacktests()).forEach(clearAgentBacktestRunning);`, `:4907`). **The 10-minute timeout branch does not.** In `if (attempts >= maxAttempts) {` (`app.js:4942`), after `liveBacktestRunId = null;` (`:4953`), add the same two lines:
+
+```js
+                Object.keys(readRunningBacktests()).forEach(clearAgentBacktestRunning);
+                liveBacktestProgress = null;
+```
+
+Why this is not optional once Step 5 lands. `liveBacktestProgress` is a single global merged into *every* entry in the running map. Today a timed-out entry only ever showed a wrong elapsed timer, and `getAgentBacktestRunning` self-expires it at `BACKTEST_POLL_MAX_SECONDS` (600s) anyway. After Step 5, that same orphaned entry renders **whatever the next run publishes**: agent A times out, agent B starts, and A's card shows B's step, percent and ETA until A's entry ages out. Clearing on timeout — the convention the finished branch already follows — closes it.
+
+The `catch` at `:4955` needs nothing: it only logs, the interval keeps ticking, and the next successful poll re-establishes state.
+
 - [ ] **Step 5: Merge progress into the running entry**
 
 In `getAgentBacktestRunning` (`app.js:3340`), change the return to fold in the polled progress:
@@ -1057,7 +1090,7 @@ In `getAgentBacktestRunning` (`app.js:3340`), change the return to fold in the p
     return { ...entry, ...(liveBacktestProgress || {}), elapsedSeconds: Math.floor(elapsed) };
 ```
 
-`backtest_status` is a single process-global on the server, so at most one backtest runs at a time and one shared progress object is correct.
+`backtest_status` is a single process-global on the server, so at most one backtest runs at a time and one shared progress object is correct **for the run that is actually live**. The spread is unconditional, though, so it also lands on any *stale* entry still in the map — which is exactly why Step 4b exists. With Step 4b in place the only remaining window is a tab that was closed mid-run and reopened, where the entry survives in `sessionStorage` with no poller to clear it; `getAgentBacktestRunning`'s 600s expiry bounds that, and it is not worth per-agent progress keying for a server that runs one backtest at a time.
 
 - [ ] **Step 6: Patch step and detail in place**
 
@@ -1239,7 +1272,19 @@ In `ensureBacktestPolling`, the `if (viewingLive) {` block (`app.js:4891`) curre
                     });
 ```
 
-Leave the other three call sites (`:4831`, `:4917`, `:4926`, `:4947`) unchanged — they are error, completion and timeout paths where an ETA is meaningless.
+Leave the other **six** call sites unchanged. Verify the inventory before editing — `command grep -n "updateBacktestRunProgress(" dashboard/frontend/app.js` should list the definition at `:4607` plus seven callers:
+
+| Site | Path | Why it stays |
+|---|---|---|
+| `:4806` | attach to an already-running backtest | no `step`/`total` in scope yet; the next poll tick paints them |
+| `:4831` | launch, elapsed 0 | nothing to estimate from |
+| **`:4891`** | **live poll — the one this step edits** | — |
+| `:4917` | error | an ETA on a failed run is noise |
+| `:4926` | completion | it is done |
+| `:4947` | 10-minute timeout | the estimate is what failed |
+| `:5491` | `runBacktest` re-entry | same as `:4831` |
+
+All six are safe unedited because every new parameter defaults to `null` and `formatBacktestEta` returns `null` on missing input — the omission is a behaviour-preserving default, not an oversight to fix later.
 
 - [ ] **Step 5: Run tests to verify they pass**
 
@@ -1299,10 +1344,10 @@ A tester could not tell what the platform's core advantage was without clicking
 in and exploring. The narrative sections (Talk/Test/Race) each describe an act
 but never state the problem being solved or who it is for.
 
-Also pins the two claims that must never appear. Both contradict the code:
-`/paper/*` is read-only (no order-submission path exists) and ROBINHOOD_EXECUTE
-defaults to false. docs/source/lab/operating_modes.rst says the same. Copy that
-promises either would be the fabricated-Performance-Drivers failure again.
+Also pins the two claims that must never appear. Both contradict the code: no
+order-submission route exists on any surface, and ROBINHOOD_EXECUTE defaults to
+false. docs/source/lab/operating_modes.rst says the same. Copy that promises
+either would be the fabricated-Performance-Drivers failure again.
 """
 
 from pathlib import Path
@@ -1569,6 +1614,13 @@ def test_talk_keeps_its_anchor_and_visual():
     body = _TALK.read_text(encoding="utf-8")
     assert 'id="talk"' in body
     assert "<DiscordMock />" in body
+
+
+def test_talk_has_exactly_one_section_label():
+    """Step 3's replacement block *re-includes* the `01 — Talk` mono-label, so
+    pasting it below the existing one stacks two identical labels. Every other
+    assertion in this file is a substring check and would stay green."""
+    assert _TALK.read_text(encoding="utf-8").count("01 — Talk") == 1
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -1578,7 +1630,7 @@ Expected: FAIL — `assert "Talk to agents on Discord" not in body`
 
 - [ ] **Step 3: Implement**
 
-In `Talk.tsx`, replace the heading, body line and step list (the `<h2>`, the `<p>` and the `<ol>`) with:
+In `Talk.tsx`, replace the contiguous span **from the `01 — Talk` mono-label `<p>` at `:15` through the closing `</ol>` at `:33`** — that is *four* elements (mono-label `<p>`, `<h2>`, body `<p>`, `<ol>`), not three. The block below **reproduces the mono-label unchanged**; keeping the original as well ships two stacked `01 — Talk` lines, which is what `test_talk_has_exactly_one_section_label` exists to catch. Leave `:34-41` (the `<Button>`) alone.
 
 ```tsx
             <p className="text-base md:text-lg font-mono tracking-wide text-primary mb-3">01 — Talk</p>
@@ -1629,7 +1681,7 @@ git commit -m "feat(landing): lead Talk with the on-site path, Discord as altern
 - [ ] **Step 1: Verify the docs destination resolves**
 
 Run: `curl -sS -o /dev/null -w '%{http_code}\n' https://finagent-orchestration.readthedocs.io/en/latest/`
-Expected: `200`. If it is not 200, stop and report — replacing a dead link with another dead link is not a fix. The URL is the one `README.md:138` publishes as canonical.
+Expected: `200`. If it is not 200, stop and report — replacing a dead link with another dead link is not a fix. This exact URL is the one the README's docs **badge** publishes (`README.md:15`); the prose link at `README.md:138` gives the bare host, which redirects to the same place. Use the badge's `/en/latest/` form so the footer link does not depend on a redirect.
 
 - [ ] **Step 2: Write the failing test**
 
@@ -1739,9 +1791,13 @@ In `dashboard/frontend/index.html`, change the `<script src="/assets/index-XXXX.
 
 Run: `pytest dashboard/backend/tests/test_frontend_bundle_integrity.py -v`
 Expected: 6 passed. Specifically:
-- `test_shipped_bundle_has_one_cta_per_landing_source_emitter` must report **7** in both source and bundle (was 6; Task 9's band adds one)
+- `test_shipped_bundle_has_one_cta_per_landing_source_emitter` must report **7** in both source and bundle (was 6; Task 9's band adds one). The count is derived from the source at run time, not hardcoded, so no assertion needs editing.
 - `test_hand_written_auth_layer_survives_a_bundle_refresh` proves Step 4 was honoured
 - `test_no_orphaned_assets` proves Step 3's deletion happened
+
+- [ ] **Step 6b: Correct the guard's stale prose**
+
+Two docstrings in `test_frontend_bundle_integrity.py` (`:134` and `:187`) say **"six"** `data-landing-auth` CTAs. The assertions are dynamic and stay green, but the prose becomes wrong the moment Task 9 lands. Change both to **seven**. Comment-only edit; commit it with Step 10.
 
 - [ ] **Step 7: Verify the rebuild is reproducible**
 
@@ -1756,11 +1812,12 @@ Expected: identical hashes, and the emitted filename equals the committed one. A
 
 ```bash
 cd /mnt/d/github/agent-trading-lab
-DATABASE_PATH=/tmp/claude-1000/-mnt-d-github-agent-trading-lab/3d290e13-de95-4210-b7fe-64653f3540e8/scratchpad/landing-check.db \
-  python -m dashboard.backend.app
+CHECK_DB="$YOUR_SCRATCHPAD/landing-check.db"   # substitute your own session scratchpad
+mkdir -p "$(dirname "$CHECK_DB")"
+DATABASE_PATH="$CHECK_DB" python -m dashboard.backend.app
 ```
 
-`DATABASE_PATH` must point at a temp file — the default is the committed prod seed DB and importing the app mutates it. Then drive `http://localhost:8000/` with `~/.venvs/htmlpdf/bin/python` (Playwright + Chromium already installed) and confirm: the band renders between hero and Talk, the first scroll lands on it, and **clicking a CTA opens the signup modal**. A `/_vercel/insights/script.js` 404 is expected off Vercel — not a defect.
+`DATABASE_PATH` must point at a temp file **that you create the parent directory for** — the default is the committed prod seed DB, and merely importing the app runs lazy `CREATE TABLE`/`ALTER` against it. Do not paste a scratchpad path from this plan or any transcript: those belong to the session that wrote them and will not exist for you. Then drive `http://localhost:8000/` with `~/.venvs/htmlpdf/bin/python` (Playwright + Chromium already installed) and confirm: the band renders between hero and Talk, the first scroll lands on it, and **clicking a CTA opens the signup modal**. A `/_vercel/insights/script.js` 404 is expected off Vercel — not a defect.
 
 - [ ] **Step 9: Run the full suite**
 
@@ -1770,7 +1827,8 @@ Expected: green
 - [ ] **Step 10: Commit**
 
 ```bash
-git add dashboard/frontend/index.html dashboard/frontend/assets
+git add dashboard/frontend/index.html dashboard/frontend/assets \
+  dashboard/backend/tests/test_frontend_bundle_integrity.py
 git commit -m "chore(landing): rebuild bundle for the value band"
 ```
 

--- a/docs/superpowers/plans/2026-08-01-user-feedback-ux-round.md
+++ b/docs/superpowers/plans/2026-08-01-user-feedback-ux-round.md
@@ -1,0 +1,1814 @@
+# User-Feedback UX Round Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three defects a real tester reported — agent creation looks broken for ~5s, a running backtest gives no sense of position, and the landing page never says what the product is for.
+
+**Architecture:** Three independent PRs over one spec. **A** adds a toast primitive and pending-button states to the vanilla-JS dashboard. **B** routes step-level progress that the backend *already emits* onto the My Agents card, adding one new backend datum (progress-file mtime) for staleness. **C** adds a value-proposition band to the React landing source and rebuilds the hand-patched bundle.
+
+**Tech Stack:** FastAPI + vanilla JS (no build step) for the dashboard; React 18 + Vite 6 + Tailwind + framer-motion for the landing; pytest for all tests, including source-guards and a node-under-pytest harness for JS behaviour.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-user-feedback-ux-round-design.md`
+
+## Global Constraints
+
+- **Docs are a non-goal.** No task edits any file under `docs/` except this plan's own checkboxes. Staleness is recorded in the spec, not fixed here.
+- **No paper-trading or real-capital claim** may appear in any user-visible string. `/paper/*` is read-only and `ROBINHOOD_EXECUTE` defaults to `false`.
+- **Run every command from the repo root.** The backend is the `dashboard.backend` package; never run a backend file by path.
+- **Tests:** `pytest dashboard/backend/tests/ -v`. Pytest is not in `requirements.txt` — install separately. The suite is green on `main`; a red test is a real regression.
+- **Never `git add -A`.** Importing a backend module runs lazy `CREATE TABLE`/`ALTER` against the committed `dashboard/storage/data/backtest.db`, which is the real prod seed database. Stage named paths only.
+- **`prefers-reduced-motion`:** every animating element added here needs a `@media (prefers-reduced-motion: reduce)` fallback. Carried forward from the 2026-07-29 running-state spec.
+- **CSS tokens** (from `styles.css:14-26`): `--bg-card: #131a35`, `--bg-surface: #0f1328`, `--text-primary: #e5e7eb`, `--border-color: #1f2937`.
+- **Branch discipline:** each phase gets its own branch off fresh `main`. Never push follow-up work to a merged branch.
+
+---
+
+# Phase A — Create-agent interaction feedback (PR 1)
+
+Branch: `fix/create-agent-feedback`
+
+`submitCreateBuiltinAgent` (`dashboard/frontend/app.js:1812`) already sets `submitBtn.disabled = true` at `:1838`. Everything the tester missed is what is not there: no label change, no spinner, no success confirmation.
+
+---
+
+### Task 1: Toast primitive
+
+There is no toast system in `/app` — `alert()` appears 18 times and is the current convention. A blocking modal for a *success* is worse than the silence it replaces, so add a real one.
+
+**Files:**
+- Modify: `dashboard/frontend/app.html` (add container before `</body>`)
+- Modify: `dashboard/frontend/app.js` (add `showAppToast`)
+- Modify: `dashboard/frontend/styles.css` (append `.app-toast` block)
+- Test: `dashboard/backend/tests/test_app_toast.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `showAppToast(message, { variant = 'success', timeoutMs = 4000 })` — global function in `app.js`. Task 2 and Task 3 call it.
+
+**Do not reuse `.home-live-toast`** (`styles.css:6792`). That is the Home live-decision widget in the same shared stylesheet; a distinct class keeps the two from co-evolving.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/backend/tests/test_app_toast.py`:
+
+```python
+"""The /app toast primitive: a non-blocking success channel.
+
+Agent creation previously closed its modal and refreshed the grid with no
+confirmation at all, so a slow create read as a dead click. `alert()` -- this
+file's 18-times-over convention -- is modal and blocking, which is a worse
+answer for a *success* than the silence it replaces.
+"""
+
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_HTML = (_FRONTEND / "app.html").read_text(encoding="utf-8")
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+_STYLES = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+
+def test_toast_container_is_a_polite_live_region():
+    """A success message screen readers never announce is not a confirmation."""
+    assert 'id="appToast"' in _APP_HTML
+    assert 'role="status"' in _APP_HTML
+    assert 'aria-live="polite"' in _APP_HTML
+
+
+def test_toast_helper_exists():
+    assert "function showAppToast(" in _APP_JS
+
+
+def test_toast_is_not_the_home_live_toast():
+    """Distinct class: .home-live-toast is the Home live-decision widget in the
+    same shared stylesheet, and conflating them couples two unrelated features."""
+    assert ".app-toast" in _STYLES
+
+
+def test_toast_animation_has_a_reduced_motion_fallback():
+    block = _STYLES[_STYLES.index(".app-toast") :]
+    assert "prefers-reduced-motion" in block
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_app_toast.py -v`
+Expected: FAIL — `assert 'id="appToast"' in _APP_HTML`
+
+- [ ] **Step 3: Add the container to `app.html`**
+
+Insert immediately before the closing `</body>` tag:
+
+```html
+<div id="appToast" class="app-toast" role="status" aria-live="polite" hidden></div>
+```
+
+- [ ] **Step 4: Add `showAppToast` to `app.js`**
+
+Add near the other top-level UI helpers (anywhere above `submitCreateBuiltinAgent` at `:1812`):
+
+```js
+let appToastTimer = null;
+
+/**
+ * Non-blocking confirmation channel for /app.
+ *
+ * The pre-existing convention here is alert(), which is modal: acceptable for a
+ * launch-time refusal the user must acknowledge, wrong for a success they only
+ * need to notice. Text (not innerHTML) -- callers pass agent names.
+ */
+function showAppToast(message, { variant = 'success', timeoutMs = 4000 } = {}) {
+  const el = document.getElementById('appToast');
+  if (!el) return;
+  el.textContent = String(message);
+  el.className = `app-toast app-toast--${variant}`;
+  el.hidden = false;
+  // Force a reflow so re-showing an already-visible toast replays the transition.
+  void el.offsetWidth;
+  el.classList.add('is-visible');
+  if (appToastTimer) clearTimeout(appToastTimer);
+  appToastTimer = setTimeout(() => {
+    el.classList.remove('is-visible');
+    appToastTimer = setTimeout(() => { el.hidden = true; }, 240);
+  }, timeoutMs);
+}
+```
+
+- [ ] **Step 5: Add the styles**
+
+Append to `dashboard/frontend/styles.css`:
+
+```css
+/* /app toast — success confirmations. Distinct from .home-live-toast, which is
+   the Home live-decision widget. */
+.app-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 32px;
+    transform: translate(-50%, 12px);
+    z-index: 9000;
+    max-width: min(420px, calc(100vw - 32px));
+    padding: 12px 18px;
+    border-radius: 10px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 600;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 220ms ease, transform 220ms ease;
+}
+
+.app-toast.is-visible {
+    opacity: 1;
+    transform: translate(-50%, 0);
+}
+
+.app-toast--success { border-color: rgba(34, 197, 94, 0.45); }
+.app-toast--error { border-color: rgba(239, 68, 68, 0.45); }
+
+@media (prefers-reduced-motion: reduce) {
+    .app-toast { transition: none; transform: translate(-50%, 0); }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_app_toast.py -v`
+Expected: 4 passed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/frontend/app.html dashboard/frontend/app.js dashboard/frontend/styles.css dashboard/backend/tests/test_app_toast.py
+git commit -m "feat(ui): add non-blocking toast primitive for /app"
+```
+
+---
+
+### Task 2: Pending button state + confirm on POST resolution
+
+**Files:**
+- Modify: `dashboard/frontend/app.js:1812-1859` (`submitCreateBuiltinAgent`)
+- Modify: `dashboard/frontend/styles.css` (spinner)
+- Test: `dashboard/backend/tests/test_create_agent_feedback.py` (create)
+
+**Interfaces:**
+- Consumes: `showAppToast(message, opts)` from Task 1.
+- Produces: `setButtonPending(btn, label)` and `restoreButton(btn)` — Task 3 does not use them, but future async submits will.
+
+Two changes, and the ordering one matters as much as the visible one. Today the flow is: close modal → `applyActiveAgent` → `await loadAgents()`, with the button restored in `finally` *after* the refresh. The confirmation must not be gated on the grid refresh.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/backend/tests/test_create_agent_feedback.py`:
+
+```python
+"""Create-agent gives feedback within one frame of the click.
+
+A tester reported ~5 seconds of apparently-dead UI after clicking "Create
+built-in agent". The agent was created correctly every time; the button just
+never changed and nothing confirmed success. The POST itself is genuinely slow
+(see the round-trip note in the spec), so the fix is feedback, not latency.
+"""
+
+import re
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+
+
+def _submit_fn() -> str:
+    start = _APP_JS.index("async function submitCreateBuiltinAgent(")
+    depth = 0
+    i = _APP_JS.index("{", start)
+    while True:
+        if _APP_JS[i] == "{":
+            depth += 1
+        elif _APP_JS[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return _APP_JS[start : i + 1]
+        i += 1
+
+
+def test_helpers_exist():
+    assert "function setButtonPending(" in _APP_JS
+    assert "function restoreButton(" in _APP_JS
+
+
+def test_pending_state_is_set_before_the_await():
+    """Set after the await, the label would appear only once the POST returned --
+    exactly the window the tester experienced as dead."""
+    fn = _submit_fn()
+    assert "setButtonPending(" in fn
+    assert fn.index("setButtonPending(") < fn.index("await API.post")
+
+
+def test_pending_label_is_creating():
+    assert "'Creating…'" in _submit_fn()
+
+
+def test_success_confirmation_is_not_gated_on_the_grid_refresh():
+    """loadAgents() is a second round trip. Confirming after it would reintroduce
+    most of the delay the toast exists to cover."""
+    fn = _submit_fn()
+    assert "showAppToast(" in fn
+    assert fn.index("showAppToast(") < fn.index("await loadAgents()")
+
+
+def test_button_is_restored_on_every_path():
+    """finally, not the success branch: an error must not strand a dead button."""
+    fn = _submit_fn()
+    finally_block = fn[fn.index("} finally {") :]
+    assert "restoreButton(" in finally_block
+
+
+def test_aria_busy_is_toggled():
+    assert re.search(r"aria-busy", _APP_JS)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_create_agent_feedback.py -v`
+Expected: FAIL — `assert "function setButtonPending(" in _APP_JS`
+
+- [ ] **Step 3: Add the helpers to `app.js`**
+
+Add immediately above `openCreateBuiltinAgentModal` (`app.js:1797`):
+
+```js
+/**
+ * Lock a submit button and say what it is doing.
+ *
+ * disabled alone is nearly invisible in this theme, which is why a create that
+ * already set it still read as a dead click.
+ */
+function setButtonPending(btn, label) {
+  if (!btn) return;
+  if (btn.dataset.idleLabel === undefined) btn.dataset.idleLabel = btn.textContent;
+  btn.disabled = true;
+  btn.setAttribute('aria-busy', 'true');
+  btn.classList.add('is-pending');
+  btn.textContent = label;
+}
+
+function restoreButton(btn) {
+  if (!btn) return;
+  btn.disabled = false;
+  btn.removeAttribute('aria-busy');
+  btn.classList.remove('is-pending');
+  if (btn.dataset.idleLabel !== undefined) btn.textContent = btn.dataset.idleLabel;
+}
+```
+
+- [ ] **Step 4: Rewrite the submit body**
+
+In `submitCreateBuiltinAgent`, replace the block from `if (submitBtn) submitBtn.disabled = true;` (`:1838`) through the end of the function with:
+
+```js
+  setButtonPending(submitBtn, 'Creating…');
+
+  try {
+    const data = await API.post(`${API_BASE}/api/v1/agents`, {
+      name,
+      model_name,
+      agent_type: 'builtin',
+      description,
+      cash_allocation,
+    });
+    // Confirm on the POST result, not after loadAgents(): that is a second
+    // round trip, and gating the toast on it reinstates most of the delay.
+    closeCreateBuiltinAgentModal();
+    showAppToast(`"${name}" created`);
+    if (data.agent) applyActiveAgent(data.agent);
+    await loadAgents();
+    if (data.agent) highlightAgentCard(data.agent.agent_id);
+  } catch (error) {
+    if (errorEl) {
+      errorEl.textContent = error.message;
+      errorEl.hidden = false;
+    }
+  } finally {
+    restoreButton(submitBtn);
+  }
+}
+```
+
+`highlightAgentCard` is defined in Task 3. Implement Task 3 before running the browser check in Step 6.
+
+- [ ] **Step 5: Add the pending spinner style**
+
+Append to `dashboard/frontend/styles.css`:
+
+```css
+/* Pending submit buttons — disabled alone is nearly invisible in this theme. */
+.auth-submit-btn.is-pending {
+    opacity: 0.75;
+    cursor: progress;
+}
+
+.auth-submit-btn.is-pending::before {
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin-right: 8px;
+    vertical-align: -1px;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: app-btn-spin 640ms linear infinite;
+}
+
+@keyframes app-btn-spin { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+    .auth-submit-btn.is-pending::before { animation: none; }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_create_agent_feedback.py -v`
+Expected: 6 passed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/frontend/app.js dashboard/frontend/styles.css dashboard/backend/tests/test_create_agent_feedback.py
+git commit -m "fix(ui): lock and label the create-agent button, confirm on success"
+```
+
+---
+
+### Task 3: Locate the newly created agent
+
+Answers "did it work?" positionally, not just textually — the grid can be long and paginated.
+
+**Files:**
+- Modify: `dashboard/frontend/app.js` (add `highlightAgentCard`)
+- Modify: `dashboard/frontend/styles.css`
+- Test: `dashboard/backend/tests/test_create_agent_feedback.py` (extend)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `highlightAgentCard(agentId)` — called by Task 2's success path.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_create_agent_feedback.py`:
+
+```python
+def test_new_agent_card_is_located_after_creation():
+    assert "function highlightAgentCard(" in _APP_JS
+    assert "highlightAgentCard(" in _submit_fn()
+
+
+def test_highlight_uses_attribute_lookup_not_selector_interpolation():
+    """Same rule refreshRunningAgentCards() follows (app.js:3370): agent ids are
+    server-supplied, so never interpolate one into a selector string."""
+    start = _APP_JS.index("function highlightAgentCard(")
+    body = _APP_JS[start : start + 900]
+    assert "querySelectorAll('[data-agent-id]')" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_create_agent_feedback.py -v -k highlight`
+Expected: FAIL — `assert "function highlightAgentCard(" in _APP_JS`
+
+- [ ] **Step 3: Confirm the card carries `data-agent-id`**
+
+Run: `command grep -n "data-agent-id" dashboard/frontend/app.js | head -5`
+
+If the attribute is absent from the card element built in `renderAgentCards` (`app.js:1121`), add `card.setAttribute('data-agent-id', agent.agent_id);` alongside the existing `card.className = ...` assignment. Do not interpolate the id into HTML.
+
+- [ ] **Step 4: Implement**
+
+Add next to `refreshRunningAgentCards` in `app.js`:
+
+```js
+/**
+ * Scroll the named agent's card into view and flash it.
+ *
+ * Attribute lookup then compare in JS -- no escaping, no CSS.escape feature
+ * detection -- matching refreshRunningAgentCards() (app.js:3370).
+ */
+function highlightAgentCard(agentId) {
+  if (!agentId) return;
+  document.querySelectorAll('[data-agent-id]').forEach((card) => {
+    if (card.getAttribute('data-agent-id') !== agentId) return;
+    card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    card.classList.add('is-just-created');
+    setTimeout(() => card.classList.remove('is-just-created'), 2400);
+  });
+}
+```
+
+- [ ] **Step 5: Add the flash style**
+
+Append to `dashboard/frontend/styles.css`:
+
+```css
+.agent-card.is-just-created {
+    animation: agent-card-flash 2.4s ease-out;
+}
+
+@keyframes agent-card-flash {
+    0%, 40% { box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.55); }
+    100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-card.is-just-created { animation: none; box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.55); }
+}
+```
+
+- [ ] **Step 6: Run the full Phase A suite**
+
+Run: `pytest dashboard/backend/tests/test_app_toast.py dashboard/backend/tests/test_create_agent_feedback.py -v`
+Expected: all passed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/frontend/app.js dashboard/frontend/styles.css dashboard/backend/tests/test_create_agent_feedback.py
+git commit -m "feat(ui): scroll to and flash a newly created agent"
+```
+
+---
+
+### Task 4: Record the create-path round-trip cost — no code change
+
+The spec makes latency an investigation, not a deliverable. The investigation is already done; this task records it so nobody re-derives it, and explicitly forbids the tempting fix.
+
+**Files:** none modified. Output goes in the PR body.
+
+**Measured:** `POST /api/v1/agents` (`agents.py:129`) calls `portfolio_service._reconcile()` **twice** — once inside `ensure_cash_for_new_agent` → `_check_new_sleeve` (`service.py:120`, only when `delta > 0`) and once inside `get_or_create_portfolio` (`agents.py:176`). Each `_reconcile` is 2–3 DB round trips: `portfolio_store.get_or_create`, `agent_store.list_agents`, and conditionally `portfolio_store.set_cash_available`. Add `agent_service.create_agent` and `agent_with_stats` and the create path is roughly **5–7 Neon round trips**, then the frontend issues `loadAgents()` on top.
+
+**Do not remove the second `_reconcile`.** It looks redundant — its return value is discarded at `agents.py:175-176` — but `service.py`'s module docstring states the design intent: *"`_reconcile` on every read and after every write"*, deriving `cash_available` from the sleeves so legacy drift self-corrects. The post-create call is the "after every write" half and it persists the new figure via `set_cash_available`. This is money accounting with documented failure modes (#175, `reclaim_on_session_match`); a latency micro-optimisation is not worth relitigating it inside a UX PR.
+
+- [ ] **Step 1: Verify the round-trip claim still holds**
+
+Run: `command grep -n "_reconcile" dashboard/backend/domain/portfolios/service.py`
+Expected: `_reconcile` defined once, called from `_check_new_sleeve` and `get_or_create_portfolio`.
+
+- [ ] **Step 2: Paste the paragraph above into the PR body under "Latency — investigated, not changed"**
+
+- [ ] **Step 3: No commit** (documentation-in-PR-body only; the spec forbids doc edits)
+
+---
+
+**Phase A exit:** `pytest dashboard/backend/tests/ -v` fully green. Open PR `fix(ui): create-agent feedback`.
+
+---
+
+# Phase B — Backtest progress (PR 2)
+
+Branch: `feat/backtest-progress-visibility`
+
+**Read this first.** The 2026-07-29 spec (`docs/superpowers/specs/2026-07-29-my-agents-capital-instruction-running-design.md`) made this a non-goal, reasoning: *"deliberately not a percentage, since no honest completion estimate exists."* That premise is false — `engine.py:287` (`_publish_live_progress`) has been writing `step`/`total_steps` on every step, and `backtests.py:1272` already computes the percentage. We are correcting a factual error, not relitigating taste. Do not revert to indeterminate.
+
+---
+
+### Task 5: Backend — expose progress-file freshness
+
+The only genuinely new datum in Phase B. Everything else already ships in the status payload.
+
+**Files:**
+- Modify: `dashboard/backend/api/routers/backtests.py:324-336` (`_read_backtest_progress`)
+- Test: `dashboard/backend/tests/test_backtest_progress_status.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `progress.progress_updated_at` — a float, epoch seconds, present in `GET /backtest/status`'s `progress` object whenever a readable progress file exists. Task 7 consumes it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/backend/tests/test_backtest_progress_status.py`:
+
+```python
+"""Progress-file freshness, so the UI can tell 'working' from 'stuck'.
+
+The status payload already carried step/total_steps; what it could not answer
+was whether those numbers were current. A run whose subprocess wedges keeps
+reporting its last step forever, which reads identically to steady progress.
+"""
+
+import json
+import time
+
+from dashboard.backend.api.routers import backtests
+
+
+def test_progress_carries_the_file_mtime(tmp_path, monkeypatch):
+    progress_file = tmp_path / "backtest_progress_test.json"
+    progress_file.write_text(json.dumps({"step": 7, "total_steps": 240}), encoding="utf-8")
+    monkeypatch.setitem(backtests.backtest_status, "progress_file", str(progress_file))
+
+    payload = backtests._read_backtest_progress()
+
+    assert payload["step"] == 7
+    assert payload["total_steps"] == 240
+    assert payload["progress_updated_at"] == progress_file.stat().st_mtime
+    assert payload["progress_updated_at"] <= time.time() + 1
+
+
+def test_missing_progress_file_still_returns_none(tmp_path, monkeypatch):
+    """Unchanged behaviour: the status payload omits `progress` entirely rather
+    than shipping a half-populated object."""
+    monkeypatch.setitem(
+        backtests.backtest_status, "progress_file", str(tmp_path / "nope.json")
+    )
+    assert backtests._read_backtest_progress() is None
+
+
+def test_malformed_progress_file_still_returns_none(tmp_path, monkeypatch):
+    progress_file = tmp_path / "broken.json"
+    progress_file.write_text("{not json", encoding="utf-8")
+    monkeypatch.setitem(backtests.backtest_status, "progress_file", str(progress_file))
+    assert backtests._read_backtest_progress() is None
+
+
+def test_non_dict_progress_file_still_returns_none(tmp_path, monkeypatch):
+    progress_file = tmp_path / "list.json"
+    progress_file.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setitem(backtests.backtest_status, "progress_file", str(progress_file))
+    assert backtests._read_backtest_progress() is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_backtest_progress_status.py -v`
+Expected: FAIL — `KeyError: 'progress_updated_at'`
+
+- [ ] **Step 3: Implement**
+
+Replace the body of `_read_backtest_progress` (`backtests.py:324-336`):
+
+```python
+def _read_backtest_progress() -> Optional[Dict[str, Any]]:
+    """Load incremental equity snapshots written by the backtest subprocess.
+
+    ``progress_updated_at`` is the file's mtime, not a field the writer emits:
+    it answers "are these numbers current?", which the payload alone cannot.
+    stat() and read_text() are separate syscalls, so a file rewritten between
+    them yields an mtime marginally older than the payload -- immaterial against
+    a 120s staleness threshold, and not worth a lock to avoid.
+    """
+    progress_file = backtest_status.get("progress_file")
+    if not progress_file:
+        return None
+    path = Path(progress_file)
+    if not path.is_file():
+        return None
+    try:
+        updated_at = path.stat().st_mtime
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return {**payload, "progress_updated_at": updated_at}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_backtest_progress_status.py -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Confirm no existing caller regressed**
+
+Run: `pytest dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/integrations/test_discord_watcher.py -v`
+Expected: all passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/backend/api/routers/backtests.py dashboard/backend/tests/test_backtest_progress_status.py
+git commit -m "feat(backtest): report progress-file freshness in status"
+```
+
+---
+
+### Task 6: Progress formatters (pure functions, real behavioural tests)
+
+These are pure, so they get executed under node rather than grepped. The harness pattern is established in `dashboard/backend/tests/test_my_agents_card_ui.py` — it lifts a function out of `app.js` by brace-matching and runs it with `node -e`.
+
+**Files:**
+- Modify: `dashboard/frontend/app.js` (add two functions near `formatBacktestElapsed`, `:4585`)
+- Test: `dashboard/backend/tests/test_backtest_progress_format.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `formatBacktestEta(elapsedSeconds, step, totalSteps)` → `string | null`. `null` when `step < 3`, when `step`/`totalSteps` are missing or non-finite, when `totalSteps <= 0`, or when `step >= totalSteps`.
+  - `formatProgressStaleness(secondsSinceUpdate)` → `string | null`. `null` below 120s.
+  - `BACKTEST_STALE_SECONDS = 120` — module constant.
+
+  Task 7 and Task 8 both call these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/backend/tests/test_backtest_progress_format.py`:
+
+```python
+"""ETA and staleness formatting for a running backtest.
+
+Both are honesty-constrained rather than precision-constrained:
+
+* an ETA derived from two or three steps is wild, and a number that visibly
+  jumps reads as broken -- so it is suppressed early and coarse thereafter;
+* a stale progress file means the numbers are old, NOT that the run is stuck.
+  An LLM pipeline step can legitimately take minutes. Claiming "stuck" would be
+  the same class of error as the fabricated Performance Drivers card.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+
+def _extract_function(src: str, name: str) -> str:
+    for marker in (f"async function {name}(", f"function {name}("):
+        start = src.find(marker)
+        if start != -1:
+            break
+    else:
+        raise AssertionError(f"{name} not found in app.js")
+    depth = 0
+    i = src.index("{", start)
+    while True:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+
+
+def _eval(expr: str) -> object:
+    script = "\n".join(
+        [
+            "const BACKTEST_STALE_SECONDS = 120;",
+            _extract_function(_APP_JS, "formatBacktestEta"),
+            _extract_function(_APP_JS, "formatProgressStaleness"),
+            f"console.log(JSON.stringify({expr}));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_eta_is_suppressed_for_the_first_two_steps():
+    assert _eval("formatBacktestEta(4, 1, 240)") is None
+    assert _eval("formatBacktestEta(8, 2, 240)") is None
+
+
+def test_eta_appears_from_step_three():
+    # 30s for 3 of 243 steps -> 10s/step -> 2400s remaining -> "~40m left"
+    assert _eval("formatBacktestEta(30, 3, 243)") == "~40m left"
+
+
+def test_eta_is_coarse_under_a_minute():
+    # 100s for 100 of 130 steps -> 1s/step -> 30s remaining
+    assert _eval("formatBacktestEta(100, 100, 130)") == "<1m left"
+
+
+def test_eta_rounds_to_whole_minutes():
+    # 125s for 25 of 50 steps -> 5s/step -> 125s remaining -> ~2m
+    assert _eval("formatBacktestEta(125, 25, 50)") == "~2m left"
+
+
+def test_eta_is_null_without_totals():
+    assert _eval("formatBacktestEta(60, 10, 0)") is None
+    assert _eval("formatBacktestEta(60, 10, null)") is None
+    assert _eval("formatBacktestEta(60, null, 240)") is None
+
+
+def test_eta_is_null_on_the_final_step():
+    """No remaining work to estimate; the completion path takes over."""
+    assert _eval("formatBacktestEta(600, 240, 240)") is None
+
+
+def test_staleness_is_silent_below_the_threshold():
+    assert _eval("formatProgressStaleness(0)") is None
+    assert _eval("formatProgressStaleness(119)") is None
+
+
+def test_staleness_reports_the_actual_gap_not_the_threshold():
+    """A message frozen at '2m' while the real gap grows to ten is worse than
+    no message -- it actively misinforms."""
+    assert "2m" in _eval("formatProgressStaleness(130)")
+    assert "9m" in _eval("formatProgressStaleness(560)")
+
+
+def test_staleness_wording_does_not_claim_the_run_is_stuck():
+    message = _eval("formatProgressStaleness(300)")
+    assert "stuck" not in message.lower()
+    assert "fail" not in message.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_backtest_progress_format.py -v`
+Expected: FAIL — `AssertionError: formatBacktestEta not found in app.js`
+
+- [ ] **Step 3: Implement**
+
+Add immediately after `formatBacktestElapsed` (`app.js:4590`):
+
+```js
+/** A progress file older than this is reported as stale (seconds). */
+const BACKTEST_STALE_SECONDS = 120;
+
+/**
+ * Coarse remaining-time estimate, or null when no honest one exists.
+ *
+ * Suppressed below step 3: the first estimates swing wildly, and a number that
+ * visibly jumps reads as broken. Coarse buckets thereafter -- a precise-looking
+ * ETA that drifts is worse than an obviously approximate one.
+ */
+function formatBacktestEta(elapsedSeconds, step, totalSteps) {
+  const elapsed = Number(elapsedSeconds);
+  const done = Number(step);
+  const total = Number(totalSteps);
+  if (!Number.isFinite(elapsed) || elapsed <= 0) return null;
+  if (!Number.isFinite(done) || !Number.isFinite(total)) return null;
+  if (total <= 0 || done < 3 || done >= total) return null;
+  const remaining = (elapsed / done) * (total - done);
+  if (!Number.isFinite(remaining) || remaining <= 0) return null;
+  if (remaining < 60) return '<1m left';
+  return `~${Math.round(remaining / 60)}m left`;
+}
+
+/**
+ * Staleness notice, or null while progress is fresh.
+ *
+ * Reports the *actual* gap, never the threshold: a message frozen at "2m" while
+ * the real gap grows to ten actively misinforms. Deliberately does not say
+ * "stuck" -- we know the file is old, not that the run died, and a long model
+ * step looks exactly like this.
+ */
+function formatProgressStaleness(secondsSinceUpdate) {
+  const gap = Number(secondsSinceUpdate);
+  if (!Number.isFinite(gap) || gap < BACKTEST_STALE_SECONDS) return null;
+  const minutes = Math.floor(gap / 60);
+  return `No progress for ${minutes}m — long model steps can do this.`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_backtest_progress_format.py -v`
+Expected: 9 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/app.js dashboard/backend/tests/test_backtest_progress_format.py
+git commit -m "feat(backtest): add ETA and staleness formatters"
+```
+
+---
+
+### Task 7: Determinate progress on the My Agents card
+
+This is the surface the tester was actually standing on. The existing running-state store (`readRunningBacktests`, `app.js:3320`) holds only `{runId, startedAt}`; it needs the polled progress too.
+
+**Files:**
+- Modify: `dashboard/frontend/app.js:782-795` (`renderAgentRunningBody`)
+- Modify: `dashboard/frontend/app.js:3362-3382` (`refreshRunningAgentCards`)
+- Modify: `dashboard/frontend/app.js:4870-4901` (the `status.running` branch of `ensureBacktestPolling`)
+- Modify: `dashboard/frontend/styles.css`
+- Test: `dashboard/backend/tests/test_backtest_progress_card.py` (create)
+
+**Interfaces:**
+- Consumes: `formatBacktestEta`, `formatProgressStaleness`, `BACKTEST_STALE_SECONDS` (Task 6); `progress.progress_updated_at` (Task 5).
+- Produces: `liveBacktestProgress` — a module-level `{ step, totalSteps, updatedAt }` object (or `null`), set by the poller and read by the renderer.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/backend/tests/test_backtest_progress_card.py`:
+
+```python
+"""The My Agents card shows step-level progress.
+
+The backend has always emitted step/total_steps (engine.py `_publish_live_progress`,
+surfaced by backtests.py `get_backtest_status`), and the Backtest tab has always
+had a percentage bar. The card -- the page a user lands on after launching --
+threw the data away and rendered an indeterminate bar plus an elapsed timer. A
+tester watched it for 3m05s and could not tell running from stuck.
+
+The 2026-07-29 spec called an indeterminate bar deliberate "since no honest
+completion estimate exists". That premise was already false when written.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+_STYLES = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+
+def _extract_function(src: str, name: str) -> str:
+    for marker in (f"async function {name}(", f"function {name}("):
+        start = src.find(marker)
+        if start != -1:
+            break
+    else:
+        raise AssertionError(f"{name} not found in app.js")
+    depth = 0
+    i = src.index("{", start)
+    while True:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+
+
+def _render(running_js: str) -> str:
+    script = "\n".join(
+        [
+            "const BACKTEST_STALE_SECONDS = 120;",
+            "function escapeHtml(s) { return String(s); }",
+            "function renderAgentAllocatedCapitalHero() { return ''; }",
+            "function formatBacktestElapsed(s) { return String(s); }",
+            _extract_function(_APP_JS, "formatBacktestEta"),
+            _extract_function(_APP_JS, "formatProgressStaleness"),
+            _extract_function(_APP_JS, "renderAgentRunningBody"),
+            f"console.log(JSON.stringify(renderAgentRunningBody("
+            f"{{agent_id: 'a1'}}, {running_js})));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_card_shows_step_and_percent_when_known():
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert "84/240" in html
+    assert "35%" in html
+
+
+def test_card_bar_is_determinate_when_step_is_known():
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert "is-determinate" in html
+    assert "width: 35%" in html
+
+
+def test_card_falls_back_to_indeterminate_before_the_first_step():
+    """Not an error state: the progress file does not exist for the opening
+    moments of every run."""
+    html = _render("{elapsedSeconds: 2}")
+    assert "is-determinate" not in html
+    assert "Backtesting" in html
+
+
+def test_card_shows_eta():
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert "left" in html
+
+
+def test_card_warns_when_progress_is_stale():
+    html = _render(
+        "{elapsedSeconds: 600, step: 84, totalSteps: 240, updatedAt: Date.now() - 300000}"
+    )
+    assert "No progress for 5m" in html
+
+
+def test_card_is_silent_when_progress_is_fresh():
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert "No progress for" not in html
+
+
+def test_determinate_bar_keeps_a_reduced_motion_fallback():
+    assert "prefers-reduced-motion" in _STYLES
+    assert "agent-card-running-bar--is-determinate" in _STYLES or "is-determinate" in _STYLES
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_backtest_progress_card.py -v`
+Expected: FAIL — `assert "84/240" in html`
+
+- [ ] **Step 3: Rewrite `renderAgentRunningBody`**
+
+Replace `app.js:775-795` (the JSDoc block and the function) with:
+
+```js
+/**
+ * Card body for an agent with a backtest in flight.
+ *
+ * The bar is determinate whenever the engine has published a step: engine.py's
+ * `_publish_live_progress` writes step/total_steps every step and the status
+ * endpoint surfaces them. (The 2026-07-29 spec specified an indeterminate bar
+ * "since no honest completion estimate exists" -- that was already untrue; see
+ * the 2026-08-01 spec.) It falls back to indeterminate before the first step,
+ * which is a normal state on every run, not an error.
+ */
+function renderAgentRunningBody(agent, running) {
+  const step = Number(running.step);
+  const total = Number(running.totalSteps);
+  const determinate =
+    Number.isFinite(step) && Number.isFinite(total) && total > 0 && step > 0;
+  const pct = determinate ? Math.min(99, Math.round((100 * step) / total)) : null;
+  const eta = determinate
+    ? formatBacktestEta(running.elapsedSeconds, step, total)
+    : null;
+  const stale = running.updatedAt
+    ? formatProgressStaleness((Date.now() - Number(running.updatedAt)) / 1000)
+    : null;
+
+  const stepLabel = determinate ? `${step}/${total}` : '';
+  // Built from raw values and escaped once at the interpolation site below --
+  // escaping here as well would double-encode.
+  const detail = [
+    determinate ? `${pct}%` : null,
+    eta,
+    `${formatBacktestElapsed(running.elapsedSeconds)} elapsed`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return `
+    <div class="agent-card-running">
+      <div class="agent-card-running-head">
+        <span class="agent-card-running-dot" aria-hidden="true"></span>
+        <span class="agent-card-running-label">Backtesting…</span>
+        <span class="agent-card-running-step" data-running-step="${escapeHtml(agent.agent_id)}">${escapeHtml(stepLabel)}</span>
+        <span class="agent-card-running-elapsed" data-running-elapsed="${escapeHtml(agent.agent_id)}">${escapeHtml(formatBacktestElapsed(running.elapsedSeconds))}</span>
+      </div>
+      <div class="agent-card-running-track" role="progressbar" aria-label="Backtest in progress"${determinate ? ` aria-valuenow="${pct}" aria-valuemin="0" aria-valuemax="100"` : ''}>
+        <div class="agent-card-running-bar${determinate ? ' is-determinate' : ''}"${determinate ? ` style="width: ${pct}%"` : ''}></div>
+      </div>
+      <p class="agent-card-running-detail" data-running-detail="${escapeHtml(agent.agent_id)}">${escapeHtml(detail)}</p>
+      ${stale ? `<p class="agent-card-running-stale">${escapeHtml(stale)}</p>` : ''}
+    </div>
+    ${renderAgentAllocatedCapitalHero(agent)}`;
+}
+```
+
+- [ ] **Step 4: Capture progress in the poller**
+
+Declare the store **next to `lastRenderedRunningKey` (`app.js:3351`)**, not next to the poller. `getAgentBacktestRunning` (`:3340`) reads it, and a `let` declared 1500 lines below its reader is a temporal-dead-zone trap waiting for the first person who calls that function during script evaluation:
+
+```js
+/** Latest polled progress for the single in-flight run.
+ *  backtest_status is one process-global dict on the server, so at most one
+ *  backtest runs at a time and a single shared object is correct. */
+let liveBacktestProgress = null;
+```
+
+Then in `ensureBacktestPolling` (`app.js:4859`), the `status.running` branch already computes `step`, `total` and `stepPct` at `:4879-4883`.
+
+Then, inside the `if (status.running) {` branch, immediately after the existing `const stepPct = ...` assignment, insert:
+
+```js
+                liveBacktestProgress = Number.isFinite(step) && step > 0
+                    ? { step, totalSteps: total, updatedAt: Number(status.progress?.progress_updated_at) * 1000 || Date.now() }
+                    : null;
+```
+
+And in the `else` branch (`:4902`, run finished), immediately after `stopBacktestPolling();`, add:
+
+```js
+                liveBacktestProgress = null;
+```
+
+- [ ] **Step 5: Merge progress into the running entry**
+
+In `getAgentBacktestRunning` (`app.js:3340`), change the return to fold in the polled progress:
+
+```js
+    return { ...entry, ...(liveBacktestProgress || {}), elapsedSeconds: Math.floor(elapsed) };
+```
+
+`backtest_status` is a single process-global on the server, so at most one backtest runs at a time and one shared progress object is correct.
+
+- [ ] **Step 6: Patch step and detail in place**
+
+In `refreshRunningAgentCards` (`app.js:3362`), extend the patch loop. Replace the `elapsedNodes` block with:
+
+```js
+    const elapsedNodes = document.querySelectorAll('[data-running-elapsed]');
+    const stepNodes = document.querySelectorAll('[data-running-step]');
+    const detailNodes = document.querySelectorAll('[data-running-detail]');
+    Object.keys(running).forEach((agentId) => {
+        const entry = getAgentBacktestRunning(agentId);
+        if (!entry) return;
+        elapsedNodes.forEach((el) => {
+            if (el.getAttribute('data-running-elapsed') !== agentId) return;
+            el.textContent = formatBacktestElapsed(entry.elapsedSeconds);
+        });
+        const step = Number(entry.step);
+        const total = Number(entry.totalSteps);
+        const determinate = Number.isFinite(step) && Number.isFinite(total) && total > 0 && step > 0;
+        if (!determinate) return;
+        const pct = Math.min(99, Math.round((100 * step) / total));
+        stepNodes.forEach((el) => {
+            if (el.getAttribute('data-running-step') !== agentId) return;
+            el.textContent = `${step}/${total}`;
+        });
+        detailNodes.forEach((el) => {
+            if (el.getAttribute('data-running-detail') !== agentId) return;
+            const eta = formatBacktestEta(entry.elapsedSeconds, step, total);
+            el.textContent = [`${pct}%`, eta, `${formatBacktestElapsed(entry.elapsedSeconds)} elapsed`]
+                .filter(Boolean)
+                .join(' · ');
+        });
+    });
+```
+
+The bar width and the staleness line still move on the next full re-render; the per-second patch covers the numbers that change every tick.
+
+- [ ] **Step 7: Add the styles**
+
+Append to `dashboard/frontend/styles.css`:
+
+```css
+.agent-card-running-step {
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    opacity: 0.75;
+}
+
+.agent-card-running-detail {
+    margin: 6px 0 0;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    opacity: 0.7;
+}
+
+.agent-card-running-stale {
+    margin: 4px 0 0;
+    font-size: 12px;
+    color: #fbbf24;
+}
+
+/* Determinate: width is data, so the indeterminate sweep must not also run. */
+.agent-card-running-bar.is-determinate {
+    animation: none;
+    transition: width 400ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-card-running-bar.is-determinate { transition: none; }
+}
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_backtest_progress_card.py dashboard/backend/tests/test_my_agents_card_ui.py -v`
+Expected: all passed. `test_my_agents_card_ui.py` must stay green — it covers the same card.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add dashboard/frontend/app.js dashboard/frontend/styles.css dashboard/backend/tests/test_backtest_progress_card.py
+git commit -m "feat(backtest): show step, percent, ETA and staleness on the agent card"
+```
+
+---
+
+### Task 8: Keep the Backtest-tab panel consistent
+
+Two surfaces showing different numbers for one run is worse than one surface showing none.
+
+**Files:**
+- Modify: `dashboard/frontend/app.js:4607-4625` (`updateBacktestRunProgress`)
+- Modify: `dashboard/frontend/app.js` (the `viewingLive` call site, `:4891-4895`)
+- Test: `dashboard/backend/tests/test_backtest_progress_card.py` (extend)
+
+**Interfaces:**
+- Consumes: `formatBacktestEta`, `formatProgressStaleness` (Task 6).
+- Produces: nothing new.
+
+The panel keeps its existing `viewingLive` gate. This changes *what* it shows, not *when*.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_backtest_progress_card.py`:
+
+```python
+def test_run_panel_shares_the_card_eta_helper():
+    """One run, two surfaces. Divergent numbers are worse than one blank surface."""
+    fn = _extract_function(_APP_JS, "updateBacktestRunProgress")
+    assert "formatBacktestEta(" in fn
+
+
+def test_run_panel_reports_staleness():
+    fn = _extract_function(_APP_JS, "updateBacktestRunProgress")
+    assert "formatProgressStaleness(" in fn
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_backtest_progress_card.py -v -k panel`
+Expected: FAIL — `assert "formatBacktestEta(" in fn`
+
+- [ ] **Step 3: Implement**
+
+Replace `updateBacktestRunProgress` (`app.js:4607-4625`) with:
+
+```js
+function updateBacktestRunProgress({
+    elapsedSeconds,
+    message = '',
+    maxSeconds = BACKTEST_POLL_MAX_SECONDS,
+    stepPct = null,
+    step = null,
+    totalSteps = null,
+    updatedAt = null,
+} = {}) {
+    const elapsedEl = document.getElementById('backtestRunElapsed');
+    const messageEl = document.getElementById('backtestRunProgressMessage');
+    const barEl = document.getElementById('backtestRunProgressBar');
+
+    if (elapsedEl && elapsedSeconds !== undefined && elapsedSeconds !== null) {
+        const elapsed = Math.max(0, Number(elapsedSeconds) || 0);
+        elapsedEl.textContent = formatBacktestElapsed(elapsed);
+    }
+    if (messageEl && message) {
+        // Same two derived facts the card shows, from the same helpers, so the
+        // two surfaces can never disagree about one run.
+        const eta = formatBacktestEta(elapsedSeconds, step, totalSteps);
+        const stale = updatedAt
+            ? formatProgressStaleness((Date.now() - Number(updatedAt)) / 1000)
+            : null;
+        messageEl.textContent = [message, eta, stale].filter(Boolean).join(' · ');
+    }
+    if (barEl) {
+        const pct = Number.isFinite(stepPct)
+            ? Math.min(99, Math.round(stepPct))
+            : (elapsedSeconds !== undefined && elapsedSeconds !== null
+                ? Math.min(95, Math.round((Math.max(0, Number(elapsedSeconds) || 0) / maxSeconds) * 100))
+                : null);
+        if (pct != null) barEl.style.width = `${pct}%`;
+    }
+}
+```
+
+- [ ] **Step 4: Pass the new fields at the live call site**
+
+In `ensureBacktestPolling`, the `if (viewingLive) {` block (`app.js:4891`) currently calls `updateBacktestRunProgress({ elapsedSeconds, message, stepPct })`. Extend it:
+
+```js
+                    updateBacktestRunProgress({
+                        elapsedSeconds: displayElapsed,
+                        message: status.message || 'Backtest is running…',
+                        stepPct,
+                        step,
+                        totalSteps: total,
+                        updatedAt: liveBacktestProgress?.updatedAt || null,
+                    });
+```
+
+Leave the other three call sites (`:4831`, `:4917`, `:4926`, `:4947`) unchanged — they are error, completion and timeout paths where an ETA is meaningless.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_backtest_progress_card.py -v`
+Expected: all passed
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `pytest dashboard/backend/tests/ -v`
+Expected: green (bar the documented `test_deleted_shim_is_not_importable` stale-bytecode case — if that fails, run `rm -rf dashboard/backend/engines dashboard/backend/services` and re-run)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/frontend/app.js dashboard/backend/tests/test_backtest_progress_card.py
+git commit -m "feat(backtest): mirror ETA and staleness in the run panel"
+```
+
+---
+
+**Phase B exit:** full suite green. Open PR `feat(backtest): progress visibility`. The PR body must state that this deliberately reverses the 2026-07-29 non-goal and why the original premise was wrong, or a reviewer who knows that spec will read it as a regression.
+
+---
+
+# Phase C — Landing below-fold rework (PR 3)
+
+Branch: `feat/landing-value-band`
+
+**Highest-risk phase.** `dashboard/frontend/index.html` is **not** Vite output — it is a hand-patched artifact carrying ~370 lines Vite cannot emit. Copying `dist/index.html` over it silently kills every landing CTA with **no console error and a page that still loads**. Issue #225.
+
+Audience for all copy: **has money to spare, not deep into trading.** Wants to test a market idea at low cost and friction.
+
+---
+
+### Task 9: The "Why you should care" band
+
+**Files:**
+- Create: `dashboard/landing/src/components/home/WhyCare.tsx`
+- Modify: `dashboard/landing/src/pages/landing-page.tsx`
+- Modify: `dashboard/landing/src/components/home/Talk.tsx:10` (move the scroll anchor)
+- Test: `dashboard/backend/tests/test_landing_value_band.py` (create)
+
+**Interfaces:**
+- Consumes: `PRIMARY_LANDING_CTA` from `@/lib/cta`.
+- Produces: `WhyCare` — default-exported named component, rendered between `<Hero />` and `<Talk />`.
+
+Hero stays frozen. The band reuses the `01/02/03` mono-label pattern from Talk/Test/Race so it reads as one system, not a bolted-on marketing block.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/backend/tests/test_landing_value_band.py`:
+
+```python
+"""The landing states what the product is for, above the three-act narrative.
+
+A tester could not tell what the platform's core advantage was without clicking
+in and exploring. The narrative sections (Talk/Test/Race) each describe an act
+but never state the problem being solved or who it is for.
+
+Also pins the two claims that must never appear. Both contradict the code:
+`/paper/*` is read-only (no order-submission path exists) and ROBINHOOD_EXECUTE
+defaults to false. docs/source/lab/operating_modes.rst says the same. Copy that
+promises either would be the fabricated-Performance-Drivers failure again.
+"""
+
+from pathlib import Path
+
+_LANDING_SRC = Path(__file__).resolve().parents[2] / "landing" / "src"
+_BAND = _LANDING_SRC / "components" / "home" / "WhyCare.tsx"
+_PAGE = _LANDING_SRC / "pages" / "landing-page.tsx"
+
+
+def test_band_component_exists():
+    assert _BAND.is_file()
+
+
+def test_band_is_rendered_between_hero_and_talk():
+    page = _PAGE.read_text(encoding="utf-8")
+    assert "WhyCare" in page
+    assert page.index("<Hero />") < page.index("<WhyCare />") < page.index("<Talk />")
+
+
+def test_band_states_the_problem_before_the_features():
+    body = _BAND.read_text(encoding="utf-8")
+    assert "Testing it properly is the expensive part" in body
+
+
+def test_band_covers_the_three_acts():
+    body = _BAND.read_text(encoding="utf-8")
+    for heading in ("Describe it in plain English", "Prove it on real market data", "See how it ranks"):
+        assert heading in body
+
+
+def test_band_names_the_uncovered_capabilities():
+    """Model choice and external agents are real and were absent from the landing."""
+    body = _BAND.read_text(encoding="utf-8")
+    assert "Pick the model" in body
+    assert "Bring your own agent" in body
+
+
+def test_band_makes_no_paper_trading_claim():
+    body = _BAND.read_text(encoding="utf-8").lower()
+    assert "paper trading" not in body
+    assert "paper-trade" not in body
+
+
+def test_band_makes_no_real_capital_claim():
+    body = _BAND.read_text(encoding="utf-8").lower()
+    for phrase in ("real capital", "real money", "go live", "trade live"):
+        assert phrase not in body
+
+
+def test_hero_scroll_anchor_still_resolves():
+    """Hero.tsx scrolls to #landing-stats. If the band takes that anchor, Talk
+    must give it up -- two elements with one id is a silent mis-scroll."""
+    sources = [p.read_text(encoding="utf-8") for p in _LANDING_SRC.rglob("*.tsx")]
+    total = sum(s.count('id="landing-stats"') for s in sources)
+    assert total == 1, f"expected exactly one #landing-stats anchor, found {total}"
+    assert 'id="landing-stats"' in _BAND.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_landing_value_band.py -v`
+Expected: FAIL — `assert _BAND.is_file()`
+
+- [ ] **Step 3: Create the component**
+
+Create `dashboard/landing/src/components/home/WhyCare.tsx`:
+
+```tsx
+import { MessageSquare, LineChart, Trophy, Cpu, Code2, Hash } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PRIMARY_LANDING_CTA } from "@/lib/cta";
+
+const ACTS = [
+  {
+    label: "01",
+    icon: MessageSquare,
+    title: "Describe it in plain English",
+    body: "No code, no formulas. Write how you want to trade the way you would explain it to a person.",
+  },
+  {
+    label: "02",
+    icon: LineChart,
+    title: "Prove it on real market data",
+    body: "Real prices, real market hours, measured against buy-and-hold and the index — so you learn whether the idea was good, not whether it felt good.",
+  },
+  {
+    label: "03",
+    icon: Trophy,
+    title: "See how it ranks",
+    body: "Same window, same rules as everyone else's agents.",
+  },
+] as const;
+
+const EXTRAS = [
+  {
+    icon: Cpu,
+    title: "Pick the model",
+    body: "Same idea, different brains: Claude, GPT, Gemini, DeepSeek, Qwen.",
+  },
+  {
+    icon: Code2,
+    title: "Bring your own agent",
+    body: "A Python SDK and an API, if you would rather write the code.",
+  },
+  {
+    icon: Hash,
+    title: "Talk to it on Discord",
+    body: "If you would rather just chat.",
+  },
+] as const;
+
+export function WhyCare() {
+  return (
+    <section id="why" className="py-24 scroll-mt-40">
+      {/* Hero's scroll target — moved here from Talk so the first scroll lands
+          on the value proposition rather than past it. Hero.tsx still anchors
+          to #landing-stats; do not rename without updating it. */}
+      <div id="landing-stats" className="h-0 w-0 overflow-hidden" aria-hidden="true" />
+
+      <div className="container mx-auto px-6">
+        <div className="max-w-3xl mb-14">
+          <h2 className="text-3xl md:text-4xl font-bold mb-4 tracking-tight">
+            You have an idea about the market.
+            <span className="block text-[#22d3ee]">Testing it properly is the expensive part.</span>
+          </h2>
+          <p className="text-foreground/80 text-lg">
+            Normally that means writing code, buying data, and waiting months to find out you
+            were wrong. Here it costs one sentence and a few minutes.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-8 mb-16">
+          {ACTS.map(({ label, icon: Icon, title, body }) => (
+            <div key={label}>
+              <p className="text-sm font-mono tracking-wide text-primary mb-3">{label}</p>
+              <Icon className="w-6 h-6 text-primary mb-3" aria-hidden="true" />
+              <h3 className="text-lg font-bold mb-2">{title}</h3>
+              <p className="text-sm text-foreground/70 leading-relaxed">{body}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid sm:grid-cols-3 gap-6 pt-10 border-t border-border">
+          {EXTRAS.map(({ icon: Icon, title, body }) => (
+            <div key={title} className="flex gap-3">
+              <Icon className="w-5 h-5 text-primary shrink-0 mt-0.5" aria-hidden="true" />
+              <div>
+                <h4 className="text-sm font-semibold text-foreground mb-1">{title}</h4>
+                <p className="text-sm text-foreground/60 leading-relaxed">{body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-14">
+          <Button
+            size="lg"
+            type="button"
+            data-landing-auth={PRIMARY_LANDING_CTA.authMode}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 text-base h-12 px-8"
+          >
+            {PRIMARY_LANDING_CTA.label}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+This adds a **7th** `data-landing-auth` emitter (currently 6: Hero, Navbar, Talk, Test, Race, FooterCTA). The bundle guard counts emitters automatically and will fail until Task 12 rebuilds — that is the guard working, not a bug.
+
+- [ ] **Step 4: Wire it into the page**
+
+Replace `dashboard/landing/src/pages/landing-page.tsx` entirely:
+
+```tsx
+import { Navbar } from "../components/home/Navbar";
+import { MarketTicker } from "../components/home/MarketTicker";
+import { Hero } from "../components/home/Hero";
+import { WhyCare } from "../components/home/WhyCare";
+import { Talk } from "../components/home/Talk";
+import { Test } from "../components/home/Test";
+import { Race } from "../components/home/Race";
+import { FooterCTA } from "../components/home/FooterCTA";
+
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground font-sans">
+      <div className="landing-chrome">
+        <Navbar />
+        <MarketTicker />
+      </div>
+      <main>
+        <Hero />
+        <WhyCare />
+        <Talk />
+        <Test />
+        <Race />
+      </main>
+      <FooterCTA />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Release the anchor from Talk**
+
+In `dashboard/landing/src/components/home/Talk.tsx`, delete lines 9-10:
+
+```tsx
+      {/* Hero scroll target — do not remove; Hero.tsx still anchors here */}
+      <div id="landing-stats" className="h-0 w-0 overflow-hidden" aria-hidden="true" />
+```
+
+Two elements sharing one id would make the scroll land on whichever the browser finds first — a silent mis-scroll, not an error.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_landing_value_band.py -v`
+Expected: 8 passed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/landing/src/components/home/WhyCare.tsx dashboard/landing/src/pages/landing-page.tsx dashboard/landing/src/components/home/Talk.tsx dashboard/backend/tests/test_landing_value_band.py
+git commit -m "feat(landing): add a value-proposition band below the hero"
+```
+
+---
+
+### Task 10: Reframe `01 — Talk` away from Discord-first
+
+The only place this round changes an existing deliberate decision rather than filling a gap. Justification: on-site plain-English authoring has existed since the agent editor shipped (`dashboard/frontend/app.html:972` — *"Tell the agent how to trade in plain language"*), and "join a Discord server" is exactly the friction this audience will not clear.
+
+Structure, the `DiscordMock` visual and the `#talk` anchor all stay. Copy and CTA emphasis change.
+
+**Files:**
+- Modify: `dashboard/landing/src/components/home/Talk.tsx`
+- Test: `dashboard/backend/tests/test_landing_value_band.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_landing_value_band.py`:
+
+```python
+_TALK = _LANDING_SRC / "components" / "home" / "Talk.tsx"
+
+
+def test_talk_leads_with_the_on_site_path():
+    """The heading no longer sells Discord as the way in. On-site plain-English
+    authoring has existed since the agent editor shipped (app.html:972)."""
+    body = _TALK.read_text(encoding="utf-8")
+    assert "Talk to agents on Discord" not in body
+    assert "Describe your idea" in body
+
+
+def test_talk_keeps_discord_as_an_alternative():
+    """Reframed, not removed -- the Discord path works and some users prefer it."""
+    assert "Discord" in _TALK.read_text(encoding="utf-8")
+
+
+def test_talk_keeps_its_anchor_and_visual():
+    body = _TALK.read_text(encoding="utf-8")
+    assert 'id="talk"' in body
+    assert "<DiscordMock />" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_landing_value_band.py -v -k talk`
+Expected: FAIL — `assert "Talk to agents on Discord" not in body`
+
+- [ ] **Step 3: Implement**
+
+In `Talk.tsx`, replace the heading, body line and step list (the `<h2>`, the `<p>` and the `<ol>`) with:
+
+```tsx
+            <p className="text-base md:text-lg font-mono tracking-wide text-primary mb-3">01 — Talk</p>
+            <h2 className="text-3xl md:text-4xl font-bold mb-3">Describe your idea, in a sentence</h2>
+            <p className="text-foreground/80 mb-8 text-lg">
+              Write how you want to trade. The agent follows it, hour by hour.
+            </p>
+            <ol className="space-y-3 mb-8 text-sm text-foreground/80">
+              <li className="flex items-start gap-3">
+                <MessageSquare className="w-4 h-4 text-primary mt-0.5 shrink-0" />
+                <span><span className="text-foreground font-medium">1.</span> Write your trading instruction in plain language</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Bot className="w-4 h-4 text-primary mt-0.5 shrink-0" />
+                <span><span className="text-foreground font-medium">2.</span> Pick a model and how much simulated cash it gets</span>
+              </li>
+              <li className="flex items-start gap-3">
+                <Hash className="w-4 h-4 text-primary mt-0.5 shrink-0" />
+                <span><span className="text-foreground font-medium">3.</span> Prefer chat? The same agent answers on Discord</span>
+              </li>
+            </ol>
+```
+
+The existing `MessageSquare`, `Bot` and `Hash` imports at the top of the file all remain in use — do not touch the import line.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_landing_value_band.py -v`
+Expected: all passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/landing/src/components/home/Talk.tsx dashboard/backend/tests/test_landing_value_band.py
+git commit -m "feat(landing): lead Talk with the on-site path, Discord as alternative"
+```
+
+---
+
+### Task 11: Fix the dead footer links
+
+`Terms`, `Privacy` and `Documentation` are all `href="#"` (`FooterCTA.tsx:27-29`) — flagged in the 2026-07-25 UI audit, still open. `Documentation` gets the real docs site. `Terms` and `Privacy` have no destination, so they are **removed**: a link to nowhere is worse than an absent one, and inventing placeholder pages is out of scope.
+
+**Files:**
+- Modify: `dashboard/landing/src/components/home/FooterCTA.tsx`
+- Test: `dashboard/backend/tests/test_landing_value_band.py` (extend)
+
+- [ ] **Step 1: Verify the docs destination resolves**
+
+Run: `curl -sS -o /dev/null -w '%{http_code}\n' https://finagent-orchestration.readthedocs.io/en/latest/`
+Expected: `200`. If it is not 200, stop and report — replacing a dead link with another dead link is not a fix. The URL is the one `README.md:138` publishes as canonical.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `dashboard/backend/tests/test_landing_value_band.py`:
+
+```python
+_FOOTER = _LANDING_SRC / "components" / "home" / "FooterCTA.tsx"
+
+
+def test_footer_has_no_dead_links():
+    """Three href="#" anchors shipped since the 2026-07-25 audit. A link that
+    goes nowhere costs more trust than an absent one."""
+    assert 'href="#"' not in _FOOTER.read_text(encoding="utf-8")
+
+
+def test_footer_documentation_points_at_the_docs_site():
+    body = _FOOTER.read_text(encoding="utf-8")
+    assert "finagent-orchestration.readthedocs.io" in body
+
+
+def test_footer_external_link_is_safe():
+    """target=_blank without rel=noopener hands the opener window to the target."""
+    body = _FOOTER.read_text(encoding="utf-8")
+    if 'target="_blank"' in body:
+        assert "noopener" in body
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest dashboard/backend/tests/test_landing_value_band.py -v -k footer`
+Expected: FAIL — `assert 'href="#"' not in ...`
+
+- [ ] **Step 4: Implement**
+
+In `FooterCTA.tsx`, replace lines 26-30 (the `<div className="flex gap-6 ...">` block) with:
+
+```tsx
+          <div className="flex gap-6 mt-4 md:mt-0">
+            <a
+              href="https://finagent-orchestration.readthedocs.io/en/latest/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground"
+            >
+              Documentation
+            </a>
+          </div>
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest dashboard/backend/tests/test_landing_value_band.py -v`
+Expected: all passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/landing/src/components/home/FooterCTA.tsx dashboard/backend/tests/test_landing_value_band.py
+git commit -m "fix(landing): point Documentation at the docs site, drop dead links"
+```
+
+---
+
+### Task 12: Rebuild and hand-patch the shipped bundle
+
+**The dangerous one.** Do not shortcut any step.
+
+**Files:**
+- Modify: `dashboard/frontend/index.html` (asset refs only — never wholesale)
+- Modify: `dashboard/frontend/assets/` (new hashed bundles in, superseded ones deleted)
+
+- [ ] **Step 1: Record the current asset refs**
+
+```bash
+command grep -oE '/(assets|images)/[^"?#]+' dashboard/frontend/index.html | sort -u
+```
+
+Keep this output. Step 5 replaces exactly these `assets/*.js` and `assets/*.css` names, nothing else.
+
+- [ ] **Step 2: Build**
+
+```bash
+cd dashboard/landing && npm ci && npm run build
+```
+
+Expected: ~90s install, ~3s build. Verified toolchain: node 22, npm 11, vite 6.4.3.
+
+- [ ] **Step 3: Copy the new assets in, delete the superseded ones**
+
+```bash
+cd /mnt/d/github/agent-trading-lab
+ls dashboard/landing/dist/public/assets/
+cp dashboard/landing/dist/public/assets/index-*.js dashboard/landing/dist/public/assets/index-*.css dashboard/frontend/assets/
+```
+
+Then delete the *old* `index-*.js` and `index-*.css` from `dashboard/frontend/assets/` — the ones named in Step 1. `test_no_orphaned_assets` fails if a superseded bundle is left behind.
+
+- [ ] **Step 4: DO NOT copy `dist/index.html`**
+
+The shipped `dashboard/frontend/index.html` carries ~370 hand-written lines Vite cannot emit: the auth-gate script, `#landingAuthModal`, `<style id="landing-auth-patch">`, and the delegated `[data-landing-auth]` handler. Overwriting it turns all seven CTAs into dead buttons with **no console error** and a page that still renders.
+
+- [ ] **Step 5: Edit only the asset references**
+
+In `dashboard/frontend/index.html`, change the `<script src="/assets/index-XXXX.js">` and `<link href="/assets/index-XXXX.css">` hashes to the new filenames from Step 3. Change nothing else.
+
+- [ ] **Step 6: Run the integrity guard**
+
+Run: `pytest dashboard/backend/tests/test_frontend_bundle_integrity.py -v`
+Expected: 6 passed. Specifically:
+- `test_shipped_bundle_has_one_cta_per_landing_source_emitter` must report **7** in both source and bundle (was 6; Task 9's band adds one)
+- `test_hand_written_auth_layer_survives_a_bundle_refresh` proves Step 4 was honoured
+- `test_no_orphaned_assets` proves Step 3's deletion happened
+
+- [ ] **Step 7: Verify the rebuild is reproducible**
+
+```bash
+cd dashboard/landing && npm run build && sha256sum dist/public/assets/index-*.js
+sha256sum ../frontend/assets/index-*.js
+```
+
+Expected: identical hashes, and the emitted filename equals the committed one. A mismatch means the committed bundle does not correspond to the committed source.
+
+- [ ] **Step 8: Browser-verify (no npm needed)**
+
+```bash
+cd /mnt/d/github/agent-trading-lab
+DATABASE_PATH=/tmp/claude-1000/-mnt-d-github-agent-trading-lab/3d290e13-de95-4210-b7fe-64653f3540e8/scratchpad/landing-check.db \
+  python -m dashboard.backend.app
+```
+
+`DATABASE_PATH` must point at a temp file — the default is the committed prod seed DB and importing the app mutates it. Then drive `http://localhost:8000/` with `~/.venvs/htmlpdf/bin/python` (Playwright + Chromium already installed) and confirm: the band renders between hero and Talk, the first scroll lands on it, and **clicking a CTA opens the signup modal**. A `/_vercel/insights/script.js` 404 is expected off Vercel — not a defect.
+
+- [ ] **Step 9: Run the full suite**
+
+Run: `pytest dashboard/backend/tests/ -v`
+Expected: green
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add dashboard/frontend/index.html dashboard/frontend/assets
+git commit -m "chore(landing): rebuild bundle for the value band"
+```
+
+---
+
+**Phase C exit:** full suite green, CTA click verified in a browser. Open PR `feat(landing): below-fold value proposition`.
+
+---
+
+## Self-review — spec coverage
+
+| Spec section | Task |
+|---|---|
+| A1 pending button state | Task 2 |
+| A2 confirm on POST resolution | Task 2 |
+| A3 success toast | Task 1 |
+| A4 locate the new agent | Task 3 |
+| A5 latency investigation | Task 4 |
+| A6 error handling preserved | Task 2 (`finally` test) |
+| A7 tests | Tasks 1-3 |
+| B1 backend `progress_updated_at` | Task 5 |
+| B2 determinate card bar | Task 7 |
+| B3 in-place patching | Task 7 |
+| B4 ETA | Task 6, Task 7 |
+| B5 staleness | Task 6, Task 7 |
+| B6 surface consistency | Task 8 |
+| B7 cancel deferred | Issue #273 — no task, by design |
+| B8 tests | Tasks 5-8 |
+| C1 structure | Task 9 |
+| C2 band copy | Task 9 |
+| C3 Talk reframe | Task 10 |
+| C4 forbidden claims | Task 9 (absence tests) |
+| C5 build discipline | Task 12 |
+| C6 footer links | Task 11 |
+| C7 docs — not implemented | Global constraint; no task, by design |
+| C8 tests | Tasks 9-12 |
+
+## Known follow-ups
+
+- **Issue #273** — cancel a running backtest. Out of scope.
+- **`docs/landing-narrative-copy.md`** is superseded by Phase C and is deliberately not updated by these PRs. The requester coordinates doc updates separately.

--- a/docs/superpowers/specs/2026-08-01-user-feedback-ux-round-design.md
+++ b/docs/superpowers/specs/2026-08-01-user-feedback-ux-round-design.md
@@ -1,0 +1,410 @@
+# User-feedback UX round — design
+
+**Date:** 2026-08-01
+**Source:** real tester feedback on the live product (three items, verbatim intent preserved below)
+**Status:** design approved; implementation plan to follow
+
+---
+
+## Origin
+
+A tester used the live product and reported three things. Translated:
+
+1. **Creating a built-in agent looks broken for ~5 seconds.** Clicking *Create built-in
+   agent* produced no visible change — no button label change, no spinner, no success
+   confirmation. The agent was created correctly and the cash allocation was right. This is
+   an interaction-feedback defect, not a creation defect. Asked for: lock the button, show
+   `Creating…`, confirm success.
+2. **A long backtest gives no sense of position.** At 3m05s the page still showed only
+   `Backtesting` and an elapsed timer — no percentage, no estimate, no way to tell running
+   from stuck, no cancel.
+3. **A first-time visitor cannot quickly tell what the platform is for.** Products like
+   Robinhood and Carry state early, with icons and short lines: what this is, what problem it
+   solves, how it differs, how to start. The tester listed seven selling points the product
+   has but does not say out loud.
+
+## Audience (settled with the requester)
+
+The reader we are writing the landing for: **has money to spare, is not deep into trading.**
+They want to test a market idea at low cost and low friction, and eventually deploy real
+capital. This audience definition drives every copy decision in Workstream C.
+
+---
+
+## What the code actually says
+
+Investigated before designing. Three findings changed the shape of the work.
+
+### Finding 1 — the backtest progress data already exists; only the surface drops it
+
+The backend has emitted step-level progress the whole time:
+
+```python
+# dashboard/backend/api/routers/backtests.py:1272
+pct = min(99, round(100 * step / total))
+message = f"Backtest running… step {step}/{total} ({pct}%)"
+```
+
+fed by a progress file the engine rewrites on every step
+(`domain/backtesting/engine.py:287`, `_publish_live_progress`). The frontend already has a
+full percentage panel (`app.js:4607`, markup `app.html:1080`).
+
+That panel only paints when `viewingLive` is true **and** it lives under the Backtest tab.
+After launching, the user lands on **My Agents**, where `renderAgentRunningBody`
+(`app.js:782`) renders an intentionally indeterminate bar. The user watched the one surface
+that discards the data.
+
+**This reverses a documented non-goal, and the reason matters.**
+`2026-07-29-my-agents-capital-instruction-running-design.md` states:
+
+> The running indicator is a pulsing dot plus an **indeterminate** animated bar —
+> deliberately not a percentage, since no honest completion estimate exists.
+
+The premise is false: `step`/`total_steps` were already being written per step when that was
+written. We are correcting a factual error, not relitigating a taste decision. Recorded here
+so the next reader does not revert it back.
+
+Carried forward from that spec: the card's animation must keep its
+`@media (prefers-reduced-motion: reduce)` fallbacks. The determinate bar inherits that rule.
+
+### Finding 2 — cancel does not exist anywhere, and is expensive
+
+`run_backtest_background` uses blocking `subprocess.run()` (`backtests.py:477`). Cancel
+requires `Popen` + a stored handle + `terminate()` + a new route + a `cancelled ≠ error`
+status path — in code that already carries a documented completion-detection race (PR #163).
+`backtest_status` is a single process-global dict: one backtest server-wide.
+
+**Decision: deferred to a tracked issue.** Not in this round.
+
+### Finding 3 — one of the seven selling points is not a shippable claim
+
+| Selling point | Reality | Verdict |
+|---|---|---|
+| Create agents in natural language | `agentEditorSimpleInstruction` — *"Tell the agent how to trade in plain language"* (`app.html:972`) | real; **absent from landing** |
+| No trading program to write | same path, no code required | real; absent from landing |
+| Choose different LLMs | `builtinAgentModel` select; 7 LLM entries on the board | real; absent from landing |
+| Historical backtests | core engine | real; landing covers (`02 — Test`) |
+| **Paper trading** | `/paper/*` is read-only. `AlpacaPaperTradingClient` has **no order-submission method**. `PaperTradingSession.add_trade` has **zero production callers**. `execution/paper_backend.py` raises `NotImplementedError`. | **not a shippable claim** |
+| Compare agent performance | leaderboard + baselines + H6 guard | real; landing covers (`03 — Race`) |
+| Connect External Agents | `/api/v1` protocol + PyPI SDK + `/api/v2` | real; **absent from landing** |
+
+The published docs already say the same thing —
+`docs/source/lab/operating_modes.rst:8`: *"Monitoring only for now — an agent cannot yet
+trade this account, so **Run Paper Trading** on an agent card is disabled."* Two independent
+sources agree. Landing copy must not contradict them.
+
+Real-capital execution **does** exist (`execution/robinhood_live_service.py` — risk gates,
+per-order notional cap, idempotency, audit log) but is disarmed by default
+(`ROBINHOOD_EXECUTE` defaults to `false`). Not claimed in this round.
+
+---
+
+## Decisions
+
+Settled with the requester before design; recorded so the plan does not relitigate them.
+
+| Question | Decision |
+|---|---|
+| How far does the landing change go? | Hero (`Talk to Agents` / `Test Trading Ideas`) **stays frozen**. Everything below it is reworked. |
+| What does the funnel promise as its endpoint? | **Proven-on-history.** Describe → prove → rank. Live deployment named once as what's next. Paper trading not claimed. |
+| Cancel a running backtest? | **Deferred to an issue.** Progress, ETA and staleness ship now. |
+| Success confirmation style for agent creation? | A minimal toast. Not `alert()` — a blocking modal for a *success* is worse than the silence it replaces. |
+| Ship as one PR or several? | Three independent PRs (A, B, C). |
+
+## Non-goals
+
+- Cancelling a running backtest (deferred; see Finding 2).
+- Building agent-driven paper trading. `execution/paper_backend.py` stays a stub.
+- Any change to the Hero section or the `Talk → Test → Race` section *structure*. Workstream C
+  changes copy and adds one band; it does not reorder or delete sections.
+- Reducing agent-creation latency as a committed deliverable (one investigation item only —
+  see Workstream A).
+- The C+D funnel pivot (on-site NL intake, lifecycle home). Separate workstream, needs
+  sign-off.
+
+---
+
+## Workstream A — create-agent interaction feedback
+
+**Surface:** `/app`, frontend only. **File:** `dashboard/frontend/app.js`,
+`app.html`, `styles.css`.
+
+`submitCreateBuiltinAgent` (`app.js:1812`) already sets `submitBtn.disabled = true` at
+`:1838`. Everything the tester missed is what is *not* there.
+
+### A1. Pending button state
+
+A small shared pair, `setButtonPending(btn, label)` / `restoreButton(btn)`:
+
+- stash the original label in a `data-` key
+- `disabled = true`, `aria-busy = "true"`
+- swap text to `Creating…` with a CSS spinner glyph
+- restore in `finally`
+
+Shared rather than inline because the same gap exists on other async submits; wired to
+create-built-in only in this round, so the diff stays honest about what was verified.
+
+### A2. Confirm on POST resolution, not after the grid refresh
+
+Current order (`app.js:1848-1850`): close modal → `applyActiveAgent` → `await loadAgents()`,
+with the button restored in `finally` *after* the refresh. Reorder so the close and the
+success confirmation fire on the POST result. `loadAgents()` continues behind the
+confirmation. `finally` still restores the button; harmless once the modal is closed.
+
+### A3. Success toast
+
+No toast system exists in `/app` — `alert()` appears 18 times and is the current convention.
+Add a minimal one:
+
+- `.app-toast`, `role="status"`, `aria-live="polite"`, ~4s auto-dismiss
+- ~30 lines JS + ~25 lines CSS
+- **distinct from `.home-live-toast`** (`styles.css:6792`), which is the Home live-decision
+  widget in the same shared stylesheet. Visually matched, semantically separate.
+- respects `prefers-reduced-motion` for its enter/exit transition
+
+Message on success: agent name + that it was created, e.g. `"Momentum Alpha" created`.
+
+### A4. Locate the new agent
+
+After `loadAgents()` resolves, scroll the new agent's card into view and flash it briefly.
+Answers "did it work?" positionally, not just textually.
+
+### A5. Latency — investigation only, not a deliverable
+
+`create_agent` (`agents.py:129`) calls `get_or_create_portfolio` at `:176` after
+`ensure_cash_for_new_agent` at `:153` has already touched the portfolio. Possibly one
+redundant Neon round-trip. `ensure_cash_for_new_agent` only runs when `cash > 0`, so the
+paths are not obviously equivalent — **investigate and report; change only if provably
+safe.** Do not block the workstream on it.
+
+### A6. Error handling
+
+Unchanged in shape: the existing `errorEl` path stays. The pending state must be cleared on
+the error path too — that is what `finally` is for, and the test asserts it.
+
+### A7. Tests
+
+Repo H8 source-guard style (`dashboard/backend/tests/integrations/test_frontend_*.py`, as
+established by PR #220):
+
+1. the submit handler sets a pending label before `await`
+2. a toast element exists in `app.html` with `role="status"` and `aria-live="polite"`
+3. the success path invokes the toast helper
+4. the error path restores the button (assert the `finally` restore is present)
+
+---
+
+## Workstream B — backtest progress on the surface the user is standing on
+
+**Surfaces:** `dashboard/backend/api/routers/backtests.py`, `dashboard/frontend/app.js`,
+`styles.css`.
+
+### B1. Backend — one new datum
+
+`_read_backtest_progress` (`backtests.py:324`) currently returns the parsed payload. Add the
+progress file's modification time as `progress_updated_at` (epoch seconds) so the client can
+compute staleness. Everything else already ships.
+
+`stat()` and `read_text()` are separate syscalls; a file rewritten between them yields an
+mtime slightly older than the payload. Harmless at a 120s staleness threshold — note it, do
+not engineer around it.
+
+Existing failure behaviour is preserved: an unreadable or malformed progress file returns
+`None` and the status payload simply omits `progress`, exactly as today.
+
+### B2. Card — determinate when known, indeterminate when not
+
+`renderAgentRunningBody` (`app.js:782`):
+
+- when `step` and `total_steps` are known → determinate bar + `step N/M` + `%`
+- when they are not (run start, file not yet written) → today's indeterminate bar
+- rewrite the stale comment at `:775`; state that the estimate is now honest and why
+
+The fallback is not a nicety: the progress file does not exist for the first moments of every
+run, so the indeterminate state is a normal state, not an error state.
+
+### B3. In-place patching
+
+`refreshRunningAgentCards()` (`app.js:3356`) already patches the elapsed timer without
+re-rendering the grid. Extend the same mechanism to step, percentage and ETA. Do not
+introduce a second update path.
+
+### B4. ETA
+
+`remaining = (elapsed / step) × (total − step)`.
+
+- suppressed until `step >= 3` — the first estimates are wild
+- rendered coarse: `~2m left`, `<1m left`
+- never rendered when `step` or `total_steps` is missing
+
+A precise-looking ETA that jumps around reads as broken; a coarse one that drifts reads as an
+estimate.
+
+### B5. Staleness — answering "is it stuck?"
+
+If `now − progress_updated_at > 120s`, show: **"No progress for {N} — long model steps can do
+this."**, where `{N}` is the *actual* stale interval rendered coarsely (`2m`, `5m`, …), not
+the literal threshold. A message frozen at "2m" while the real gap grows to ten would be
+worse than no message.
+
+Neutral by design. We know the file is stale; we do not know the run is stuck, and an LLM
+pipeline step can legitimately take minutes. Claiming "stuck" would be the same class of
+error as the fabricated Performance Drivers card.
+
+### B6. Surface consistency
+
+Mirror the same numbers into the Backtest-tab panel via `updateBacktestRunProgress`
+(`app.js:4607`) so the two surfaces never disagree. The panel keeps its existing
+`viewingLive` gate — this changes the numbers it shows, not when it shows them.
+
+### B7. Deferred — cancel
+
+Draft the follow-up issue but **ask before filing**: filing on the shared repo implicitly
+assigns work to others. Content: `POST /backtest/cancel`, `subprocess.run` → `Popen` + stored
+handle + `terminate()`, `cancelled` as a status distinct from `error`, and preservation of
+the existing timeout path.
+
+### B8. Tests
+
+1. backend: status payload carries `progress_updated_at` when a progress file exists; omits
+   `progress` entirely when the file is missing or malformed
+2. pure-function unit tests for the ETA formatter (suppression below `step 3`, coarse
+   buckets, missing-input handling) and the staleness formatter — both are pure, so TDD
+   applies directly
+3. source-guard: the card markup renders step/total when present and falls back otherwise
+4. source-guard: the `prefers-reduced-motion` fallback still covers the bar
+
+---
+
+## Workstream C — landing below-fold rework
+
+**Source:** `dashboard/landing/src/**`. **Shipped artifact:**
+`dashboard/frontend/index.html` + `dashboard/frontend/assets/`.
+
+### C1. Structure
+
+```
+[ Hero — FROZEN, untouched ]
+─────────────────────────────
+▸ NEW BAND: "Why you should care"
+    problem statement
+    01 Describe it   02 Prove it   03 Rank it
+    secondary row: pick the model · bring your own agent · Discord
+─────────────────────────────
+[ 01 — Talk  ]  copy reframed, structure kept
+[ 02 — Test  ]  copy touched lightly
+[ 03 — Race  ]  unchanged
+[ FooterCTA  ]
+```
+
+The new band reuses the existing `01/02/03` mono-label pattern from Talk/Test/Race so it
+reads as one system rather than a bolted-on marketing block. It sits above them and names the
+same three acts — the band is the scannable summary, the sections are the detail.
+
+### C2. Copy — the band
+
+Lead with the problem, not the features:
+
+> **You have an idea about the market. Testing it properly is the expensive part.**
+> Normally that means writing code, buying data, and waiting months to find out you were
+> wrong. Here it costs one sentence and a few minutes.
+
+Three steps, icon + heading + one line each:
+
+| Step | Heading | Line |
+|---|---|---|
+| 01 | Describe it in plain English | No code, no formulas. Write how you want to trade the way you would explain it to a person. |
+| 02 | Prove it on real market data | Real prices, real market hours, measured against buy-and-hold and the index — so you learn whether the idea was good, not whether it felt good. |
+| 03 | See how it ranks | Same window, same rules as everyone else's agents. |
+
+Secondary row, three compact items — this is where the remaining verified selling points go
+without the section becoming a feature dump:
+
+- **Pick the model** — same idea, different brains: Claude, GPT, Gemini, DeepSeek, Qwen.
+  Verified against the live select at `app.html:781` (Claude Haiku 4.5, Claude Sonnet 4.6,
+  GPT-5.5, Gemini 3.1 Pro Preview, DeepSeek V4 Pro, Qwen3.7 Plus). Naming families rather
+  than versions keeps the copy from going stale on every model bump — but if a family is
+  ever dropped from that select, this line goes stale silently.
+- **Bring your own agent** — Python SDK and an API, if you would rather write the code.
+- **Talk to it on Discord** — if you would rather just chat.
+
+### C3. Copy — `01 — Talk` reframe
+
+Currently Discord-first: heading *"Talk to agents on Discord"*, steps *"Join the server →
+Talk to the agent → Get your backtest result"*, CTA into Discord.
+
+For this audience, "join a Discord server" is the friction the section is supposed to remove.
+The app has had on-site plain-English authoring since the agent editor shipped
+(`app.html:972`). Reframe so the **on-site instruction field is the primary path** and
+Discord is the alternative. Structure, `DiscordMock` visual, and the `#talk` anchor stay —
+this is a copy and CTA-emphasis change.
+
+The hidden `#landing-stats` anchor inside `Talk.tsx:10` is Hero's scroll target and **must
+survive**. If the new band is inserted above Talk, the scroll target should move to the band
+so the first scroll lands on the value proposition.
+
+### C4. What must not appear
+
+- **Paper trading**, in any form implying an agent trades an account. Contradicts the code
+  and `operating_modes.rst:8`.
+- **Any "deploy real capital" promise.** `ROBINHOOD_EXECUTE` defaults to `false`.
+- Live deployment appears exactly once, labelled as what is next — not as a capability.
+
+### C5. Build discipline — the real risk in this workstream
+
+`dashboard/frontend/index.html` is **not** Vite output. It is a hand-patched artifact
+carrying ~370 lines Vite cannot emit: the auth-gate script, `#landingAuthModal`,
+`<style id="landing-auth-patch">`, and the delegated `[data-landing-auth]` handler. Copying
+`dist/index.html` over it — the obvious refresh — **silently kills every landing CTA with no
+console error and a passing page load.** Tracked as issue #225.
+
+Procedure:
+
+1. `cd dashboard/landing && npm ci && npm run build` (~90s + ~3s; node 22 / npm 11 verified
+   present)
+2. verify the emitted asset hash equals the committed filename — the build is
+   byte-reproducible on this toolchain, so a mismatch means the source and bundle disagree
+3. re-apply the auth patch by hand
+4. run `dashboard/backend/tests/test_frontend_bundle_integrity.py` — 4 checks including one
+   `data-landing-auth` per emitter and every `lib/cta.ts` label present in the bundle
+5. any new CTA in the band needs its own `data-landing-auth` attribute, which moves the
+   emitter count and must be reflected in the guard
+
+### C6. Docs to update in the same PR
+
+`docs/landing-narrative-copy.md` is the copy deck this work supersedes. Its "Hero — **Frozen
+— do not change**" note stays true; its stated tone (*"No feature dumps"*) and the
+Talk/Test/Race-only arc do not. Amend it to record the new band, the audience definition, and
+the reframed `01 — Talk`, so the deck and the shipped page do not drift.
+
+### C7. Tests
+
+1. bundle integrity guard passes (C5 step 4)
+2. source-guard: the band exists, carries the three step headings, and contains no
+   paper-trading or real-capital claim — a string-absence assertion, cheap and durable
+3. source-guard: `#landing-stats` still resolves to an element that exists
+
+---
+
+## Sequencing
+
+Three independent PRs, no shared state:
+
+| PR | Scope | Risk |
+|---|---|---|
+| **A** | create-agent feedback (`app.js`, `app.html`, `styles.css`) | low — additive, guarded |
+| **B** | backtest progress (`backtests.py`, `app.js`, `styles.css`) | low-medium — reverses a documented non-goal on a corrected premise |
+| **C** | landing below-fold (`landing/src/**` + rebuilt bundle) | **highest** — the bundle refresh has a silent-failure mode |
+
+A and B both touch `app.js` but in disjoint regions (`:1812` vs `:782`/`:3356`/`:4607`).
+Order is not enforced; C is independent of both.
+
+## Open follow-ups
+
+- **Cancel a running backtest** — issue drafted in B7, **ask before filing**.
+- **Dead footer links** — `Terms` / `Privacy` / `Documentation` in `FooterCTA.tsx` are all
+  `#`. Flagged in the 2026-07-25 UI audit and still open. Since C already pays the
+  bundle-rebuild cost, pointing `Documentation` at the real docs site is nearly free —
+  propose as an opt-in addition to C, not an assumed inclusion.
+- **`docs/source/lab/*.rst`** — light scan found the paper-trading claims accurate. No action;
+  recorded so the next reader does not re-scan.

--- a/docs/superpowers/specs/2026-08-01-user-feedback-ux-round-design.md
+++ b/docs/superpowers/specs/2026-08-01-user-feedback-ux-round-design.md
@@ -121,6 +121,9 @@ Settled with the requester before design; recorded so the plan does not relitiga
   see Workstream A).
 - The C+D funnel pivot (on-site NL intake, lifecycle home). Separate workstream, needs
   sign-off.
+- **Any documentation update.** Docs are coordinated separately by the requester and are
+  never edited by the implementation PRs, even where this work makes them stale. Staleness is
+  recorded (C7, Open follow-ups) so it is visible rather than silent.
 
 ---
 
@@ -259,10 +262,10 @@ Mirror the same numbers into the Backtest-tab panel via `updateBacktestRunProgre
 
 ### B7. Deferred — cancel
 
-Draft the follow-up issue but **ask before filing**: filing on the shared repo implicitly
-assigns work to others. Content: `POST /backtest/cancel`, `subprocess.run` → `Popen` + stored
-handle + `terminate()`, `cancelled` as a status distinct from `error`, and preservation of
-the existing timeout path.
+**Filed as [issue #273](https://github.com/Open-Finance-Lab/AgenticTrading/issues/273).** Not
+in this round. Covers `POST /backtest/cancel`, `subprocess.run` → `Popen` + stored handle +
+`terminate()`, `cancelled` as a status distinct from `error`, preservation of the existing
+timeout path, and the PR #163 completion-detection race as the hazard to design around.
 
 ### B8. Tests
 
@@ -370,19 +373,34 @@ Procedure:
 5. any new CTA in the band needs its own `data-landing-auth` attribute, which moves the
    emitter count and must be reflected in the guard
 
-### C6. Docs to update in the same PR
+### C6. Footer links
 
-`docs/landing-narrative-copy.md` is the copy deck this work supersedes. Its "Hero — **Frozen
-— do not change**" note stays true; its stated tone (*"No feature dumps"*) and the
-Talk/Test/Race-only arc do not. Amend it to record the new band, the audience definition, and
-the reframed `01 — Talk`, so the deck and the shipped page do not drift.
+`FooterCTA.tsx` ships `Terms`, `Privacy` and `Documentation` as dead `#` anchors — flagged in
+the 2026-07-25 UI audit and still open. `Documentation` points at the real docs site.
+`Terms` and `Privacy` have no destination to point at, so they are **removed** rather than
+left dead: a link that goes nowhere is worse than an absent one, and inventing placeholder
+pages is out of scope.
 
-### C7. Tests
+Included here because C already pays the bundle-rebuild cost; on its own this would not
+justify a rebuild.
+
+### C7. Docs — followup, NOT part of the implementation
+
+`docs/landing-narrative-copy.md` is the copy deck this work supersedes: its "Hero — **Frozen
+— do not change**" note stays true, but its stated tone (*"No feature dumps"*) and the
+Talk/Test/Race-only arc do not survive Workstream C.
+
+**It is not updated by the implementation PR.** Doc updates are coordinated separately by the
+requester. Recorded here, and surfaced as an explicit session followup, so the deck and the
+shipped page do not drift silently.
+
+### C8. Tests
 
 1. bundle integrity guard passes (C5 step 4)
 2. source-guard: the band exists, carries the three step headings, and contains no
    paper-trading or real-capital claim — a string-absence assertion, cheap and durable
 3. source-guard: `#landing-stats` still resolves to an element that exists
+4. source-guard: no `href="#"` remains in `FooterCTA.tsx` (C6)
 
 ---
 
@@ -401,10 +419,11 @@ Order is not enforced; C is independent of both.
 
 ## Open follow-ups
 
-- **Cancel a running backtest** — issue drafted in B7, **ask before filing**.
-- **Dead footer links** — `Terms` / `Privacy` / `Documentation` in `FooterCTA.tsx` are all
-  `#`. Flagged in the 2026-07-25 UI audit and still open. Since C already pays the
-  bundle-rebuild cost, pointing `Documentation` at the real docs site is nearly free —
-  propose as an opt-in addition to C, not an assumed inclusion.
+- **Cancel a running backtest** — filed as
+  [issue #273](https://github.com/Open-Finance-Lab/AgenticTrading/issues/273). Out of scope
+  here; see B7.
+- **Dead footer links** — now **in scope** as C6, not a follow-up.
+- **`docs/landing-narrative-copy.md`** — superseded by Workstream C, but **deliberately not
+  updated by the implementation**. The requester coordinates doc updates separately. See C7.
 - **`docs/source/lab/*.rst`** — light scan found the paper-trading claims accurate. No action;
   recorded so the next reader does not re-scan.

--- a/docs/superpowers/specs/2026-08-01-user-feedback-ux-round-design.md
+++ b/docs/superpowers/specs/2026-08-01-user-feedback-ux-round-design.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-08-01
 **Source:** real tester feedback on the live product (three items, verbatim intent preserved below)
-**Status:** design approved; implementation plan to follow
+**Status:** design approved; implementation plan written and reviewed (2026-08-01) — no
+blockers, seven source-verified corrections folded back into this document and the plan
 
 ---
 
@@ -84,9 +85,17 @@ status path — in code that already carries a documented completion-detection r
 | No trading program to write | same path, no code required | real; absent from landing |
 | Choose different LLMs | `builtinAgentModel` select; 7 LLM entries on the board | real; absent from landing |
 | Historical backtests | core engine | real; landing covers (`02 — Test`) |
-| **Paper trading** | `/paper/*` is read-only. `AlpacaPaperTradingClient` has **no order-submission method**. `PaperTradingSession.add_trade` has **zero production callers**. `execution/paper_backend.py` raises `NotImplementedError`. | **not a shippable claim** |
+| **Paper trading** | **No order-submission route exists.** `AlpacaPaperTradingClient` has **no order-submission method**. `PaperTradingSession.add_trade` has **zero production callers**. `execution/paper_backend.py` raises `NotImplementedError`. | **not a shippable claim** |
 | Compare agent performance | leaderboard + baselines + H6 guard | real; landing covers (`03 — Race`) |
 | Connect External Agents | `/api/v1` protocol + PyPI SDK + `/api/v2` | real; **absent from landing** |
+
+**Say it as "no order-submission route exists", not as "`/paper/*` is read-only".** The
+conclusion is right; that particular shorthand is not. `POST /paper/start-session`
+(`api/routers/paper_trading.py:253`) *does* write — a run row via `db.insert_run(...)`. It
+places no order, reads only `client.get_account()`, and no frontend code calls it, so nothing
+about the verdict changes. But a PR body that says "read-only" hands a reviewer a
+thirty-second refutation of the one claim this workstream is built on. Use the wording that
+survives the grep.
 
 The published docs already say the same thing —
 `docs/source/lab/operating_modes.rst:8`: *"Monitoring only for now — an agent cannot yet
@@ -172,6 +181,11 @@ Message on success: agent name + that it was created, e.g. `"Momentum Alpha" cre
 After `loadAgents()` resolves, scroll the new agent's card into view and flash it briefly.
 Answers "did it work?" positionally, not just textually.
 
+The card element itself carries no `data-agent-id` today — all ten occurrences in `app.js` are
+*buttons inside* a card. Tag the card, and scope the lookup to `.agent-card[data-agent-id]`:
+the unscoped attribute selector matches every child button too and would scroll six to eight
+times per creation.
+
 ### A5. Latency — investigation only, not a deliverable
 
 `create_agent` (`agents.py:129`) calls `get_or_create_portfolio` at `:176` after
@@ -187,8 +201,12 @@ the error path too — that is what `finally` is for, and the test asserts it.
 
 ### A7. Tests
 
-Repo H8 source-guard style (`dashboard/backend/tests/integrations/test_frontend_*.py`, as
-established by PR #220):
+Repo H8 source-guard style, at the **tests root** — `dashboard/backend/tests/test_frontend_*.py`
+/ `test_my_agents_*_ui.py`. That is the dominant convention: thirteen frontend source-guards
+live at the root against two under `tests/integrations/`, and the two nearest analogues to
+this work (`test_my_agents_card_ui.py`, `test_frontend_bundle_integrity.py`) are both at the
+root. `tests/integrations/` holds cross-surface wiring checks (Discord, docs commands), not
+frontend markup guards.
 
 1. the submit handler sets a pending label before `await`
 2. a toast element exists in `app.html` with `role="status"` and `aria-live="polite"`
@@ -232,6 +250,17 @@ run, so the indeterminate state is a normal state, not an error state.
 re-rendering the grid. Extend the same mechanism to step, percentage and ETA. Do not
 introduce a second update path.
 
+**One consequence to close, not to accept.** The polled progress is a single module-level
+object (correct — `backtest_status` is one process-global, so one backtest runs server-wide)
+merged into *every* entry of the `sessionStorage` running map. Today a stranded entry costs
+only a wrong elapsed timer; once it carries step/percent/ETA, a stranded entry renders the
+*next* run's numbers. The finished branch of the poller already clears the map
+(`app.js:4907`); **the 10-minute timeout branch (`:4942`) does not**, and that is the leak —
+agent A times out, agent B starts, A's card shows B's progress until `getAgentBacktestRunning`
+expires it at 600s. Clear on timeout too, following the convention the finished branch set.
+The remaining window — a tab closed mid-run and reopened, no poller alive to clear — is
+bounded by the same 600s expiry and does not justify per-agent progress keying.
+
 ### B4. ETA
 
 `remaining = (elapsed / step) × (total − step)`.
@@ -257,8 +286,14 @@ error as the fabricated Performance Drivers card.
 ### B6. Surface consistency
 
 Mirror the same numbers into the Backtest-tab panel via `updateBacktestRunProgress`
-(`app.js:4607`) so the two surfaces never disagree. The panel keeps its existing
-`viewingLive` gate — this changes the numbers it shows, not when it shows them.
+(`app.js:4607`) so the two surfaces never disagree. This changes the numbers the panel shows,
+not when it shows them.
+
+The gate is on the call *site*, not the function: of the seven callers, four sit behind a
+`viewingLive` / `isViewingLiveBacktest(...)` check (`:4891`, `:4917`, `:4926`, `:4947`) and
+three do not (`:4806`, `:4831`, `:5491`). Only the live-poll site (`:4891`) gains the new
+fields; the rest are launch, error, completion and timeout paths where an ETA is noise, and
+they stay correct unedited because every added parameter defaults to `null`.
 
 ### B7. Deferred — cancel
 


### PR DESCRIPTION
Design spec + implementation plan for the UX fixes from the tester feedback round. Docs only — no code, no behaviour change.

- `docs/superpowers/specs/2026-08-01-user-feedback-ux-round-design.md`
- `docs/superpowers/plans/2026-08-01-user-feedback-ux-round.md`

12 tasks across 3 planned PRs. Review findings from the 2026-08-01 pass are already folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)