### PR TITLE
fix(ui): create-agent feedback

### DIFF
--- a/dashboard/backend/tests/_frontend_source.py
+++ b/dashboard/backend/tests/_frontend_source.py
@@ -1,0 +1,74 @@
+"""Readers for the frontend static-text guards.
+
+/app has no build step and no JS test toolchain, so its contracts are guarded by
+asserting against the shipped source as text (the convention set by
+test_ai_hedge_fund_frontend.py). This module is the half those guards share:
+load each file once, and slice a named region out of it by brace matching.
+
+Shared rather than copied because the slicing is where the subtle bugs live -- a
+helper that returns the wrong region makes every assertion built on it vacuous,
+and a copy in each test file would have to be fixed in each test file.
+"""
+
+import re
+from pathlib import Path
+
+FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+APP_HTML = (FRONTEND / "app.html").read_text(encoding="utf-8")
+APP_JS = (FRONTEND / "app.js").read_text(encoding="utf-8")
+STYLES = (FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+
+def _match_brace(source: str, index: int) -> int:
+    """Index of the "}" closing the "{" at `index`."""
+    depth = 0
+    while True:
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+
+
+def fn_body(signature: str) -> str:
+    """The named function's source, brace-matched to its real closing brace.
+
+    Brace-matching rather than a fixed-width slice: a `[start:start + 900]`
+    window over-reads into whatever unrelated top-level code happens to follow,
+    so an assertion can pass on a neighbour's source instead of the function
+    under test.
+
+    The parameter list is walked by paren *before* the first brace is taken. A
+    signature may legally contain braces of its own -- `f(msg, { opt = 1 } = {})`
+    is a destructured parameter -- and matching from the textually-first "{"
+    returns that parameter block instead of the body: a short, plausible-looking
+    string in which every `assert "..." in body` fails, or worse, passes.
+    """
+    start = APP_JS.index(signature)
+    index = APP_JS.index("(", start)
+    depth = 0
+    while True:
+        if APP_JS[index] == "(":
+            depth += 1
+        elif APP_JS[index] == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        index += 1
+    open_brace = APP_JS.index("{", index)
+    return APP_JS[start : _match_brace(APP_JS, open_brace) + 1]
+
+
+def at_rule_blocks(prelude: str) -> list[str]:
+    """Every styles.css at-rule block with this prelude, brace-matched.
+
+    styles.css carries eight separate reduced-motion blocks. Slicing from a
+    class name to end-of-file would sweep in all the later ones, so any test
+    asking "does *this* rule have a fallback" has to isolate the real block.
+    """
+    return [
+        STYLES[match.start() : _match_brace(STYLES, STYLES.index("{", match.start())) + 1]
+        for match in re.finditer(re.escape(prelude) + r"\s*\{", STYLES)
+    ]

--- a/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
+++ b/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
@@ -4,6 +4,7 @@ The dashboard ships as vanilla JavaScript, so these checks protect the UI
 contract without introducing a second frontend test toolchain.
 """
 
+import re
 from pathlib import Path
 
 
@@ -88,6 +89,19 @@ def test_stored_credential_can_be_removed_from_the_editor():
 
 
 def test_editor_asset_cache_bust_advances_with_its_source():
-    """A stale ?v= serves the old editor to every returning browser."""
-    assert "js/agent-editor.js?v=17" in _APP_HTML
-    assert "styles.css?v=71" in _APP_HTML
+    """A stale ?v= serves the old editor to every returning browser.
+
+    Parsed >= rather than literal pins, matching
+    test_frontend_account_page.py::test_cache_bust_versions_were_bumped and for
+    the reason that test already documents: styles.css is the single shared
+    stylesheet, so its counter is bumped by unrelated work too, and an equality
+    assert turns CI red on whichever PR happens to bump it next (the failure
+    mode that blocked #88-#91). The floors are the versions that shipped the
+    hosted editor -- going backwards would serve a stale editor, which is what
+    this guard is actually for.
+    """
+    editor_version = int(re.search(r"js/agent-editor\.js\?v=(\d+)", _APP_HTML).group(1))
+    styles_version = int(re.search(r"styles\.css\?v=(\d+)", _APP_HTML).group(1))
+
+    assert editor_version >= 17
+    assert styles_version >= 71

--- a/dashboard/backend/tests/test_app_toast.py
+++ b/dashboard/backend/tests/test_app_toast.py
@@ -6,12 +6,38 @@ file's 18-times-over convention -- is modal and blocking, which is a worse
 answer for a *success* than the silence it replaces.
 """
 
+import re
 from pathlib import Path
 
 _FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
 _APP_HTML = (_FRONTEND / "app.html").read_text(encoding="utf-8")
 _APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
 _STYLES = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+_REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)"
+
+
+def _at_rule_blocks(prelude: str) -> list[str]:
+    """Every at-rule block with this prelude, brace-matched to its own end.
+
+    styles.css carries eight separate reduced-motion blocks. Slicing from a
+    class name to end-of-file would sweep in all the later ones, so any test
+    asking "does *this* rule have a fallback" has to isolate the real block.
+    """
+    blocks = []
+    for match in re.finditer(re.escape(prelude) + r"\s*\{", _STYLES):
+        index = _STYLES.index("{", match.start())
+        depth = 0
+        while True:
+            if _STYLES[index] == "{":
+                depth += 1
+            elif _STYLES[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(_STYLES[match.start() : index + 1])
+                    break
+            index += 1
+    return blocks
 
 
 def test_toast_container_is_a_polite_live_region():
@@ -34,10 +60,29 @@ def test_toast_helper_exists():
 
 def test_toast_is_not_the_home_live_toast():
     """Distinct class: .home-live-toast is the Home live-decision widget in the
-    same shared stylesheet, and conflating them couples two unrelated features."""
+    same shared stylesheet, and conflating them couples two unrelated features.
+
+    Asserts the two are never selected *together*, not merely that the string
+    exists somewhere: a later `.app-toast, .home-live-toast { ... }` merge is
+    precisely the coupling this guards against, and a bare substring check
+    would wave it through.
+    """
     assert ".app-toast" in _STYLES
+    conflated = [
+        line
+        for line in _STYLES.splitlines()
+        if ".app-toast" in line and "home-live-toast" in line
+    ]
+    assert not conflated, conflated
 
 
 def test_toast_animation_has_a_reduced_motion_fallback():
-    block = _STYLES[_STYLES.index(".app-toast") :]
-    assert "prefers-reduced-motion" in block
+    """Scoped to the reduced-motion block that actually names .app-toast.
+
+    Slicing from the first ".app-toast" to end-of-file would also cover the
+    unrelated reduced-motion blocks that follow it (.is-pending and
+    .agent-card.is-just-created), so deleting the toast's own fallback would
+    leave this passing on somebody else's rule.
+    """
+    blocks = _at_rule_blocks(_REDUCED_MOTION)
+    assert any(".app-toast" in block for block in blocks), blocks

--- a/dashboard/backend/tests/test_app_toast.py
+++ b/dashboard/backend/tests/test_app_toast.py
@@ -1,0 +1,43 @@
+"""The /app toast primitive: a non-blocking success channel.
+
+Agent creation previously closed its modal and refreshed the grid with no
+confirmation at all, so a slow create read as a dead click. `alert()` -- this
+file's 18-times-over convention -- is modal and blocking, which is a worse
+answer for a *success* than the silence it replaces.
+"""
+
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_HTML = (_FRONTEND / "app.html").read_text(encoding="utf-8")
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+_STYLES = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+
+def test_toast_container_is_a_polite_live_region():
+    """A success message screen readers never announce is not a confirmation.
+
+    Asserted as one whole tag, not three independent substrings: app.html:377
+    (the ticker) already carries role="status" and aria-live="polite", so
+    file-wide substring checks for those two would pass before the toast
+    exists -- two thirds of a vacuous test.
+    """
+    assert (
+        '<div id="appToast" class="app-toast" role="status" aria-live="polite" hidden>'
+        in _APP_HTML
+    )
+
+
+def test_toast_helper_exists():
+    assert "function showAppToast(" in _APP_JS
+
+
+def test_toast_is_not_the_home_live_toast():
+    """Distinct class: .home-live-toast is the Home live-decision widget in the
+    same shared stylesheet, and conflating them couples two unrelated features."""
+    assert ".app-toast" in _STYLES
+
+
+def test_toast_animation_has_a_reduced_motion_fallback():
+    block = _STYLES[_STYLES.index(".app-toast") :]
+    assert "prefers-reduced-motion" in block

--- a/dashboard/backend/tests/test_app_toast.py
+++ b/dashboard/backend/tests/test_app_toast.py
@@ -7,70 +7,78 @@ answer for a *success* than the silence it replaces.
 """
 
 import re
-from pathlib import Path
 
-_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
-_APP_HTML = (_FRONTEND / "app.html").read_text(encoding="utf-8")
-_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
-_STYLES = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+from dashboard.backend.tests._frontend_source import (
+    APP_HTML,
+    APP_JS,
+    STYLES,
+    at_rule_blocks,
+    fn_body,
+)
 
 _REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)"
 
 
-def _at_rule_blocks(prelude: str) -> list[str]:
-    """Every at-rule block with this prelude, brace-matched to its own end.
-
-    styles.css carries eight separate reduced-motion blocks. Slicing from a
-    class name to end-of-file would sweep in all the later ones, so any test
-    asking "does *this* rule have a fallback" has to isolate the real block.
-    """
-    blocks = []
-    for match in re.finditer(re.escape(prelude) + r"\s*\{", _STYLES):
-        index = _STYLES.index("{", match.start())
-        depth = 0
-        while True:
-            if _STYLES[index] == "{":
-                depth += 1
-            elif _STYLES[index] == "}":
-                depth -= 1
-                if depth == 0:
-                    blocks.append(_STYLES[match.start() : index + 1])
-                    break
-            index += 1
-    return blocks
+def _toast_tag() -> str:
+    match = re.search(r"<div id=\"appToast\"[^>]*>", APP_HTML)
+    assert match, "no #appToast container in app.html"
+    return match.group(0)
 
 
 def test_toast_container_is_a_polite_live_region():
     """A success message screen readers never announce is not a confirmation.
 
-    Asserted as one whole tag, not three independent substrings: app.html:377
+    Asserted within the one matched tag, not as file-wide substrings: app.html:377
     (the ticker) already carries role="status" and aria-live="polite", so
-    file-wide substring checks for those two would pass before the toast
-    exists -- two thirds of a vacuous test.
+    independent substring checks for those two would pass before the toast
+    exists -- two thirds of a vacuous test. Matching the tag by id and asserting
+    inside it keeps that property without also pinning attribute order.
     """
-    assert (
-        '<div id="appToast" class="app-toast" role="status" aria-live="polite" hidden>'
-        in _APP_HTML
-    )
+    tag = _toast_tag()
+    assert 'role="status"' in tag
+    assert 'aria-live="polite"' in tag
+
+
+def test_toast_container_is_never_display_none():
+    """`hidden` is display:none, and an unrendered live region is not monitored.
+
+    Populate-then-unhide is the intuitive order and it announces nothing on most
+    screen readers -- a bug invisible to every other test here, because the
+    markup and the CSS are both correct and only the call order is wrong. The
+    container hides itself via .app-toast's opacity, so it must never be given
+    `hidden`, in markup or at runtime.
+    """
+    assert "hidden" not in _toast_tag()
+    assert "hidden" not in fn_body("function showAppToast(")
+
+
+def test_toast_message_is_cleared_rather_than_hidden():
+    """What replaces `hidden` on the way out.
+
+    Leaving the last message in the DOM strands it for anyone browsing the page
+    afterwards; emptying the region keeps it registered for the next write.
+    """
+    assert "el.textContent = ''" in fn_body("function showAppToast(")
 
 
 def test_toast_helper_exists():
-    assert "function showAppToast(" in _APP_JS
+    assert "function showAppToast(" in APP_JS
 
 
 def test_toast_is_not_the_home_live_toast():
-    """Distinct class: .home-live-toast is the Home live-decision widget in the
-    same shared stylesheet, and conflating them couples two unrelated features.
+    """Distinct class: .home-live-toast is a leftover selector family in the same
+    shared stylesheet -- no markup applies it any more -- and reviving a dead
+    name is how two unrelated features end up sharing one rule.
 
     Asserts the two are never selected *together*, not merely that the string
     exists somewhere: a later `.app-toast, .home-live-toast { ... }` merge is
     precisely the coupling this guards against, and a bare substring check
     would wave it through.
     """
-    assert ".app-toast" in _STYLES
+    assert ".app-toast" in STYLES
     conflated = [
         line
-        for line in _STYLES.splitlines()
+        for line in STYLES.splitlines()
         if ".app-toast" in line and "home-live-toast" in line
     ]
     assert not conflated, conflated
@@ -84,5 +92,5 @@ def test_toast_animation_has_a_reduced_motion_fallback():
     .agent-card.is-just-created), so deleting the toast's own fallback would
     leave this passing on somebody else's rule.
     """
-    blocks = _at_rule_blocks(_REDUCED_MOTION)
+    blocks = at_rule_blocks(_REDUCED_MOTION)
     assert any(".app-toast" in block for block in blocks), blocks

--- a/dashboard/backend/tests/test_create_agent_feedback.py
+++ b/dashboard/backend/tests/test_create_agent_feedback.py
@@ -6,25 +6,35 @@ never changed and nothing confirmed success. The POST itself is genuinely slow
 (see the round-trip note in the spec), so the fix is feedback, not latency.
 """
 
-import re
 from pathlib import Path
 
 _FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
 _APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
 
 
-def _submit_fn() -> str:
-    start = _APP_JS.index("async function submitCreateBuiltinAgent(")
+def _fn_body(signature: str) -> str:
+    """The named function's source, brace-matched to its real closing brace.
+
+    Brace-matching rather than a fixed-width slice: a `[start:start + 900]`
+    window over-reads into whatever unrelated top-level code happens to follow,
+    so an assertion can pass on a neighbour's source instead of the function
+    under test.
+    """
+    start = _APP_JS.index(signature)
+    index = _APP_JS.index("{", start)
     depth = 0
-    i = _APP_JS.index("{", start)
     while True:
-        if _APP_JS[i] == "{":
+        if _APP_JS[index] == "{":
             depth += 1
-        elif _APP_JS[i] == "}":
+        elif _APP_JS[index] == "}":
             depth -= 1
             if depth == 0:
-                return _APP_JS[start : i + 1]
-        i += 1
+                return _APP_JS[start : index + 1]
+        index += 1
+
+
+def _submit_fn() -> str:
+    return _fn_body("async function submitCreateBuiltinAgent(")
 
 
 def test_helpers_exist():
@@ -59,8 +69,16 @@ def test_button_is_restored_on_every_path():
     assert "restoreButton(" in finally_block
 
 
-def test_aria_busy_is_toggled():
-    assert re.search(r"aria-busy", _APP_JS)
+def test_aria_busy_is_toggled_in_both_directions():
+    """Set *and* removed, each checked inside the function that owns it.
+
+    A whole-file search for "aria-busy" passes on the set call alone, so a
+    restoreButton() that stopped removing the attribute -- leaving the button
+    announcing itself as busy to a screen reader for the rest of the session --
+    would not be caught.
+    """
+    assert "setAttribute('aria-busy', 'true')" in _fn_body("function setButtonPending(")
+    assert "removeAttribute('aria-busy')" in _fn_body("function restoreButton(")
 
 
 def test_new_agent_card_is_located_after_creation():
@@ -71,6 +89,5 @@ def test_new_agent_card_is_located_after_creation():
 def test_highlight_uses_attribute_lookup_not_selector_interpolation():
     """Same rule refreshRunningAgentCards() follows (app.js:3370): agent ids are
     server-supplied, so never interpolate one into a selector string."""
-    start = _APP_JS.index("function highlightAgentCard(")
-    body = _APP_JS[start : start + 900]
+    body = _fn_body("function highlightAgentCard(")
     assert "querySelectorAll('.agent-card[data-agent-id]')" in body

--- a/dashboard/backend/tests/test_create_agent_feedback.py
+++ b/dashboard/backend/tests/test_create_agent_feedback.py
@@ -6,40 +6,16 @@ never changed and nothing confirmed success. The POST itself is genuinely slow
 (see the round-trip note in the spec), so the fix is feedback, not latency.
 """
 
-from pathlib import Path
-
-_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
-_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
-
-
-def _fn_body(signature: str) -> str:
-    """The named function's source, brace-matched to its real closing brace.
-
-    Brace-matching rather than a fixed-width slice: a `[start:start + 900]`
-    window over-reads into whatever unrelated top-level code happens to follow,
-    so an assertion can pass on a neighbour's source instead of the function
-    under test.
-    """
-    start = _APP_JS.index(signature)
-    index = _APP_JS.index("{", start)
-    depth = 0
-    while True:
-        if _APP_JS[index] == "{":
-            depth += 1
-        elif _APP_JS[index] == "}":
-            depth -= 1
-            if depth == 0:
-                return _APP_JS[start : index + 1]
-        index += 1
+from dashboard.backend.tests._frontend_source import APP_JS, fn_body
 
 
 def _submit_fn() -> str:
-    return _fn_body("async function submitCreateBuiltinAgent(")
+    return fn_body("async function submitCreateBuiltinAgent(")
 
 
 def test_helpers_exist():
-    assert "function setButtonPending(" in _APP_JS
-    assert "function restoreButton(" in _APP_JS
+    assert "function setButtonPending(" in APP_JS
+    assert "function restoreButton(" in APP_JS
 
 
 def test_pending_state_is_set_before_the_await():
@@ -52,6 +28,20 @@ def test_pending_state_is_set_before_the_await():
 
 def test_pending_label_is_creating():
     assert "'Creating…'" in _submit_fn()
+
+
+def test_idle_label_is_captured_and_restored():
+    """Both halves of the round trip, each inside the function that owns it.
+
+    Losing either one is worse than the dead click this whole file is about: the
+    button reads "Creating…" for the rest of the session, and cannot recover.
+    setButtonPending captures the idle label once, behind an `=== undefined`
+    guard, so a later create finds dataset.idleLabel already set to "Creating…"
+    (or never set at all) and has nothing to restore from. A whole-file search
+    for either string passes on the other one's line.
+    """
+    assert "btn.dataset.idleLabel = btn.textContent" in fn_body("function setButtonPending(")
+    assert "btn.textContent = btn.dataset.idleLabel" in fn_body("function restoreButton(")
 
 
 def test_success_confirmation_is_not_gated_on_the_grid_refresh():
@@ -77,17 +67,45 @@ def test_aria_busy_is_toggled_in_both_directions():
     announcing itself as busy to a screen reader for the rest of the session --
     would not be caught.
     """
-    assert "setAttribute('aria-busy', 'true')" in _fn_body("function setButtonPending(")
-    assert "removeAttribute('aria-busy')" in _fn_body("function restoreButton(")
+    assert "setAttribute('aria-busy', 'true')" in fn_body("function setButtonPending(")
+    assert "removeAttribute('aria-busy')" in fn_body("function restoreButton(")
 
 
 def test_new_agent_card_is_located_after_creation():
-    assert "function highlightAgentCard(" in _APP_JS
+    assert "function highlightAgentCard(" in APP_JS
     assert "highlightAgentCard(" in _submit_fn()
 
 
 def test_highlight_uses_attribute_lookup_not_selector_interpolation():
     """Same rule refreshRunningAgentCards() follows (app.js:3370): agent ids are
     server-supplied, so never interpolate one into a selector string."""
-    body = _fn_body("function highlightAgentCard(")
+    body = fn_body("function highlightAgentCard(")
     assert "querySelectorAll('.agent-card[data-agent-id]')" in body
+
+
+def test_cards_carry_the_attribute_the_highlight_reads():
+    """The writer half. Without it the reader matches nothing, forever.
+
+    highlightAgentCard() is a lookup against an attribute that renderAgentCards()
+    has to put there; the two are only connected through the DOM, so every other
+    test in this file passes with the setAttribute call deleted and the feature a
+    silent no-op. Asserted inside renderAgentCards because ~8 *buttons* per card
+    carry a data-agent-id too -- a whole-file search matches those instead.
+    """
+    assert (
+        "card.setAttribute('data-agent-id', agent.agent_id)"
+        in fn_body("function renderAgentCards(")
+    )
+
+
+def test_external_create_uses_the_same_feedback_primitives():
+    """The sibling flow posts to the same slow /api/v1/agents endpoint.
+
+    Left on a bare `disabled = true` it reproduces the exact dead click this file
+    exists to fix, and its confirmation (the API key, shown once and recoverable
+    only by rotating) sat behind loadAgents().
+    """
+    fn = fn_body("async function submitCreateExternalAgent(")
+    assert "setButtonPending(" in fn
+    assert "restoreButton(" in fn[fn.index("} finally {") :]
+    assert fn.index("showAgentCredentials(") < fn.index("await loadAgents()")

--- a/dashboard/backend/tests/test_create_agent_feedback.py
+++ b/dashboard/backend/tests/test_create_agent_feedback.py
@@ -61,3 +61,16 @@ def test_button_is_restored_on_every_path():
 
 def test_aria_busy_is_toggled():
     assert re.search(r"aria-busy", _APP_JS)
+
+
+def test_new_agent_card_is_located_after_creation():
+    assert "function highlightAgentCard(" in _APP_JS
+    assert "highlightAgentCard(" in _submit_fn()
+
+
+def test_highlight_uses_attribute_lookup_not_selector_interpolation():
+    """Same rule refreshRunningAgentCards() follows (app.js:3370): agent ids are
+    server-supplied, so never interpolate one into a selector string."""
+    start = _APP_JS.index("function highlightAgentCard(")
+    body = _APP_JS[start : start + 900]
+    assert "querySelectorAll('.agent-card[data-agent-id]')" in body

--- a/dashboard/backend/tests/test_create_agent_feedback.py
+++ b/dashboard/backend/tests/test_create_agent_feedback.py
@@ -1,0 +1,63 @@
+"""Create-agent gives feedback within one frame of the click.
+
+A tester reported ~5 seconds of apparently-dead UI after clicking "Create
+built-in agent". The agent was created correctly every time; the button just
+never changed and nothing confirmed success. The POST itself is genuinely slow
+(see the round-trip note in the spec), so the fix is feedback, not latency.
+"""
+
+import re
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+
+
+def _submit_fn() -> str:
+    start = _APP_JS.index("async function submitCreateBuiltinAgent(")
+    depth = 0
+    i = _APP_JS.index("{", start)
+    while True:
+        if _APP_JS[i] == "{":
+            depth += 1
+        elif _APP_JS[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return _APP_JS[start : i + 1]
+        i += 1
+
+
+def test_helpers_exist():
+    assert "function setButtonPending(" in _APP_JS
+    assert "function restoreButton(" in _APP_JS
+
+
+def test_pending_state_is_set_before_the_await():
+    """Set after the await, the label would appear only once the POST returned --
+    exactly the window the tester experienced as dead."""
+    fn = _submit_fn()
+    assert "setButtonPending(" in fn
+    assert fn.index("setButtonPending(") < fn.index("await API.post")
+
+
+def test_pending_label_is_creating():
+    assert "'Creating…'" in _submit_fn()
+
+
+def test_success_confirmation_is_not_gated_on_the_grid_refresh():
+    """loadAgents() is a second round trip. Confirming after it would reintroduce
+    most of the delay the toast exists to cover."""
+    fn = _submit_fn()
+    assert "showAppToast(" in fn
+    assert fn.index("showAppToast(") < fn.index("await loadAgents()")
+
+
+def test_button_is_restored_on_every_path():
+    """finally, not the success branch: an error must not strand a dead button."""
+    fn = _submit_fn()
+    finally_block = fn[fn.index("} finally {") :]
+    assert "restoreButton(" in finally_block
+
+
+def test_aria_busy_is_toggled():
+    assert re.search(r"aria-busy", _APP_JS)

--- a/dashboard/backend/tests/test_frontend_source_helpers.py
+++ b/dashboard/backend/tests/test_frontend_source_helpers.py
@@ -1,0 +1,44 @@
+"""The slicing helpers behind the frontend static-text guards.
+
+Worth testing because of how they fail. Every guard in test_app_toast.py and
+test_create_agent_feedback.py is `assert "..." in fn_body(...)`; a helper that
+returns the wrong region does not error, it just makes those assertions describe
+somebody else's source -- vacuous in one direction, red for no reason in the
+other. Nothing downstream can tell the difference.
+"""
+
+from dashboard.backend.tests._frontend_source import at_rule_blocks, fn_body
+
+
+def test_fn_body_walks_past_the_parameter_list():
+    """Matching from the textually-first "{" lands in the parameter list.
+
+    showAgentCredentials(apiKey, options = {}) is a live instance in app.js: the
+    default value's braces come before the body's, so a first-brace matcher
+    returns the two-character string "{}" and every assertion against it is
+    trivially false. Anchored on real source rather than a synthetic fixture so
+    the case cannot quietly stop existing.
+    """
+    body = fn_body("function showAgentCredentials(")
+    assert "getElementById('agentCredentialsModal')" in body
+
+
+def test_fn_body_stops_at_the_functions_own_closing_brace():
+    """The other direction: over-reading into whatever follows.
+
+    setButtonPending is immediately followed by restoreButton, and the two are
+    near-mirror images, so a slice that runs past the closing brace lets a
+    "removed in restoreButton" assertion pass on setButtonPending's source.
+    """
+    body = fn_body("function setButtonPending(")
+    assert body.endswith("}")
+    assert "function restoreButton(" not in body
+
+
+def test_at_rule_blocks_isolates_each_block():
+    """styles.css has several reduced-motion blocks; a fallback test that swept
+    them all together would pass on any one of them."""
+    blocks = at_rule_blocks("@media (prefers-reduced-motion: reduce)")
+    assert len(blocks) > 1
+    assert all(block.endswith("}") for block in blocks)
+    assert all(block.count("{") == block.count("}") for block in blocks)

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=72">
+    <link rel="stylesheet" href="styles.css?v=73">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -1644,7 +1644,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
     <script src="js/agent-editor.js?v=17"></script>
-    <script src="app.js?v=53"></script>
+    <script src="app.js?v=54"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
@@ -1652,6 +1652,8 @@
          both loaded above — not beside the market-events/* block, which loads
          before app.js. -->
     <script src="home-news-signals.js"></script>
-    <div id="appToast" class="app-toast" role="status" aria-live="polite" hidden></div>
+    <!-- Never `hidden`: a live region has to stay rendered to be monitored. It
+         hides itself visually via .app-toast's opacity + pointer-events. -->
+    <div id="appToast" class="app-toast" role="status" aria-live="polite"></div>
 </body>
 </html>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=71">
+    <link rel="stylesheet" href="styles.css?v=72">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -1644,7 +1644,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
     <script src="js/agent-editor.js?v=17"></script>
-    <script src="app.js?v=52"></script>
+    <script src="app.js?v=53"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1652,5 +1652,6 @@
          both loaded above — not beside the market-events/* block, which loads
          before app.js. -->
     <script src="home-news-signals.js"></script>
+    <div id="appToast" class="app-toast" role="status" aria-live="polite" hidden></div>
 </body>
 </html>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1819,6 +1819,29 @@ function closeCreateExternalAgentModal() {
   if (modal) modal.hidden = true;
 }
 
+/**
+ * Lock a submit button and say what it is doing.
+ *
+ * disabled alone is nearly invisible in this theme, which is why a create that
+ * already set it still read as a dead click.
+ */
+function setButtonPending(btn, label) {
+  if (!btn) return;
+  if (btn.dataset.idleLabel === undefined) btn.dataset.idleLabel = btn.textContent;
+  btn.disabled = true;
+  btn.setAttribute('aria-busy', 'true');
+  btn.classList.add('is-pending');
+  btn.textContent = label;
+}
+
+function restoreButton(btn) {
+  if (!btn) return;
+  btn.disabled = false;
+  btn.removeAttribute('aria-busy');
+  btn.classList.remove('is-pending');
+  if (btn.dataset.idleLabel !== undefined) btn.textContent = btn.dataset.idleLabel;
+}
+
 function openCreateBuiltinAgentModal() {
   closeAddAgentModal();
   const modal = document.getElementById('createBuiltinAgentModal');
@@ -1860,7 +1883,7 @@ async function submitCreateBuiltinAgent(event) {
   }
 
   if (errorEl) errorEl.hidden = true;
-  if (submitBtn) submitBtn.disabled = true;
+  setButtonPending(submitBtn, 'Creating…');
 
   try {
     const data = await API.post(`${API_BASE}/api/v1/agents`, {
@@ -1870,16 +1893,20 @@ async function submitCreateBuiltinAgent(event) {
       description,
       cash_allocation,
     });
+    // Confirm on the POST result, not after loadAgents(): that is a second
+    // round trip, and gating the toast on it reinstates most of the delay.
     closeCreateBuiltinAgentModal();
+    showAppToast(`"${name}" created`);
     if (data.agent) applyActiveAgent(data.agent);
     await loadAgents();
+    if (data.agent) highlightAgentCard(data.agent.agent_id);
   } catch (error) {
     if (errorEl) {
       errorEl.textContent = error.message;
       errorEl.hidden = false;
     }
   } finally {
-    if (submitBtn) submitBtn.disabled = false;
+    restoreButton(submitBtn);
   }
 }
 

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -136,27 +136,38 @@ function formatTokenCount(value) {
 
 let appToastTimer = null;
 
+const APP_TOAST_VISIBLE_MS = 4000;
+const APP_TOAST_FADE_MS = 240;
+
 /**
  * Non-blocking confirmation channel for /app.
  *
  * The pre-existing convention here is alert(), which is modal: acceptable for a
  * launch-time refusal the user must acknowledge, wrong for a success they only
  * need to notice. Text (not innerHTML) -- callers pass agent names.
+ *
+ * The container is never `hidden`, and this function must never set it. `hidden`
+ * is display:none, which takes the node out of the render tree, and a live
+ * region is only monitored for mutations while it is rendered -- so writing the
+ * message first and unhiding after (the obvious order) announces nothing on the
+ * screen readers this role="status" exists for. .app-toast hides itself with
+ * opacity + pointer-events, so `hidden` was buying no visual behaviour either.
+ * Emptying the text on the way out is what replaces it: the region stays
+ * registered from page load, and no stale message is left for a browsing user.
  */
-function showAppToast(message, { variant = 'success', timeoutMs = 4000 } = {}) {
+function showAppToast(message) {
   const el = document.getElementById('appToast');
   if (!el) return;
-  el.textContent = String(message);
-  el.className = `app-toast app-toast--${variant}`;
-  el.hidden = false;
+  el.classList.remove('is-visible');
   // Force a reflow so re-showing an already-visible toast replays the transition.
   void el.offsetWidth;
+  el.textContent = String(message);
   el.classList.add('is-visible');
   if (appToastTimer) clearTimeout(appToastTimer);
   appToastTimer = setTimeout(() => {
     el.classList.remove('is-visible');
-    appToastTimer = setTimeout(() => { el.hidden = true; }, 240);
-  }, timeoutMs);
+    appToastTimer = setTimeout(() => { el.textContent = ''; }, APP_TOAST_FADE_MS);
+  }, APP_TOAST_VISIBLE_MS);
 }
 
 // ============================================================================
@@ -1992,21 +2003,25 @@ async function submitCreateExternalAgent(event) {
   }
 
   if (errorEl) errorEl.hidden = true;
-  if (submitBtn) submitBtn.disabled = true;
+  setButtonPending(submitBtn, 'Creating…');
 
   try {
     const data = await API.post(`${API_BASE}/api/v1/agents`, { name, model_name, cash_allocation });
+    // Same POST, same round trip as the built-in flow, so the same rule: confirm
+    // on the response. The API key is shown once and exists only in this
+    // response, so gating it on loadAgents() delays the one thing the user has
+    // to copy before it is unrecoverable.
     closeCreateExternalAgentModal();
+    showAgentCredentials(data.api_key);
     applyActiveAgent(data.agent);
     await loadAgents();
-    showAgentCredentials(data.api_key);
   } catch (error) {
     if (errorEl) {
       errorEl.textContent = error.message;
       errorEl.hidden = false;
     }
   } finally {
-    if (submitBtn) submitBtn.disabled = false;
+    restoreButton(submitBtn);
   }
 }
 

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1147,6 +1147,7 @@ function renderAgentCards(grid, agents, categoryKey) {
     const statusBadge = resolveAgentStatusBadge(agent);
     const card = document.createElement('div');
     card.className = `section-card agent-card agent-card--status agent-card--${statusBadge.key}${isBuiltin ? ' agent-card-builtin' : ''}`;
+    card.setAttribute('data-agent-id', agent.agent_id);
     const model = escapeHtml(formatAgentModelLabel(agent.model_name));
     const type = escapeHtml(agentTypeLabel(agent));
     const running = getAgentBacktestRunning(agent.agent_id);
@@ -3431,6 +3432,25 @@ function refreshRunningAgentCards() {
             el.textContent = formatBacktestElapsed(entry.elapsedSeconds);
         });
     });
+}
+
+/**
+ * Scroll the named agent's card into view and flash it.
+ *
+ * Attribute lookup then compare in JS -- no escaping, no CSS.escape feature
+ * detection -- matching refreshRunningAgentCards() above.
+ *
+ * Scoped to .agent-card: every card also contains 5-8 buttons carrying the same
+ * data-agent-id, and the unscoped selector would scroll to each of them in turn.
+ */
+function highlightAgentCard(agentId) {
+  if (!agentId) return;
+  document.querySelectorAll('.agent-card[data-agent-id]').forEach((card) => {
+    if (card.getAttribute('data-agent-id') !== agentId) return;
+    card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    card.classList.add('is-just-created');
+    setTimeout(() => card.classList.remove('is-just-created'), 2400);
+  });
 }
 let liveBacktestChartMeta = { timestamps: [] };
 let tradingLogCache = [];

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -134,6 +134,31 @@ function formatTokenCount(value) {
   return String(num);
 }
 
+let appToastTimer = null;
+
+/**
+ * Non-blocking confirmation channel for /app.
+ *
+ * The pre-existing convention here is alert(), which is modal: acceptable for a
+ * launch-time refusal the user must acknowledge, wrong for a success they only
+ * need to notice. Text (not innerHTML) -- callers pass agent names.
+ */
+function showAppToast(message, { variant = 'success', timeoutMs = 4000 } = {}) {
+  const el = document.getElementById('appToast');
+  if (!el) return;
+  el.textContent = String(message);
+  el.className = `app-toast app-toast--${variant}`;
+  el.hidden = false;
+  // Force a reflow so re-showing an already-visible toast replays the transition.
+  void el.offsetWidth;
+  el.classList.add('is-visible');
+  if (appToastTimer) clearTimeout(appToastTimer);
+  appToastTimer = setTimeout(() => {
+    el.classList.remove('is-visible');
+    appToastTimer = setTimeout(() => { el.hidden = true; }, 240);
+  }, timeoutMs);
+}
+
 // ============================================================================
 // Local mock agents — fallback used when the backend returns no agents (or is
 // unavailable). Lets the redesigned My Agents page render without a backend.

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9426,3 +9426,28 @@ body.agent-editor-open {
 @media (prefers-reduced-motion: reduce) {
     .app-toast { transition: none; transform: translate(-50%, 0); }
 }
+
+/* Pending submit buttons — disabled alone is nearly invisible in this theme. */
+.auth-submit-btn.is-pending {
+    opacity: 0.75;
+    cursor: progress;
+}
+
+.auth-submit-btn.is-pending::before {
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin-right: 8px;
+    vertical-align: -1px;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: app-btn-spin 640ms linear infinite;
+}
+
+@keyframes app-btn-spin { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+    .auth-submit-btn.is-pending::before { animation: none; }
+}

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9451,3 +9451,16 @@ body.agent-editor-open {
 @media (prefers-reduced-motion: reduce) {
     .auth-submit-btn.is-pending::before { animation: none; }
 }
+
+.agent-card.is-just-created {
+    animation: agent-card-flash 2.4s ease-out;
+}
+
+@keyframes agent-card-flash {
+    0%, 40% { box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.55); }
+    100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-card.is-just-created { animation: none; box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.55); }
+}

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9392,3 +9392,37 @@ body.agent-editor-open {
     opacity: 0.6;
     cursor: default;
 }
+
+/* /app toast — success confirmations. Distinct from .home-live-toast, which is
+   the Home live-decision widget. */
+.app-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 32px;
+    transform: translate(-50%, 12px);
+    z-index: 9000;
+    max-width: min(420px, calc(100vw - 32px));
+    padding: 12px 18px;
+    border-radius: 10px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 600;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 220ms ease, transform 220ms ease;
+}
+
+.app-toast.is-visible {
+    opacity: 1;
+    transform: translate(-50%, 0);
+}
+
+.app-toast--success { border-color: rgba(34, 197, 94, 0.45); }
+.app-toast--error { border-color: rgba(239, 68, 68, 0.45); }
+
+@media (prefers-reduced-motion: reduce) {
+    .app-toast { transition: none; transform: translate(-50%, 0); }
+}

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9393,8 +9393,11 @@ body.agent-editor-open {
     cursor: default;
 }
 
-/* /app toast — success confirmations. Distinct from .home-live-toast, which is
-   the Home live-decision widget. */
+/* /app toast — success confirmations. Deliberately not named .home-live-toast:
+   that selector family is a leftover with no remaining markup anywhere in
+   app.html/index.html, and reusing a dead name is how two features end up
+   sharing one rule by accident. Kept opacity-hidden rather than [hidden] so the
+   live region stays rendered (see showAppToast). */
 .app-toast {
     position: fixed;
     left: 50%;
@@ -9404,7 +9407,7 @@ body.agent-editor-open {
     max-width: min(420px, calc(100vw - 32px));
     padding: 12px 18px;
     border-radius: 10px;
-    border: 1px solid var(--border-color);
+    border: 1px solid rgba(34, 197, 94, 0.45);
     background: var(--bg-card);
     color: var(--text-primary);
     font-size: 14px;
@@ -9419,9 +9422,6 @@ body.agent-editor-open {
     opacity: 1;
     transform: translate(-50%, 0);
 }
-
-.app-toast--success { border-color: rgba(34, 197, 94, 0.45); }
-.app-toast--error { border-color: rgba(239, 68, 68, 0.45); }
 
 @media (prefers-reduced-motion: reduce) {
     .app-toast { transition: none; transform: translate(-50%, 0); }


### PR DESCRIPTION
## Summary

A tester reported ~5s of apparently-dead UI after clicking "Create built-in agent". The create always worked; nothing said so. This is a feedback fix, not a latency fix.

- `showAppToast` — non-blocking success channel. `/app` had only `alert()` (18 uses), which is modal.
- `setButtonPending`/`restoreButton` — label and spinner set *before* the await, restored in `finally`.
- Confirmation fires on the POST result, not after `loadAgents()`: that second round trip is most of the delay it exists to cover.
- `highlightAgentCard` — scrolls to and flashes the new card.
- Same treatment for the external-agent flow, whose once-only API key also sat behind `loadAgents()`.

`prefers-reduced-motion` fallbacks on all three animations. Rationale for the non-obvious calls is in the code comments.

## Review round

- The toast live region was populated while `hidden`, i.e. `display: none`, so the mutation happened outside the render tree and nothing was announced. It now stays rendered and empties itself on the way out.
- Guards added for the two halves that were untested and silently deletable: the `data-agent-id` that `renderAgentCards` writes and `highlightAgentCard` reads, and the idle-label save/restore (losing either leaves the button reading "Creating…" for the rest of the session).
- `_fn_body()` brace-matched from the first `{` after a signature — the parameter list for `f(a, opts = {})`, a live case in `app.js`. Fixed, moved to `_frontend_source.py`, and covered by its own test.
- Dropped `.app-toast--error` and the `timeoutMs` knob: no callers.

## Not changed

`POST /api/v1/agents` calls `portfolio_service._reconcile()` twice. The second looks redundant but is the "after every write" half `service.py`'s module docstring mandates — money accounting with documented failure modes (#175). Not worth relitigating in a UX PR.

`.auth-submit-btn:disabled` and `.auth-submit-btn.is-pending` have equal specificity, so `.is-pending` wins on source order alone. Correct as it stands; would flip if the stylesheet were reordered.

## Test plan

- [x] `pytest dashboard/backend/tests/ -q` — 2055 passed, 64 skipped. The one failure (`test_ifind_engine_resolves_csi300_sample20_and_records_provenance`) is the known `.env`-leakage case, unrelated to these files.
- [x] Every new guard mutation-tested: 8 mutations, 8 caught.
- [x] CodeQL on `refs/pull/275/merge`: 0 alerts, both languages.

No user-facing docs go stale: `docs/source/lab/` mentions "click **Add Agent +**" but never the modal's post-submit behaviour.

Phase A of `docs/superpowers/plans/2026-08-01-user-feedback-ux-round.md`.
