### PR TITLE
feat(backtest): progress visibility

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -322,7 +322,14 @@ backtest_session_id = None  # Track which session owns the running backtest
 
 
 def _read_backtest_progress() -> Optional[Dict[str, Any]]:
-    """Load incremental equity snapshots written by the backtest subprocess."""
+    """Load incremental equity snapshots written by the backtest subprocess.
+
+    ``progress_updated_at`` is the file's mtime, not a field the writer emits:
+    it answers "are these numbers current?", which the payload alone cannot.
+    stat() and read_text() are separate syscalls, so a file rewritten between
+    them yields an mtime marginally older than the payload -- immaterial against
+    a 120s staleness threshold, and not worth a lock to avoid.
+    """
     progress_file = backtest_status.get("progress_file")
     if not progress_file:
         return None
@@ -330,10 +337,13 @@ def _read_backtest_progress() -> Optional[Dict[str, Any]]:
     if not path.is_file():
         return None
     try:
+        updated_at = path.stat().st_mtime
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
-    return payload if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        return None
+    return {**payload, "progress_updated_at": updated_at}
 
 def run_backtest_background(
     start_date: str,

--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -324,8 +324,18 @@ backtest_session_id = None  # Track which session owns the running backtest
 def _read_backtest_progress() -> Optional[Dict[str, Any]]:
     """Load incremental equity snapshots written by the backtest subprocess.
 
-    ``progress_updated_at`` is the file's mtime, not a field the writer emits:
-    it answers "are these numbers current?", which the payload alone cannot.
+    ``progress_updated_at`` (the file's mtime) and ``progress_age_seconds`` (how
+    old that is) are not fields the writer emits. Together they answer "are these
+    numbers current?", which the payload alone cannot.
+
+    The *age* is what the UI reads, and it is computed here rather than in the
+    browser deliberately: differencing a server mtime against the client clock
+    makes any machine more than the staleness threshold out of step
+    indistinguishable from a wedged run -- a fast clock pins a permanent "No
+    progress for 47m" onto a healthy backtest, a slow one suppresses the warning
+    forever, and suspended laptops drift by minutes routinely. Both ends of this
+    subtraction are read in this process, so it carries no skew.
+
     stat() and read_text() are separate syscalls, so a file rewritten between
     them yields an mtime marginally older than the payload -- immaterial against
     a 120s staleness threshold, and not worth a lock to avoid.
@@ -343,7 +353,13 @@ def _read_backtest_progress() -> Optional[Dict[str, Any]]:
         return None
     if not isinstance(payload, dict):
         return None
-    return {**payload, "progress_updated_at": updated_at}
+    return {
+        **payload,
+        "progress_updated_at": updated_at,
+        # Clamped at zero: a clock stepping backwards between the write and this
+        # read would otherwise report a negative age, and "-3s" reads as a bug.
+        "progress_age_seconds": max(0.0, time.time() - updated_at),
+    }
 
 def run_backtest_background(
     start_date: str,

--- a/dashboard/backend/tests/_frontend_source.py
+++ b/dashboard/backend/tests/_frontend_source.py
@@ -61,14 +61,36 @@ def fn_body(signature: str) -> str:
     return APP_JS[start : _match_brace(APP_JS, open_brace) + 1]
 
 
-def at_rule_blocks(prelude: str) -> list[str]:
-    """Every styles.css at-rule block with this prelude, brace-matched.
+def js_const(name: str) -> str:
+    """The named top-level `const` declaration, verbatim including the `;`.
+
+    For guards that execute app.js source under node: a harness that restates a
+    threshold instead of lifting it tests the code against the harness's own
+    value, so changing the shipped constant silently stops being covered while
+    every case stays green.
+    """
+    match = re.search(rf"^const {re.escape(name)} = [^;]+;", APP_JS, re.MULTILINE)
+    assert match, f"{name} not found in app.js"
+    return match.group(0)
+
+
+def css_blocks(prelude: str) -> list[str]:
+    """Every styles.css block introduced by this prelude, brace-matched.
 
     styles.css carries eight separate reduced-motion blocks. Slicing from a
     class name to end-of-file would sweep in all the later ones, so any test
     asking "does *this* rule have a fallback" has to isolate the real block.
+
+    Returns every match rather than the first: a selector commonly appears both
+    as a plain rule and again inside a media query, and a test that silently
+    took whichever came first would depend on authoring order.
     """
     return [
         STYLES[match.start() : _match_brace(STYLES, STYLES.index("{", match.start())) + 1]
         for match in re.finditer(re.escape(prelude) + r"\s*\{", STYLES)
     ]
+
+
+def at_rule_blocks(prelude: str) -> list[str]:
+    """`css_blocks` under its original name, kept for the Phase A guards."""
+    return css_blocks(prelude)

--- a/dashboard/backend/tests/_frontend_source.py
+++ b/dashboard/backend/tests/_frontend_source.py
@@ -68,10 +68,29 @@ def js_const(name: str) -> str:
     threshold instead of lifting it tests the code against the harness's own
     value, so changing the shipped constant silently stops being covered while
     every case stays green.
+
+    The initializer stops at the first `;`, so a value that *contains* one is
+    truncated. That fails loudly rather than vacuously -- the truncation is not
+    valid JS, so node exits non-zero and the harness's `returncode == 0` assert
+    reports it. Use `js_string_const` for string constants.
     """
     match = re.search(rf"^const {re.escape(name)} = [^;]+;", APP_JS, re.MULTILINE)
     assert match, f"{name} not found in app.js"
     return match.group(0)
+
+
+def js_string_const(name: str) -> str:
+    """The *value* of a single-quoted JS string constant in app.js.
+
+    The sibling of `js_const`, which returns the whole declaration: guards that
+    execute app.js under node need the declaration verbatim, guards that compare
+    a frontend copy against its Python original need the string itself.
+    """
+    match = re.search(
+        rf"const\s+{re.escape(name)}\s*=\s*\n?\s*'((?:[^'\\]|\\.)*)'", APP_JS
+    )
+    assert match, f"{name} is no longer a single-quoted const in app.js"
+    return match.group(1).replace("\\'", "'")
 
 
 def css_blocks(prelude: str) -> list[str]:

--- a/dashboard/backend/tests/test_agent_starter_defaults.py
+++ b/dashboard/backend/tests/test_agent_starter_defaults.py
@@ -32,6 +32,7 @@ from dashboard.backend.domain.agents.defaults import (
     SIMPLE_INSTRUCTION_OUTPUT_FORMAT,
     SIMPLE_INSTRUCTION_PRESET_KEY,
 )
+from dashboard.backend.tests._frontend_source import js_string_const
 
 AgentStore = agent_store_module.AgentStore
 
@@ -164,11 +165,9 @@ def test_marketplace_clone_without_a_pipeline_gets_the_starter_seed(client, monk
 # --------------------------------------------------------------------------
 
 
-def _js_const(name: str) -> str:
-    """Read a single-quoted JS string constant out of app.js."""
-    match = re.search(rf"const\s+{name}\s*=\s*\n?\s*'((?:[^'\\]|\\.)*)'", _APP_JS)
-    assert match, f"{name} is no longer a single-quoted const in app.js"
-    return match.group(1).replace("\\'", "'")
+#: Shared with the node-executing frontend guards -- see _frontend_source.py.
+#: Kept under the local name so the assertions below read unchanged.
+_js_const = js_string_const
 
 
 def test_the_js_constants_are_still_matched():

--- a/dashboard/backend/tests/test_backtest_progress_card.py
+++ b/dashboard/backend/tests/test_backtest_progress_card.py
@@ -71,6 +71,31 @@ def test_card_shows_eta():
     assert "left" in html
 
 
+def test_card_does_not_print_elapsed_twice():
+    """The head already carries the timer; repeating it in the detail line one
+    row below is the noise this change exists to remove.
+
+    Scoped to the detail node's text: a whole-document search for "elapsed"
+    also matches the head's own class name and data attribute, which must both
+    stay -- so the obvious assertion would fail against correct output.
+    """
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    detail = html.split('data-running-detail="a1">')[1].split("</p>")[0]
+    assert "elapsed" not in detail, detail
+    assert detail == "35% · ~6m left"
+    # The head keeps its timer -- this removes a duplicate, not the value.
+    assert "data-running-elapsed" in html
+
+
+def test_card_detail_is_empty_before_the_first_step():
+    """Empty rather than absent: the per-second patch targets this node by
+    attribute, and only a change to the *set* of running agents re-renders."""
+    html = _render("{elapsedSeconds: 2}")
+    assert 'data-running-detail="a1"></p>' in html
+    blocks = css_blocks(".agent-card-running-detail:empty")
+    assert any("display: none" in block for block in blocks), blocks
+
+
 def test_card_warns_when_progress_is_stale():
     html = _render(
         "{elapsedSeconds: 600, step: 84, totalSteps: 240, updatedAt: Date.now() - 300000}"

--- a/dashboard/backend/tests/test_backtest_progress_card.py
+++ b/dashboard/backend/tests/test_backtest_progress_card.py
@@ -221,6 +221,82 @@ def test_run_panel_falls_back_to_the_elapsed_guess():
     assert panel["width"] == "10%"  # 60 / 600
 
 
+def _resolve_entry(map_js: str, live_run_id: str, progress_js: str, agent: str) -> dict:
+    """Run the real getAgentBacktestRunning against a stubbed running map."""
+    script = "\n".join(
+        [
+            js_const("BACKTEST_POLL_MAX_SECONDS"),
+            f"const MAP = {map_js};",
+            "function readRunningBacktests() { return MAP; }",
+            "function clearAgentBacktestRunning(id) { delete MAP[id]; }",
+            f"let liveBacktestRunId = {live_run_id};",
+            f"let liveBacktestProgress = {progress_js};",
+            fn_body("function getAgentBacktestRunning("),
+            f"console.log(JSON.stringify(getAgentBacktestRunning('{agent}')));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+_TWO_AGENTS = (
+    "{'agent-A': {runId: 'run-1', startedAt: Date.now() - 185000},"
+    " 'agent-B': {runId: null, startedAt: Date.now() - 500}}"
+)
+_PROGRESS = "{step: 45, totalSteps: 50, updatedAt: Date.now()}"
+
+
+def test_progress_reaches_the_agent_whose_run_is_live():
+    entry = _resolve_entry(_TWO_AGENTS, "'run-1'", _PROGRESS, "agent-A")
+    assert entry["step"] == 45
+    assert entry["totalSteps"] == 50
+
+
+def test_progress_does_not_bleed_onto_an_unconfirmed_launch():
+    """runBacktest() marks an agent running BEFORE its POST resolves, and the
+    backend refuses a second concurrent run. So clicking Run on an idle agent
+    while another is genuinely in flight leaves both in the map for one
+    round-trip. An unconditional spread painted the live agent's 45/50 (90%,
+    "<1m left") onto a card whose launch was about to be rejected.
+    """
+    entry = _resolve_entry(_TWO_AGENTS, "'run-1'", _PROGRESS, "agent-B")
+    assert entry.get("step") is None
+    assert entry.get("totalSteps") is None
+    assert entry["runId"] is None
+    # It is still "running" -- just indeterminate, which is honest here.
+    assert entry["elapsedSeconds"] >= 0
+
+
+def test_progress_is_withheld_when_no_run_is_identified():
+    """Without a live run id nothing can be attributed, so attribute nothing
+    rather than guessing -- an indeterminate bar beats a wrong percentage."""
+    entry = _resolve_entry(_TWO_AGENTS, "null", _PROGRESS, "agent-A")
+    assert entry.get("step") is None
+
+
+def test_progress_store_is_written_before_the_card_repaints():
+    """Same poll response, two surfaces. refreshRunningAgentCards() reads
+    liveBacktestProgress via getAgentBacktestRunning; the Backtest panel is
+    handed the fresh step/total directly. Repainting before the assignment made
+    the card show the previous tick's numbers while the panel showed this
+    tick's -- deterministic every tick, not a race.
+    """
+    poller = fn_body("function ensureBacktestPolling(")
+    running_branch = poller[poller.index("if (status.running) {") :]
+    # Comments stripped first: the explanatory comment above the assignment
+    # names refreshRunningAgentCards(), so a raw text search finds the *comment*
+    # earlier than the assignment and reports correct code as broken.
+    code = "\n".join(
+        line for line in running_branch.splitlines() if not line.lstrip().startswith("//")
+    )
+    assert code.index("liveBacktestProgress =") < code.index(
+        "refreshRunningAgentCards()"
+    ), "liveBacktestProgress must be assigned before the card repaints"
+
+
 def test_timeout_branch_clears_the_running_map_and_the_progress_store():
     """The leak that makes one run render another run's numbers.
 

--- a/dashboard/backend/tests/test_backtest_progress_card.py
+++ b/dashboard/backend/tests/test_backtest_progress_card.py
@@ -8,6 +8,19 @@ tester watched it for 3m05s and could not tell running from stuck.
 
 The 2026-07-29 spec called an indeterminate bar deliberate "since no honest
 completion estimate exists". That premise was already false when written.
+
+**Two renderers, one card.** renderAgentRunningBody() paints it on a full
+re-render; refreshRunningAgentCards() patches it in place every second, because
+renderAgentCards() opens with `grid.innerHTML = ''` and doing that once a second
+would destroy focus, scroll and any open menu for the whole run. A full
+re-render fires only when the *set* of running agents changes -- twice in a
+normal run -- so anything the patch path does not touch is frozen at its launch
+value. The first cut patched three text nodes and left the bar, its
+aria-valuenow and the staleness note behind, which put correct numbers beside a
+bar still running the indeterminate sweep and made the staleness warning
+unreachable. Both renderers now derive from deriveRunningProgress(), and the
+patch cases below drive the real patch path over the real DOM the real template
+produced.
 """
 
 import json
@@ -24,6 +37,33 @@ pytestmark = pytest.mark.skipif(
 
 _REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)"
 
+#: Lifted wholesale rather than re-listed per harness: a helper missing from one
+#: list is a ReferenceError, but a helper *stubbed* in one list quietly tests the
+#: stub. One list means every harness runs the same shipped code.
+_PROGRESS_HELPERS = (
+    "function formatBacktestEta(",
+    "function resolveBacktestEta(",
+    "function resolveProgressAgeSeconds(",
+    "function formatProgressStaleness(",
+    "function formatStartupStaleness(",
+    "function resolveRunningNotice(",
+    "function deriveRunningProgress(",
+)
+
+#: 84 of 240 steps (35%), 80 of them observed over 184s -> 2.3s/step -> ~6m left.
+_LIVE_PROGRESS = (
+    "{step: 84, totalSteps: 240, ageSeconds: 1, ageAt: Date.now(),"
+    " firstStep: 4, firstStepAt: Date.now() - 184000}"
+)
+
+
+def _node(script: str) -> object:
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
 
 def _render(running_js: str) -> str:
     script = "\n".join(
@@ -32,28 +72,23 @@ def _render(running_js: str) -> str:
             "function escapeHtml(s) { return String(s); }",
             "function renderAgentAllocatedCapitalHero() { return ''; }",
             "function formatBacktestElapsed(s) { return String(s); }",
-            fn_body("function formatBacktestEta("),
-            fn_body("function formatProgressStaleness("),
+            *[fn_body(signature) for signature in _PROGRESS_HELPERS],
             fn_body("function renderAgentRunningBody("),
             f"console.log(JSON.stringify(renderAgentRunningBody("
             f"{{agent_id: 'a1'}}, {running_js})));",
         ]
     )
-    result = subprocess.run(
-        ["node", "-e", script], capture_output=True, text=True, timeout=30
-    )
-    assert result.returncode == 0, result.stderr
-    return json.loads(result.stdout)
+    return _node(script)
 
 
 def test_card_shows_step_and_percent_when_known():
-    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    html = _render(f"{{elapsedSeconds: 185, ...{_LIVE_PROGRESS}}}")
     assert "84/240" in html
     assert "35%" in html
 
 
 def test_card_bar_is_determinate_when_step_is_known():
-    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    html = _render(f"{{elapsedSeconds: 185, ...{_LIVE_PROGRESS}}}")
     assert "is-determinate" in html
     assert "width: 35%" in html
 
@@ -67,8 +102,12 @@ def test_card_falls_back_to_indeterminate_before_the_first_step():
 
 
 def test_card_shows_eta():
-    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
-    assert "left" in html
+    """Pinned to the exact string, not just "left": a harness that accepts any
+    output containing the word passes on "0m left" and on an ETA computed from
+    the wrong window, which is precisely the bug the anchor exists to prevent.
+    """
+    html = _render(f"{{elapsedSeconds: 185, ...{_LIVE_PROGRESS}}}")
+    assert "~6m left" in html
 
 
 def test_card_does_not_print_elapsed_twice():
@@ -79,7 +118,7 @@ def test_card_does_not_print_elapsed_twice():
     also matches the head's own class name and data attribute, which must both
     stay -- so the obvious assertion would fail against correct output.
     """
-    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    html = _render(f"{{elapsedSeconds: 185, ...{_LIVE_PROGRESS}}}")
     detail = html.split('data-running-detail="a1">')[1].split("</p>")[0]
     assert "elapsed" not in detail, detail
     assert detail == "35% · ~6m left"
@@ -98,20 +137,41 @@ def test_card_detail_is_empty_before_the_first_step():
 
 def test_card_warns_when_progress_is_stale():
     html = _render(
-        "{elapsedSeconds: 600, step: 84, totalSteps: 240, updatedAt: Date.now() - 300000}"
+        "{elapsedSeconds: 600, step: 84, totalSteps: 240,"
+        " ageSeconds: 300, ageAt: Date.now()}"
     )
     assert "No progress for 5m" in html
 
 
 def test_card_is_silent_when_progress_is_fresh():
-    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    html = _render(f"{{elapsedSeconds: 185, ...{_LIVE_PROGRESS}}}")
     assert "No progress for" not in html
+
+
+def test_card_warns_when_a_run_never_publishes_a_step():
+    """The likeliest wedge -- a subprocess that hangs in imports, the
+    market-data fetch or the LLM gateway -- writes no progress file at all, so
+    the staleness notice above can never fire. Without this the motivating
+    scenario is the one case with no signal, for the full poll ceiling."""
+    html = _render("{elapsedSeconds: 200}")
+    assert "no steps reported after 3m" in html
+    assert "is-determinate" not in html
+
+
+def test_card_stale_node_is_empty_and_hidden_while_healthy():
+    """Rendered unconditionally for the same reason the detail node is: the
+    patch path fills it by attribute, and a node that appears only once it has
+    something to say can never be filled in mid-run."""
+    html = _render(f"{{elapsedSeconds: 185, ...{_LIVE_PROGRESS}}}")
+    assert 'data-running-stale="a1"></p>' in html
+    blocks = css_blocks(".agent-card-running-stale:empty")
+    assert any("display: none" in block for block in blocks), blocks
 
 
 def test_progressbar_reports_its_value_to_assistive_tech():
     """role=progressbar without aria-valuenow announces as an unlabelled busy
     widget -- the same "is it moving?" question the sighted tester had."""
-    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    html = _render(f"{{elapsedSeconds: 185, ...{_LIVE_PROGRESS}}}")
     assert 'aria-valuenow="35"' in html
     assert 'aria-valuemax="100"' in html
 
@@ -142,13 +202,293 @@ def test_determinate_bar_suppresses_the_indeterminate_sweep():
     assert any("animation: none" in block for block in blocks), blocks
 
 
+# --- The per-second patch path, over the DOM the template really produces -----
+
+#: A minimal DOM: parse the template's own output into nodes the patch path can
+#: query and mutate. Hand-built stub nodes would be the vacuity trap here -- they
+#: would let the patcher pass against attributes the template never emits, which
+#: is the exact class of drift these cases exist to catch.
+_DOM_SHIM = r"""
+function parseNodes(html) {
+    const nodes = [];
+    const tagRe = /<(\w+)([^>]*)>([^<]*)/g;
+    let tag;
+    while ((tag = tagRe.exec(html)) !== null) {
+        const attrs = {};
+        const attrRe = /([\w-]+)(?:="([^"]*)")?/g;
+        let attr;
+        while ((attr = attrRe.exec(tag[2])) !== null) {
+            attrs[attr[1]] = attr[2] === undefined ? '' : attr[2];
+        }
+        nodes.push(makeNode(attrs, tag[3]));
+    }
+    return nodes;
+}
+
+function makeNode(attrs, text) {
+    const classes = new Set((attrs.class || '').split(/\s+/).filter(Boolean));
+    const width = /width:\s*([^;"]+)/.exec(attrs.style || '');
+    const owns = (name) => Object.prototype.hasOwnProperty.call(attrs, name);
+    return {
+        has: owns,
+        textContent: text,
+        style: { width: width ? width[1].trim() : '' },
+        classList: {
+            contains: (name) => classes.has(name),
+            toggle: (name, force) => { if (force) { classes.add(name); } else { classes.delete(name); } },
+        },
+        getAttribute: (name) => (owns(name) ? attrs[name] : null),
+        setAttribute: (name, value) => { attrs[name] = String(value); },
+        removeAttribute: (name) => { delete attrs[name]; },
+    };
+}
+
+function snapshotOf(nodes) {
+    const by = (attr) => nodes.find((node) => node.has(attr));
+    const track = by('data-running-track');
+    const bar = by('data-running-bar');
+    return {
+        step: by('data-running-step').textContent,
+        detail: by('data-running-detail').textContent,
+        stale: by('data-running-stale').textContent,
+        elapsed: by('data-running-elapsed').textContent,
+        ariaValueNow: track.getAttribute('aria-valuenow'),
+        ariaValueMax: track.getAttribute('aria-valuemax'),
+        determinate: bar.classList.contains('is-determinate'),
+        barWidth: bar.style.width,
+    };
+}
+"""
+
+
+def _patch(progress_js: str, then_progress_js: str | None = None, elapsed_ms: int = 185000) -> dict:
+    """Launch-paint a card, then run the real per-second patch over it.
+
+    The card is rendered in the state every run genuinely starts in -- marked
+    running, no progress published yet, so indeterminate -- and then patched
+    with what the poller has a moment later. That sequence is what the live UI
+    does and what no earlier case covered: every card test called
+    renderAgentRunningBody() directly with progress already populated, a state
+    the browser reaches only on a re-render.
+
+    Returns the patched snapshot alongside a fresh full render of the same
+    state, so the two renderers can be compared field by field.
+    """
+    second_tick = (
+        f"liveBacktestProgress = {then_progress_js};\nrefreshRunningAgentCards();"
+        if then_progress_js is not None
+        else ""
+    )
+    script = "\n".join(
+        [
+            js_const("BACKTEST_POLL_MAX_SECONDS"),
+            js_const("BACKTEST_STALE_SECONDS"),
+            f"const MAP = {{a1: {{runId: 'run-1', startedAt: Date.now() - {elapsed_ms}}}}};",
+            "let liveBacktestRunId = 'run-1';",
+            "let liveBacktestProgress = null;",
+            "let lastRenderedRunningKey = null;",
+            "let applyCalls = 0;",
+            "function readRunningBacktests() { return MAP; }",
+            "function clearAgentBacktestRunning(id) { delete MAP[id]; }",
+            "function applyAgentFilters() { applyCalls += 1; }",
+            "function escapeHtml(s) { return String(s); }",
+            "function renderAgentAllocatedCapitalHero() { return ''; }",
+            "function formatBacktestElapsed(s) { return String(s); }",
+            *[fn_body(signature) for signature in _PROGRESS_HELPERS],
+            fn_body("function getAgentBacktestRunning("),
+            fn_body("function renderAgentRunningBody("),
+            fn_body("function refreshRunningAgentCards("),
+            _DOM_SHIM,
+            "const launchHtml = renderAgentRunningBody({agent_id: 'a1'}, getAgentBacktestRunning('a1'));",
+            "const NODES = parseNodes(launchHtml);",
+            "const document = { querySelectorAll: (sel) =>"
+            " NODES.filter((node) => node.has(sel.slice(1, -1))) };",
+            # The set of running agents is unchanged, which is what forces the
+            # patch path instead of a full re-render -- the steady state for all
+            # but two ticks of a run.
+            "lastRenderedRunningKey = Object.keys(MAP).sort().join(',');",
+            f"liveBacktestProgress = {progress_js};",
+            "refreshRunningAgentCards();",
+            second_tick,
+            "console.log(JSON.stringify({",
+            "  launch: snapshotOf(parseNodes(launchHtml)),",
+            "  patched: snapshotOf(NODES),",
+            "  rendered: snapshotOf(parseNodes("
+            "    renderAgentRunningBody({agent_id: 'a1'}, getAgentBacktestRunning('a1')))),",
+            "  applyCalls,",
+            "}));",
+        ]
+    )
+    return _node(script)
+
+
+def test_the_patch_path_is_what_ran():
+    """Guard the guard. If a stray re-render satisfied these cases the patcher
+    could be deleted outright and every assertion below would still pass."""
+    result = _patch(_LIVE_PROGRESS)
+    assert result["applyCalls"] == 0
+
+
+def test_patch_moves_the_bar_off_the_indeterminate_sweep():
+    """The headline defect: the numbers climbed while the bar kept sweeping."""
+    result = _patch(_LIVE_PROGRESS)
+    assert result["launch"]["determinate"] is False
+    assert result["patched"]["determinate"] is True
+    assert result["patched"]["barWidth"] == "35%"
+
+
+def test_patch_updates_the_aria_value():
+    """Without this the progressbar announces as an unlabelled busy widget for
+    the entire run -- the launch paint is the only one screen readers get."""
+    result = _patch(_LIVE_PROGRESS)
+    assert result["launch"]["ariaValueNow"] is None
+    assert result["patched"]["ariaValueNow"] == "35"
+    assert result["patched"]["ariaValueMax"] == "100"
+
+
+def test_patch_surfaces_the_staleness_notice():
+    """The affordance this whole feature exists for. Reachable only on a full
+    re-render before, i.e. essentially never during a run.
+
+    The launch paint carries the *startup* notice here -- 185s in with no step
+    published yet -- so this also covers the patch replacing existing text
+    rather than merely filling a blank node.
+    """
+    result = _patch(
+        "{step: 84, totalSteps: 240, ageSeconds: 300, ageAt: Date.now(),"
+        " firstStep: 4, firstStepAt: Date.now() - 184000}"
+    )
+    assert "no steps reported" in result["launch"]["stale"]
+    assert "No progress for 5m" in result["patched"]["stale"]
+
+
+def test_patch_clears_a_notice_that_no_longer_applies():
+    """A card launched slowly enough to earn the startup notice must drop it the
+    moment steps start flowing -- a patch that only ever *sets* text would leave
+    "still starting up" printed under a moving percentage."""
+    result = _patch(_LIVE_PROGRESS)
+    assert "no steps reported" in result["launch"]["stale"]
+    assert result["patched"]["stale"] == ""
+
+
+def test_patch_surfaces_the_startup_notice():
+    """A run that has published nothing at all: no step ever reaches the store,
+    so only the elapsed-based notice can fire."""
+    result = _patch("null", elapsed_ms=200000)
+    assert "no steps reported after 3m" in result["patched"]["stale"]
+    assert result["patched"]["determinate"] is False
+
+
+def test_patch_updates_the_text_nodes():
+    result = _patch(_LIVE_PROGRESS)
+    assert result["patched"]["step"] == "84/240"
+    assert result["patched"]["detail"] == "35% · ~6m left"
+
+
+def test_patch_clears_the_numbers_when_progress_vanishes():
+    """A tick where the status endpoint reports no progress -- file caught
+    mid-rewrite, transient OSError -- must clear the last numbers rather than
+    leave "84/240 · 35% · ~6m left" standing as though it were current."""
+    result = _patch(_LIVE_PROGRESS, then_progress_js="null")
+    assert result["patched"]["step"] == ""
+    assert result["patched"]["detail"] == ""
+
+
+def test_patch_returns_the_bar_to_indeterminate_when_progress_vanishes():
+    """Symmetrical with the text: a bar frozen at 35% with a valuenow to match
+    is a claim the payload no longer supports."""
+    result = _patch(_LIVE_PROGRESS, then_progress_js="null")
+    assert result["patched"]["determinate"] is False
+    assert result["patched"]["ariaValueNow"] is None
+    # Cleared, not zeroed: the stylesheet's 40% is what makes the indeterminate
+    # sweep visible, and a 0%-wide bar animates nothing.
+    assert result["patched"]["barWidth"] == ""
+
+
+def test_the_two_renderers_agree():
+    """The invariant behind the defect, stated directly.
+
+    renderAgentRunningBody() builds an HTML string and refreshRunningAgentCards()
+    mutates live DOM, so they cannot share the emitting code -- only the
+    derivation. This compares the patched card against a full re-render of the
+    same state, field by field, so the next field added to one and not the other
+    fails here rather than in a browser.
+    """
+    result = _patch(_LIVE_PROGRESS)
+    assert result["patched"] == result["rendered"]
+
+
+def test_the_two_renderers_agree_when_progress_vanishes():
+    result = _patch(_LIVE_PROGRESS, then_progress_js="null")
+    assert result["patched"] == result["rendered"]
+
+
+# --- The live progress store --------------------------------------------------
+
+
+def _advance(previous_js: str, progress_js: str, now: int) -> dict:
+    script = "\n".join(
+        [
+            fn_body("function advanceBacktestProgress("),
+            f"console.log(JSON.stringify("
+            f"advanceBacktestProgress({previous_js}, {progress_js}, {now})));",
+        ]
+    )
+    return _node(script)
+
+
+def test_the_store_anchors_on_the_first_step_it_sees():
+    stored = _advance("null", "{step: 5, total_steps: 240, progress_age_seconds: 1}", 1000)
+    assert stored["firstStep"] == 5
+    assert stored["firstStepAt"] == 1000
+
+
+def test_the_anchor_is_carried_across_ticks():
+    """The point of the anchor. Re-stamping it every tick would silently restore
+    the launch-biased ETA -- and would still produce a plausible number, so
+    nothing else would catch it."""
+    first = "{step: 5, firstStep: 5, firstStepAt: 1000}"
+    stored = _advance(first, "{step: 9, total_steps: 240}", 5000)
+    assert stored["firstStep"] == 5
+    assert stored["firstStepAt"] == 1000
+
+
+def test_the_anchor_resets_when_the_step_count_moves_backwards():
+    """Only happens when a fresh run's first tick lands before the previous run
+    was cleared. Keeping the old anchor would measure the new run's rate over
+    the old run's clock."""
+    stale = "{step: 200, firstStep: 5, firstStepAt: 1000}"
+    stored = _advance(stale, "{step: 2, total_steps: 240}", 9000)
+    assert stored["firstStep"] == 2
+    assert stored["firstStepAt"] == 9000
+
+
+def test_the_store_is_null_before_the_first_step():
+    assert _advance("null", "{total_steps: 240}", 1000) is None
+    assert _advance("null", "{step: 0, total_steps: 240}", 1000) is None
+    assert _advance("null", "null", 1000) is None
+
+
+def test_the_store_keeps_the_server_age():
+    stored = _advance("null", "{step: 5, total_steps: 240, progress_age_seconds: 42.5}", 1000)
+    assert stored["ageSeconds"] == 42.5
+    assert stored["ageAt"] == 1000
+
+
+def test_a_missing_server_age_is_stored_as_null_not_zero():
+    """Zero would assert freshness the payload never claimed, permanently
+    suppressing the staleness notice against an older backend."""
+    stored = _advance("null", "{step: 5, total_steps: 240}", 1000)
+    assert stored["ageSeconds"] is None
+
+
 # --- Task 8: the Backtest tab panel, driven by the same two helpers -----------
 
 
 def _run_panel(options_js: str) -> dict:
     """Execute updateBacktestRunProgress against three stub elements.
 
-    Executed rather than grepped: `"formatBacktestEta(" in source` passes even
+    Executed rather than grepped: `"resolveBacktestEta(" in source` passes even
     if the returned value is dropped on the floor, which is precisely the bug
     that would let the two surfaces disagree.
     """
@@ -162,9 +502,8 @@ def _run_panel(options_js: str) -> dict:
             "  backtestRunProgressBar: { style: { width: '' } },",
             "};",
             "const document = { getElementById: (id) => els[id] || null };",
-            fn_body("function formatBacktestElapsed("),
-            fn_body("function formatBacktestEta("),
-            fn_body("function formatProgressStaleness("),
+            "function formatBacktestElapsed(s) { return String(s); }",
+            *[fn_body(signature) for signature in _PROGRESS_HELPERS],
             fn_body("function updateBacktestRunProgress("),
             f"updateBacktestRunProgress({options_js});",
             "console.log(JSON.stringify({",
@@ -174,44 +513,52 @@ def _run_panel(options_js: str) -> dict:
             "}));",
         ]
     )
-    result = subprocess.run(
-        ["node", "-e", script], capture_output=True, text=True, timeout=30
-    )
-    assert result.returncode == 0, result.stderr
-    return json.loads(result.stdout)
+    return _node(script)
 
 
 def test_run_panel_shows_the_same_eta_the_card_does():
     """One run, two surfaces. Divergent numbers are worse than one blank
-    surface, so both derive the ETA from formatBacktestEta."""
+    surface, so both derive the ETA from the same helper and the same object."""
     panel = _run_panel(
         "{elapsedSeconds: 185, message: 'Backtest is running…',"
-        " stepPct: 35, step: 84, totalSteps: 240}"
+        f" stepPct: 35, progress: {_LIVE_PROGRESS}}}"
     )
-    assert "left" in panel["message"]
-    assert panel["message"].startswith("Backtest is running…")
+    assert panel["message"] == "Backtest is running… · ~6m left"
 
 
 def test_run_panel_reports_staleness():
     panel = _run_panel(
         "{elapsedSeconds: 600, message: 'Backtest is running…', stepPct: 35,"
-        " step: 84, totalSteps: 240, updatedAt: Date.now() - 300000}"
+        " progress: {step: 84, totalSteps: 240, ageSeconds: 300, ageAt: Date.now()}}"
     )
     assert "No progress for 5m" in panel["message"]
 
 
+def test_run_panel_reports_a_run_that_never_started_stepping():
+    """`{}` -- the live branch's stand-in before the first step -- is what opts
+    this surface into the startup notice. The subprocess has published nothing,
+    so this is the only warning either surface can give."""
+    panel = _run_panel(
+        "{elapsedSeconds: 200, message: 'Backtest is running…', progress: {}}"
+    )
+    assert "no steps reported after 3m" in panel["message"]
+
+
 def test_run_panel_stays_quiet_without_the_new_fields():
-    """The six unedited call sites pass none of step/totalSteps/updatedAt. They
-    must render exactly what they rendered before -- the message alone."""
+    """The terminal call sites pass no progress object at all. They must render
+    exactly what they rendered before -- the message alone -- even though their
+    elapsed is well past the staleness threshold."""
     panel = _run_panel("{elapsedSeconds: 42, message: 'Backtest is running…'}")
     assert panel["message"] == "Backtest is running…"
+    done = _run_panel("{elapsedSeconds: 600, message: 'Completed in 10:00.'}")
+    assert done["message"] == "Completed in 10:00."
 
 
 def test_run_panel_prefers_step_percent_over_the_elapsed_guess():
     """The elapsed-based width is a fallback for runs with no step data; a real
     percentage must win, otherwise the bar contradicts the number beside it."""
     panel = _run_panel(
-        "{elapsedSeconds: 60, message: 'x', stepPct: 35, step: 84, totalSteps: 240}"
+        f"{{elapsedSeconds: 60, message: 'x', stepPct: 35, progress: {_LIVE_PROGRESS}}}"
     )
     assert panel["width"] == "35%"
 
@@ -235,18 +582,14 @@ def _resolve_entry(map_js: str, live_run_id: str, progress_js: str, agent: str) 
             f"console.log(JSON.stringify(getAgentBacktestRunning('{agent}')));",
         ]
     )
-    result = subprocess.run(
-        ["node", "-e", script], capture_output=True, text=True, timeout=30
-    )
-    assert result.returncode == 0, result.stderr
-    return json.loads(result.stdout)
+    return _node(script)
 
 
 _TWO_AGENTS = (
     "{'agent-A': {runId: 'run-1', startedAt: Date.now() - 185000},"
     " 'agent-B': {runId: null, startedAt: Date.now() - 500}}"
 )
-_PROGRESS = "{step: 45, totalSteps: 50, updatedAt: Date.now()}"
+_PROGRESS = "{step: 45, totalSteps: 50, ageSeconds: 1, ageAt: Date.now()}"
 
 
 def test_progress_reaches_the_agent_whose_run_is_live():
@@ -280,9 +623,9 @@ def test_progress_is_withheld_when_no_run_is_identified():
 def test_progress_store_is_written_before_the_card_repaints():
     """Same poll response, two surfaces. refreshRunningAgentCards() reads
     liveBacktestProgress via getAgentBacktestRunning; the Backtest panel is
-    handed the fresh step/total directly. Repainting before the assignment made
-    the card show the previous tick's numbers while the panel showed this
-    tick's -- deterministic every tick, not a race.
+    handed the same object. Repainting before the assignment made the card show
+    the previous tick's numbers while the panel showed this tick's --
+    deterministic every tick, not a race.
     """
     poller = fn_body("function ensureBacktestPolling(")
     running_branch = poller[poller.index("if (status.running) {") :]
@@ -295,6 +638,20 @@ def test_progress_store_is_written_before_the_card_repaints():
     assert code.index("liveBacktestProgress =") < code.index(
         "refreshRunningAgentCards()"
     ), "liveBacktestProgress must be assigned before the card repaints"
+
+
+def test_the_poller_reads_the_server_computed_age_not_the_mtime():
+    """Deriving the age in the browser (`Date.now() - progress_updated_at`)
+    makes any client more than the staleness threshold out of step
+    indistinguishable from a wedged run: a fast clock pins a permanent
+    "No progress for 47m" onto a healthy backtest, a slow one suppresses the
+    warning forever. Suspended laptops drift by minutes routinely.
+    """
+    store = fn_body("function advanceBacktestProgress(")
+    assert "progress_age_seconds" in store
+    assert "progress_updated_at" not in store
+    poller = fn_body("function ensureBacktestPolling(")
+    assert "progress_updated_at" not in poller
 
 
 def test_timeout_branch_clears_the_running_map_and_the_progress_store():
@@ -311,23 +668,35 @@ def test_timeout_branch_clears_the_running_map_and_the_progress_store():
     in the finished branch a few lines above -- a whole-function search would
     pass with the timeout branch completely untouched.
     """
-    poller = fn_body("function ensureBacktestPolling(")
-    start = poller.index("if (attempts >= maxAttempts) {")
-    branch = poller[start : poller.index("\n        } catch (error) {", start)]
+    branch = _timeout_branch()
     assert "clearAgentBacktestRunning" in branch, branch
     assert "liveBacktestProgress = null" in branch, branch
 
 
-def test_live_poll_passes_the_progress_fields_to_the_panel():
-    """The helpers only matter if the live call site actually supplies step,
-    totalSteps and updatedAt; every other call site correctly omits them."""
+def test_timeout_branch_repaints_the_cards_it_just_cleared():
+    """Clearing the map is invisible on its own: polling has just stopped, so
+    refreshRunningAgentCards() never runs again and the card sits on
+    "Backtesting…" with a frozen timer until some unrelated re-render happens
+    by. The finished branch has always repainted; this one did not."""
+    branch = _timeout_branch()
+    assert "loadAgents()" in branch, branch
+
+
+def _timeout_branch() -> str:
+    poller = fn_body("function ensureBacktestPolling(")
+    start = poller.index("if (attempts >= maxAttempts) {")
+    return poller[start : poller.index("\n        } catch (error) {", start)]
+
+
+def test_live_poll_hands_the_panel_the_shared_progress_object():
+    """The helpers only matter if the live call site actually supplies it; every
+    terminal call site correctly omits it, and `{}` before the first step is
+    what keeps the startup notice reachable."""
     poller = fn_body("function ensureBacktestPolling(")
     # Anchored to the running branch rather than "the first call in the
     # function": the error, completion and timeout sites are all in here too,
-    # and they must NOT gain these fields.
+    # and they must NOT gain this field.
     running_branch = poller[poller.index("const stepPct") :]
     call = running_branch[running_branch.index("updateBacktestRunProgress({") :]
     call = call[: call.index("});") + 3]
-    assert "step," in call
-    assert "totalSteps: total," in call
-    assert "updatedAt: liveBacktestProgress?.updatedAt" in call
+    assert "progress: liveBacktestProgress || {}" in call

--- a/dashboard/backend/tests/test_backtest_progress_card.py
+++ b/dashboard/backend/tests/test_backtest_progress_card.py
@@ -221,6 +221,27 @@ def test_run_panel_falls_back_to_the_elapsed_guess():
     assert panel["width"] == "10%"  # 60 / 600
 
 
+def test_timeout_branch_clears_the_running_map_and_the_progress_store():
+    """The leak that makes one run render another run's numbers.
+
+    `liveBacktestProgress` is a single global spread into *every* entry of the
+    running map. The finished branch has always cleared that map; the 10-minute
+    timeout branch never did. Before this change an orphaned entry only showed a
+    stale elapsed timer -- now it would render the NEXT run's step, percent and
+    ETA until `getAgentBacktestRunning`'s 600s expiry caught it.
+
+    Guarded by source slice rather than execution: reaching the branch takes 600
+    poll ticks. Scoped to the branch itself, because both statements also appear
+    in the finished branch a few lines above -- a whole-function search would
+    pass with the timeout branch completely untouched.
+    """
+    poller = fn_body("function ensureBacktestPolling(")
+    start = poller.index("if (attempts >= maxAttempts) {")
+    branch = poller[start : poller.index("\n        } catch (error) {", start)]
+    assert "clearAgentBacktestRunning" in branch, branch
+    assert "liveBacktestProgress = null" in branch, branch
+
+
 def test_live_poll_passes_the_progress_fields_to_the_panel():
     """The helpers only matter if the live call site actually supplies step,
     totalSteps and updatedAt; every other call site correctly omits them."""

--- a/dashboard/backend/tests/test_backtest_progress_card.py
+++ b/dashboard/backend/tests/test_backtest_progress_card.py
@@ -1,0 +1,117 @@
+"""The My Agents card shows step-level progress.
+
+The backend has always emitted step/total_steps (engine.py `_publish_live_progress`,
+surfaced by backtests.py `get_backtest_status`), and the Backtest tab has always
+had a percentage bar. The card -- the page a user lands on after launching --
+threw the data away and rendered an indeterminate bar plus an elapsed timer. A
+tester watched it for 3m05s and could not tell running from stuck.
+
+The 2026-07-29 spec called an indeterminate bar deliberate "since no honest
+completion estimate exists". That premise was already false when written.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from dashboard.backend.tests._frontend_source import css_blocks, fn_body, js_const
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+_REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)"
+
+
+def _render(running_js: str) -> str:
+    script = "\n".join(
+        [
+            js_const("BACKTEST_STALE_SECONDS"),
+            "function escapeHtml(s) { return String(s); }",
+            "function renderAgentAllocatedCapitalHero() { return ''; }",
+            "function formatBacktestElapsed(s) { return String(s); }",
+            fn_body("function formatBacktestEta("),
+            fn_body("function formatProgressStaleness("),
+            fn_body("function renderAgentRunningBody("),
+            f"console.log(JSON.stringify(renderAgentRunningBody("
+            f"{{agent_id: 'a1'}}, {running_js})));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_card_shows_step_and_percent_when_known():
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert "84/240" in html
+    assert "35%" in html
+
+
+def test_card_bar_is_determinate_when_step_is_known():
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert "is-determinate" in html
+    assert "width: 35%" in html
+
+
+def test_card_falls_back_to_indeterminate_before_the_first_step():
+    """Not an error state: the progress file does not exist for the opening
+    moments of every run."""
+    html = _render("{elapsedSeconds: 2}")
+    assert "is-determinate" not in html
+    assert "Backtesting" in html
+
+
+def test_card_shows_eta():
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert "left" in html
+
+
+def test_card_warns_when_progress_is_stale():
+    html = _render(
+        "{elapsedSeconds: 600, step: 84, totalSteps: 240, updatedAt: Date.now() - 300000}"
+    )
+    assert "No progress for 5m" in html
+
+
+def test_card_is_silent_when_progress_is_fresh():
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert "No progress for" not in html
+
+
+def test_progressbar_reports_its_value_to_assistive_tech():
+    """role=progressbar without aria-valuenow announces as an unlabelled busy
+    widget -- the same "is it moving?" question the sighted tester had."""
+    html = _render("{elapsedSeconds: 185, step: 84, totalSteps: 240, updatedAt: Date.now()}")
+    assert 'aria-valuenow="35"' in html
+    assert 'aria-valuemax="100"' in html
+
+
+def test_indeterminate_bar_omits_aria_valuenow():
+    """A progressbar claiming valuenow=0 forever is a false statement; omitting
+    it is what tells assistive tech the value is indeterminate."""
+    html = _render("{elapsedSeconds: 2}")
+    assert "aria-valuenow" not in html
+
+
+def test_determinate_bar_keeps_a_reduced_motion_fallback():
+    """Scoped to the reduced-motion block that names the determinate bar.
+
+    `"is-determinate" in _STYLES` would be satisfied by the plain
+    `.agent-card-running-bar.is-determinate` rule alone, so deleting the
+    fallback entirely would leave this green -- the same vacuity closed in
+    the Phase A guards.
+    """
+    blocks = css_blocks(_REDUCED_MOTION)
+    assert any("agent-card-running-bar.is-determinate" in block for block in blocks), blocks
+
+
+def test_determinate_bar_suppresses_the_indeterminate_sweep():
+    """The width is data once determinate; leaving the keyframe sweep running
+    on top of it animates the bar away from the value it is reporting."""
+    blocks = css_blocks(".agent-card-running-bar.is-determinate")
+    assert any("animation: none" in block for block in blocks), blocks

--- a/dashboard/backend/tests/test_backtest_progress_card.py
+++ b/dashboard/backend/tests/test_backtest_progress_card.py
@@ -115,3 +115,97 @@ def test_determinate_bar_suppresses_the_indeterminate_sweep():
     on top of it animates the bar away from the value it is reporting."""
     blocks = css_blocks(".agent-card-running-bar.is-determinate")
     assert any("animation: none" in block for block in blocks), blocks
+
+
+# --- Task 8: the Backtest tab panel, driven by the same two helpers -----------
+
+
+def _run_panel(options_js: str) -> dict:
+    """Execute updateBacktestRunProgress against three stub elements.
+
+    Executed rather than grepped: `"formatBacktestEta(" in source` passes even
+    if the returned value is dropped on the floor, which is precisely the bug
+    that would let the two surfaces disagree.
+    """
+    script = "\n".join(
+        [
+            js_const("BACKTEST_POLL_MAX_SECONDS"),
+            js_const("BACKTEST_STALE_SECONDS"),
+            "const els = {",
+            "  backtestRunElapsed: { textContent: '' },",
+            "  backtestRunProgressMessage: { textContent: '' },",
+            "  backtestRunProgressBar: { style: { width: '' } },",
+            "};",
+            "const document = { getElementById: (id) => els[id] || null };",
+            fn_body("function formatBacktestElapsed("),
+            fn_body("function formatBacktestEta("),
+            fn_body("function formatProgressStaleness("),
+            fn_body("function updateBacktestRunProgress("),
+            f"updateBacktestRunProgress({options_js});",
+            "console.log(JSON.stringify({",
+            "  elapsed: els.backtestRunElapsed.textContent,",
+            "  message: els.backtestRunProgressMessage.textContent,",
+            "  width: els.backtestRunProgressBar.style.width,",
+            "}));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_run_panel_shows_the_same_eta_the_card_does():
+    """One run, two surfaces. Divergent numbers are worse than one blank
+    surface, so both derive the ETA from formatBacktestEta."""
+    panel = _run_panel(
+        "{elapsedSeconds: 185, message: 'Backtest is running…',"
+        " stepPct: 35, step: 84, totalSteps: 240}"
+    )
+    assert "left" in panel["message"]
+    assert panel["message"].startswith("Backtest is running…")
+
+
+def test_run_panel_reports_staleness():
+    panel = _run_panel(
+        "{elapsedSeconds: 600, message: 'Backtest is running…', stepPct: 35,"
+        " step: 84, totalSteps: 240, updatedAt: Date.now() - 300000}"
+    )
+    assert "No progress for 5m" in panel["message"]
+
+
+def test_run_panel_stays_quiet_without_the_new_fields():
+    """The six unedited call sites pass none of step/totalSteps/updatedAt. They
+    must render exactly what they rendered before -- the message alone."""
+    panel = _run_panel("{elapsedSeconds: 42, message: 'Backtest is running…'}")
+    assert panel["message"] == "Backtest is running…"
+
+
+def test_run_panel_prefers_step_percent_over_the_elapsed_guess():
+    """The elapsed-based width is a fallback for runs with no step data; a real
+    percentage must win, otherwise the bar contradicts the number beside it."""
+    panel = _run_panel(
+        "{elapsedSeconds: 60, message: 'x', stepPct: 35, step: 84, totalSteps: 240}"
+    )
+    assert panel["width"] == "35%"
+
+
+def test_run_panel_falls_back_to_the_elapsed_guess():
+    panel = _run_panel("{elapsedSeconds: 60, message: 'x'}")
+    assert panel["width"] == "10%"  # 60 / 600
+
+
+def test_live_poll_passes_the_progress_fields_to_the_panel():
+    """The helpers only matter if the live call site actually supplies step,
+    totalSteps and updatedAt; every other call site correctly omits them."""
+    poller = fn_body("function ensureBacktestPolling(")
+    # Anchored to the running branch rather than "the first call in the
+    # function": the error, completion and timeout sites are all in here too,
+    # and they must NOT gain these fields.
+    running_branch = poller[poller.index("const stepPct") :]
+    call = running_branch[running_branch.index("updateBacktestRunProgress({") :]
+    call = call[: call.index("});") + 3]
+    assert "step," in call
+    assert "totalSteps: total," in call
+    assert "updatedAt: liveBacktestProgress?.updatedAt" in call

--- a/dashboard/backend/tests/test_backtest_progress_card.py
+++ b/dashboard/backend/tests/test_backtest_progress_card.py
@@ -301,8 +301,8 @@ def _patch(progress_js: str, then_progress_js: str | None = None, elapsed_ms: in
             _DOM_SHIM,
             "const launchHtml = renderAgentRunningBody({agent_id: 'a1'}, getAgentBacktestRunning('a1'));",
             "const NODES = parseNodes(launchHtml);",
-            "const document = { querySelectorAll: (sel) =>"
-            " NODES.filter((node) => node.has(sel.slice(1, -1))) };",
+            "const document = { querySelectorAll: (sel) => "
+            + "NODES.filter((node) => node.has(sel.slice(1, -1))) };",
             # The set of running agents is unchanged, which is what forces the
             # patch path instead of a full re-render -- the steady state for all
             # but two ticks of a run.
@@ -314,7 +314,7 @@ def _patch(progress_js: str, then_progress_js: str | None = None, elapsed_ms: in
             "  launch: snapshotOf(parseNodes(launchHtml)),",
             "  patched: snapshotOf(NODES),",
             "  rendered: snapshotOf(parseNodes("
-            "    renderAgentRunningBody({agent_id: 'a1'}, getAgentBacktestRunning('a1')))),",
+            + "renderAgentRunningBody({agent_id: 'a1'}, getAgentBacktestRunning('a1')))),",
             "  applyCalls,",
             "}));",
         ]

--- a/dashboard/backend/tests/test_backtest_progress_format.py
+++ b/dashboard/backend/tests/test_backtest_progress_format.py
@@ -1,0 +1,129 @@
+"""ETA and staleness formatting for a running backtest.
+
+Both are honesty-constrained rather than precision-constrained:
+
+* an ETA derived from two or three steps is wild, and a number that visibly
+  jumps reads as broken -- so it is suppressed early and coarse thereafter;
+* a stale progress file means the numbers are old, NOT that the run is stuck.
+  An LLM pipeline step can legitimately take minutes. Claiming "stuck" would be
+  the same class of error as the fabricated Performance Drivers card.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node is not installed"
+)
+
+
+def _extract_function(src: str, name: str) -> str:
+    for marker in (f"async function {name}(", f"function {name}("):
+        start = src.find(marker)
+        if start != -1:
+            break
+    else:
+        raise AssertionError(f"{name} not found in app.js")
+    depth = 0
+    i = src.index("{", start)
+    while True:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+
+
+def _extract_const(src: str, name: str) -> str:
+    """Lift the real declaration out of app.js rather than restating its value.
+
+    A harness that hardcodes `const BACKTEST_STALE_SECONDS = 120` tests the
+    formatter against the harness's own threshold, so raising the shipped
+    constant would silently stop being covered while every case stayed green.
+    """
+    match = re.search(rf"^const {re.escape(name)} = [^;]+;", src, re.MULTILINE)
+    assert match, f"{name} not found in app.js"
+    return match.group(0)
+
+
+def _eval(expr: str) -> object:
+    script = "\n".join(
+        [
+            _extract_const(_APP_JS, "BACKTEST_STALE_SECONDS"),
+            _extract_function(_APP_JS, "formatBacktestEta"),
+            _extract_function(_APP_JS, "formatProgressStaleness"),
+            f"console.log(JSON.stringify({expr}));",
+        ]
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_staleness_threshold_is_two_minutes():
+    """Pins the shipped constant, since every staleness case below is scaled to
+    it. Lowering it would make the UI cry wolf on ordinary model latency."""
+    assert _extract_const(_APP_JS, "BACKTEST_STALE_SECONDS") == (
+        "const BACKTEST_STALE_SECONDS = 120;"
+    )
+
+
+def test_eta_is_suppressed_for_the_first_two_steps():
+    assert _eval("formatBacktestEta(4, 1, 240)") is None
+    assert _eval("formatBacktestEta(8, 2, 240)") is None
+
+
+def test_eta_appears_from_step_three():
+    # 30s for 3 of 243 steps -> 10s/step -> 2400s remaining -> "~40m left"
+    assert _eval("formatBacktestEta(30, 3, 243)") == "~40m left"
+
+
+def test_eta_is_coarse_under_a_minute():
+    # 100s for 100 of 130 steps -> 1s/step -> 30s remaining
+    assert _eval("formatBacktestEta(100, 100, 130)") == "<1m left"
+
+
+def test_eta_rounds_to_whole_minutes():
+    # 125s for 25 of 50 steps -> 5s/step -> 125s remaining -> ~2m
+    assert _eval("formatBacktestEta(125, 25, 50)") == "~2m left"
+
+
+def test_eta_is_null_without_totals():
+    assert _eval("formatBacktestEta(60, 10, 0)") is None
+    assert _eval("formatBacktestEta(60, 10, null)") is None
+    assert _eval("formatBacktestEta(60, null, 240)") is None
+
+
+def test_eta_is_null_on_the_final_step():
+    """No remaining work to estimate; the completion path takes over."""
+    assert _eval("formatBacktestEta(600, 240, 240)") is None
+
+
+def test_staleness_is_silent_below_the_threshold():
+    assert _eval("formatProgressStaleness(0)") is None
+    assert _eval("formatProgressStaleness(119)") is None
+
+
+def test_staleness_reports_the_actual_gap_not_the_threshold():
+    """A message frozen at '2m' while the real gap grows to ten is worse than
+    no message -- it actively misinforms."""
+    assert "2m" in _eval("formatProgressStaleness(130)")
+    assert "9m" in _eval("formatProgressStaleness(560)")
+
+
+def test_staleness_wording_does_not_claim_the_run_is_stuck():
+    message = _eval("formatProgressStaleness(300)")
+    assert "stuck" not in message.lower()
+    assert "fail" not in message.lower()

--- a/dashboard/backend/tests/test_backtest_progress_format.py
+++ b/dashboard/backend/tests/test_backtest_progress_format.py
@@ -10,58 +10,24 @@ Both are honesty-constrained rather than precision-constrained:
 """
 
 import json
-import re
 import shutil
 import subprocess
-from pathlib import Path
 
 import pytest
 
-_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
-_APP_JS = (_FRONTEND / "app.js").read_text(encoding="utf-8")
+from dashboard.backend.tests._frontend_source import fn_body, js_const
 
 pytestmark = pytest.mark.skipif(
     shutil.which("node") is None, reason="node is not installed"
 )
 
 
-def _extract_function(src: str, name: str) -> str:
-    for marker in (f"async function {name}(", f"function {name}("):
-        start = src.find(marker)
-        if start != -1:
-            break
-    else:
-        raise AssertionError(f"{name} not found in app.js")
-    depth = 0
-    i = src.index("{", start)
-    while True:
-        if src[i] == "{":
-            depth += 1
-        elif src[i] == "}":
-            depth -= 1
-            if depth == 0:
-                return src[start : i + 1]
-        i += 1
-
-
-def _extract_const(src: str, name: str) -> str:
-    """Lift the real declaration out of app.js rather than restating its value.
-
-    A harness that hardcodes `const BACKTEST_STALE_SECONDS = 120` tests the
-    formatter against the harness's own threshold, so raising the shipped
-    constant would silently stop being covered while every case stayed green.
-    """
-    match = re.search(rf"^const {re.escape(name)} = [^;]+;", src, re.MULTILINE)
-    assert match, f"{name} not found in app.js"
-    return match.group(0)
-
-
 def _eval(expr: str) -> object:
     script = "\n".join(
         [
-            _extract_const(_APP_JS, "BACKTEST_STALE_SECONDS"),
-            _extract_function(_APP_JS, "formatBacktestEta"),
-            _extract_function(_APP_JS, "formatProgressStaleness"),
+            js_const("BACKTEST_STALE_SECONDS"),
+            fn_body("function formatBacktestEta("),
+            fn_body("function formatProgressStaleness("),
             f"console.log(JSON.stringify({expr}));",
         ]
     )
@@ -75,9 +41,7 @@ def _eval(expr: str) -> object:
 def test_staleness_threshold_is_two_minutes():
     """Pins the shipped constant, since every staleness case below is scaled to
     it. Lowering it would make the UI cry wolf on ordinary model latency."""
-    assert _extract_const(_APP_JS, "BACKTEST_STALE_SECONDS") == (
-        "const BACKTEST_STALE_SECONDS = 120;"
-    )
+    assert js_const("BACKTEST_STALE_SECONDS") == "const BACKTEST_STALE_SECONDS = 120;"
 
 
 def test_eta_is_suppressed_for_the_first_two_steps():

--- a/dashboard/backend/tests/test_backtest_progress_format.py
+++ b/dashboard/backend/tests/test_backtest_progress_format.py
@@ -7,6 +7,13 @@ Both are honesty-constrained rather than precision-constrained:
 * a stale progress file means the numbers are old, NOT that the run is stuck.
   An LLM pipeline step can legitimately take minutes. Claiming "stuck" would be
   the same class of error as the fabricated Performance Drivers card.
+
+Two corrections to the first cut are guarded here. The ETA is measured over the
+*observed* window rather than from launch, because both elapsed clocks start
+before any step exists and folding startup into the per-step rate inflates the
+estimate by an order of magnitude. And staleness is computed from a
+server-supplied age rather than from an mtime diffed against the browser clock,
+because a skewed client is otherwise indistinguishable from a wedged run.
 """
 
 import json
@@ -21,13 +28,21 @@ pytestmark = pytest.mark.skipif(
     shutil.which("node") is None, reason="node is not installed"
 )
 
+_HELPERS = (
+    "function formatBacktestEta(",
+    "function resolveBacktestEta(",
+    "function resolveProgressAgeSeconds(",
+    "function formatProgressStaleness(",
+    "function formatStartupStaleness(",
+    "function resolveRunningNotice(",
+)
+
 
 def _eval(expr: str) -> object:
     script = "\n".join(
         [
             js_const("BACKTEST_STALE_SECONDS"),
-            fn_body("function formatBacktestEta("),
-            fn_body("function formatProgressStaleness("),
+            *[fn_body(signature) for signature in _HELPERS],
             f"console.log(JSON.stringify({expr}));",
         ]
     )
@@ -44,35 +59,101 @@ def test_staleness_threshold_is_two_minutes():
     assert js_const("BACKTEST_STALE_SECONDS") == "const BACKTEST_STALE_SECONDS = 120;"
 
 
-def test_eta_is_suppressed_for_the_first_two_steps():
-    assert _eval("formatBacktestEta(4, 1, 240)") is None
-    assert _eval("formatBacktestEta(8, 2, 240)") is None
+# --- ETA over the observed window --------------------------------------------
 
 
-def test_eta_appears_from_step_three():
-    # 30s for 3 of 243 steps -> 10s/step -> 2400s remaining -> "~40m left"
-    assert _eval("formatBacktestEta(30, 3, 243)") == "~40m left"
+def test_eta_is_suppressed_for_the_first_two_observed_steps():
+    assert _eval("formatBacktestEta(4, 1, 239)") is None
+    assert _eval("formatBacktestEta(8, 2, 238)") is None
+
+
+def test_eta_appears_from_the_third_observed_step():
+    # 30s for 3 observed steps -> 10s/step -> 240 remaining -> "~40m left"
+    assert _eval("formatBacktestEta(30, 3, 240)") == "~40m left"
 
 
 def test_eta_is_coarse_under_a_minute():
-    # 100s for 100 of 130 steps -> 1s/step -> 30s remaining
-    assert _eval("formatBacktestEta(100, 100, 130)") == "<1m left"
+    # 100s for 100 observed steps -> 1s/step -> 30 remaining -> 30s
+    assert _eval("formatBacktestEta(100, 100, 30)") == "<1m left"
 
 
 def test_eta_rounds_to_whole_minutes():
-    # 125s for 25 of 50 steps -> 5s/step -> 125s remaining -> ~2m
-    assert _eval("formatBacktestEta(125, 25, 50)") == "~2m left"
+    # 125s for 25 observed steps -> 5s/step -> 25 remaining -> 125s -> ~2m
+    assert _eval("formatBacktestEta(125, 25, 25)") == "~2m left"
 
 
-def test_eta_is_null_without_totals():
+def test_eta_is_null_without_remaining_work():
     assert _eval("formatBacktestEta(60, 10, 0)") is None
     assert _eval("formatBacktestEta(60, 10, null)") is None
     assert _eval("formatBacktestEta(60, null, 240)") is None
 
 
+def test_eta_is_measured_from_the_first_observed_step():
+    """19 steps observed over 19s -> 1s/step -> 220 remaining -> ~4m."""
+    eta = _eval(
+        "resolveBacktestEta({step: 20, totalSteps: 240,"
+        " firstStep: 1, firstStepAt: Date.now() - 19000})"
+    )
+    assert eta == "~4m left"
+
+
+def test_eta_is_withheld_rather_than_inflated_by_launch_cost():
+    """The bias the anchor exists to remove.
+
+    Launch costs ~25s (process start, imports, market-data fetch, gateway
+    warm-up) and steps run ~1s. Measured from launch, step 3 divides 28s by 3
+    and reports "~37m left" for a run that finishes in four minutes -- and the
+    later collapse to "~4m left" is itself an "is this broken?" signal. Measured
+    from the first observed step there are only two observed steps yet, so the
+    honest answer is no estimate at all.
+    """
+    assert _eval("formatBacktestEta(28, 3, 237)") == "~37m left"  # the old form
+    assert (
+        _eval(
+            "resolveBacktestEta({step: 3, totalSteps: 240,"
+            " firstStep: 1, firstStepAt: Date.now() - 2000})"
+        )
+        is None
+    )
+
+
+def test_eta_needs_an_anchor():
+    """No anchor means the poller has not yet seen a step in this run, so there
+    is no window to measure over -- and the whole-run fallback is exactly the
+    biased form this replaced."""
+    assert _eval("resolveBacktestEta({step: 84, totalSteps: 240})") is None
+
+
 def test_eta_is_null_on_the_final_step():
     """No remaining work to estimate; the completion path takes over."""
-    assert _eval("formatBacktestEta(600, 240, 240)") is None
+    eta = _eval(
+        "resolveBacktestEta({step: 240, totalSteps: 240,"
+        " firstStep: 1, firstStepAt: Date.now() - 240000})"
+    )
+    assert eta is None
+
+
+# --- Progress age, computed on the server ------------------------------------
+
+
+def test_age_adds_only_the_time_since_this_client_read_it():
+    """The server's age plus the local elapsed since the poll. The second term
+    is a difference of two Date.now() calls on one machine, so it is skew-free
+    in a way `Date.now() - serverTimestamp` is not."""
+    age = _eval("resolveProgressAgeSeconds({ageSeconds: 100, ageAt: Date.now() - 5000})")
+    assert 104 <= age <= 107
+
+
+def test_a_null_age_is_not_coerced_to_zero():
+    """Number(null) is 0, so a coercing check would report a run with *no age
+    reading at all* as perfectly fresh -- indistinguishable from one updated a
+    moment ago. Returning null suppresses the notice instead of asserting
+    freshness the payload never claimed."""
+    assert _eval("resolveProgressAgeSeconds({ageSeconds: null, ageAt: Date.now()})") is None
+    assert _eval("resolveProgressAgeSeconds({})") is None
+
+
+# --- Which notice applies ----------------------------------------------------
 
 
 def test_staleness_is_silent_below_the_threshold():
@@ -91,3 +172,44 @@ def test_staleness_wording_does_not_claim_the_run_is_stuck():
     message = _eval("formatProgressStaleness(300)")
     assert "stuck" not in message.lower()
     assert "fail" not in message.lower()
+
+
+def test_the_notice_depends_only_on_the_server_supplied_age():
+    """A client clock offset can neither manufacture nor suppress it, which is
+    the whole reason the age is computed server-side."""
+    fresh = "{step: 84, totalSteps: 240, ageSeconds: 2, ageAt: Date.now()}"
+    wedged = "{step: 84, totalSteps: 240, ageSeconds: 300, ageAt: Date.now()}"
+    assert _eval(f"resolveRunningNotice({fresh})") is None
+    assert "No progress for 5m" in _eval(f"resolveRunningNotice({wedged})")
+
+
+def test_a_run_that_never_published_a_step_still_warns():
+    """The likeliest wedge -- a subprocess that dies or hangs in imports, the
+    market-data fetch or the LLM gateway -- writes no progress file at all, so
+    there is no mtime to age and the staleness notice above can never fire. That
+    left the exact scenario this feature exists for as the one case with no
+    signal on either surface, for the full ten-minute poll ceiling.
+    """
+    notice = _eval("resolveRunningNotice({elapsedSeconds: 200})")
+    assert "no steps" in notice.lower()
+    assert "3m" in notice
+
+
+def test_the_startup_notice_waits_for_the_same_threshold():
+    """Every run is stepless for its opening moments; warning about that would
+    make the notice meaningless."""
+    assert _eval("resolveRunningNotice({elapsedSeconds: 30})") is None
+    assert _eval("formatStartupStaleness(119)") is None
+
+
+def test_the_startup_notice_does_not_claim_the_run_is_dead():
+    message = _eval("formatStartupStaleness(300)")
+    assert "stuck" not in message.lower()
+    assert "fail" not in message.lower()
+    assert "dead" not in message.lower()
+
+
+def test_a_stepping_run_never_gets_the_startup_notice():
+    """Once steps are flowing the startup wording would be flatly wrong, even
+    if the server stopped supplying an age."""
+    assert _eval("resolveRunningNotice({step: 84, totalSteps: 240, elapsedSeconds: 600})") is None

--- a/dashboard/backend/tests/test_backtest_progress_status.py
+++ b/dashboard/backend/tests/test_backtest_progress_status.py
@@ -6,15 +6,21 @@ reporting its last step forever, which reads identically to steady progress.
 """
 
 import json
+import os
 import time
 
 from dashboard.backend.api.routers import backtests
 
 
-def test_progress_carries_the_file_mtime(tmp_path, monkeypatch):
-    progress_file = tmp_path / "backtest_progress_test.json"
+def _seed(tmp_path, monkeypatch, name="backtest_progress_test.json"):
+    progress_file = tmp_path / name
     progress_file.write_text(json.dumps({"step": 7, "total_steps": 240}), encoding="utf-8")
     monkeypatch.setitem(backtests.backtest_status, "progress_file", str(progress_file))
+    return progress_file
+
+
+def test_progress_carries_the_file_mtime(tmp_path, monkeypatch):
+    progress_file = _seed(tmp_path, monkeypatch)
 
     payload = backtests._read_backtest_progress()
 
@@ -22,6 +28,44 @@ def test_progress_carries_the_file_mtime(tmp_path, monkeypatch):
     assert payload["total_steps"] == 240
     assert payload["progress_updated_at"] == progress_file.stat().st_mtime
     assert payload["progress_updated_at"] <= time.time() + 1
+
+
+def test_progress_carries_a_server_computed_age(tmp_path, monkeypatch):
+    """The age, not just the timestamp, is what the browser reads.
+
+    Differencing the mtime against the client clock makes any machine more than
+    the staleness threshold out of step indistinguishable from a wedged run: a
+    fast clock pins a permanent "No progress for 47m" onto a healthy backtest, a
+    slow one suppresses the warning forever. Both ends of this subtraction are
+    read in one process, so it carries no skew.
+    """
+    _seed(tmp_path, monkeypatch)
+
+    payload = backtests._read_backtest_progress()
+
+    assert 0 <= payload["progress_age_seconds"] < 30
+
+
+def test_age_reports_the_real_gap_for_a_wedged_run(tmp_path, monkeypatch):
+    """The case the field exists for: a subprocess that stopped writing keeps
+    reporting its last step forever, which reads identically to progress."""
+    progress_file = _seed(tmp_path, monkeypatch, "stale.json")
+    five_minutes_ago = time.time() - 300
+    os.utime(progress_file, (five_minutes_ago, five_minutes_ago))
+
+    payload = backtests._read_backtest_progress()
+
+    assert 295 < payload["progress_age_seconds"] < 310
+
+
+def test_age_is_never_negative(tmp_path, monkeypatch):
+    """A clock stepping backwards between the write and this read would
+    otherwise report "-3s", which reads as a bug rather than as freshness."""
+    progress_file = _seed(tmp_path, monkeypatch, "future.json")
+    later = time.time() + 600
+    os.utime(progress_file, (later, later))
+
+    assert backtests._read_backtest_progress()["progress_age_seconds"] == 0.0
 
 
 def test_missing_progress_file_still_returns_none(tmp_path, monkeypatch):

--- a/dashboard/backend/tests/test_backtest_progress_status.py
+++ b/dashboard/backend/tests/test_backtest_progress_status.py
@@ -1,0 +1,47 @@
+"""Progress-file freshness, so the UI can tell 'working' from 'stuck'.
+
+The status payload already carried step/total_steps; what it could not answer
+was whether those numbers were current. A run whose subprocess wedges keeps
+reporting its last step forever, which reads identically to steady progress.
+"""
+
+import json
+import time
+
+from dashboard.backend.api.routers import backtests
+
+
+def test_progress_carries_the_file_mtime(tmp_path, monkeypatch):
+    progress_file = tmp_path / "backtest_progress_test.json"
+    progress_file.write_text(json.dumps({"step": 7, "total_steps": 240}), encoding="utf-8")
+    monkeypatch.setitem(backtests.backtest_status, "progress_file", str(progress_file))
+
+    payload = backtests._read_backtest_progress()
+
+    assert payload["step"] == 7
+    assert payload["total_steps"] == 240
+    assert payload["progress_updated_at"] == progress_file.stat().st_mtime
+    assert payload["progress_updated_at"] <= time.time() + 1
+
+
+def test_missing_progress_file_still_returns_none(tmp_path, monkeypatch):
+    """Unchanged behaviour: the status payload omits `progress` entirely rather
+    than shipping a half-populated object."""
+    monkeypatch.setitem(
+        backtests.backtest_status, "progress_file", str(tmp_path / "nope.json")
+    )
+    assert backtests._read_backtest_progress() is None
+
+
+def test_malformed_progress_file_still_returns_none(tmp_path, monkeypatch):
+    progress_file = tmp_path / "broken.json"
+    progress_file.write_text("{not json", encoding="utf-8")
+    monkeypatch.setitem(backtests.backtest_status, "progress_file", str(progress_file))
+    assert backtests._read_backtest_progress() is None
+
+
+def test_non_dict_progress_file_still_returns_none(tmp_path, monkeypatch):
+    progress_file = tmp_path / "list.json"
+    progress_file.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setitem(backtests.backtest_status, "progress_file", str(progress_file))
+    assert backtests._read_backtest_progress() is None

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -687,9 +687,12 @@ def test_backtest_status_includes_live_progress(tmp_path):
     assert body["progress"]["trades"][0]["symbol"] == "AAPL"
     assert "step 5/100" in body["message"]
     # Pinned at the wire, not just at _read_backtest_progress: the payload is
-    # assigned wholesale today, so a later whitelist would drop this field with
+    # assigned wholesale today, so a later whitelist would drop these fields with
     # a green helper test and a UI that silently stops reporting staleness.
     assert body["progress"]["progress_updated_at"] == progress_file.stat().st_mtime
+    # The age is the field the browser actually reads -- deriving it client-side
+    # from the mtime above would make a skewed clock look like a wedged run.
+    assert 0 <= body["progress"]["progress_age_seconds"] < 30
 
 
 def test_get_run_trades_endpoint(client, monkeypatch):

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -683,10 +683,13 @@ def test_backtest_status_includes_live_progress(tmp_path):
     assert body["progress"]["step"] == 5
     assert body["progress"]["total_steps"] == 100
     assert len(body["progress"]["equity_curve"]) == 1
-    assert len(body["progress"]["equity_curve"]) == 1
     assert len(body["progress"]["trades"]) == 1
     assert body["progress"]["trades"][0]["symbol"] == "AAPL"
     assert "step 5/100" in body["message"]
+    # Pinned at the wire, not just at _read_backtest_progress: the payload is
+    # assigned wholesale today, so a later whitelist would drop this field with
+    # a green helper test and a UI that silently stops reporting staleness.
+    assert body["progress"]["progress_updated_at"] == progress_file.stat().st_mtime
 
 
 def test_get_run_trades_endpoint(client, monkeypatch):

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=74">
+    <link rel="stylesheet" href="styles.css?v=75">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -1644,7 +1644,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
     <script src="js/agent-editor.js?v=17"></script>
-    <script src="app.js?v=55"></script>
+    <script src="app.js?v=56"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=73">
+    <link rel="stylesheet" href="styles.css?v=74">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -1644,7 +1644,7 @@
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
     <script src="js/agent-editor.js?v=17"></script>
-    <script src="app.js?v=54"></script>
+    <script src="app.js?v=55"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -3439,7 +3439,21 @@ function getAgentBacktestRunning(agentId) {
         clearAgentBacktestRunning(agentId);
         return null;
     }
-    return { ...entry, ...(liveBacktestProgress || {}), elapsedSeconds: Math.floor(elapsed) };
+    // Progress belongs to the run the poller is following, and ONLY to it.
+    // The map can transiently hold two entries: runBacktest() marks an agent
+    // running before its POST resolves (:5689, runId still null) and the
+    // backend rejects a second concurrent run, so clicking Run on an idle
+    // agent while another is genuinely in flight briefly leaves both marked.
+    // An unconditional spread would paint the running agent's step/percent/ETA
+    // onto a card whose launch is about to be refused. An entry with no runId
+    // yet is pre-confirmation and correctly renders indeterminate -- there is
+    // no progress to show that early anyway.
+    const ownsProgress = Boolean(liveBacktestRunId) && entry.runId === liveBacktestRunId;
+    return {
+        ...entry,
+        ...(ownsProgress && liveBacktestProgress ? liveBacktestProgress : {}),
+        elapsedSeconds: Math.floor(elapsed),
+    };
 }
 
 /** Latest polled progress for the single in-flight run.
@@ -5062,6 +5076,19 @@ function ensureBacktestPolling() {
 
             if (status.running) {
                 if (liveId) liveBacktestRunId = liveId;
+                const step = Number(status.progress?.step);
+                const total = Number(status.progress?.total_steps);
+                const stepPct = Number.isFinite(step) && Number.isFinite(total) && total > 0
+                    ? (100 * step / total)
+                    : null;
+                // Assigned BEFORE refreshRunningAgentCards() below, which reads
+                // it through getAgentBacktestRunning(). Painting first would
+                // show the previous tick's step on the card while the Backtest
+                // panel — fed the fresh step/total directly a few lines down —
+                // showed this tick's: two surfaces disagreeing by one poll.
+                liveBacktestProgress = Number.isFinite(step) && step > 0
+                    ? { step, totalSteps: total, updatedAt: Number(status.progress?.progress_updated_at) * 1000 || Date.now() }
+                    : null;
                 // Repaint the My Agents card even when the user is not on the
                 // Backtest tab — that page is now the landing page after launch.
                 // refreshRunningAgentCards() patches the elapsed timer in place
@@ -5069,14 +5096,6 @@ function ensureBacktestPolling() {
                 if (playgroundTab === 'agents' && currentPage === 'playground') {
                     refreshRunningAgentCards();
                 }
-                const step = Number(status.progress?.step);
-                const total = Number(status.progress?.total_steps);
-                const stepPct = Number.isFinite(step) && Number.isFinite(total) && total > 0
-                    ? (100 * step / total)
-                    : null;
-                liveBacktestProgress = Number.isFinite(step) && step > 0
-                    ? { step, totalSteps: total, updatedAt: Number(status.progress?.progress_updated_at) * 1000 || Date.now() }
-                    : null;
 
                 if (viewingLive) {
                     liveBacktestChartActive = true;

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -4781,7 +4781,15 @@ function showBacktestRunProgress(show, { isError = false } = {}) {
     if (hint) hint.hidden = !!isError;
 }
 
-function updateBacktestRunProgress({ elapsedSeconds, message = '', maxSeconds = BACKTEST_POLL_MAX_SECONDS, stepPct = null } = {}) {
+function updateBacktestRunProgress({
+    elapsedSeconds,
+    message = '',
+    maxSeconds = BACKTEST_POLL_MAX_SECONDS,
+    stepPct = null,
+    step = null,
+    totalSteps = null,
+    updatedAt = null,
+} = {}) {
     const elapsedEl = document.getElementById('backtestRunElapsed');
     const messageEl = document.getElementById('backtestRunProgressMessage');
     const barEl = document.getElementById('backtestRunProgressBar');
@@ -4790,7 +4798,15 @@ function updateBacktestRunProgress({ elapsedSeconds, message = '', maxSeconds = 
         const elapsed = Math.max(0, Number(elapsedSeconds) || 0);
         elapsedEl.textContent = formatBacktestElapsed(elapsed);
     }
-    if (messageEl && message) messageEl.textContent = message;
+    if (messageEl && message) {
+        // Same two derived facts the card shows, from the same helpers, so the
+        // two surfaces can never disagree about one run.
+        const eta = formatBacktestEta(elapsedSeconds, step, totalSteps);
+        const stale = updatedAt
+            ? formatProgressStaleness((Date.now() - Number(updatedAt)) / 1000)
+            : null;
+        messageEl.textContent = [message, eta, stale].filter(Boolean).join(' · ');
+    }
     if (barEl) {
         const pct = Number.isFinite(stepPct)
             ? Math.min(99, Math.round(stepPct))
@@ -5072,6 +5088,9 @@ function ensureBacktestPolling() {
                         elapsedSeconds: displayElapsed,
                         message: status.message || 'Backtest is running…',
                         stepPct,
+                        step,
+                        totalSteps: total,
+                        updatedAt: liveBacktestProgress?.updatedAt || null,
                     });
                     showBacktestRunProgress(true);
                     renderBacktestRunConfig(

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -811,21 +811,50 @@ function renderAgentAllocatedCapitalHero(agent) {
 /**
  * Card body for an agent with a backtest in flight.
  *
- * The bar is deliberately indeterminate rather than a percentage: the launch
- * path has no honest completion estimate, and a fake percentage that stalls is
- * worse than an animation that only claims "still working".
+ * The bar is determinate whenever the engine has published a step: engine.py's
+ * `_publish_live_progress` writes step/total_steps every step and the status
+ * endpoint surfaces them. (The 2026-07-29 spec specified an indeterminate bar
+ * "since no honest completion estimate exists" -- that was already untrue; see
+ * the 2026-08-01 spec.) It falls back to indeterminate before the first step,
+ * which is a normal state on every run, not an error.
  */
 function renderAgentRunningBody(agent, running) {
+  const step = Number(running.step);
+  const total = Number(running.totalSteps);
+  const determinate =
+    Number.isFinite(step) && Number.isFinite(total) && total > 0 && step > 0;
+  const pct = determinate ? Math.min(99, Math.round((100 * step) / total)) : null;
+  const eta = determinate
+    ? formatBacktestEta(running.elapsedSeconds, step, total)
+    : null;
+  const stale = running.updatedAt
+    ? formatProgressStaleness((Date.now() - Number(running.updatedAt)) / 1000)
+    : null;
+
+  const stepLabel = determinate ? `${step}/${total}` : '';
+  // Built from raw values and escaped once at the interpolation site below --
+  // escaping here as well would double-encode.
+  const detail = [
+    determinate ? `${pct}%` : null,
+    eta,
+    `${formatBacktestElapsed(running.elapsedSeconds)} elapsed`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
   return `
     <div class="agent-card-running">
       <div class="agent-card-running-head">
         <span class="agent-card-running-dot" aria-hidden="true"></span>
         <span class="agent-card-running-label">Backtesting…</span>
+        <span class="agent-card-running-step" data-running-step="${escapeHtml(agent.agent_id)}">${escapeHtml(stepLabel)}</span>
         <span class="agent-card-running-elapsed" data-running-elapsed="${escapeHtml(agent.agent_id)}">${escapeHtml(formatBacktestElapsed(running.elapsedSeconds))}</span>
       </div>
-      <div class="agent-card-running-track" role="progressbar" aria-label="Backtest in progress">
-        <div class="agent-card-running-bar"></div>
+      <div class="agent-card-running-track" role="progressbar" aria-label="Backtest in progress"${determinate ? ` aria-valuenow="${pct}" aria-valuemin="0" aria-valuemax="100"` : ''}>
+        <div class="agent-card-running-bar${determinate ? ' is-determinate' : ''}"${determinate ? ` style="width: ${pct}%"` : ''}></div>
       </div>
+      <p class="agent-card-running-detail" data-running-detail="${escapeHtml(agent.agent_id)}">${escapeHtml(detail)}</p>
+      ${stale ? `<p class="agent-card-running-stale">${escapeHtml(stale)}</p>` : ''}
     </div>
     ${renderAgentAllocatedCapitalHero(agent)}`;
 }
@@ -3413,8 +3442,13 @@ function getAgentBacktestRunning(agentId) {
         clearAgentBacktestRunning(agentId);
         return null;
     }
-    return { ...entry, elapsedSeconds: Math.floor(elapsed) };
+    return { ...entry, ...(liveBacktestProgress || {}), elapsedSeconds: Math.floor(elapsed) };
 }
+
+/** Latest polled progress for the single in-flight run.
+ *  backtest_status is one process-global dict on the server, so at most one
+ *  backtest runs at a time and a single shared object is correct. */
+let liveBacktestProgress = null;
 
 let lastRenderedRunningKey = null;
 
@@ -3439,12 +3473,30 @@ function refreshRunningAgentCards() {
     // interpolating an agent id into a selector string: no escaping, no
     // CSS.escape feature detection, and nothing to get wrong later.
     const elapsedNodes = document.querySelectorAll('[data-running-elapsed]');
+    const stepNodes = document.querySelectorAll('[data-running-step]');
+    const detailNodes = document.querySelectorAll('[data-running-detail]');
     Object.keys(running).forEach((agentId) => {
         const entry = getAgentBacktestRunning(agentId);
         if (!entry) return;
         elapsedNodes.forEach((el) => {
             if (el.getAttribute('data-running-elapsed') !== agentId) return;
             el.textContent = formatBacktestElapsed(entry.elapsedSeconds);
+        });
+        const step = Number(entry.step);
+        const total = Number(entry.totalSteps);
+        const determinate = Number.isFinite(step) && Number.isFinite(total) && total > 0 && step > 0;
+        if (!determinate) return;
+        const pct = Math.min(99, Math.round((100 * step) / total));
+        stepNodes.forEach((el) => {
+            if (el.getAttribute('data-running-step') !== agentId) return;
+            el.textContent = `${step}/${total}`;
+        });
+        detailNodes.forEach((el) => {
+            if (el.getAttribute('data-running-detail') !== agentId) return;
+            const eta = formatBacktestEta(entry.elapsedSeconds, step, total);
+            el.textContent = [`${pct}%`, eta, `${formatBacktestElapsed(entry.elapsedSeconds)} elapsed`]
+                .filter(Boolean)
+                .join(' · ');
         });
     });
 }
@@ -5006,6 +5058,9 @@ function ensureBacktestPolling() {
                 const stepPct = Number.isFinite(step) && Number.isFinite(total) && total > 0
                     ? (100 * step / total)
                     : null;
+                liveBacktestProgress = Number.isFinite(step) && step > 0
+                    ? { step, totalSteps: total, updatedAt: Number(status.progress?.progress_updated_at) * 1000 || Date.now() }
+                    : null;
 
                 if (viewingLive) {
                     liveBacktestChartActive = true;
@@ -5029,6 +5084,7 @@ function ensureBacktestPolling() {
                 liveBacktestChartActive = false;
                 const finishedId = liveBacktestRunId;
                 liveBacktestRunId = null;
+                liveBacktestProgress = null;
                 Object.keys(readRunningBacktests()).forEach(clearAgentBacktestRunning);
                 if (playgroundTab === 'agents' && currentPage === 'playground') {
                     loadAgents();
@@ -5076,6 +5132,13 @@ function ensureBacktestPolling() {
                 }
                 liveBacktestChartActive = false;
                 liveBacktestRunId = null;
+                // The finished branch above clears the running map; this one
+                // never did. Harmless while an orphaned entry only showed a
+                // wrong elapsed timer, but liveBacktestProgress is a single
+                // global spread into *every* entry, so a stale entry would
+                // render the NEXT run's step, percent and ETA until it aged out.
+                Object.keys(readRunningBacktests()).forEach(clearAgentBacktestRunning);
+                liveBacktestProgress = null;
             }
         } catch (error) {
             console.error('Error polling backtest status:', error);

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -4794,8 +4794,13 @@ function updateBacktestRunProgress({
         elapsedEl.textContent = formatBacktestElapsed(elapsed);
     }
     if (messageEl && message) {
-        // Same two derived facts the card shows, from the same helpers, so the
-        // two surfaces can never disagree about one run.
+        // Same two derived facts the card shows, from the same helpers. Not
+        // byte-identical output: the card's elapsed is client-side (startedAt),
+        // this one is the server's elapsed_seconds, so they differ by launch
+        // latency and clock skew. Both round to whole minutes, which absorbs
+        // that everywhere except a bucket boundary -- close enough that one
+        // shared source of elapsed is not worth breaking the card's
+        // between-poll ticking for.
         const eta = formatBacktestEta(elapsedSeconds, step, totalSteps);
         const stale = updatedAt
             ? formatProgressStaleness((Date.now() - Number(updatedAt)) / 1000)

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -819,39 +819,27 @@ function renderAgentAllocatedCapitalHero(agent) {
  * which is a normal state on every run, not an error.
  */
 function renderAgentRunningBody(agent, running) {
-  const step = Number(running.step);
-  const total = Number(running.totalSteps);
-  const determinate =
-    Number.isFinite(step) && Number.isFinite(total) && total > 0 && step > 0;
-  const pct = determinate ? Math.min(99, Math.round((100 * step) / total)) : null;
-  const eta = determinate
-    ? formatBacktestEta(running.elapsedSeconds, step, total)
-    : null;
-  const stale = running.updatedAt
-    ? formatProgressStaleness((Date.now() - Number(running.updatedAt)) / 1000)
-    : null;
-
-  const stepLabel = determinate ? `${step}/${total}` : '';
-  // Deliberately excludes elapsed: the head already renders it one line above,
-  // and printing "3:05" beside "3:05 elapsed" is the kind of noise this change
-  // exists to remove. Empty before the first step, hidden by :empty in CSS.
-  // Built from raw values and escaped once at the interpolation site below --
-  // escaping here as well would double-encode.
-  const detail = [determinate ? `${pct}%` : null, eta].filter(Boolean).join(' · ');
+  // Every value below comes from deriveRunningProgress, which the per-second
+  // patch path reads too -- see refreshRunningAgentCards().
+  const view = deriveRunningProgress(running);
+  // Every dynamic node carries a data-running-* hook, including the ones that
+  // are empty right now: the patch path finds nodes by attribute, and a node
+  // rendered only when it has content can never be filled in later.
+  const id = escapeHtml(agent.agent_id);
 
   return `
     <div class="agent-card-running">
       <div class="agent-card-running-head">
         <span class="agent-card-running-dot" aria-hidden="true"></span>
         <span class="agent-card-running-label">Backtesting…</span>
-        <span class="agent-card-running-step" data-running-step="${escapeHtml(agent.agent_id)}">${escapeHtml(stepLabel)}</span>
-        <span class="agent-card-running-elapsed" data-running-elapsed="${escapeHtml(agent.agent_id)}">${escapeHtml(formatBacktestElapsed(running.elapsedSeconds))}</span>
+        <span class="agent-card-running-step" data-running-step="${id}">${escapeHtml(view.stepLabel)}</span>
+        <span class="agent-card-running-elapsed" data-running-elapsed="${id}">${escapeHtml(formatBacktestElapsed(running.elapsedSeconds))}</span>
       </div>
-      <div class="agent-card-running-track" role="progressbar" aria-label="Backtest in progress"${determinate ? ` aria-valuenow="${pct}" aria-valuemin="0" aria-valuemax="100"` : ''}>
-        <div class="agent-card-running-bar${determinate ? ' is-determinate' : ''}"${determinate ? ` style="width: ${pct}%"` : ''}></div>
+      <div class="agent-card-running-track" role="progressbar" aria-label="Backtest in progress" data-running-track="${id}"${view.determinate ? ` aria-valuenow="${view.pct}" aria-valuemin="0" aria-valuemax="100"` : ''}>
+        <div class="agent-card-running-bar${view.determinate ? ' is-determinate' : ''}" data-running-bar="${id}"${view.determinate ? ` style="width: ${view.pct}%"` : ''}></div>
       </div>
-      <p class="agent-card-running-detail" data-running-detail="${escapeHtml(agent.agent_id)}">${escapeHtml(detail)}</p>
-      ${stale ? `<p class="agent-card-running-stale">${escapeHtml(stale)}</p>` : ''}
+      <p class="agent-card-running-detail" data-running-detail="${id}">${escapeHtml(view.detail)}</p>
+      <p class="agent-card-running-stale" data-running-stale="${id}">${escapeHtml(view.notice)}</p>
     </div>
     ${renderAgentAllocatedCapitalHero(agent)}`;
 }
@@ -3382,6 +3370,13 @@ let chartInstance = null;
 let liveBacktestChartActive = false;
 /** When set, Backtest view is pinned to this in-flight run (blocks history chart paint). */
 let liveBacktestRunId = null;
+/** Latest polled progress for the single in-flight run, or null before the
+ *  first step. backtest_status is one process-global dict on the server, so at
+ *  most one backtest runs at a time and a single shared object is correct.
+ *  Declared beside liveBacktestRunId because the two are only ever read
+ *  together: getAgentBacktestRunning() applies this to a card only when the
+ *  card's run id matches liveBacktestRunId. */
+let liveBacktestProgress = null;
 let liveBacktestLaunchPending = false;
 let liveBacktestLaunchError = false;
 /** Active status-poll timer id (so dropdown can re-attach to a running job). */
@@ -3456,11 +3451,6 @@ function getAgentBacktestRunning(agentId) {
     };
 }
 
-/** Latest polled progress for the single in-flight run.
- *  backtest_status is one process-global dict on the server, so at most one
- *  backtest runs at a time and a single shared object is correct. */
-let liveBacktestProgress = null;
-
 let lastRenderedRunningKey = null;
 
 /**
@@ -3483,29 +3473,70 @@ function refreshRunningAgentCards() {
     // Query by attribute presence and compare values in JS rather than
     // interpolating an agent id into a selector string: no escaping, no
     // CSS.escape feature detection, and nothing to get wrong later.
-    const elapsedNodes = document.querySelectorAll('[data-running-elapsed]');
-    const stepNodes = document.querySelectorAll('[data-running-step]');
-    const detailNodes = document.querySelectorAll('[data-running-detail]');
+    //
+    // EVERY field renderAgentRunningBody() paints is patched here, not just the
+    // text ones. A full re-render fires only when the *set* of running agents
+    // changes -- twice in a normal run -- so anything missing from this list is
+    // frozen at its launch value for the whole run. That is how the bar, its
+    // aria-valuenow and the staleness note previously never moved while the
+    // numbers beside them climbed: the card showed "84/240 · 35%" next to a bar
+    // still running the indeterminate sweep, and the staleness warning this
+    // feature exists for was unreachable outside a re-render.
+    const nodes = {
+        elapsed: document.querySelectorAll('[data-running-elapsed]'),
+        step: document.querySelectorAll('[data-running-step]'),
+        detail: document.querySelectorAll('[data-running-detail]'),
+        stale: document.querySelectorAll('[data-running-stale]'),
+        track: document.querySelectorAll('[data-running-track]'),
+        bar: document.querySelectorAll('[data-running-bar]'),
+    };
+    const patch = (list, attribute, agentId, apply) => {
+        list.forEach((el) => {
+            if (el.getAttribute(attribute) !== agentId) return;
+            apply(el);
+        });
+    };
     Object.keys(running).forEach((agentId) => {
         const entry = getAgentBacktestRunning(agentId);
         if (!entry) return;
-        elapsedNodes.forEach((el) => {
-            if (el.getAttribute('data-running-elapsed') !== agentId) return;
+        // Same derivation the full render uses, so the two cannot drift.
+        const view = deriveRunningProgress(entry);
+        patch(nodes.elapsed, 'data-running-elapsed', agentId, (el) => {
             el.textContent = formatBacktestElapsed(entry.elapsedSeconds);
         });
-        const step = Number(entry.step);
-        const total = Number(entry.totalSteps);
-        const determinate = Number.isFinite(step) && Number.isFinite(total) && total > 0 && step > 0;
-        if (!determinate) return;
-        const pct = Math.min(99, Math.round((100 * step) / total));
-        stepNodes.forEach((el) => {
-            if (el.getAttribute('data-running-step') !== agentId) return;
-            el.textContent = `${step}/${total}`;
+        // Assigned unconditionally, empty string included: a tick where the
+        // status endpoint reports no progress (file caught mid-rewrite, a
+        // transient OSError) must clear the last numbers rather than leave them
+        // on screen looking current.
+        patch(nodes.step, 'data-running-step', agentId, (el) => {
+            el.textContent = view.stepLabel;
         });
-        detailNodes.forEach((el) => {
-            if (el.getAttribute('data-running-detail') !== agentId) return;
-            const eta = formatBacktestEta(entry.elapsedSeconds, step, total);
-            el.textContent = [`${pct}%`, eta].filter(Boolean).join(' · ');
+        patch(nodes.detail, 'data-running-detail', agentId, (el) => {
+            el.textContent = view.detail;
+        });
+        patch(nodes.stale, 'data-running-stale', agentId, (el) => {
+            el.textContent = view.notice;
+        });
+        patch(nodes.track, 'data-running-track', agentId, (el) => {
+            if (!view.determinate) {
+                // Removed, not zeroed: a progressbar reporting valuenow=0
+                // forever is a false statement, whereas the absent attribute is
+                // exactly what tells assistive tech the value is indeterminate.
+                el.removeAttribute('aria-valuenow');
+                el.removeAttribute('aria-valuemin');
+                el.removeAttribute('aria-valuemax');
+                return;
+            }
+            el.setAttribute('aria-valuenow', String(view.pct));
+            el.setAttribute('aria-valuemin', '0');
+            el.setAttribute('aria-valuemax', '100');
+        });
+        patch(nodes.bar, 'data-running-bar', agentId, (el) => {
+            el.classList.toggle('is-determinate', view.determinate);
+            // Cleared rather than set to 0%: the stylesheet's 40% width is what
+            // makes the indeterminate sweep visible, and a 0%-wide bar would
+            // animate nothing across the track.
+            el.style.width = view.determinate ? `${view.pct}%` : '';
         });
     });
 }
@@ -4743,21 +4774,72 @@ const BACKTEST_STALE_SECONDS = 120;
 /**
  * Coarse remaining-time estimate, or null when no honest one exists.
  *
- * Suppressed below step 3: the first estimates swing wildly, and a number that
- * visibly jumps reads as broken. Coarse buckets thereafter -- a precise-looking
- * ETA that drifts is worse than an obviously approximate one.
+ * Measured over an *observed* window -- seconds and steps counted from the first
+ * step this client saw -- rather than over the whole run. Both elapsed clocks
+ * start before any step exists (the card's at the click that fires the POST, the
+ * panel's at the server's run start), so dividing the full span by the step
+ * count folds process start, imports, the market-data fetch and gateway warm-up
+ * into the per-step rate. With ~25s of startup and ~1s steps that reports
+ * "~37m left" for a run that finishes in four, and the later collapse to
+ * "~4m left" is itself an "is this broken?" signal.
+ *
+ * Suppressed below three observed steps: the first estimates swing wildly, and
+ * a number that visibly jumps reads as broken. Coarse buckets thereafter -- a
+ * precise-looking ETA that drifts is worse than an obviously approximate one.
  */
-function formatBacktestEta(elapsedSeconds, step, totalSteps) {
-    const elapsed = Number(elapsedSeconds);
-    const done = Number(step);
-    const total = Number(totalSteps);
-    if (!Number.isFinite(elapsed) || elapsed <= 0) return null;
-    if (!Number.isFinite(done) || !Number.isFinite(total)) return null;
-    if (total <= 0 || done < 3 || done >= total) return null;
-    const remaining = (elapsed / done) * (total - done);
+function formatBacktestEta(observedSeconds, observedSteps, remainingSteps) {
+    const seconds = Number(observedSeconds);
+    const done = Number(observedSteps);
+    const left = Number(remainingSteps);
+    if (!Number.isFinite(seconds) || seconds <= 0) return null;
+    if (!Number.isFinite(done) || done < 3) return null;
+    if (!Number.isFinite(left) || left <= 0) return null;
+    const remaining = (seconds / done) * left;
     if (!Number.isFinite(remaining) || remaining <= 0) return null;
     if (remaining < 60) return '<1m left';
     return `~${Math.round(remaining / 60)}m left`;
+}
+
+/**
+ * ETA for a running entry, anchored to the step this client first observed.
+ *
+ * `firstStep`/`firstStepAt` are stamped by the poller the first time a run
+ * reports a step and then carried forward untouched, so launch cost never
+ * enters the per-step rate. Both ends of the elapsed subtraction are Date.now()
+ * reads on this machine, so -- unlike the server's elapsed_seconds -- it
+ * carries no clock skew.
+ */
+function resolveBacktestEta(running) {
+    const step = Number(running.step);
+    const total = Number(running.totalSteps);
+    const anchorStep = Number(running.firstStep);
+    const anchorAt = Number(running.firstStepAt);
+    if (!Number.isFinite(step) || !Number.isFinite(total) || total <= 0) return null;
+    if (step <= 0 || step >= total) return null;
+    if (!Number.isFinite(anchorStep) || !Number.isFinite(anchorAt)) return null;
+    return formatBacktestEta((Date.now() - anchorAt) / 1000, step - anchorStep, total - step);
+}
+
+/**
+ * Seconds since the progress file was last written, or null when unknown.
+ *
+ * The age arrives already computed from the server (`progress_age_seconds`)
+ * rather than being derived from the mtime here. Differencing a server
+ * timestamp against the browser clock makes any client more than
+ * BACKTEST_STALE_SECONDS out of step indistinguishable from a wedged run: a
+ * fast clock pins a permanent "No progress for 47m" onto a healthy backtest, a
+ * slow one suppresses the warning forever. Only the time since *this* client
+ * took the reading is added, which is a difference of two local Date.now()
+ * calls and so skew-free.
+ */
+function resolveProgressAgeSeconds(running) {
+    const age = running.ageSeconds;
+    // typeof, not Number(): Number(null) is 0, so a coercing check would report
+    // a run with no age reading at all as perfectly fresh.
+    if (typeof age !== 'number' || !Number.isFinite(age) || age < 0) return null;
+    const takenAt = Number(running.ageAt);
+    const local = Number.isFinite(takenAt) ? Math.max(0, (Date.now() - takenAt) / 1000) : 0;
+    return age + local;
 }
 
 /**
@@ -4775,6 +4857,107 @@ function formatProgressStaleness(secondsSinceUpdate) {
     return `No progress for ${minutes}m — long model steps can do this.`;
 }
 
+/**
+ * Startup-phase counterpart of formatProgressStaleness.
+ *
+ * The likeliest wedge publishes *no* progress file at all: a subprocess that
+ * dies or hangs in imports, the market-data fetch or the LLM gateway never
+ * writes a step, so there is no mtime to age and the notice above can never
+ * fire. That left the exact scenario this feature exists for -- "watched it and
+ * could not tell running from stuck" -- as the one case with no signal on either
+ * surface, for the full ten-minute poll ceiling.
+ *
+ * Same honesty constraint as the other notice: reports what is known (no steps
+ * yet), not a diagnosis (dead).
+ */
+function formatStartupStaleness(elapsedSeconds) {
+    const elapsed = Number(elapsedSeconds);
+    if (!Number.isFinite(elapsed) || elapsed < BACKTEST_STALE_SECONDS) return null;
+    const minutes = Math.floor(elapsed / 60);
+    return `Still starting up — no steps reported after ${minutes}m.`;
+}
+
+/** Whichever staleness notice applies to this running entry, or null. */
+function resolveRunningNotice(running) {
+    const step = Number(running.step);
+    if (!Number.isFinite(step) || step <= 0) {
+        return formatStartupStaleness(running.elapsedSeconds);
+    }
+    const age = resolveProgressAgeSeconds(running);
+    return age === null ? null : formatProgressStaleness(age);
+}
+
+/**
+ * Fold a poll's `progress` payload into the shared live-progress store.
+ *
+ * `firstStep`/`firstStepAt` anchor the ETA to the first step this client saw and
+ * are then carried forward untouched, so process start, imports, the
+ * market-data fetch and gateway warm-up never enter the per-step rate. The
+ * anchor resets with the store itself at every terminal branch, and again here
+ * if a step count moves backwards -- which only happens when a fresh run's
+ * first tick lands before the previous run was cleared.
+ *
+ * Split out of ensureBacktestPolling() so it can be exercised directly: an
+ * anchor accidentally re-stamped on every tick would quietly restore the
+ * launch-biased ETA while every other assertion stayed green.
+ */
+function advanceBacktestProgress(previous, progress, now) {
+    const step = Number(progress?.step);
+    const total = Number(progress?.total_steps);
+    if (!Number.isFinite(step) || step <= 0) return null;
+    const anchorStep = previous ? Number(previous.firstStep) : NaN;
+    const anchorAt = previous ? Number(previous.firstStepAt) : NaN;
+    const keepAnchor =
+        Number.isFinite(anchorStep) && Number.isFinite(anchorAt) && anchorStep <= step;
+    const age = Number(progress?.progress_age_seconds);
+    return {
+        step,
+        totalSteps: total,
+        // Server-computed (see resolveProgressAgeSeconds), and null when a
+        // backend omits it -- which suppresses the staleness notice rather than
+        // guessing at a value the payload never claimed.
+        ageSeconds: Number.isFinite(age) ? age : null,
+        ageAt: now,
+        firstStep: keepAnchor ? anchorStep : step,
+        firstStepAt: keepAnchor ? anchorAt : now,
+    };
+}
+
+/**
+ * Everything a running card reports, derived once for both renderers.
+ *
+ * renderAgentRunningBody() builds an HTML string and refreshRunningAgentCards()
+ * mutates the live DOM, so they cannot share the emitting code -- but they must
+ * never disagree about *what* to emit. Deriving here is what stops the next
+ * added field from reaching only one of them, which is exactly how the bar,
+ * aria-valuenow and the staleness note came to repaint on a full re-render and
+ * never on the per-second patch that runs for the rest of the run.
+ *
+ * Text is returned as '' rather than null so the patch path can assign it
+ * unconditionally -- a tick with no progress must *clear* the last numbers, not
+ * leave them standing as though current. :empty hides the emptied nodes.
+ */
+function deriveRunningProgress(running) {
+    const step = Number(running.step);
+    const total = Number(running.totalSteps);
+    const determinate =
+        Number.isFinite(step) && Number.isFinite(total) && total > 0 && step > 0;
+    const pct = determinate ? Math.min(99, Math.round((100 * step) / total)) : null;
+    const eta = determinate ? resolveBacktestEta(running) : null;
+    return {
+        determinate,
+        pct,
+        eta,
+        stepLabel: determinate ? `${step}/${total}` : '',
+        // Deliberately excludes elapsed: the head already renders it one line
+        // above, and printing "3:05" beside "3:05 elapsed" is the kind of noise
+        // this change exists to remove. Built from raw values; escaping happens
+        // once at each interpolation site.
+        detail: [determinate ? `${pct}%` : null, eta].filter(Boolean).join(' · '),
+        notice: resolveRunningNotice(running) || '',
+    };
+}
+
 function showBacktestRunProgress(show, { isError = false } = {}) {
     const panel = document.getElementById('backtestRunProgress');
     if (!panel) return;
@@ -4790,14 +4973,22 @@ function showBacktestRunProgress(show, { isError = false } = {}) {
     if (hint) hint.hidden = !!isError;
 }
 
+/**
+ * Repaint the Backtest tab's run panel.
+ *
+ * `progress` is the live poller's shared progress object -- the same one the My
+ * Agents card reads -- or null. Null at the five terminal call sites (launch
+ * error, backtest error, completion, timeout): those render their own message
+ * alone and must not gain an ETA or a "still starting up" notice. The running
+ * branch always passes an object, `{}` included, which is what opts it into the
+ * startup-staleness notice before any step exists.
+ */
 function updateBacktestRunProgress({
     elapsedSeconds,
     message = '',
     maxSeconds = BACKTEST_POLL_MAX_SECONDS,
     stepPct = null,
-    step = null,
-    totalSteps = null,
-    updatedAt = null,
+    progress = null,
 } = {}) {
     const elapsedEl = document.getElementById('backtestRunElapsed');
     const messageEl = document.getElementById('backtestRunProgressMessage');
@@ -4808,18 +4999,18 @@ function updateBacktestRunProgress({
         elapsedEl.textContent = formatBacktestElapsed(elapsed);
     }
     if (messageEl && message) {
-        // Same two derived facts the card shows, from the same helpers. Not
-        // byte-identical output: the card's elapsed is client-side (startedAt),
-        // this one is the server's elapsed_seconds, so they differ by launch
-        // latency and clock skew. Both round to whole minutes, which absorbs
-        // that everywhere except a bucket boundary -- close enough that one
-        // shared source of elapsed is not worth breaking the card's
-        // between-poll ticking for.
-        const eta = formatBacktestEta(elapsedSeconds, step, totalSteps);
-        const stale = updatedAt
-            ? formatProgressStaleness((Date.now() - Number(updatedAt)) / 1000)
+        // Same two derived facts the card shows, from the same helper fed the
+        // same object -- so the ETA and the staleness notice cannot diverge
+        // between the two surfaces. Elapsed still differs (the card's is
+        // client-side from startedAt, this one is the server's elapsed_seconds)
+        // but nothing derived from it does: the ETA is measured from the
+        // poller's own step anchor, not from either elapsed clock.
+        const view = progress
+            ? deriveRunningProgress({ ...progress, elapsedSeconds })
             : null;
-        messageEl.textContent = [message, eta, stale].filter(Boolean).join(' · ');
+        messageEl.textContent = [message, view?.eta, view?.notice]
+            .filter(Boolean)
+            .join(' · ');
     }
     if (barEl) {
         const pct = Number.isFinite(stepPct)
@@ -5084,11 +5275,13 @@ function ensureBacktestPolling() {
                 // Assigned BEFORE refreshRunningAgentCards() below, which reads
                 // it through getAgentBacktestRunning(). Painting first would
                 // show the previous tick's step on the card while the Backtest
-                // panel — fed the fresh step/total directly a few lines down —
-                // showed this tick's: two surfaces disagreeing by one poll.
-                liveBacktestProgress = Number.isFinite(step) && step > 0
-                    ? { step, totalSteps: total, updatedAt: Number(status.progress?.progress_updated_at) * 1000 || Date.now() }
-                    : null;
+                // panel — handed the same object a few lines down — showed this
+                // tick's: two surfaces disagreeing by one poll.
+                liveBacktestProgress = advanceBacktestProgress(
+                    liveBacktestProgress,
+                    status.progress,
+                    Date.now(),
+                );
                 // Repaint the My Agents card even when the user is not on the
                 // Backtest tab — that page is now the landing page after launch.
                 // refreshRunningAgentCards() patches the elapsed timer in place
@@ -5107,9 +5300,11 @@ function ensureBacktestPolling() {
                         elapsedSeconds: displayElapsed,
                         message: status.message || 'Backtest is running…',
                         stepPct,
-                        step,
-                        totalSteps: total,
-                        updatedAt: liveBacktestProgress?.updatedAt || null,
+                        // `{}` rather than null before the first step: an empty
+                        // object still opts this surface into the startup
+                        // staleness notice, which is the only warning available
+                        // while the subprocess has published nothing.
+                        progress: liveBacktestProgress || {},
                     });
                     showBacktestRunProgress(true);
                     renderBacktestRunConfig(
@@ -5124,6 +5319,7 @@ function ensureBacktestPolling() {
                 liveBacktestRunId = null;
                 liveBacktestProgress = null;
                 Object.keys(readRunningBacktests()).forEach(clearAgentBacktestRunning);
+                lastRenderedRunningKey = null;
                 if (playgroundTab === 'agents' && currentPage === 'playground') {
                     loadAgents();
                 }
@@ -5177,6 +5373,15 @@ function ensureBacktestPolling() {
                 // render the NEXT run's step, percent and ETA until it aged out.
                 Object.keys(readRunningBacktests()).forEach(clearAgentBacktestRunning);
                 liveBacktestProgress = null;
+                lastRenderedRunningKey = null;
+                // Clearing the map is not visible on its own: polling has just
+                // stopped, so refreshRunningAgentCards() will never run again
+                // and the card would sit on "Backtesting…" with a frozen timer
+                // until some unrelated re-render happened by. Same repaint the
+                // finished branch does.
+                if (playgroundTab === 'agents' && currentPage === 'playground') {
+                    loadAgents();
+                }
             }
         } catch (error) {
             console.error('Error polling backtest status:', error);

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -832,15 +832,12 @@ function renderAgentRunningBody(agent, running) {
     : null;
 
   const stepLabel = determinate ? `${step}/${total}` : '';
+  // Deliberately excludes elapsed: the head already renders it one line above,
+  // and printing "3:05" beside "3:05 elapsed" is the kind of noise this change
+  // exists to remove. Empty before the first step, hidden by :empty in CSS.
   // Built from raw values and escaped once at the interpolation site below --
   // escaping here as well would double-encode.
-  const detail = [
-    determinate ? `${pct}%` : null,
-    eta,
-    `${formatBacktestElapsed(running.elapsedSeconds)} elapsed`,
-  ]
-    .filter(Boolean)
-    .join(' · ');
+  const detail = [determinate ? `${pct}%` : null, eta].filter(Boolean).join(' · ');
 
   return `
     <div class="agent-card-running">
@@ -3494,9 +3491,7 @@ function refreshRunningAgentCards() {
         detailNodes.forEach((el) => {
             if (el.getAttribute('data-running-detail') !== agentId) return;
             const eta = formatBacktestEta(entry.elapsedSeconds, step, total);
-            el.textContent = [`${pct}%`, eta, `${formatBacktestElapsed(entry.elapsedSeconds)} elapsed`]
-                .filter(Boolean)
-                .join(' · ');
+            el.textContent = [`${pct}%`, eta].filter(Boolean).join(' · ');
         });
     });
 }

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -4676,6 +4676,44 @@ function formatBacktestElapsed(seconds) {
     return `${minutes}:${String(secs).padStart(2, '0')}`;
 }
 
+/** A progress file older than this is reported as stale (seconds). */
+const BACKTEST_STALE_SECONDS = 120;
+
+/**
+ * Coarse remaining-time estimate, or null when no honest one exists.
+ *
+ * Suppressed below step 3: the first estimates swing wildly, and a number that
+ * visibly jumps reads as broken. Coarse buckets thereafter -- a precise-looking
+ * ETA that drifts is worse than an obviously approximate one.
+ */
+function formatBacktestEta(elapsedSeconds, step, totalSteps) {
+    const elapsed = Number(elapsedSeconds);
+    const done = Number(step);
+    const total = Number(totalSteps);
+    if (!Number.isFinite(elapsed) || elapsed <= 0) return null;
+    if (!Number.isFinite(done) || !Number.isFinite(total)) return null;
+    if (total <= 0 || done < 3 || done >= total) return null;
+    const remaining = (elapsed / done) * (total - done);
+    if (!Number.isFinite(remaining) || remaining <= 0) return null;
+    if (remaining < 60) return '<1m left';
+    return `~${Math.round(remaining / 60)}m left`;
+}
+
+/**
+ * Staleness notice, or null while progress is fresh.
+ *
+ * Reports the *actual* gap, never the threshold: a message frozen at "2m" while
+ * the real gap grows to ten actively misinforms. Deliberately does not say
+ * "stuck" -- we know the file is old, not that the run died, and a long model
+ * step looks exactly like this.
+ */
+function formatProgressStaleness(secondsSinceUpdate) {
+    const gap = Number(secondsSinceUpdate);
+    if (!Number.isFinite(gap) || gap < BACKTEST_STALE_SECONDS) return null;
+    const minutes = Math.floor(gap / 60);
+    return `No progress for ${minutes}m — long model steps can do this.`;
+}
+
 function showBacktestRunProgress(show, { isError = false } = {}) {
     const panel = document.getElementById('backtestRunProgress');
     if (!panel) return;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9464,3 +9464,34 @@ body.agent-editor-open {
 @media (prefers-reduced-motion: reduce) {
     .agent-card.is-just-created { animation: none; box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.55); }
 }
+
+.agent-card-running-step {
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    opacity: 0.75;
+}
+
+.agent-card-running-detail {
+    margin: 6px 0 0;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    opacity: 0.7;
+}
+
+.agent-card-running-stale {
+    margin: 4px 0 0;
+    font-size: 12px;
+    color: #fbbf24;
+}
+
+/* Determinate: width is data, so the indeterminate sweep must not also run. */
+.agent-card-running-bar.is-determinate {
+    animation: none;
+    transition: width 400ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-card-running-bar.is-determinate { transition: none; }
+}

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9480,6 +9480,13 @@ body.agent-editor-open {
     opacity: 0.7;
 }
 
+/* Empty before the first step. The node must still exist -- the per-second
+   patch targets it by attribute and only a change to the *set* of running
+   agents triggers a full re-render -- so hide it rather than omit it. */
+.agent-card-running-detail:empty {
+    display: none;
+}
+
 .agent-card-running-stale {
     margin: 4px 0 0;
     font-size: 12px;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9472,6 +9472,13 @@ body.agent-editor-open {
     opacity: 0.75;
 }
 
+/* Empty before the first step. The head is a flex row with an 8px gap, so an
+   empty span is not free -- it opens a visible hole between the label and the
+   elapsed timer. */
+.agent-card-running-step:empty {
+    display: none;
+}
+
 .agent-card-running-detail {
     margin: 6px 0 0;
     font-size: 12px;
@@ -9491,6 +9498,13 @@ body.agent-editor-open {
     margin: 4px 0 0;
     font-size: 12px;
     color: #fbbf24;
+}
+
+/* Rendered on every running card and empty while progress is fresh -- same
+   reason as the detail node: the per-second patch fills this in by attribute,
+   and a node that only exists once it has content can never be filled in. */
+.agent-card-running-stale:empty {
+    display: none;
 }
 
 /* Determinate: width is data, so the indeterminate sweep must not also run. */


### PR DESCRIPTION
Phase B of the 2026-08-01 UX feedback round. A tester watched a running
backtest for 3m05s and could not tell working from stuck.

**This deliberately reverses a non-goal from the 2026-07-29 spec**, which
specified an indeterminate bar "since no honest completion estimate exists".
That premise was false when written: `engine.py::_publish_live_progress` has
written `step`/`total_steps` every step since `a7c392d` (2026-07-10), and
`backtests.py` already formatted a percentage from it. Only
`renderAgentRunningBody` discarded the data. Not a regression — read the spec.

- Backend: `progress.progress_updated_at` (the file mtime) so the UI can tell
  *old numbers* from *no progress*.
- Card: determinate bar, `84/240`, percent, coarse ETA, and a staleness note
  that says "long model steps can do this" rather than claiming the run is stuck.
- Run panel: same two helpers, so the numbers are derived the same way. Not
  byte-identical — the card's elapsed is client-side, the panel's is the
  server's `elapsed_seconds`; minute rounding absorbs the gap.
- Clears the running map on the 10-min timeout branch, which the finished branch
  has always done. Harmless before this PR; now an orphaned entry would render
  the *next* run's numbers.

Two defects found in self-review, both introduced here and fixed in-PR:

1. **Cross-run bleed.** `liveBacktestProgress` is one un-keyed global spread
   into every running-map entry. `runBacktest()` marks an agent running before
   its POST resolves, and the backend refuses a second concurrent run — so
   clicking Run on an idle agent while another is in flight left both marked
   for one round-trip and painted the live agent's step/percent/ETA onto a card
   whose launch was about to be rejected. Now gated on the entry's `runId`
   matching `liveBacktestRunId`.
2. **The card lagged the panel by one poll tick** — `refreshRunningAgentCards()`
   ran before `liveBacktestProgress` was reassigned. Reordered.

## Test plan
- [x] `pytest dashboard/backend/tests/` — 2092 passed, 1 pre-existing `.env`-leak
      failure (`test_ifind_engine_resolves_csi300_sample20`, red on `main` too)
- [x] 37 new tests; the pure and DOM helpers are executed under `node`, not grepped
- [x] Browser-verified against the real `app.js`: the poller→store→renderer chain
      with a real-shaped status payload; the bleed scenario (live agent renders
      `84/240 · 35% · ~6m left`, unconfirmed agent stays indeterminate); an
      XSS-hostile `agent_id` (the node harness stubs `escapeHtml`, so only a
      browser can catch that); and the finish path clearing store and map.
      No console errors.
- [x] Mutation-tested every guard that could have been vacuous, including both
      fixes above
- [x] `node --check dashboard/frontend/app.js`
