### PR TITLE
chore: clear the fixable CodeQL quality alerts

### DIFF
--- a/dashboard/backend/domain/backtesting/algo_service.py
+++ b/dashboard/backend/domain/backtesting/algo_service.py
@@ -97,8 +97,16 @@ def _default_backtest_dates() -> tuple[str, str]:
             end = settings.get("endDate")
             if start and end:
                 return start, end
-        except (json.JSONDecodeError, OSError):
-            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            # A bare `pass` here made "the file is absent" and "the file is on
+            # disk and unreadable" produce byte-identical behaviour: both fall
+            # through to the hardcoded pair below, silently running every
+            # backtest over the wrong window. print(), not logging -- under the
+            # deployed uvicorn, logger calls emit nothing.
+            print(
+                f"[algo_service] {DEFAULTS_FILE} is unreadable ({exc}); "
+                "falling back to the built-in default date range"
+            )
     return "2026-05-04", "2026-05-12"
 
 

--- a/dashboard/backend/domain/backtesting/algo_service.py
+++ b/dashboard/backend/domain/backtesting/algo_service.py
@@ -88,6 +88,24 @@ def get_default_blocks() -> dict[str, str]:
     return deepcopy(DEFAULT_BLOCKS)
 
 
+def _report_unusable_defaults(reason: str) -> None:
+    """Announce that the settings file is present but yielded no date range.
+
+    A bare `pass` made "the file is absent" and "the file is on disk but
+    unusable" produce byte-identical behaviour: both fall through to the
+    hardcoded pair, silently running every backtest over the wrong window.
+    ``reason`` separates the ways that happens, so the notice says which fault
+    occurred rather than only that one did.
+
+    print(), not logging -- under the deployed uvicorn, logger calls emit
+    nothing.
+    """
+    print(
+        f"[algo_service] {DEFAULTS_FILE} {reason}; "
+        "falling back to the built-in default date range"
+    )
+
+
 def _default_backtest_dates() -> tuple[str, str]:
     if DEFAULTS_FILE.exists():
         try:
@@ -97,16 +115,19 @@ def _default_backtest_dates() -> tuple[str, str]:
             end = settings.get("endDate")
             if start and end:
                 return start, end
-        except (json.JSONDecodeError, OSError) as exc:
-            # A bare `pass` here made "the file is absent" and "the file is on
-            # disk and unreadable" produce byte-identical behaviour: both fall
-            # through to the hardcoded pair below, silently running every
-            # backtest over the wrong window. print(), not logging -- under the
-            # deployed uvicorn, logger calls emit nothing.
-            print(
-                f"[algo_service] {DEFAULTS_FILE} is unreadable ({exc}); "
-                "falling back to the built-in default date range"
+            # Parsed, right shape, no range: an upstream key rename or a
+            # blanked value. Likelier than a corrupt write, and a bare
+            # fall-through hid it just as completely.
+            _report_unusable_defaults(
+                "has no usable defaultSettings.startDate/endDate"
             )
+        except (json.JSONDecodeError, OSError, AttributeError) as exc:
+            # AttributeError included deliberately: valid JSON that is not an
+            # object (`[]`, a bare string) makes `.get` raise, which is neither
+            # a decode nor an OS error, so it used to escape this handler and
+            # 500 the caller. The try block is three lines wide, so this cannot
+            # swallow an unrelated attribute bug.
+            _report_unusable_defaults(f"could not be read as a settings object ({exc})")
     return "2026-05-04", "2026-05-12"
 
 
@@ -357,7 +378,10 @@ def execute_algo(
             "Set ALPACA_API_KEY / ALPACA_SECRET_KEY or create credentials/alpaca.json"
         )
 
-    start, end = start_date or _default_backtest_dates()[0], end_date or _default_backtest_dates()[1]
+    # Resolved once, not once per bound: the resolver now prints on a bad
+    # settings file, and calling it twice reported the same fault twice.
+    default_start, default_end = _default_backtest_dates()
+    start, end = start_date or default_start, end_date or default_end
     name = (team_name or _default_team_name(blocks)).strip() or "My Trading Algo"
     submission_id = f"{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
 

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -19,23 +19,24 @@ from typing import Any, Dict, List, Optional, Tuple
 import dashboard.backend.infrastructure.llm.token_cost as token_cost
 from dashboard.backend.database import db
 import dashboard.backend.domain.leaderboard.baselines as _baselines
+from dashboard.backend.domain.leaderboard.strategies._common import reference_start_date
+from dashboard.backend.domain.leaderboard.strategies import get_strategy
+from dashboard.backend.infrastructure.llm import backtest_harness as llm_harness
+from dashboard.backend.paths import CONFIG_DIR, DATA_DIR
 
 # Bound by assignment from the module alias rather than a bare
 # `from ... import X`. Five of these are used below, but `downsample_daily` is a
 # pure re-export: test_service_move asserts `service.downsample_daily is
 # baselines.downsample_daily`, a cross-module contract `py/unused-import`
 # (intra-file only) cannot see. One import form for the module, so this does not
-# trade that alert for `py/import-and-import-from`.
+# trade that alert for `py/import-and-import-from`. Kept below the import block
+# rather than inside it so the imports stay one contiguous section.
 INITIAL_CAPITAL = _baselines.INITIAL_CAPITAL
 align_equity_curves = _baselines.align_equity_curves
 calc_metrics = _baselines.calc_metrics
 chart_equity_curve = _baselines.chart_equity_curve
 downsample_daily = _baselines.downsample_daily
 fetch_hourly_bars = _baselines.fetch_hourly_bars
-from dashboard.backend.domain.leaderboard.strategies._common import reference_start_date
-from dashboard.backend.domain.leaderboard.strategies import get_strategy
-from dashboard.backend.infrastructure.llm import backtest_harness as llm_harness
-from dashboard.backend.paths import CONFIG_DIR, DATA_DIR
 
 LEADERBOARD_MODE = "leaderboard"
 VALID_PERIODS = ("contest", "daily")

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -18,14 +18,20 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import dashboard.backend.infrastructure.llm.token_cost as token_cost
 from dashboard.backend.database import db
-from dashboard.backend.domain.leaderboard.baselines import (
-    INITIAL_CAPITAL,
-    align_equity_curves,
-    calc_metrics,
-    chart_equity_curve,
-    downsample_daily,
-    fetch_hourly_bars,
-)
+import dashboard.backend.domain.leaderboard.baselines as _baselines
+
+# Bound by assignment from the module alias rather than a bare
+# `from ... import X`. Five of these are used below, but `downsample_daily` is a
+# pure re-export: test_service_move asserts `service.downsample_daily is
+# baselines.downsample_daily`, a cross-module contract `py/unused-import`
+# (intra-file only) cannot see. One import form for the module, so this does not
+# trade that alert for `py/import-and-import-from`.
+INITIAL_CAPITAL = _baselines.INITIAL_CAPITAL
+align_equity_curves = _baselines.align_equity_curves
+calc_metrics = _baselines.calc_metrics
+chart_equity_curve = _baselines.chart_equity_curve
+downsample_daily = _baselines.downsample_daily
+fetch_hourly_bars = _baselines.fetch_hourly_bars
 from dashboard.backend.domain.leaderboard.strategies._common import reference_start_date
 from dashboard.backend.domain.leaderboard.strategies import get_strategy
 from dashboard.backend.infrastructure.llm import backtest_harness as llm_harness

--- a/dashboard/backend/infrastructure/llm/backtest_harness.py
+++ b/dashboard/backend/infrastructure/llm/backtest_harness.py
@@ -53,7 +53,12 @@ try:
 
     Anthropic = anthropic.Anthropic
     HAS_ANTHROPIC = True
-except ImportError:
+except (ImportError, AttributeError):
+    # AttributeError as well as ImportError: attribute access is what makes the
+    # re-export visible to `py/unused-import`, but it also moves the "SDK is
+    # unusable" signal from ImportError to AttributeError. This module is on the
+    # backend's import path, so an unhandled one would not just disable LLM
+    # trading -- it would take the app's import down with it.
     # Bind ``Anthropic`` to None (instead of leaving it undefined) so the legacy
     # script can unconditionally re-export it; consumers always guard on
     # ``HAS_ANTHROPIC`` before using the client.

--- a/dashboard/backend/infrastructure/llm/backtest_harness.py
+++ b/dashboard/backend/infrastructure/llm/backtest_harness.py
@@ -45,7 +45,13 @@ from dashboard.backend.infrastructure.llm.providers import (
 # Optional: LLM integration. Mirrors the original optional-dependency behavior
 # (no API key required at import time; only the SDK presence is detected).
 try:
-    from anthropic import Anthropic
+    # Reached by attribute rather than `from anthropic import Anthropic`: the
+    # name exists here only to be re-exported (backtest_hourly_agent and the
+    # engines read it through this module), which `py/unused-import` cannot see
+    # because the rule is intra-file.
+    import anthropic
+
+    Anthropic = anthropic.Anthropic
     HAS_ANTHROPIC = True
 except ImportError:
     # Bind ``Anthropic`` to None (instead of leaving it undefined) so the legacy

--- a/dashboard/backend/tests/domain/backtesting/test_algo_service_move.py
+++ b/dashboard/backend/tests/domain/backtesting/test_algo_service_move.py
@@ -179,3 +179,41 @@ def test_execute_algo_writes_config_and_forwards(monkeypatch, tmp_path):
     assert fwd[1] == "sess-1"  # session_id
     assert fwd[2] == "My Team"  # team_name
     assert Path(fwd[0]).parent == tmp_path / "data" / "algo_configs"
+
+
+# ---------------------------------------------------------------------------
+# Default date range: a corrupt settings file must not fail silently
+# ---------------------------------------------------------------------------
+
+
+def test_unreadable_defaults_file_is_reported(tmp_path, monkeypatch, capsys):
+    """A bare `except: pass` here made "the file is absent" and "the file is on
+    disk and unreadable" byte-identical: both fall through to the hardcoded
+    pair, silently running every backtest over the wrong window with no error,
+    no metric and a green suite -- the fail-closed-but-not-fail-visible shape
+    the news adapter already taught this repo.
+
+    Asserted on stdout, not caplog: `logger.info()` emits nothing under the
+    deployed uvicorn, so print() is the convention here.
+    """
+    broken = tmp_path / "defaults.json"
+    broken.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(svc, "DEFAULTS_FILE", broken)
+
+    start, end = svc._default_backtest_dates()
+
+    assert (start, end) == ("2026-05-04", "2026-05-12")  # fallback unchanged
+    assert "unreadable" in capsys.readouterr().out
+
+
+def test_a_readable_defaults_file_says_nothing(tmp_path, monkeypatch, capsys):
+    """The notice must mark the anomaly, not narrate the happy path."""
+    good = tmp_path / "defaults.json"
+    good.write_text(
+        json.dumps({"defaultSettings": {"startDate": "2026-01-02", "endDate": "2026-01-09"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(svc, "DEFAULTS_FILE", good)
+
+    assert svc._default_backtest_dates() == ("2026-01-02", "2026-01-09")
+    assert capsys.readouterr().out == ""

--- a/dashboard/backend/tests/domain/backtesting/test_algo_service_move.py
+++ b/dashboard/backend/tests/domain/backtesting/test_algo_service_move.py
@@ -182,38 +182,86 @@ def test_execute_algo_writes_config_and_forwards(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Default date range: a corrupt settings file must not fail silently
+# Default date range: a settings file that yields no range must not fail
+# silently
 # ---------------------------------------------------------------------------
+#
+# A bare `except: pass` here made "the file is absent" and "the file is on disk
+# but unusable" byte-identical: both fall through to the hardcoded pair,
+# silently running every backtest over the wrong window with no error, no
+# metric and a green suite -- the fail-closed-but-not-fail-visible shape the
+# news adapter already taught this repo.
+#
+# There are three ways to reach that fallback with the file present, and each
+# must announce itself: unparseable bytes, valid JSON of the wrong *shape*, and
+# valid JSON of the right shape carrying no usable range. The last two are the
+# likelier failures in practice (a key rename outlives a corrupt write), and a
+# fix that covers only the first leaves the hole where it actually opens.
+#
+# Asserted on stdout, not caplog: `logger.info()` emits nothing under the
+# deployed uvicorn, so print() is the convention here.
+
+FALLBACK_DATES = ("2026-05-04", "2026-05-12")
 
 
-def test_unreadable_defaults_file_is_reported(tmp_path, monkeypatch, capsys):
-    """A bare `except: pass` here made "the file is absent" and "the file is on
-    disk and unreadable" byte-identical: both fall through to the hardcoded
-    pair, silently running every backtest over the wrong window with no error,
-    no metric and a green suite -- the fail-closed-but-not-fail-visible shape
-    the news adapter already taught this repo.
-
-    Asserted on stdout, not caplog: `logger.info()` emits nothing under the
-    deployed uvicorn, so print() is the convention here.
-    """
-    broken = tmp_path / "defaults.json"
-    broken.write_text("{not json", encoding="utf-8")
-    monkeypatch.setattr(svc, "DEFAULTS_FILE", broken)
-
-    start, end = svc._default_backtest_dates()
-
-    assert (start, end) == ("2026-05-04", "2026-05-12")  # fallback unchanged
-    assert "unreadable" in capsys.readouterr().out
+def _resolve_dates(tmp_path, monkeypatch, capsys, text):
+    """Point the service at a defaults.json holding ``text``; return result + stdout."""
+    path = tmp_path / "defaults.json"
+    path.write_text(text, encoding="utf-8")
+    monkeypatch.setattr(svc, "DEFAULTS_FILE", path)
+    result = svc._default_backtest_dates()
+    return result, capsys.readouterr().out, path
 
 
-def test_a_readable_defaults_file_says_nothing(tmp_path, monkeypatch, capsys):
-    """The notice must mark the anomaly, not narrate the happy path."""
-    good = tmp_path / "defaults.json"
-    good.write_text(
-        json.dumps({"defaultSettings": {"startDate": "2026-01-02", "endDate": "2026-01-09"}}),
-        encoding="utf-8",
+def test_unparseable_defaults_file_is_reported(tmp_path, monkeypatch, capsys):
+    dates, out, path = _resolve_dates(tmp_path, monkeypatch, capsys, "{not json")
+
+    assert dates == FALLBACK_DATES
+    assert str(path) in out  # the operator has to learn *which* file
+
+
+def test_defaults_file_without_a_usable_range_is_reported(tmp_path, monkeypatch, capsys):
+    """Parses fine, right shape, but the keys were renamed upstream."""
+    dates, out, path = _resolve_dates(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        json.dumps({"defaultSettings": {"from": "2026-01-02", "to": "2026-01-09"}}),
     )
-    monkeypatch.setattr(svc, "DEFAULTS_FILE", good)
 
-    assert svc._default_backtest_dates() == ("2026-01-02", "2026-01-09")
-    assert capsys.readouterr().out == ""
+    assert dates == FALLBACK_DATES
+    assert str(path) in out
+
+
+def test_defaults_file_that_is_not_an_object_is_reported(tmp_path, monkeypatch, capsys):
+    """Valid JSON, wrong shape: `.get` on a list raises, which is neither a
+    JSONDecodeError nor an OSError, so it escaped the handler entirely."""
+    dates, out, path = _resolve_dates(tmp_path, monkeypatch, capsys, "[]")
+
+    assert dates == FALLBACK_DATES
+    assert str(path) in out
+
+
+def test_the_failure_modes_are_distinguishable(tmp_path, monkeypatch, capsys):
+    """The whole point of the notice: two different faults must not read the
+    same, or the message is back to hiding which one happened."""
+    _, corrupt, _ = _resolve_dates(tmp_path, monkeypatch, capsys, "{not json")
+    _, no_range, _ = _resolve_dates(
+        tmp_path, monkeypatch, capsys, json.dumps({"defaultSettings": {}})
+    )
+
+    assert corrupt and no_range
+    assert corrupt != no_range
+
+
+def test_a_usable_defaults_file_says_nothing(tmp_path, monkeypatch, capsys):
+    """The notice must mark the anomaly, not narrate the happy path."""
+    dates, out, _ = _resolve_dates(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        json.dumps({"defaultSettings": {"startDate": "2026-01-02", "endDate": "2026-01-09"}}),
+    )
+
+    assert dates == ("2026-01-02", "2026-01-09")
+    assert out == ""

--- a/dashboard/backend/tests/infrastructure/llm/test_backtest_harness_optional_sdk.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_backtest_harness_optional_sdk.py
@@ -1,0 +1,66 @@
+"""The optional Anthropic SDK import must degrade, never crash the import.
+
+``backtest_harness`` is on the backend's import path, so anything that escapes
+its optional-dependency handler does not merely disable LLM trading -- it takes
+the whole app's import down with it. The module binds the client class by
+attribute (``anthropic.Anthropic``) so the name is visibly *used* for
+``py/unused-import``; that form raises ``AttributeError`` where the older
+``from anthropic import Anthropic`` raised ``ImportError``, and only the latter
+was handled.
+
+Run in a subprocess, like ``test_canonical_consumers`` does: the SDK stub has to
+be installed before the module is first imported, and reloading it in-process
+would rebind functions that other suites assert the identity of.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+
+_HARNESS = "dashboard.backend.infrastructure.llm.backtest_harness"
+
+
+def _import_with_sdk_stub(body: str) -> dict:
+    """Import the harness with ``sys.modules['anthropic']`` replaced by a stub."""
+    code = (
+        "import sys, types, json\n"
+        "stub = types.ModuleType('anthropic')\n"
+        f"{body}\n"
+        "sys.modules['anthropic'] = stub\n"
+        f"import importlib; h = importlib.import_module({_HARNESS!r})\n"
+        "print(json.dumps({'has': h.HAS_ANTHROPIC, 'client_is_none': h.Anthropic is None}))\n"
+    )
+    with tempfile.TemporaryDirectory(prefix="atl_sdk_") as tmp:
+        env = {**os.environ, "DATABASE_PATH": os.path.join(tmp, "t.db")}
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=str(_REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+    assert proc.returncode == 0, f"importing the harness failed:\n{proc.stderr}"
+    import json
+
+    last = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")][-1]
+    return json.loads(last)
+
+
+def test_sdk_without_the_client_class_degrades():
+    """An `anthropic` package that imports but exposes no `Anthropic`."""
+    res = _import_with_sdk_stub("pass  # stub deliberately has no .Anthropic")
+
+    assert res["has"] is False
+    assert res["client_is_none"] is True
+
+
+def test_sdk_with_the_client_class_is_detected():
+    """The success path still binds the real class and flips the flag."""
+    res = _import_with_sdk_stub("stub.Anthropic = type('Anthropic', (), {})")
+
+    assert res["has"] is True
+    assert res["client_is_none"] is False

--- a/dashboard/scripts/backtest_hourly_agent.py
+++ b/dashboard/scripts/backtest_hourly_agent.py
@@ -68,6 +68,10 @@ if importlib.util.find_spec("pandas_ta") is None:
     # venv whose pip is not first on PATH, and installing into the wrong
     # interpreter would leave the import below still failing.
     subprocess.check_call([sys.executable, "-m", "pip", "install", "pandas_ta"])
+    # The probe above populated the path-finder's directory caches with a miss;
+    # drop them so the module just written to site-packages is discoverable by
+    # the features import below rather than on the next process start.
+    importlib.invalidate_caches()
 
 # ---------------------------------------------------------------------------
 # Phase 2A extraction: the implementations below now live under the canonical

--- a/dashboard/scripts/backtest_hourly_agent.py
+++ b/dashboard/scripts/backtest_hourly_agent.py
@@ -19,6 +19,8 @@ Usage:
 import sys
 import json
 import argparse
+import importlib.util
+import subprocess
 from pathlib import Path
 
 # Bootstrap for non-package execution contexts: when this module is run directly
@@ -44,19 +46,28 @@ from dashboard.backend.infrastructure.llm.validator import DJIA_30
 # harness at dashboard.backend.infrastructure.llm.backtest_harness. These symbols
 # are re-exported here so existing consumers (engines/strategies/llm_agent.py,
 # backtest_custom_algo.py, and bha.* callers) keep working unchanged.
-from dashboard.backend.infrastructure.llm.backtest_harness import (
-    Anthropic,
-    HAS_ANTHROPIC,
-    LLM_MODEL_NAME,
-)
+#
+# Bound by assignment from a module alias rather than a bare `from ... import X`
+# so each re-export is explicit and static analysis sees it as used -- the
+# convention external_run_service.py already documents. Do not collapse back:
+# `py/unused-import` is intra-file only, so it cannot see the cross-module
+# contract these three exist to satisfy.
+import dashboard.backend.infrastructure.llm.backtest_harness as _backtest_harness
 
-try:
-    import pandas_ta as ta
-except ImportError:
+Anthropic = _backtest_harness.Anthropic
+HAS_ANTHROPIC = _backtest_harness.HAS_ANTHROPIC
+LLM_MODEL_NAME = _backtest_harness.LLM_MODEL_NAME
+
+# A presence probe, not a use: dashboard.backend.domain.backtesting.features
+# imports pandas_ta itself. This script installs it first so that import cannot
+# fail part-way through a run. find_spec rather than a try/except import because
+# nothing here needs the module object -- only the answer to "is it installed?".
+if importlib.util.find_spec("pandas_ta") is None:
     print("Installing pandas_ta...")
-    import subprocess
-    subprocess.check_call(["pip", "install", "pandas_ta"])
-    import pandas_ta as ta
+    # sys.executable, not a bare "pip": the script may well be running under a
+    # venv whose pip is not first on PATH, and installing into the wrong
+    # interpreter would leave the import below still failing.
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "pandas_ta"])
 
 # ---------------------------------------------------------------------------
 # Phase 2A extraction: the implementations below now live under the canonical
@@ -65,13 +76,23 @@ except ImportError:
 # stays unchanged. pandas_ta is imported above first so the features module can
 # rely on it being available.
 # ---------------------------------------------------------------------------
-from dashboard.backend.domain.backtesting.features import TechnicalIndicators
-from dashboard.backend.domain.backtesting.metrics import (
-    calculate_sharpe,
-    calculate_max_drawdown,
-)
-from dashboard.backend.infrastructure.llm.decision_parsing import fix_json_formatting
-from dashboard.backend.infrastructure.market_data.alpaca_bars import AlpacaDataLoader
+#
+# Same explicit-assignment form as the harness re-exports above, for the same
+# reason: these five are referenced only through `bha.<name>` from other
+# modules, which `py/unused-import` cannot see. The guard suites
+# (test_backtest_compatibility, test_canonical_consumers) assert each one is the
+# canonical object, so deleting any of them reddens those tests.
+import dashboard.backend.domain.backtesting.features as _features
+import dashboard.backend.domain.backtesting.metrics as _metrics
+import dashboard.backend.infrastructure.llm.decision_parsing as _decision_parsing
+import dashboard.backend.infrastructure.market_data.alpaca_bars as _alpaca_bars
+
+TechnicalIndicators = _features.TechnicalIndicators
+calculate_sharpe = _metrics.calculate_sharpe
+calculate_max_drawdown = _metrics.calculate_max_drawdown
+fix_json_formatting = _decision_parsing.fix_json_formatting
+AlpacaDataLoader = _alpaca_bars.AlpacaDataLoader
+
 from dashboard.backend.infrastructure.market_data.provider import (
     ALPACA,
     IFIND_ASHARE,
@@ -137,10 +158,11 @@ TIMEFRAME = "1h"  # Hourly
 # `PortfolioManager` now lives in
 # dashboard.backend.domain.backtesting.portfolio_manager and is re-exported
 # here so the legacy public path (bha.PortfolioManager) and existing
-# subclasses (e.g. backtest_custom_algo) keep working unchanged.
-from dashboard.backend.domain.backtesting.portfolio_manager import (
-    PortfolioManager,
-)
+# subclasses (e.g. backtest_custom_algo) keep working unchanged. Explicit
+# assignment, as above.
+import dashboard.backend.domain.backtesting.portfolio_manager as _portfolio_manager
+
+PortfolioManager = _portfolio_manager.PortfolioManager
 
 
 # ============================================================================
@@ -436,13 +458,13 @@ def main():
 
 
 if __name__ == "__main__":
-    from dashboard.backend.infrastructure.market_data.alpaca_bars import (
-        MarketDataUnavailableError,
-    )
-
+    # Reached through the module alias bound at the top rather than a second
+    # `from` import of the same module: importing one module both ways in one
+    # file is its own CodeQL finding (py/import-and-import-from), and the alias
+    # already exists.
     try:
         main()
-    except MarketDataUnavailableError as exc:
+    except _alpaca_bars.MarketDataUnavailableError as exc:
         # Library code raises (so server threads can catch it); the CLI
         # boundary is where the process exit belongs.
         print(f"❌ {exc}")


### PR DESCRIPTION
Takes `main`'s open CodeQL alerts to **0** (11 open today: 10 `py/unused-import` + 1 `py/empty-except`, all `note` severity). 0 security-severity, 0 open Dependabot. The rest of the original backlog is already dismissed with reasons on the security tab as false positives or by-design dispositions, not patched.

- **`py/unused-import` ×10** (`backtest_hourly_agent.py`, `backtest_harness.py`, `leaderboard/service.py`) — documented back-compat re-exports; the rule is intra-file only, so it cannot see the `bha.<name>` / `service.downsample_daily is baselines.downsample_daily` contracts the guard suites assert. Rebound by explicit assignment from a module alias (the form `external_run_service.py` already documents), which keeps one import form per module and so does not trade the alert for `py/import-and-import-from`. The `pandas_ta` pair was a presence probe, not a use → `importlib.util.find_spec`.
- **`py/empty-except` ×1** (`algo_service.py`) — a `defaults.json` that yields no date range fell through to a hardcoded pair with no signal, running backtests over the wrong window. Now announces, via `print()`: logger output is invisible under the deployed uvicorn.

Review round on `28fd303` found the empty-except fix covered only the rarest of the three ways that fallback is reached. Both follow-ups had a live failing case:

- valid JSON that is **not an object** made `.get` raise `AttributeError` — outside `(JSONDecodeError, OSError)`, so it escaped the handler and 500'd the caller rather than falling back
- valid JSON with **renamed or blanked** date keys still fell through in silence, which is the likelier failure than a corrupt write
- `Anthropic = anthropic.Anthropic` moved the "SDK unusable" signal from `ImportError` to `AttributeError`, which the optional-dependency handler does not catch; the module sits on the backend's import path, so that turned a degrade-to-rule-based into a dead app import

Each now has a test that was watched failing first. Also resolves the default dates once per launch instead of twice, invalidates the path-finder cache after a `pandas_ta` install, and keeps `service.py`'s imports one contiguous section.

Verified: 2080 passed / 64 skipped locally. The single local failure (`test_ifind_engine_resolves_csi300_sample20`) is the known `dashboard/.env` leak — the case asserts LLM init fails with no key, and the key leaks in from an earlier test — so it passes in isolation and in CI, which has no `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWaKh6uYzCzoZcwzDTjWVf
