### PR TITLE
fix(security): drop unsafe-eval from CSP

### DIFF
--- a/dashboard/backend/middleware.py
+++ b/dashboard/backend/middleware.py
@@ -117,8 +117,9 @@ class CSPHeaderMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         response = await call_next(request)
         # Allow Chart.js and scripts from same origin, plus unsafe-inline for development
-        # Dropped 'unsafe-eval' (PR7). Chart.js 4 from jsDelivr does not need
-        # eval; keep 'unsafe-inline' until scripts are nonced/externalized.
+        # No 'unsafe-eval': Chart.js 4 from jsDelivr does not need eval, and
+        # nothing in dashboard/frontend calls eval()/new Function(). Keep
+        # 'unsafe-inline' until the inline scripts are nonced or externalized.
         response.headers["Content-Security-Policy"] = (
             "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "

--- a/dashboard/backend/middleware.py
+++ b/dashboard/backend/middleware.py
@@ -117,8 +117,10 @@ class CSPHeaderMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         response = await call_next(request)
         # Allow Chart.js and scripts from same origin, plus unsafe-inline for development
+        # Dropped 'unsafe-eval' (PR7). Chart.js 4 from jsDelivr does not need
+        # eval; keep 'unsafe-inline' until scripts are nonced/externalized.
         response.headers["Content-Security-Policy"] = (
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; "
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
             "font-src 'self' https://fonts.gstatic.com data:; "
             "connect-src *; img-src * data:;"

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -325,6 +325,16 @@ def test_csp_middleware_lives_in_middleware_module():
     assert app_csp is middleware_mod.CSPHeaderMiddleware
 
 
+def test_csp_header_omits_unsafe_eval():
+    from fastapi.testclient import TestClient
+    from dashboard.backend.app import app
+
+    response = TestClient(app).get("/api/health")
+    csp = response.headers.get("content-security-policy", "")
+    assert "script-src" in csp
+    assert "unsafe-eval" not in csp
+
+
 def test_middleware_order_preserved():
     names = [m.cls.__name__ for m in app.user_middleware]
     assert names == ["CSPHeaderMiddleware", "SessionMiddleware", "CORSMiddleware"]

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=3600"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://agentictrading.onrender.com; img-src 'self' data: https:;"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Remove `'unsafe-eval'` from the Render `CSPHeaderMiddleware` policy (Chart.js does not need it).
- Add the same no-eval CSP on Vercel static responses so the marketing/dashboard HTML is covered when served from Vercel alone.
- Keep `'unsafe-inline'` for now; noncing/externalizing inline scripts is a follow-up.

## Test plan
- [ ] `pytest dashboard/backend/tests/test_app_composition.py::test_csp_header_omits_unsafe_eval`
- [ ] Smoke `/app` charts (equity / backtest) still render under the new CSP