### PR TITLE
fix(db): pre-ping pooled Neon connections

### DIFF
--- a/dashboard/backend/db_pool.py
+++ b/dashboard/backend/db_pool.py
@@ -2,9 +2,13 @@
 
 Replaces the fresh psycopg.connect() (a full TLS handshake to Neon) every
 store call used to pay. Small and short-lived by design: max_size 5 fits the
-single-worker deployment, and max_idle 300s closes idle sockets before Neon's
-scale-to-zero suspend can hand back a dead one. row_factory is configured at
-pool construction because every twin relies on dict-style row access.
+single-worker deployment. Two guards against Neon's ~5-minute scale-to-zero
+suspend killing pooled sockets: max_idle 120s retires idle connections well
+before the suspend timer can beat them to it, and check= pre-pings each
+connection at checkout so a socket that died anyway costs one silent
+reconnect instead of a 500 on the first request after idle. row_factory is
+configured at pool construction because every twin relies on dict-style row
+access.
 """
 
 from __future__ import annotations
@@ -39,8 +43,9 @@ def get_pool(database_url: str) -> ConnectionPool:
                 database_url,
                 min_size=0,
                 max_size=5,
-                max_idle=300,
+                max_idle=120,
                 timeout=POOL_TIMEOUT_SECONDS,
+                check=ConnectionPool.check_connection,
                 kwargs={"row_factory": dict_row},
                 open=True,
             )

--- a/dashboard/backend/tests/test_db_pool.py
+++ b/dashboard/backend/tests/test_db_pool.py
@@ -13,6 +13,13 @@ from dashboard.backend import db_pool
 class _FakePool:
     instances = []
 
+    # Mirrors psycopg_pool.ConnectionPool.check_connection: production passes
+    # ``check=ConnectionPool.check_connection`` and resolves it off whatever
+    # class the module holds, so the fake must expose one too.
+    @staticmethod
+    def check_connection(conn):
+        raise AssertionError("not used in dispatch tests")
+
     def __init__(self, url, **kwargs):
         self.url = url
         self.kwargs = kwargs
@@ -50,7 +57,14 @@ def test_pool_configured_for_neon_and_dict_rows():
     db_pool.get_pool("postgresql://u@h/db")
     kwargs = _FakePool.instances[0].kwargs
     assert kwargs["max_size"] == 5
-    assert kwargs["max_idle"] == 300          # < Neon scale-to-zero idle window
+    # Well below Neon's ~300s scale-to-zero suspend. At exactly 300 the pool
+    # and Neon race: whichever side's timer fires first decides whether the
+    # next caller gets a live socket or a dead one.
+    assert kwargs["max_idle"] == 120
+    # Pre-ping at checkout: a connection Neon killed during suspend costs one
+    # silent reconnect instead of a user-visible 500 on the first request
+    # after idle.
+    assert kwargs["check"] is _FakePool.check_connection
     assert kwargs["kwargs"] == {"row_factory": dict_row}
 
 


### PR DESCRIPTION
Closes the first-request-after-idle 500: `db_pool`'s `max_idle=300` exactly ties Neon's 5-minute scale-to-zero suspend, so a stale socket reaching a request was a coin flip — and `/health` (no DB) stayed green throughout.

- `max_idle` 300 → 120: idle sockets retire well before the suspend timer.
- `check=ConnectionPool.check_connection`: pre-ping at checkout, so a socket that died anyway costs one silent reconnect, not a user-visible 500.
- Docstring fixed — it previously claimed 300s "closes idle sockets before Neon's suspend", which was the race, not a guard.

The `@pg_only` round-trip in CI exercises the real pool with the `check` kwarg.

Safe to merge anytime; independent of #292/#293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)