### PR TITLE
fix(auth): rate-limit login and signup attempts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,13 +197,21 @@ ACCOUNT_EMAIL_FROM=noreply@example.com
 ACCOUNT_EMAIL_FROM_NAME=Agentic Trading Lab
 
 # Auth rate limits (optional). Best-effort in-process budgets for
-# POST /api/auth/login and /signup. Defaults shown. Per-email login counters
-# meter *failed* attempts only so an attacker cannot lock out a correct password.
-# AUTH_LOGIN_IP_MAX=30
+# POST /api/auth/login and /signup; defaults shown, and each is echoed at
+# startup as "auth rate limit AUTH_...: N per Ns" so the effective value is
+# readable in the deploy log. Set any *_MAX to 0 to disable that budget.
+#
+# Both login budgets meter *failed* attempts only, so a correct password is
+# never refused because of someone else's guesses. The per-IP budgets are loose
+# on purpose: they are keyed on caller-supplied headers (X-Browser-Id, then
+# X-Forwarded-For), so they bound naive abuse rather than a real attacker, and
+# a tight value mostly punishes shared addresses. AUTH_LOGIN_EMAIL_MAX is the
+# one that actually bounds password guessing -- keyed on the targeted account.
+# AUTH_LOGIN_IP_MAX=60
 # AUTH_LOGIN_IP_WINDOW_SECONDS=900
 # AUTH_LOGIN_EMAIL_MAX=10
 # AUTH_LOGIN_EMAIL_WINDOW_SECONDS=900
-# AUTH_SIGNUP_IP_MAX=10
+# AUTH_SIGNUP_IP_MAX=60
 # AUTH_SIGNUP_IP_WINDOW_SECONDS=3600
 # AUTH_SIGNUP_EMAIL_MAX=5
 # AUTH_SIGNUP_EMAIL_WINDOW_SECONDS=3600

--- a/.env.example
+++ b/.env.example
@@ -196,6 +196,18 @@ BREVO_API_KEY=your_brevo_api_key_here
 ACCOUNT_EMAIL_FROM=noreply@example.com
 ACCOUNT_EMAIL_FROM_NAME=Agentic Trading Lab
 
+# Auth rate limits (optional). Best-effort in-process budgets for
+# POST /api/auth/login and /signup. Defaults shown. Per-email login counters
+# meter *failed* attempts only so an attacker cannot lock out a correct password.
+# AUTH_LOGIN_IP_MAX=30
+# AUTH_LOGIN_IP_WINDOW_SECONDS=900
+# AUTH_LOGIN_EMAIL_MAX=10
+# AUTH_LOGIN_EMAIL_WINDOW_SECONDS=900
+# AUTH_SIGNUP_IP_MAX=10
+# AUTH_SIGNUP_IP_WINDOW_SECONDS=3600
+# AUTH_SIGNUP_EMAIL_MAX=5
+# AUTH_SIGNUP_EMAIL_WINDOW_SECONDS=3600
+
 # API Configuration
 PORT=8000
 DEBUG=false

--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -4,6 +4,7 @@ import hmac
 import logging
 import math
 import os
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 from urllib.parse import urlencode
@@ -90,9 +91,29 @@ _SIGNUP_IP_LIMITER = _build_limiter("AUTH_SIGNUP_IP", 60, 3600)
 _SIGNUP_EMAIL_LIMITER = _build_limiter("AUTH_SIGNUP_EMAIL", 5, 3600)
 
 
+# Leading run of characters a hostname may contain. Anchored and non-greedy
+# about nothing: it stops at the first byte a domain cannot hold, so injected
+# text is cut off rather than folded into the value.
+_DOMAIN_PREFIX = re.compile(r"[a-z0-9.\-]*")
+
+
 def _email_domain(email: str) -> str:
-    """Domain only: enough to spot a scripted sweep, never the address itself."""
-    return email.rsplit("@", 1)[-1]
+    """Domain only: enough to spot a scripted sweep, never the address itself.
+
+    Filtered, not just split. ``_normalize_email`` strips the *ends* of the
+    address, so ``"victim@example.com\\nauth.login_failed domain=attacker.test"``
+    validates -- it has an ``@`` and a dotted right-hand side -- and would let an
+    unauthenticated caller write whole forged lines into the log an operator
+    reads while deciding whether they are under attack. CodeQL caught this as
+    py/log-injection while these were ``logger`` calls and stops reporting it at
+    a ``print`` sink it does not model, so the guard has to be the code, not the
+    alert. Truncating at the first character a domain cannot hold, rather than
+    filtering them out: dropping them would splice the injected text onto the
+    real domain instead of discarding it, and nothing downstream needs to
+    reverse this.
+    """
+    domain = email.rsplit("@", 1)[-1].lower()
+    return _DOMAIN_PREFIX.match(domain).group()[:64] or "?"
 
 
 def _auth_rate_limited(limiter: FixedWindowRateLimiter, key: str, detail: str) -> HTTPException:

--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -33,36 +33,66 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 # Generic copy for failed logins — never reveal whether the email is registered.
 LOGIN_FAILURE_DETAIL = "Invalid email or password."
+RATE_LIMIT_DETAIL = "Too many login attempts; please try again later."
 
-# Best-effort in-process limits (see rate_limit.py). Tunable via env; defaults
-# bound naive password guessing without permanently locking an account.
-def _env_int(name: str, default: int) -> int:
+
+def _env_int(name: str, default: int, *, minimum: int = 0) -> int:
+    """Read an int override from the environment, or return ``default``.
+
+    ``minimum=0`` for counts, because 0 is a real value meaning "switch this
+    budget off" — the convention ``MAX_ACTIVE_RUNS_GLOBAL`` already uses — so an
+    operator can disable a limit from the Render dashboard without a deploy.
+    Windows pass ``minimum=1`` (a zero-width window is not a setting anyone
+    means).
+
+    Anything unparseable or out of range falls back to the default *and says so
+    on stdout*. Silently honouring a typo is how the limit that is running stops
+    being the limit everyone believes is running.
+    """
     raw = (os.getenv(name) or "").strip()
     if not raw:
         return default
     try:
         value = int(raw)
     except ValueError:
+        print(f"WARNING: {name}={raw!r} is not an integer; using default {default}")
         return default
-    return value if value >= 1 else default
+    if value < minimum:
+        print(f"WARNING: {name}={value} is below the minimum {minimum}; using default {default}")
+        return default
+    return value
 
 
-_LOGIN_IP_LIMITER = FixedWindowRateLimiter(
-    max_events=_env_int("AUTH_LOGIN_IP_MAX", 30),
-    window_seconds=float(_env_int("AUTH_LOGIN_IP_WINDOW_SECONDS", 900)),
-)
-_LOGIN_EMAIL_LIMITER = FixedWindowRateLimiter(
-    max_events=_env_int("AUTH_LOGIN_EMAIL_MAX", 10),
-    window_seconds=float(_env_int("AUTH_LOGIN_EMAIL_WINDOW_SECONDS", 900)),
-)
-_SIGNUP_IP_LIMITER = FixedWindowRateLimiter(
-    max_events=_env_int("AUTH_SIGNUP_IP_MAX", 10),
-    window_seconds=float(_env_int("AUTH_SIGNUP_IP_WINDOW_SECONDS", 3600)),
-)
-_SIGNUP_EMAIL_LIMITER = FixedWindowRateLimiter(
-    max_events=_env_int("AUTH_SIGNUP_EMAIL_MAX", 5),
-    window_seconds=float(_env_int("AUTH_SIGNUP_EMAIL_WINDOW_SECONDS", 3600)),
-)
+def _build_limiter(prefix: str, max_default: int, window_default: int) -> FixedWindowRateLimiter:
+    """Best-effort in-process limit (see rate_limit.py), tunable via env.
+
+    Reports the effective setting at startup, following the same rule as the
+    ``*_DATABASE_URL`` backends: a limit nobody can read is a limit nobody can
+    verify, and these are exactly the knobs an operator reaches for while
+    something is already going wrong.
+    """
+    max_events = _env_int(f"{prefix}_MAX", max_default)
+    window = _env_int(f"{prefix}_WINDOW_SECONDS", window_default, minimum=1)
+    effective = "disabled" if max_events == 0 else f"{max_events} per {window}s"
+    print(f"auth rate limit {prefix}: {effective}")
+    return FixedWindowRateLimiter(max_events=max_events, window_seconds=float(window))
+
+
+# Per-client budgets are deliberately loose: they are keyed on headers the
+# caller controls, so they bound naive abuse and cap queued bcrypt work rather
+# than stopping an attacker, and a tight value costs a shared address (one
+# office, one classroom, one NAT) far more than it costs anyone hostile. The
+# per-email failure budget is the control that actually holds; see the
+# rate_limit module docstring.
+_LOGIN_IP_LIMITER = _build_limiter("AUTH_LOGIN_IP", 60, 900)
+_LOGIN_EMAIL_LIMITER = _build_limiter("AUTH_LOGIN_EMAIL", 10, 900)
+_SIGNUP_IP_LIMITER = _build_limiter("AUTH_SIGNUP_IP", 60, 3600)
+_SIGNUP_EMAIL_LIMITER = _build_limiter("AUTH_SIGNUP_EMAIL", 5, 3600)
+
+
+def _email_domain(email: str) -> str:
+    """Domain only: enough to spot a scripted sweep, never the address itself."""
+    return email.rsplit("@", 1)[-1]
 
 
 def _auth_rate_limited(limiter: FixedWindowRateLimiter, key: str, detail: str) -> HTTPException:
@@ -210,6 +240,17 @@ def get_current_user(authorization: Optional[str] = Header(default=None)) -> dic
 
 @router.post("/signup", response_model=AuthResponse)
 async def signup(payload: SignupRequest, request: Request):
+    # Password policy first, budgets second. A rejected password creates
+    # nothing and costs nothing, so charging for it would let someone spend
+    # their whole signup allowance discovering the strength rules and end up
+    # rate-limited out of the account they were being careful about.
+    violations = validate_new_password(payload.password, payload.email)
+    if violations:
+        raise HTTPException(status_code=400, detail=" ".join(violations))
+
+    # allow(), not the check/record split login uses: here both outcomes are
+    # worth metering. A success spends a bcrypt hash and a durable row; a 409 is
+    # an account-existence probe (see below).
     ip_key = _signup_ip_key(request)
     if not _SIGNUP_IP_LIMITER.allow(ip_key):
         raise _auth_rate_limited(
@@ -225,23 +266,27 @@ async def signup(payload: SignupRequest, request: Request):
             "Too many signup attempts for this email; please try again later.",
         )
 
-    violations = validate_new_password(payload.password, payload.email)
-    if violations:
-        raise HTTPException(status_code=400, detail=" ".join(violations))
-
     try:
-        user = users_module.user_store.create_user(
+        # Threaded for the same reason as login's authenticate(): create_user
+        # hashes with bcrypt (~190 ms), and this route is unauthenticated.
+        user = await asyncio.to_thread(
+            users_module.user_store.create_user,
             email=payload.email,
             display_name=payload.display_name,
             password=payload.password,
         )
     except ValueError as exc:
         if str(exc) == "email_already_registered":
-            # Keep 409 for product UX, but do not log the password / token.
-            logger.info(
-                "auth.signup_conflict",
-                extra={"email_domain": payload.email.rsplit("@", 1)[-1]},
-            )
+            # This 409 tells an anonymous caller that an address has an account,
+            # which /login deliberately no longer does. Kept anyway, and kept
+            # honestly: the alternative that actually closes it is confirm-by-
+            # email signup (accept every attempt, reveal nothing, mail the
+            # address), which is a product change, not a copy change. Nothing
+            # here bounds it either -- one request per address answers the
+            # question, and the budgets above are keyed on headers the caller
+            # rotates for free. Documented as a known gap rather than papered
+            # over, so nobody reads the /login fix as covering both routes.
+            print(f"auth.signup_conflict domain={_email_domain(payload.email)}")
             raise HTTPException(status_code=409, detail="Email is already registered") from exc
         raise
 
@@ -252,37 +297,38 @@ async def signup(payload: SignupRequest, request: Request):
 @router.post("/login", response_model=AuthResponse)
 async def login(payload: LoginRequest, request: Request):
     ip_key = _login_ip_key(request)
-    if not _LOGIN_IP_LIMITER.allow(ip_key):
-        logger.info("auth.login_rate_limited", extra={"scope": "ip"})
-        raise _auth_rate_limited(
-            _LOGIN_IP_LIMITER,
-            ip_key,
-            "Too many login attempts; please try again later.",
-        )
+    # check(), not allow(): both budgets here meter *failures* only. Charging a
+    # correct password would make a busy shared address lock its own users out
+    # of an endpoint they are using correctly -- and every landing-page visitor
+    # shares one key whenever no forwarded address is available at all, which is
+    # what client_ip() in rate_limit.py exists to avoid. The check still runs
+    # before authenticate(), so an over-budget caller is refused without
+    # spending a bcrypt round on them.
+    if not _LOGIN_IP_LIMITER.check(ip_key):
+        print("auth.login_rate_limited scope=ip")
+        raise _auth_rate_limited(_LOGIN_IP_LIMITER, ip_key, RATE_LIMIT_DETAIL)
 
-    user = users_module.user_store.authenticate(payload.email, payload.password)
+    # Off the event loop: authenticate() now runs one bcrypt compare on *both*
+    # branches (see users.verify_password_for_account), so an unknown email
+    # costs ~190 ms of CPU where it used to cost ~0. Inline, that is a
+    # single-threaded stall any unauthenticated caller can drive, and the
+    # limiters above cannot close it -- rotating X-Browser-Id buys a fresh
+    # budget. Matches how the OAuth calls further down already offload.
+    user = await asyncio.to_thread(
+        users_module.user_store.authenticate, payload.email, payload.password
+    )
     if not user:
+        _LOGIN_IP_LIMITER.record(ip_key)
         email_key = f"login:email:{payload.email}"
         # Count only failures against the per-email budget so a successful
         # login is not blocked by an attacker's prior guesses — but repeated
         # failures still earn a temporary cooldown (not a permanent lockout).
+        # This is the budget that actually bounds guessing: it is keyed on the
+        # account under attack, not on anything the attacker chooses.
         if not _LOGIN_EMAIL_LIMITER.allow(email_key):
-            logger.info(
-                "auth.login_rate_limited",
-                extra={
-                    "scope": "email",
-                    "email_domain": payload.email.rsplit("@", 1)[-1],
-                },
-            )
-            raise _auth_rate_limited(
-                _LOGIN_EMAIL_LIMITER,
-                email_key,
-                "Too many login attempts; please try again later.",
-            )
-        logger.info(
-            "auth.login_failed",
-            extra={"email_domain": payload.email.rsplit("@", 1)[-1]},
-        )
+            print(f"auth.login_rate_limited scope=email domain={_email_domain(payload.email)}")
+            raise _auth_rate_limited(_LOGIN_EMAIL_LIMITER, email_key, RATE_LIMIT_DETAIL)
+        print(f"auth.login_failed domain={_email_domain(payload.email)}")
         raise HTTPException(status_code=401, detail=LOGIN_FAILURE_DETAIL)
 
     token = users_module.user_store.create_session(user["id"])

--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -8,11 +8,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field, field_validator
 
 from dashboard.backend.api import discord_oauth
+from dashboard.backend.api.rate_limit import FixedWindowRateLimiter, client_key
 from dashboard.backend.domain.brokers.repository import broker_store
 from dashboard.backend.infrastructure.brokers import pending_links, robinhood_oauth
 from dashboard.backend.infrastructure.email import sender as email_sender
@@ -29,6 +30,55 @@ from dashboard.backend.verification_codes import generate_code, hash_code
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+# Generic copy for failed logins — never reveal whether the email is registered.
+LOGIN_FAILURE_DETAIL = "Invalid email or password."
+
+# Best-effort in-process limits (see rate_limit.py). Tunable via env; defaults
+# bound naive password guessing without permanently locking an account.
+def _env_int(name: str, default: int) -> int:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 1 else default
+
+
+_LOGIN_IP_LIMITER = FixedWindowRateLimiter(
+    max_events=_env_int("AUTH_LOGIN_IP_MAX", 30),
+    window_seconds=float(_env_int("AUTH_LOGIN_IP_WINDOW_SECONDS", 900)),
+)
+_LOGIN_EMAIL_LIMITER = FixedWindowRateLimiter(
+    max_events=_env_int("AUTH_LOGIN_EMAIL_MAX", 10),
+    window_seconds=float(_env_int("AUTH_LOGIN_EMAIL_WINDOW_SECONDS", 900)),
+)
+_SIGNUP_IP_LIMITER = FixedWindowRateLimiter(
+    max_events=_env_int("AUTH_SIGNUP_IP_MAX", 10),
+    window_seconds=float(_env_int("AUTH_SIGNUP_IP_WINDOW_SECONDS", 3600)),
+)
+_SIGNUP_EMAIL_LIMITER = FixedWindowRateLimiter(
+    max_events=_env_int("AUTH_SIGNUP_EMAIL_MAX", 5),
+    window_seconds=float(_env_int("AUTH_SIGNUP_EMAIL_WINDOW_SECONDS", 3600)),
+)
+
+
+def _auth_rate_limited(limiter: FixedWindowRateLimiter, key: str, detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=429,
+        detail=detail,
+        headers={"Retry-After": str(limiter.retry_after_seconds(key))},
+    )
+
+
+def _login_ip_key(request: Request) -> str:
+    return f"login:{client_key(request)}"
+
+
+def _signup_ip_key(request: Request) -> str:
+    return f"signup:{client_key(request)}"
 
 
 def _app_redirect(query: dict[str, str]) -> RedirectResponse:
@@ -159,7 +209,22 @@ def get_current_user(authorization: Optional[str] = Header(default=None)) -> dic
 
 
 @router.post("/signup", response_model=AuthResponse)
-async def signup(payload: SignupRequest):
+async def signup(payload: SignupRequest, request: Request):
+    ip_key = _signup_ip_key(request)
+    if not _SIGNUP_IP_LIMITER.allow(ip_key):
+        raise _auth_rate_limited(
+            _SIGNUP_IP_LIMITER,
+            ip_key,
+            "Too many signup attempts from this network; please try again later.",
+        )
+    email_key = f"signup:email:{payload.email}"
+    if not _SIGNUP_EMAIL_LIMITER.allow(email_key):
+        raise _auth_rate_limited(
+            _SIGNUP_EMAIL_LIMITER,
+            email_key,
+            "Too many signup attempts for this email; please try again later.",
+        )
+
     violations = validate_new_password(payload.password, payload.email)
     if violations:
         raise HTTPException(status_code=400, detail=" ".join(violations))
@@ -172,6 +237,11 @@ async def signup(payload: SignupRequest):
         )
     except ValueError as exc:
         if str(exc) == "email_already_registered":
+            # Keep 409 for product UX, but do not log the password / token.
+            logger.info(
+                "auth.signup_conflict",
+                extra={"email_domain": payload.email.rsplit("@", 1)[-1]},
+            )
             raise HTTPException(status_code=409, detail="Email is already registered") from exc
         raise
 
@@ -180,10 +250,40 @@ async def signup(payload: SignupRequest):
 
 
 @router.post("/login", response_model=AuthResponse)
-async def login(payload: LoginRequest):
+async def login(payload: LoginRequest, request: Request):
+    ip_key = _login_ip_key(request)
+    if not _LOGIN_IP_LIMITER.allow(ip_key):
+        logger.info("auth.login_rate_limited", extra={"scope": "ip"})
+        raise _auth_rate_limited(
+            _LOGIN_IP_LIMITER,
+            ip_key,
+            "Too many login attempts; please try again later.",
+        )
+
     user = users_module.user_store.authenticate(payload.email, payload.password)
     if not user:
-        raise HTTPException(status_code=401, detail="Invalid email or password")
+        email_key = f"login:email:{payload.email}"
+        # Count only failures against the per-email budget so a successful
+        # login is not blocked by an attacker's prior guesses — but repeated
+        # failures still earn a temporary cooldown (not a permanent lockout).
+        if not _LOGIN_EMAIL_LIMITER.allow(email_key):
+            logger.info(
+                "auth.login_rate_limited",
+                extra={
+                    "scope": "email",
+                    "email_domain": payload.email.rsplit("@", 1)[-1],
+                },
+            )
+            raise _auth_rate_limited(
+                _LOGIN_EMAIL_LIMITER,
+                email_key,
+                "Too many login attempts; please try again later.",
+            )
+        logger.info(
+            "auth.login_failed",
+            extra={"email_domain": payload.email.rsplit("@", 1)[-1]},
+        )
+        raise HTTPException(status_code=401, detail=LOGIN_FAILURE_DETAIL)
 
     token = users_module.user_store.create_session(user["id"])
     return {"user": public_user(user), "token": token}

--- a/dashboard/backend/api/rate_limit.py
+++ b/dashboard/backend/api/rate_limit.py
@@ -5,12 +5,23 @@ This is a **best-effort abuse control, not a security boundary**:
 * State is per-process — it resets on restart and is not shared across multiple
   workers/replicas. On a single-instance deployment (the current Render setup)
   that is adequate; a multi-replica deployment would need a shared store.
-* Keys are derived from client-supplied headers (session/browser id), which a
-  determined attacker can rotate, falling back to the peer host.
+* Keys are derived from client-supplied headers (session/browser id, then
+  ``X-Forwarded-For``), which a determined attacker can rotate, falling back to
+  the peer host.
 
 It exists to bound *accidental / naive* abuse of public endpoints that spend
 real resources (operator LLM credits, unbounded DB writes) without requiring
 auth. Endpoints that need real protection must add authentication.
+
+**The auth routes are the one exception to that last sentence**, because
+``POST /api/auth/login`` *is* the authentication endpoint — it has no stronger
+gate to defer to. So do not read the per-client budgets there as brute-force
+protection: every key this module can compute comes from a header the caller
+controls, and an attacker who rotates it gets a fresh budget for free. What
+actually bounds password guessing is the **per-email failure counter** in
+``api/auth.py``, which is keyed on the account being attacked rather than on
+anything the attacker supplies. The per-client budgets bound accidental abuse
+and cap the bcrypt work one naive client can queue; nothing more.
 """
 
 from __future__ import annotations
@@ -27,6 +38,10 @@ class FixedWindowRateLimiter:
     """Sliding-window counter: at most ``max_events`` per ``window_seconds`` per key.
 
     ``clock`` is injectable so tests are deterministic (no wall-clock sleeps).
+
+    ``max_events=0`` disables the limiter entirely (every call is allowed and
+    nothing is recorded), so an operator can switch a budget off through config
+    without a deploy. Negative values are still a configuration error.
     """
 
     def __init__(
@@ -37,13 +52,67 @@ class FixedWindowRateLimiter:
         clock: Callable[[], float] = time.monotonic,
         max_keys: int = 10_000,
     ) -> None:
-        if max_events < 1:
-            raise ValueError("max_events must be >= 1")
+        if max_events < 0:
+            raise ValueError("max_events must be >= 0 (0 disables the limiter)")
         self.max_events = max_events
         self.window_seconds = window_seconds
         self.max_keys = max_keys
         self._clock = clock
         self._events: Dict[str, Deque[float]] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_events > 0
+
+    def _pruned(self, key: str) -> Deque[float] | None:
+        """``key``'s bucket with expired events dropped, or None if unknown.
+
+        Pruning only removes entries the window has already released, so calling
+        this from a read-only method does not change any answer it could give.
+        """
+        q = self._events.get(key)
+        if q is None:
+            return None
+        cutoff = self._clock() - self.window_seconds
+        while q and q[0] <= cutoff:
+            q.popleft()
+        return q
+
+    def check(self, key: str) -> bool:
+        """True iff ``key`` is currently under its limit. Consumes nothing.
+
+        Pair this with :meth:`record` when the budget should be spent on some
+        outcomes but not others — guarding an expensive call without charging
+        for its *successful* result. :meth:`allow` is the combined form.
+        """
+        if not self.enabled:
+            return True
+        q = self._pruned(key)
+        return q is None or len(q) < self.max_events
+
+    def record(self, key: str) -> None:
+        """Spend one unit of ``key``'s budget.
+
+        Never grows a bucket past ``max_events``: the cap is what bounds memory
+        per key, and a caller that records without checking must not defeat it.
+        """
+        if not self.enabled:
+            return
+        now = self._clock()
+        q = self._pruned(key)
+        if q is None:
+            # New key. Opportunistically reclaim fully-expired buckets before
+            # growing so total key-cardinality stays bounded over the process
+            # lifetime. (The previous ``del`` guard here was dead code: it needed
+            # both ``len(q) >= max_events`` and ``q`` empty, impossible when
+            # max_events >= 1, so empty buckets were never reclaimed.)
+            if len(self._events) >= self.max_keys:
+                self._sweep(now - self.window_seconds)
+            q = deque()
+            self._events[key] = q
+        if len(q) >= self.max_events:
+            return
+        q.append(now)
 
     def allow(self, key: str) -> bool:
         """Record an attempt for ``key``; return True iff it is within the limit.
@@ -52,25 +121,9 @@ class FixedWindowRateLimiter:
         timestamp), so a client hammering the endpoint recovers exactly one
         window after its *allowed* burst, not after it stops trying.
         """
-        now = self._clock()
-        cutoff = now - self.window_seconds
-        q = self._events.get(key)
-        if q is None:
-            # New key. Opportunistically reclaim fully-expired buckets before
-            # growing so total key-cardinality stays bounded over the process
-            # lifetime. (The previous ``del`` guard here was dead code: it needed
-            # both ``len(q) >= max_events`` and ``q`` empty, impossible when
-            # max_events >= 1, so empty buckets were never reclaimed.)
-            if len(self._events) >= self.max_keys:
-                self._sweep(cutoff)
-            q = deque()
-            self._events[key] = q
-        else:
-            while q and q[0] <= cutoff:
-                q.popleft()
-        if len(q) >= self.max_events:
+        if not self.check(key):
             return False
-        q.append(now)
+        self.record(key)
         return True
 
     def _sweep(self, cutoff: float) -> None:
@@ -88,27 +141,61 @@ class FixedWindowRateLimiter:
     def retry_after_seconds(self, key: str) -> int:
         """Seconds until ``key`` can pass ``allow`` again (at least 1).
 
-        Uses the oldest recorded event: once it ages out of the window the
-        client recovers one slot. Empty / unknown keys fall back to the full
-        window width.
+        Uses the oldest *live* recorded event: once it ages out of the window
+        the client recovers one slot. Prunes first, so this is correct when
+        called on its own and not only straight after a rejecting ``allow``
+        (which pruned as a side effect). Empty / unknown keys fall back to the
+        full window width. Never exceeds the window.
         """
-        q = self._events.get(key)
+        if not self.enabled:
+            return 1
+        q = self._pruned(key)
         if not q:
-            return max(1, int(math.ceil(self.window_seconds)))
+            return max(1, math.ceil(self.window_seconds))
         remaining = q[0] + self.window_seconds - self._clock()
-        return max(1, int(math.ceil(remaining)))
+        return max(1, math.ceil(remaining))
+
+
+# Longest textual IPv6 form ("ffff:...:255.255.255.255%eth0" territory). The
+# forwarded header is attacker-controlled and unbounded, and an untruncated
+# value would let one client mint arbitrarily large dict keys.
+_MAX_IP_KEY_LEN = 64
+
+
+def client_ip(request: Request) -> str:
+    """Best-effort originating client IP.
+
+    Reads the left-most ``X-Forwarded-For`` entry before falling back to the
+    socket peer, because behind a PaaS router the peer is *the router* — the
+    same value for every visitor on earth, which collapses a per-client budget
+    into one shared site-wide budget.
+
+    uvicorn can do this itself, but only when the peer appears in
+    ``--forwarded-allow-ips``, which ``uvicorn.Config`` resolves to
+    ``os.environ["FORWARDED_ALLOW_IPS"]`` or ``"127.0.0.1"``. Render's router is
+    neither, so ``request.client`` is left untouched there and enabling
+    ``--proxy-headers`` (already the default) changes nothing. Doing it here
+    keeps the behaviour independent of how the process happens to be launched.
+
+    The header is trivially spoofable, so this is a granularity fix, not a
+    security control — see the module docstring.
+    """
+    for part in request.headers.get("x-forwarded-for", "").split(","):
+        candidate = part.strip()
+        if candidate:
+            return candidate[:_MAX_IP_KEY_LEN]
+    return request.client.host if request.client else "unknown"
 
 
 def client_key(request: Request) -> str:
     """Best-effort stable key for an anonymous client.
 
     Prefers the browser/session id the rest of the anonymous app already uses,
-    else falls back to the peer host. Prefixed so an id can never collide with
+    else falls back to the client IP. Prefixed so an id can never collide with
     an ip.
     """
     hdr = request.headers
     ident = hdr.get("x-browser-id") or hdr.get("x-session-id")
     if ident and ident.strip():
         return f"id:{ident.strip()}"
-    host = request.client.host if request.client else "unknown"
-    return f"ip:{host}"
+    return f"ip:{client_ip(request)}"

--- a/dashboard/backend/api/rate_limit.py
+++ b/dashboard/backend/api/rate_limit.py
@@ -15,6 +15,7 @@ auth. Endpoints that need real protection must add authentication.
 
 from __future__ import annotations
 
+import math
 import time
 from collections import deque
 from typing import Callable, Deque, Dict
@@ -83,6 +84,19 @@ class FixedWindowRateLimiter:
     def reset(self) -> None:
         """Clear all state (used by tests and between logical sessions)."""
         self._events.clear()
+
+    def retry_after_seconds(self, key: str) -> int:
+        """Seconds until ``key`` can pass ``allow`` again (at least 1).
+
+        Uses the oldest recorded event: once it ages out of the window the
+        client recovers one slot. Empty / unknown keys fall back to the full
+        window width.
+        """
+        q = self._events.get(key)
+        if not q:
+            return max(1, int(math.ceil(self.window_seconds)))
+        remaining = q[0] + self.window_seconds - self._clock()
+        return max(1, int(math.ceil(remaining)))
 
 
 def client_key(request: Request) -> str:

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -99,11 +99,19 @@ def _reset_shared_scale_state(monkeypatch):
     from dashboard.backend.domain.backtesting import baseline_worker, market_data_store
     from dashboard.backend.domain.agents import auth_cache
     from dashboard.backend import db_pool
+    from dashboard.backend.api import auth as auth_api
+
     monkeypatch.setattr(db_pool, "POOL_TIMEOUT_SECONDS", 1.0)
     market_data_store._reset_for_tests()
     baseline_worker._reset_for_tests()
     auth_cache._reset_for_tests()
     db_pool._reset_for_tests()
+    # Login/signup limiters are process-global; without a reset, the shared
+    # TestClient peer (testclient) burns the signup IP budget across the suite.
+    auth_api._LOGIN_IP_LIMITER.reset()
+    auth_api._LOGIN_EMAIL_LIMITER.reset()
+    auth_api._SIGNUP_IP_LIMITER.reset()
+    auth_api._SIGNUP_EMAIL_LIMITER.reset()
     yield
     # Best-effort drain so a job enqueued in this test doesn't leak into the
     # next. Note pytest tears fixtures down LIFO, so a test's own monkeypatches

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -24,8 +24,14 @@ def temp_user_store():
 @pytest.fixture
 def client(temp_user_store, monkeypatch):
     from dashboard.backend import users
+    from dashboard.backend.api import auth as auth_api
 
     monkeypatch.setattr(users, "user_store", temp_user_store)
+    # Module-level limiters retain state across tests in this process.
+    auth_api._LOGIN_IP_LIMITER.reset()
+    auth_api._LOGIN_EMAIL_LIMITER.reset()
+    auth_api._SIGNUP_IP_LIMITER.reset()
+    auth_api._SIGNUP_EMAIL_LIMITER.reset()
     return TestClient(app)
 
 
@@ -99,6 +105,33 @@ def test_login_invalid_password(client):
         json={"email": "bob@example.com", "password": "wrong-password"},
     )
     assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid email or password."
+
+
+def test_login_unknown_email_uses_same_generic_error(client):
+    """Do not reveal whether an address is registered."""
+    known = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "known@example.com",
+            "display_name": "Known",
+            "password": "securepass1",
+        },
+    )
+    assert known.status_code == 200
+    wrong_password = client.post(
+        "/api/auth/login",
+        json={"email": "known@example.com", "password": "not-the-password"},
+    )
+    unknown = client.post(
+        "/api/auth/login",
+        json={"email": "nobody@example.com", "password": "securepass1"},
+    )
+    assert wrong_password.status_code == 401
+    assert unknown.status_code == 401
+    assert wrong_password.json()["detail"] == unknown.json()["detail"] == (
+        "Invalid email or password."
+    )
 
 
 def test_signup_rejects_common_password(client):
@@ -1212,3 +1245,173 @@ def test_changing_the_password_cancels_a_pending_email_change(client, sent_email
     assert password_change.status_code == 200
 
     assert client.get("/api/auth/email-change", headers=headers).json()["pending"] is False
+
+
+# --- Login / signup rate limits -------------------------------------------------
+
+
+@pytest.fixture
+def auth_rate_limit_clock(monkeypatch):
+    """Deterministic clock + tiny limits for auth rate-limit tests."""
+    from dashboard.backend.api import auth as auth_api
+    from dashboard.backend.api.rate_limit import FixedWindowRateLimiter
+
+    now = [1000.0]
+
+    def clock() -> float:
+        return now[0]
+
+    monkeypatch.setattr(
+        auth_api,
+        "_LOGIN_IP_LIMITER",
+        FixedWindowRateLimiter(max_events=5, window_seconds=60, clock=clock),
+    )
+    monkeypatch.setattr(
+        auth_api,
+        "_LOGIN_EMAIL_LIMITER",
+        FixedWindowRateLimiter(max_events=3, window_seconds=60, clock=clock),
+    )
+    monkeypatch.setattr(
+        auth_api,
+        "_SIGNUP_IP_LIMITER",
+        FixedWindowRateLimiter(max_events=2, window_seconds=60, clock=clock),
+    )
+    monkeypatch.setattr(
+        auth_api,
+        "_SIGNUP_EMAIL_LIMITER",
+        FixedWindowRateLimiter(max_events=2, window_seconds=60, clock=clock),
+    )
+    return now
+
+
+def test_login_ip_rate_limit_returns_429(client, auth_rate_limit_clock, monkeypatch):
+    from dashboard.backend.api import auth as auth_api
+    from dashboard.backend.api.rate_limit import FixedWindowRateLimiter
+
+    now = auth_rate_limit_clock
+    monkeypatch.setattr(
+        auth_api,
+        "_LOGIN_EMAIL_LIMITER",
+        FixedWindowRateLimiter(max_events=100, window_seconds=60, clock=lambda: now[0]),
+    )
+    monkeypatch.setattr(
+        auth_api,
+        "_SIGNUP_IP_LIMITER",
+        FixedWindowRateLimiter(max_events=100, window_seconds=60, clock=lambda: now[0]),
+    )
+    monkeypatch.setattr(
+        auth_api,
+        "_SIGNUP_EMAIL_LIMITER",
+        FixedWindowRateLimiter(max_events=100, window_seconds=60, clock=lambda: now[0]),
+    )
+    assert (
+        client.post(
+            "/api/auth/signup",
+            json={
+                "email": "rate-ip@example.com",
+                "display_name": "Rate",
+                "password": "securepass1",
+            },
+        ).status_code
+        == 200
+    )
+    for _ in range(5):
+        resp = client.post(
+            "/api/auth/login",
+            json={"email": "rate-ip@example.com", "password": "wrong"},
+        )
+        assert resp.status_code == 401, resp.text
+
+    blocked = client.post(
+        "/api/auth/login",
+        json={"email": "rate-ip@example.com", "password": "wrong"},
+    )
+    assert blocked.status_code == 429
+    assert "Retry-After" in blocked.headers
+    assert int(blocked.headers["Retry-After"]) >= 1
+
+
+def test_login_email_rate_limit_after_failures(client, auth_rate_limit_clock, monkeypatch):
+    from dashboard.backend.api import auth as auth_api
+    from dashboard.backend.api.rate_limit import FixedWindowRateLimiter
+
+    now = auth_rate_limit_clock
+    # Generous IP budget so only the per-email failure counter trips.
+    monkeypatch.setattr(
+        auth_api,
+        "_LOGIN_IP_LIMITER",
+        FixedWindowRateLimiter(max_events=100, window_seconds=60, clock=lambda: now[0]),
+    )
+
+    client.post(
+        "/api/auth/signup",
+        json={
+            "email": "rate-email@example.com",
+            "display_name": "Rate",
+            "password": "securepass1",
+        },
+    )
+    for _ in range(3):
+        resp = client.post(
+            "/api/auth/login",
+            json={"email": "rate-email@example.com", "password": "wrong"},
+        )
+        assert resp.status_code == 401, resp.text
+
+    blocked = client.post(
+        "/api/auth/login",
+        json={"email": "rate-email@example.com", "password": "wrong"},
+    )
+    assert blocked.status_code == 429
+    assert int(blocked.headers["Retry-After"]) >= 1
+
+    # Correct password still works: the email counter only meters *failures*
+    # so an attacker cannot lock the account out of a legitimate login.
+    ok = client.post(
+        "/api/auth/login",
+        json={"email": "rate-email@example.com", "password": "securepass1"},
+    )
+    assert ok.status_code == 200, ok.text
+
+    now[0] += 61
+    # After the window, wrong passwords are accepted into the failure budget again.
+    again = client.post(
+        "/api/auth/login",
+        json={"email": "rate-email@example.com", "password": "wrong"},
+    )
+    assert again.status_code == 401
+
+
+def test_signup_ip_rate_limit_returns_429(client, auth_rate_limit_clock):
+    assert (
+        client.post(
+            "/api/auth/signup",
+            json={
+                "email": "su1@example.com",
+                "display_name": "One",
+                "password": "securepass1",
+            },
+        ).status_code
+        == 200
+    )
+    assert (
+        client.post(
+            "/api/auth/signup",
+            json={
+                "email": "su2@example.com",
+                "display_name": "Two",
+                "password": "securepass1",
+            },
+        ).status_code
+        == 200
+    )
+    blocked = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "su3@example.com",
+            "display_name": "Three",
+            "password": "securepass1",
+        },
+    )
+    assert blocked.status_code == 429
+    assert "Retry-After" in blocked.headers

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -24,14 +24,10 @@ def temp_user_store():
 @pytest.fixture
 def client(temp_user_store, monkeypatch):
     from dashboard.backend import users
-    from dashboard.backend.api import auth as auth_api
 
     monkeypatch.setattr(users, "user_store", temp_user_store)
-    # Module-level limiters retain state across tests in this process.
-    auth_api._LOGIN_IP_LIMITER.reset()
-    auth_api._LOGIN_EMAIL_LIMITER.reset()
-    auth_api._SIGNUP_IP_LIMITER.reset()
-    auth_api._SIGNUP_EMAIL_LIMITER.reset()
+    # The process-global auth limiters are reset by conftest's autouse
+    # _reset_shared_scale_state, which pytest runs before this fixture.
     return TestClient(app)
 
 
@@ -1328,7 +1324,9 @@ def test_login_ip_rate_limit_returns_429(client, auth_rate_limit_clock, monkeypa
     )
     assert blocked.status_code == 429
     assert "Retry-After" in blocked.headers
-    assert int(blocked.headers["Retry-After"]) >= 1
+    # Bounded at both ends: >= 1 alone would pass for a header telling the
+    # client to wait longer than the window it is actually waiting on.
+    assert 1 <= int(blocked.headers["Retry-After"]) <= 60
 
 
 def test_login_email_rate_limit_after_failures(client, auth_rate_limit_clock, monkeypatch):
@@ -1363,7 +1361,7 @@ def test_login_email_rate_limit_after_failures(client, auth_rate_limit_clock, mo
         json={"email": "rate-email@example.com", "password": "wrong"},
     )
     assert blocked.status_code == 429
-    assert int(blocked.headers["Retry-After"]) >= 1
+    assert 1 <= int(blocked.headers["Retry-After"]) <= 60
 
     # Correct password still works: the email counter only meters *failures*
     # so an attacker cannot lock the account out of a legitimate login.
@@ -1414,4 +1412,191 @@ def test_signup_ip_rate_limit_returns_429(client, auth_rate_limit_clock):
         },
     )
     assert blocked.status_code == 429
-    assert "Retry-After" in blocked.headers
+    assert 1 <= int(blocked.headers["Retry-After"]) <= 60
+
+
+def test_successful_logins_do_not_consume_the_ip_budget(client, auth_rate_limit_clock):
+    """The per-IP budget meters failures only.
+
+    Without this, ``allow()`` runs before ``authenticate()`` and charges every
+    caller including the ones typing the right password -- so the budget is
+    really a cap on *how many people may sign in*, which is a self-inflicted
+    outage rather than a control. It bites hardest exactly where the key is
+    coarsest: one office, one classroom, or (before client_ip() read the
+    forwarded header) every visitor to the site at once.
+    """
+    signup = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "busy@example.com",
+            "display_name": "Busy",
+            "password": "securepass1",
+        },
+    )
+    assert signup.status_code == 200
+
+    # The fixture's IP budget is 5; sign in more times than that.
+    for i in range(8):
+        ok = client.post(
+            "/api/auth/login",
+            json={"email": "busy@example.com", "password": "securepass1"},
+        )
+        assert ok.status_code == 200, f"login {i + 1} refused: {ok.text}"
+
+    # And the budget is genuinely untouched, not merely not-yet-exhausted: a
+    # wrong password is still answered 401 rather than 429.
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"email": "busy@example.com", "password": "wrong"},
+        ).status_code
+        == 401
+    )
+
+
+def test_login_ip_budget_is_per_forwarded_address(
+    client, auth_rate_limit_clock, monkeypatch
+):
+    """Two clients behind the same proxy get their own budgets.
+
+    ``request.client.host`` is the proxy for every visitor on a PaaS router, so
+    keying on it alone puts the whole site in one bucket. Nothing here is
+    spoof-proof -- the point is that honest clients stop colliding.
+    """
+    from dashboard.backend.api import auth as auth_api
+    from dashboard.backend.api.rate_limit import FixedWindowRateLimiter
+
+    now = auth_rate_limit_clock
+    # Generous per-email budget so only the per-IP one can trip.
+    monkeypatch.setattr(
+        auth_api,
+        "_LOGIN_EMAIL_LIMITER",
+        FixedWindowRateLimiter(max_events=100, window_seconds=60, clock=lambda: now[0]),
+    )
+
+    for email in ("fwd-a@example.com", "fwd-b@example.com"):
+        assert (
+            client.post(
+                "/api/auth/signup",
+                json={
+                    "email": email,
+                    "display_name": "Fwd",
+                    "password": "securepass1",
+                },
+            ).status_code
+            == 200
+        )
+
+    # Exhaust the 5-failure IP budget for one address...
+    for _ in range(5):
+        assert (
+            client.post(
+                "/api/auth/login",
+                json={"email": "fwd-a@example.com", "password": "wrong"},
+                headers={"x-forwarded-for": "203.0.113.7"},
+            ).status_code
+            == 401
+        )
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"email": "fwd-a@example.com", "password": "wrong"},
+            headers={"x-forwarded-for": "203.0.113.7"},
+        ).status_code
+        == 429
+    )
+
+    # ...a different forwarded address is unaffected.
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"email": "fwd-b@example.com", "password": "wrong"},
+            headers={"x-forwarded-for": "198.51.100.4"},
+        ).status_code
+        == 401
+    )
+
+
+def test_login_unknown_email_still_costs_one_password_compare(client, monkeypatch):
+    """Constant-time miss path: the generic 401 copy is not enough on its own.
+
+    Returning before bcrypt made an unknown address answer ~3000x faster than a
+    wrong password (0.06 ms vs 182 ms measured), so the *timing* kept answering
+    the question the *body* had stopped answering. Asserted behaviourally --
+    that a compare happens, at the real cost factor -- because a wall-clock
+    assertion would be flaky under CI load.
+    """
+    from dashboard.backend import users as users_mod
+
+    seen: list[str] = []
+    real_verify = users_mod.verify_password
+
+    def spy(password: str, password_hash: str) -> bool:
+        seen.append(password_hash)
+        return real_verify(password, password_hash)
+
+    monkeypatch.setattr(users_mod, "verify_password", spy)
+
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": "no-such-account@example.com", "password": "whatever1"},
+    )
+    assert resp.status_code == 401
+    assert len(seen) == 1, "an unknown email must still pay one bcrypt compare"
+    # Same cost factor as a stored password, or the two paths diverge again.
+    assert seen[0].startswith("$2b$")
+    assert seen[0].split("$")[2] == str(users_mod.BCRYPT_ROUNDS)
+
+
+def test_weak_password_signup_does_not_consume_the_signup_budget(
+    client, auth_rate_limit_clock
+):
+    """Policy first, budget second: iterating on a rejected password creates
+    nothing, so it must not spend the allowance for the account being created."""
+    for _ in range(4):
+        rejected = client.post(
+            "/api/auth/signup",
+            json={"email": "weak@example.com", "display_name": "W", "password": "short"},
+        )
+        assert rejected.status_code == 400
+
+    # The fixture's signup IP budget is 2 and is still fully available.
+    for email in ("real1@example.com", "real2@example.com"):
+        assert (
+            client.post(
+                "/api/auth/signup",
+                json={
+                    "email": email,
+                    "display_name": "Real",
+                    "password": "securepass1",
+                },
+            ).status_code
+            == 200
+        )
+
+
+def test_env_int_disables_on_zero_and_reports_bad_overrides(monkeypatch, capsys):
+    """0 disables (the MAX_ACTIVE_RUNS_GLOBAL convention) and junk is loud.
+
+    capsys, not caplog: logger output is invisible under the deployed uvicorn
+    config, so these warnings go to stdout.
+    """
+    from dashboard.backend.api import auth as auth_api
+
+    monkeypatch.setenv("AUTH_FAKE_MAX", "0")
+    assert auth_api._env_int("AUTH_FAKE_MAX", 30) == 0
+
+    monkeypatch.setenv("AUTH_FAKE_MAX", "thirty")
+    assert auth_api._env_int("AUTH_FAKE_MAX", 30) == 30
+    assert "not an integer" in capsys.readouterr().out
+
+    monkeypatch.setenv("AUTH_FAKE_MAX", "-1")
+    assert auth_api._env_int("AUTH_FAKE_MAX", 30) == 30
+    assert "below the minimum" in capsys.readouterr().out
+
+    # A window of 0 is not a setting anyone means, so counts and windows differ.
+    monkeypatch.setenv("AUTH_FAKE_WINDOW", "0")
+    assert auth_api._env_int("AUTH_FAKE_WINDOW", 900, minimum=1) == 900
+
+    monkeypatch.delenv("AUTH_FAKE_MAX")
+    assert auth_api._env_int("AUTH_FAKE_MAX", 30) == 30

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -1575,6 +1575,29 @@ def test_weak_password_signup_does_not_consume_the_signup_budget(
         )
 
 
+def test_login_logging_cannot_be_used_to_forge_log_lines(client, capsys):
+    """Log injection: the failure line is the record an operator reads while
+    deciding whether they are under attack, so an unauthenticated caller must
+    not be able to write entries into it.
+
+    ``_normalize_email`` only strips the ends of the address, so an interior
+    newline survives validation. CodeQL reported this as py/log-injection while
+    these were ``logger`` calls and goes quiet at a ``print`` sink it does not
+    model -- the alert going away is not what makes it safe, this is.
+    """
+    forged = "auth.login_failed domain=attacker.test"
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": f"victim@example.com\n{forged}", "password": "whatever1"},
+    )
+    assert resp.status_code == 401
+
+    out = capsys.readouterr().out
+    assert "auth.login_failed domain=example.com" in out, "the real line is still logged"
+    assert forged not in out
+    assert "attacker.test" not in out
+
+
 def test_env_int_disables_on_zero_and_reports_bad_overrides(monkeypatch, capsys):
     """0 disables (the MAX_ACTIVE_RUNS_GLOBAL convention) and junk is loud.
 

--- a/dashboard/backend/tests/test_strategies_api.py
+++ b/dashboard/backend/tests/test_strategies_api.py
@@ -11,7 +11,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 from dashboard.backend.app import app
-from dashboard.backend.api.rate_limit import FixedWindowRateLimiter
+from dashboard.backend.api.rate_limit import (
+    _MAX_IP_KEY_LEN,
+    FixedWindowRateLimiter,
+    client_ip,
+    client_key,
+)
 import dashboard.backend.api.routers.strategies as strategies_router
 
 
@@ -66,6 +71,105 @@ def test_rate_limiter_reclaims_expired_keys_when_over_max_keys():
     now[0] = 100.0  # every existing key's window has fully expired
     assert rl.allow("k_new") is True
     assert len(rl._events) <= 3  # expired buckets reclaimed, not unbounded
+
+
+def test_rate_limiter_check_does_not_consume_budget():
+    """check() must be a pure read, or the split is pointless: its whole purpose
+    is guarding an expensive call without charging for a successful outcome."""
+    now = [0.0]
+    rl = FixedWindowRateLimiter(max_events=2, window_seconds=10, clock=lambda: now[0])
+    for _ in range(50):
+        assert rl.check("k") is True
+    assert rl.allow("k") is True
+    assert rl.allow("k") is True
+    assert rl.check("k") is False
+
+
+def test_rate_limiter_record_never_grows_past_max_events():
+    """A caller that records without checking must not defeat the per-key cap --
+    that cap is what bounds memory for a key under sustained abuse."""
+    now = [0.0]
+    rl = FixedWindowRateLimiter(max_events=2, window_seconds=10, clock=lambda: now[0])
+    for _ in range(100):
+        rl.record("k")
+    assert len(rl._events["k"]) == 2
+
+
+def test_rate_limiter_zero_max_events_disables_it():
+    """0 means "switch this budget off" so an operator can disable a limit from
+    config without a deploy."""
+    rl = FixedWindowRateLimiter(max_events=0, window_seconds=10)
+    assert rl.enabled is False
+    for _ in range(1000):
+        assert rl.allow("k") is True
+    assert rl._events == {}  # disabled means no bookkeeping at all
+    assert rl.retry_after_seconds("k") == 1
+
+
+def test_rate_limiter_negative_max_events_still_rejected():
+    with pytest.raises(ValueError):
+        FixedWindowRateLimiter(max_events=-1, window_seconds=10)
+
+
+def test_retry_after_seconds_counts_down_and_never_exceeds_the_window():
+    now = [0.0]
+    rl = FixedWindowRateLimiter(max_events=1, window_seconds=10, clock=lambda: now[0])
+    assert rl.allow("k") is True
+    assert rl.retry_after_seconds("k") == 10
+    now[0] = 6.0
+    assert rl.retry_after_seconds("k") == 4  # oldest event ages out at t=10
+    assert rl.retry_after_seconds("never-seen") == 10  # full window, not more
+
+
+def test_retry_after_seconds_prunes_expired_events():
+    """Correct when called on its own, not only straight after a rejecting
+    allow() that pruned as a side effect."""
+    now = [0.0]
+    rl = FixedWindowRateLimiter(max_events=1, window_seconds=10, clock=lambda: now[0])
+    assert rl.allow("k") is True
+    now[0] = 50.0  # the recorded event is long expired
+    # Reading a stale q[0] here would return max(1, 10 + 0 - 50) == 1 by luck;
+    # the real tell is that the bucket is empty, so the answer is a full window.
+    assert rl.retry_after_seconds("k") == 10
+    assert rl.check("k") is True
+
+
+# --- client key derivation --------------------------------------------------
+
+def _fake_request(*, headers=None, peer="10.0.0.1"):
+    from starlette.requests import Request
+
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request({"type": "http", "headers": raw, "client": (peer, 1234) if peer else None})
+
+
+def test_client_ip_prefers_the_leftmost_forwarded_entry():
+    """Behind a PaaS router the socket peer is the router for every visitor, so
+    keying on it alone collapses per-client budgets into one shared bucket."""
+    req = _fake_request(headers={"X-Forwarded-For": "203.0.113.7, 70.41.3.18, 10.0.0.1"})
+    assert client_ip(req) == "203.0.113.7"
+
+
+def test_client_ip_falls_back_to_the_peer():
+    assert client_ip(_fake_request()) == "10.0.0.1"
+    assert client_ip(_fake_request(headers={"X-Forwarded-For": "  ,  "})) == "10.0.0.1"
+    assert client_ip(_fake_request(peer=None)) == "unknown"
+
+
+def test_client_ip_bounds_the_key_length():
+    """The header is attacker-controlled; an untruncated value would let one
+    client mint arbitrarily large keys in the limiter's dict."""
+    req = _fake_request(headers={"X-Forwarded-For": "9" * 5000})
+    assert len(client_ip(req)) == _MAX_IP_KEY_LEN
+
+
+def test_client_key_prefers_browser_id_then_ip():
+    assert client_key(_fake_request(headers={"X-Browser-Id": " abc "})) == "id:abc"
+    # A blank id must not win: it would key every such caller to one bucket.
+    assert client_key(_fake_request(headers={"X-Browser-Id": "   "})) == "ip:10.0.0.1"
+    assert client_key(
+        _fake_request(headers={"X-Forwarded-For": "203.0.113.7"})
+    ) == "ip:203.0.113.7"
 
 
 # --- endpoint tests ---------------------------------------------------------

--- a/dashboard/backend/users.py
+++ b/dashboard/backend/users.py
@@ -150,6 +150,42 @@ def verify_password(password: str, password_hash: str) -> bool:
     return _verify_legacy_pbkdf2(password, password_hash)
 
 
+_DUMMY_PASSWORD_HASH: Optional[str] = None
+
+
+def _dummy_password_hash() -> str:
+    """A bcrypt hash of a value nobody can present, built on first use.
+
+    Lazily, because generating it costs a full bcrypt round (~190 ms at
+    ``BCRYPT_ROUNDS=12``) and every CLI script and test collection imports this
+    module. The cost of that is one skewed sample: the first unknown-email
+    login after a restart pays the hash *and* the compare. An attacker would
+    have to already be probing at that exact moment to see it.
+    """
+    global _DUMMY_PASSWORD_HASH
+    if _DUMMY_PASSWORD_HASH is None:
+        _DUMMY_PASSWORD_HASH = hash_password(secrets.token_urlsafe(32))
+    return _DUMMY_PASSWORD_HASH
+
+
+def verify_password_for_account(password: str, password_hash: Optional[str]) -> bool:
+    """``verify_password`` that costs the same whether or not the account exists.
+
+    Returning early when the email matches no row makes a miss ~3000x faster
+    than a wrong password (measured: 0.06 ms vs 182 ms), so response *time*
+    answers "is this address registered?" no matter how carefully the response
+    *body* is made uniform. Hashing against a throwaway hash on that path puts
+    both branches through the same single bcrypt compare.
+
+    Callers must still discard the result for a missing account -- this only
+    equalises the clock, it never authenticates one.
+    """
+    if password_hash is None:
+        verify_password(password, _dummy_password_hash())
+        return False
+    return verify_password(password, password_hash)
+
+
 def public_user(row: sqlite3.Row | Dict[str, Any]) -> Dict[str, Any]:
     data = dict(row)
     discord_user_id = data.get("discord_user_id")
@@ -304,10 +340,11 @@ class UserStore:
         return dict(row) if row else None
 
     def authenticate(self, email: str, password: str) -> Optional[Dict[str, Any]]:
+        # One bcrypt compare on both branches -- see verify_password_for_account.
         user = self.get_user_by_email(email)
-        if not user:
-            return None
-        if not verify_password(password, user["password_hash"]):
+        if not verify_password_for_account(
+            password, user["password_hash"] if user else None
+        ):
             return None
         return user
 

--- a/dashboard/backend/users_postgres.py
+++ b/dashboard/backend/users_postgres.py
@@ -22,7 +22,7 @@ from dashboard.backend.users import (
     hash_password,
     is_expired,
     public_user,
-    verify_password,
+    verify_password_for_account,
 )
 
 SESSION_TTL_DAYS = 7
@@ -153,10 +153,11 @@ class PostgresUserStore:
         return dict(row) if row else None
 
     def authenticate(self, email: str, password: str) -> Optional[Dict[str, Any]]:
+        # One bcrypt compare on both branches -- see verify_password_for_account.
         user = self.get_user_by_email(email)
-        if not user:
-            return None
-        if not verify_password(password, user["password_hash"]):
+        if not verify_password_for_account(
+            password, user["password_hash"] if user else None
+        ):
             return None
         return user
 


### PR DESCRIPTION
## Summary
- Best-effort in-process rate limits on `POST /api/auth/login` and `/signup` (per client + per email), with `Retry-After`.
- Login failures return `Invalid email or password.` **and** cost the same bcrypt compare whether or not the address exists (was 0.06 ms vs 182 ms — the timing answered what the copy did not).
- Both login budgets meter **failed** attempts only, so a correct password is never refused because of someone else's guesses.
- Per-client keys read the left-most `X-Forwarded-For`: uvicorn rewrites `request.client` only when the peer is in `--forwarded-allow-ips` (default `127.0.0.1`), which Render's router is not, so otherwise every landing-page visitor shares one bucket.
- Env knobs in `.env.example`, each echoed at startup; `0` disables a budget. Agent API-key routes untouched.

## Known gap
`POST /api/auth/signup` still answers "does this address have an account?" — 409, one request. The `/login` change does not cover it and the new budgets do not bound it (one request is enough, and the keys are caller-supplied). Closing it means confirm-by-email signup, which is a product change.

## Not a security boundary
Per-client budgets are keyed on headers the caller controls, so they bound naive abuse and cap queued bcrypt work — not an attacker. What bounds password guessing is the per-email failure counter, keyed on the account under attack. See the `rate_limit` module docstring.

## Test plan
- [x] `pytest dashboard/backend/tests/ -q` — 2093 passed, 64 skipped (1 pre-existing unrelated failure, `test_ifind_engine_resolves_csi300_sample20`, red on this branch's base too)
- [x] Timing re-measured after the fix: 185.3 ms known vs 184.3 ms unknown = 1.01x (was 3112x)
- [x] CodeQL on `refs/pull/281/merge`: 0 open alerts
- [ ] Manual: hammer login from one IP → 429; correct password still works after the email failure budget is spent
