### PR TITLE
perf(app): respond to clicks and show loading state during boot

### DIFF
--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -1,0 +1,176 @@
+"""Boot-order contracts for /app: interactive before network, feedback while slow.
+
+The boot regression this pins: the DOMContentLoaded handler used to serially
+await ~12 network round trips (auth refresh, agent claim + list, deep link,
+defaults, feature flags) before initNavigation() wired a single nav button and
+before the ticker's first fetch was even issued. On a Render cold start that
+left the page looking dead for 30+ seconds -- nav clicks silently dropped, no
+loading state anywhere, ticker (the de-facto "app is ready" signal) dead last.
+
+Guarded as source text per the convention in _frontend_source.py.
+"""
+
+from dashboard.backend.tests._frontend_source import (
+    APP_HTML,
+    APP_JS,
+    STYLES,
+    _match_brace,
+    fn_body,
+)
+
+
+def _boot_handler() -> str:
+    """The DOMContentLoaded handler's source, brace-matched."""
+    start = APP_JS.index("document.addEventListener('DOMContentLoaded'")
+    open_brace = APP_JS.index("{", start)
+    return APP_JS[start : _match_brace(APP_JS, open_brace) + 1]
+
+
+# ---------------------------------------------------------------------------
+# 1. Interactivity and the ticker must not queue behind the auth waterfall.
+# ---------------------------------------------------------------------------
+
+def test_nav_wiring_precedes_first_network_await():
+    boot = _boot_handler()
+    assert "initNavigation()" in boot
+    assert boot.index("initNavigation()") < boot.index(
+        "await restoreActiveAgentSession()"
+    ), "nav buttons must be wired before the first network await, not after it"
+
+
+def test_ticker_starts_before_auth_waterfall():
+    boot = _boot_handler()
+    assert boot.index("loadMarketTicker()") < boot.index(
+        "await restoreActiveAgentSession()"
+    ), "the ticker is the page's liveness signal; it must not wait on auth"
+
+
+def test_config_fetches_are_not_serial_awaits():
+    boot = _boot_handler()
+    assert "await loadDefaults()" not in boot, (
+        "loadDefaults must be kicked off in parallel (awaited later as a "
+        "promise), not serially awaited on the boot critical path"
+    )
+    assert "await loadMarketDataFeatures()" not in boot
+
+
+# ---------------------------------------------------------------------------
+# 2. Early nav clicks must not race the account-claim ordering invariant:
+#    refreshAuthUser -> claimAgentsForUser must land before the first real
+#    agents fetch, or a landing-signup handoff misses the guest Foundation
+#    agent and provisions a duplicate starter.
+# ---------------------------------------------------------------------------
+
+def test_load_agents_waits_for_auth_boot_gate():
+    body = fn_body("async function loadAgents(")
+    assert "authBootGate" in body, (
+        "loadAgents must await the auth boot gate so an early nav click "
+        "cannot fetch agents before the account claim settles"
+    )
+    assert "agentsLoadInFlight" in body, (
+        "concurrent early clicks must coalesce into one fetch, not stack "
+        "identical requests behind the gate"
+    )
+
+
+def test_claim_calls_the_ungated_loader():
+    body = fn_body("async function claimAgentsForUser(")
+    assert "loadAgentsNow(" in body, (
+        "claimAgentsForUser runs inside the gated section of boot; calling "
+        "the gated loadAgents() from there would deadlock on the gate"
+    )
+
+
+def test_boot_opens_the_gate_after_auth_refresh():
+    boot = _boot_handler()
+    assert "openAuthBootGate()" in boot
+    assert boot.index("refreshAuthUser()") < boot.index("openAuthBootGate()"), (
+        "the gate must open only after the refresh/claim phase has settled"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. A slow boot must not yank the page from under an explicit user click.
+# ---------------------------------------------------------------------------
+
+def test_initial_navigation_respects_user_click():
+    body = fn_body("function applyInitialNavigation(")
+    assert "userHasNavigated" in body, (
+        "with nav live during boot, restoring the saved page must be skipped "
+        "once the user has explicitly navigated"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. The network head start: preconnect + warmup so the Render cold start
+#    begins before the JS pipeline finishes downloading.
+# ---------------------------------------------------------------------------
+
+def test_app_html_preconnects_to_api_origin():
+    assert (
+        '<link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>'
+        in APP_HTML
+    )
+
+
+def test_boot_script_warms_the_backend():
+    head = APP_HTML[: APP_HTML.index("</head>")]
+    assert "/health" in head and "API_WARMUP" in head, (
+        "the inline boot script must fire a /health warmup fetch so a Render "
+        "cold start begins during JS download, not after it"
+    )
+
+
+def test_scripts_are_deferred():
+    # Every external script must carry defer: the Chart.js CDN tag in <head>
+    # was render-blocking, and defer preserves execution order document-wide
+    # (head tag first, body tags after, all before DOMContentLoaded).
+    import re
+
+    tags = re.findall(r"<script [^>]*src=[^>]*>", APP_HTML)
+    assert tags, "expected external script tags in app.html"
+    offenders = [t for t in tags if "defer" not in t]
+    assert offenders == [], f"script tags missing defer: {offenders}"
+
+
+# ---------------------------------------------------------------------------
+# 5. Visible loading feedback.
+# ---------------------------------------------------------------------------
+
+def test_agents_grid_ships_loading_skeleton():
+    # Pre-JS, My Agents must show placeholder cards instead of a blank panel.
+    builtin_grid_at = APP_HTML.index('id="agentsGridBuiltin"')
+    external_grid_at = APP_HTML.index('id="agentsGridExternal"')
+    skeletons = [
+        m for m in range(len(APP_HTML)) if APP_HTML.startswith("agent-card--skeleton", m)
+    ]
+    assert any(builtin_grid_at < at < builtin_grid_at + 2000 for at in skeletons)
+    assert any(external_grid_at < at < external_grid_at + 2000 for at in skeletons)
+    assert ".agent-card--skeleton" in STYLES
+
+
+def test_skeletons_self_clear_on_every_render():
+    # The skeletons need no removal code IF every render path overwrites the
+    # grid. renderAgentCards clears unconditionally; renderAgentsError clears
+    # explicitly. This pins the clear so a future early-return above it
+    # cannot strand skeletons behind real content.
+    body = fn_body("function renderAgentCards(")
+    assert body.index("grid.innerHTML = ''") < body.index("agents.length")
+    assert "grid.innerHTML = ''" in fn_body("function renderAgentsError(")
+
+
+def test_slow_boot_notice_is_wired():
+    boot = _boot_handler()
+    assert "API_WARMUP" in boot and "showAppToast(" in boot, (
+        "when the warmup ping is still pending after the notice delay, the "
+        "user must be told the free-tier server is waking up"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Cache busters: shipped HTML must reference the new revisions.
+# ---------------------------------------------------------------------------
+
+def test_cache_busters_bumped():
+    assert "app.js?v=57" in APP_HTML
+    assert "styles.css?v=76" in APP_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -8,9 +8,16 @@
     <link rel="apple-touch-icon" href="/images/atltransparent.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- API origin (Vercel serves this page, Render answers its fetches):
+         start the TCP+TLS handshake now, not at the first fetch. crossorigin
+         because every API call is a CORS request. -->
+    <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=75">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <link rel="stylesheet" href="styles.css?v=76">
+    <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
+         document order (this one first, the body-end ones after), all before
+         DOMContentLoaded, so Chart is defined before any chart renders. -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-e6nUZLBkQ86NJ6TVVKAeSaK8jWa3NhkYWZFomE39AvDbQWeie9PlQqM3pmYW5d1g" crossorigin="anonymous" defer></script>
     <script>
     (function () {
         var NAV_STATE_KEY = 'nav-state';
@@ -82,6 +89,15 @@
         html.setAttribute('data-nav-page', nav.page);
         html.setAttribute('data-nav-playground-tab', nav.playgroundTab || 'agents');
         html.setAttribute('data-nav-competition-tab', nav.competitionTab || 'daily');
+        // Warm the API before the JS pipeline even finishes downloading: on
+        // Render's free tier the first request may pay a 30-60s cold start,
+        // so every second saved here comes straight off page readiness.
+        // Mirrors app.js's API_BASE host rule; app.js reads window.API_WARMUP
+        // to decide whether to show the slow-boot notice.
+        var apiBase = (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
+            ? location.origin
+            : 'https://agentictrading.onrender.com';
+        window.API_WARMUP = fetch(apiBase + '/health').catch(function () { return null; });
     })();
     </script>
     <style id="nav-boot-style">
@@ -885,7 +901,15 @@
                             <h3 class="agents-category-title">Foundation Agents</h3>
                             <p class="agents-category-sub">A prompting game — give it money, an instruction, and a model, then backtest.</p>
                         </div>
-                        <div id="agentsGridBuiltin" class="agents-grid"></div>
+                        <div id="agentsGridBuiltin" class="agents-grid">
+                            <!-- Loading skeletons: visible pre-JS and while the first
+                                 agents fetch runs. No removal code needed — every render
+                                 path overwrites this grid's innerHTML (pinned by
+                                 test_frontend_fast_boot.py). -->
+                            <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
+                            <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
+                            <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
+                        </div>
                         <div id="agentsGridFooterBuiltin" class="agents-grid-footer" hidden></div>
                         <p id="agentsEmptyBuiltin" class="control-helper" hidden>No foundation agents yet. Click <strong>Add Agent</strong> to create one.</p>
                     </section>
@@ -894,7 +918,9 @@
                             <h3 class="agents-category-title">External Agents</h3>
                             <p class="agents-category-sub">Bring your own agent and connect it with an API key.</p>
                         </div>
-                        <div id="agentsGridExternal" class="agents-grid"></div>
+                        <div id="agentsGridExternal" class="agents-grid">
+                            <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
+                        </div>
                         <div id="agentsGridFooterExternal" class="agents-grid-footer" hidden></div>
                         <p id="agentsEmptyExternal" class="control-helper" hidden>No external agents match your search.</p>
                     </section>
@@ -1638,20 +1664,23 @@
     </div>
 
 
-    <script src="market-events/mockMarketEvents.js"></script>
-    <script src="market-events/marketEventRelativeTime.js"></script>
-    <script src="market-events/MarketEventCard.js"></script>
-    <script src="market-events/MarketEventFeed.js"></script>
-    <script src="js/portfolio.js?v=15"></script>
-    <script src="js/agent-editor.js?v=17"></script>
-    <script src="app.js?v=56"></script>
-    <script src="js/leaderboard.js?v=16"></script>
-    <script src="home-page.js?v=36"></script>
+    <!-- All deferred so the Chart.js CDN tag in <head> (also deferred) can
+         stay first in execution order: deferred scripts run in document
+         order, all before DOMContentLoaded. -->
+    <script src="market-events/mockMarketEvents.js" defer></script>
+    <script src="market-events/marketEventRelativeTime.js" defer></script>
+    <script src="market-events/MarketEventCard.js" defer></script>
+    <script src="market-events/MarketEventFeed.js" defer></script>
+    <script src="js/portfolio.js?v=15" defer></script>
+    <script src="js/agent-editor.js?v=17" defer></script>
+    <script src="app.js?v=57" defer></script>
+    <script src="js/leaderboard.js?v=16" defer></script>
+    <script src="home-page.js?v=36" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),
          both loaded above — not beside the market-events/* block, which loads
          before app.js. -->
-    <script src="home-news-signals.js"></script>
+    <script src="home-news-signals.js" defer></script>
     <!-- Never `hidden`: a live region has to stay rendered to be monitored. It
          hides itself visually via .app-toast's opacity + pointer-events. -->
     <div id="appToast" class="app-toast" role="status" aria-live="polite"></div>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -138,6 +138,10 @@ let appToastTimer = null;
 
 const APP_TOAST_VISIBLE_MS = 4000;
 const APP_TOAST_FADE_MS = 240;
+// How long the head boot script's /health warmup may stay pending before the
+// boot handler tells the user the free-tier server is waking up. A warm
+// server answers well under this; a cold start takes 30-60s.
+const SLOW_BOOT_NOTICE_MS = 3000;
 
 /**
  * Non-blocking confirmation channel for /app.
@@ -1589,7 +1593,38 @@ async function ensureDefaultFoundationAgent(agents) {
   }
 }
 
+// Auth boot gate: nav goes live before the boot's auth awaits, so a My Agents
+// click can arrive while refreshAuthUser → claimAgentsForUser is still in
+// flight. Fetching agents at that moment misses the guest Foundation agent a
+// landing signup is about to claim, and ensureDefaultFoundationAgent would
+// provision a duplicate starter. Every external caller therefore waits here;
+// the DOMContentLoaded handler opens the gate once the claim phase settles.
+let openAuthBootGate;
+const authBootGate = new Promise((resolve) => {
+  openAuthBootGate = resolve;
+});
+let agentsLoadInFlight = null;
+
 async function loadAgents() {
+  // Coalesce concurrent callers: several early clicks during a cold boot must
+  // share one fetch, not stack identical requests behind the gate. Sequential
+  // calls still refetch (re-clicking the subtab is the user's refresh).
+  if (agentsLoadInFlight) return agentsLoadInFlight;
+  agentsLoadInFlight = (async () => {
+    try {
+      await authBootGate;
+      return await loadAgentsNow();
+    } finally {
+      agentsLoadInFlight = null;
+    }
+  })();
+  return agentsLoadInFlight;
+}
+
+// The ungated loader: only for callers already ordered after the account
+// claim (claimAgentsForUser itself, which runs inside the gated section and
+// would deadlock on the gate above).
+async function loadAgentsNow() {
   try {
     let data = await API.get(`${API_BASE}/api/v1/agents`);
     let agents = data.agents || [];
@@ -2474,7 +2509,9 @@ async function claimAgentsForUser({ reload = true } = {}) {
     console.warn('Agent account claim skipped:', error.message);
   }
   if (reload) {
-    await loadAgents();
+    // Ungated on purpose: this call IS the claim-then-load ordering the auth
+    // boot gate exists to protect, and it runs before the gate opens.
+    await loadAgentsNow();
   }
 }
 
@@ -3567,6 +3604,11 @@ let currentMode = "home";
 let currentPage = "home";
 let playgroundTab = "agents";
 let competitionTab = "daily";
+// True once the user explicitly navigates (any history:'push' navigation).
+// Nav is wired before boot's auth awaits, so applyInitialNavigation may run
+// AFTER a real click — restoring the saved page then would yank the page out
+// from under the user.
+let userHasNavigated = false;
 let allRuns = [];
 let comparisonData = null;
 let backtestChartData = null;
@@ -3580,86 +3622,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     // landing signup → /app handoff does not miss the guest Foundation agent.
     initAuthUI({ refresh: false });
     bindCashStepInputs();
-    await restoreActiveAgentSession();
-    if (localStorage.getItem(AUTH_TOKEN_KEY)) {
-        try {
-            await refreshAuthUser();
-        } catch (error) {
-            console.warn('Boot refreshAuthUser failed:', error?.message || error);
-        }
-    }
-    // Portfolio overview must not wait on the agents waterfall. Paint any
-    // sessionStorage snapshot immediately, kick GET /portfolio in parallel,
-    // then show the page while loadAgents continues in the background.
-    if (typeof window.paintPortfolioBoot === 'function') {
-        try {
-            window.paintPortfolioBoot(
-                Array.isArray(allAgents) ? allAgents.map(decorateAgent) : [],
-            );
-        } catch (error) {
-            console.warn('Portfolio boot paint failed:', error?.message || error);
-        }
-    }
-    if (typeof window.prefetchPortfolio === 'function') {
-        Promise.resolve(
-            window.prefetchPortfolio(
-                Array.isArray(allAgents) ? allAgents.map(decorateAgent) : [],
-            ),
-        ).catch((error) => {
-            console.warn('Portfolio prefetch failed:', error?.message || error);
-        });
-    }
-    // refreshAuthUser → claimAgentsForUser already loadAgents when signed in.
-    const agentsReady = localStorage.getItem(AUTH_TOKEN_KEY) && getStoredAuthUser()
-        ? Promise.resolve()
-        : loadAgents().catch((error) => {
-            console.warn('Initial loadAgents failed:', error.message);
-        });
-    applyInitialNavigation();
-    // Home modules / agent cards catch up once the list lands; do not block
-    // first navigation on that wait.
-    await agentsReady;
-    window.addEventListener('agent-editor-saved', async (event) => {
-        const agent = event.detail?.agent;
-        if (agent?.agent_id) {
-            const idx = allAgents.findIndex((a) => a.agent_id === agent.agent_id);
-            if (idx >= 0) {
-                allAgents[idx] = { ...allAgents[idx], ...agent };
-            }
-            applyAgentFilters();
-        }
-        if (agent?.agent_id === localStorage.getItem(ACTIVE_AGENT_KEY)) {
-            localStorage.setItem(ACTIVE_AGENT_NAME_KEY, agent.name || '');
-            const nameEl = document.getElementById('playgroundAgentName');
-            if (nameEl) nameEl.textContent = agent.name || 'Agent';
-        }
-        await loadAgents();
-    });
-    window.addEventListener('agent-editor-open-run', async (event) => {
-        const { agent, runId } = event.detail || {};
-        if (!agent || !runId) return;
-        if (window.AgentEditor) window.AgentEditor.close(true);
-        await activateAgent(agent);
-        localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, runId);
-        navigateToPage('playground', { playgroundTab: 'backtest' });
-        currentMode = 'backtest';
-        await loadData();
-    });
-    // Guarded: this awaits loadData() internally, and an unhandled rejection here
-    // used to abort the rest of boot — including initNavigation(), which wires
-    // every nav button. A failed deep link must not cost the user navigation.
-    try {
-        await applyAgentRunDeepLink();
-    } catch (error) {
-        console.warn('Deep link failed:', error.message);
-    }
-    const config = loadConfigFromURL();
-    window.CURRENT_CONFIG = config;
-    console.log('⚙️ Experiment config:', config);
-    console.log('Session ID:', window.SESSION_ID);
-    
-    console.log('Dashboard initializing...');
 
+    // ---- Pure-DOM wiring before ANY network await. On a cold backend start
+    // every fetch below this block can hang for tens of seconds, and nothing
+    // here needs one: nav must respond to clicks immediately. Data loads an
+    // early click triggers are held by authBootGate until the account-claim
+    // phase settles, so wiring early cannot reorder the claim invariant. ----
+    initNavigation();
     setupTickerResizeHandler();
     setupTickerScrollControls();
 
@@ -3734,46 +3703,144 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.universe-tab').forEach(tab => {
         tab.addEventListener('click', (e) => handleUniverseTabSwitch(e.target));
     });
-    
+
     // Setup preset cards
     document.getElementById('djiaCard')?.addEventListener('click', () => selectPreset('djia'));
     document.getElementById('mag7Card')?.addEventListener('click', () => selectPreset('mag7'));
-    
+
     // Setup custom universe builder
     setupAssetSearch();
-    
+
     const addAssetBtn = document.querySelector('.add-asset-btn');
     if (addAssetBtn) {
         addAssetBtn.addEventListener('click', handleAddAsset);
     }
-    
+
     const searchInput = document.getElementById('assetSearchInput');
     if (searchInput) {
         searchInput.addEventListener('keypress', (e) => {
             if (e.key === 'Enter') handleAddAsset();
         });
     }
-    
+
     // Setup chip removal
     document.querySelectorAll('.chip-remove').forEach(btn => {
         btn.addEventListener('click', (e) => removeChip(e.target.closest('.chip')));
     });
 
-    // Load default configuration if available (after DOM is ready)
-    try {
-      await loadDefaults();
-    } catch (error) {
-      console.warn('Failed to load defaults:', error);
-    }
-    await loadMarketDataFeatures();
-
-    initNavigation();
-
-    // Load ticker without blocking the rest of the page
+    // Ticker immediately: it is the page's de-facto liveness signal and
+    // depends on nothing above.
     loadMarketTicker();
     setInterval(loadMarketTicker, 30000);
     updateMarketsOpenStatus();
     setInterval(updateMarketsOpenStatus, 60000);
+
+    // Config fetches in parallel, off the boot critical path; awaited at the
+    // end of boot so "Dashboard ready" still means fully configured.
+    const configReady = Promise.all([
+        loadDefaults().catch((error) => {
+            console.warn('Failed to load defaults:', error);
+        }),
+        loadMarketDataFeatures(),
+    ]);
+
+    // If the head boot script's warmup ping is still pending after a beat,
+    // say so — a free-tier cold start otherwise looks like a broken page.
+    if (window.API_WARMUP) {
+        let warmupSettled = false;
+        window.API_WARMUP.then(() => { warmupSettled = true; });
+        setTimeout(() => {
+            if (!warmupSettled) {
+                showAppToast('Waking up the server — the first load can take up to a minute on our free hosting.');
+            }
+        }, SLOW_BOOT_NOTICE_MS);
+    }
+
+    await restoreActiveAgentSession();
+    if (localStorage.getItem(AUTH_TOKEN_KEY)) {
+        try {
+            await refreshAuthUser();
+        } catch (error) {
+            console.warn('Boot refreshAuthUser failed:', error?.message || error);
+        }
+    }
+    // Claim phase settled (or there was nothing to claim): gated loadAgents
+    // callers queued by early clicks may fetch now.
+    openAuthBootGate();
+    // Portfolio overview must not wait on the agents waterfall. Paint any
+    // sessionStorage snapshot immediately, kick GET /portfolio in parallel,
+    // then show the page while loadAgents continues in the background.
+    if (typeof window.paintPortfolioBoot === 'function') {
+        try {
+            window.paintPortfolioBoot(
+                Array.isArray(allAgents) ? allAgents.map(decorateAgent) : [],
+            );
+        } catch (error) {
+            console.warn('Portfolio boot paint failed:', error?.message || error);
+        }
+    }
+    if (typeof window.prefetchPortfolio === 'function') {
+        Promise.resolve(
+            window.prefetchPortfolio(
+                Array.isArray(allAgents) ? allAgents.map(decorateAgent) : [],
+            ),
+        ).catch((error) => {
+            console.warn('Portfolio prefetch failed:', error?.message || error);
+        });
+    }
+    // refreshAuthUser → claimAgentsForUser already loadAgents when signed in.
+    const agentsReady = localStorage.getItem(AUTH_TOKEN_KEY) && getStoredAuthUser()
+        ? Promise.resolve()
+        : loadAgents().catch((error) => {
+            console.warn('Initial loadAgents failed:', error.message);
+        });
+    applyInitialNavigation();
+    // Home modules / agent cards catch up once the list lands; do not block
+    // first navigation on that wait.
+    await agentsReady;
+    window.addEventListener('agent-editor-saved', async (event) => {
+        const agent = event.detail?.agent;
+        if (agent?.agent_id) {
+            const idx = allAgents.findIndex((a) => a.agent_id === agent.agent_id);
+            if (idx >= 0) {
+                allAgents[idx] = { ...allAgents[idx], ...agent };
+            }
+            applyAgentFilters();
+        }
+        if (agent?.agent_id === localStorage.getItem(ACTIVE_AGENT_KEY)) {
+            localStorage.setItem(ACTIVE_AGENT_NAME_KEY, agent.name || '');
+            const nameEl = document.getElementById('playgroundAgentName');
+            if (nameEl) nameEl.textContent = agent.name || 'Agent';
+        }
+        await loadAgents();
+    });
+    window.addEventListener('agent-editor-open-run', async (event) => {
+        const { agent, runId } = event.detail || {};
+        if (!agent || !runId) return;
+        if (window.AgentEditor) window.AgentEditor.close(true);
+        await activateAgent(agent);
+        localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, runId);
+        navigateToPage('playground', { playgroundTab: 'backtest' });
+        currentMode = 'backtest';
+        await loadData();
+    });
+    // Guarded: this awaits loadData() internally, and an unhandled rejection here
+    // used to abort the rest of boot — including initNavigation(), which wires
+    // every nav button. A failed deep link must not cost the user navigation.
+    try {
+        await applyAgentRunDeepLink();
+    } catch (error) {
+        console.warn('Deep link failed:', error.message);
+    }
+    const config = loadConfigFromURL();
+    window.CURRENT_CONFIG = config;
+    console.log('⚙️ Experiment config:', config);
+    console.log('Session ID:', window.SESSION_ID);
+    
+    console.log('Dashboard initializing...');
+
+    // Kicked off before the auth awaits; settled before boot reports ready.
+    await configReady;
 
     console.log('🎯 Dashboard ready. Default runs:', window.DEFAULT_RUNS || 'None configured');
 });
@@ -6144,12 +6211,17 @@ function applyInitialNavigation() {
     // single point of failure when the listener is free and order-independent.
     window.addEventListener('popstate', onNavigationPopState);
 
-    const initial = resolveInitialNavigation();
-    navigateToPage(initial.page, {
-        playgroundTab: initial.playgroundTab || 'agents',
-        competitionTab: initial.competitionTab || 'daily',
-        history: 'replace',
-    });
+    // Skip the restore once the user has already clicked somewhere: nav is
+    // live during boot's auth awaits, and stomping an explicit navigation
+    // with the saved page reads as the app fighting the user.
+    if (!userHasNavigated) {
+        const initial = resolveInitialNavigation();
+        navigateToPage(initial.page, {
+            playgroundTab: initial.playgroundTab || 'agents',
+            competitionTab: initial.competitionTab || 'daily',
+            history: 'replace',
+        });
+    }
     if (typeof initHomePage === 'function') {
         initHomePage();
     }
@@ -6429,6 +6501,7 @@ function navigateToPage(page, options = {}) {
     }
 
     const historyMode = options.history || 'push';
+    if (historyMode === 'push') userHasNavigated = true;
     const prevState = getNavigationState();
 
     currentPage = page;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -6938,6 +6938,26 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     gap: 10px;
 }
 
+/* My Agents loading skeletons — shipped in app.html so the grid shows card
+   shapes pre-JS; the first agents render overwrites the grid and clears them. */
+.agent-card--skeleton {
+    min-height: 172px;
+    border: 1px solid var(--border-color);
+    background: linear-gradient(100deg,
+        var(--bg-card) 40%, var(--bg-hover) 50%, var(--bg-card) 60%);
+    background-size: 200% 100%;
+    animation: agent-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes agent-skeleton-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-card--skeleton { animation: none; }
+}
+
 .agent-card-head {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
Frontend half of the load-time fix (backend: #292, ops: #293, DB: #294). Safe to merge independently of all of them.

**What was wrong:** boot serially awaited ~12 network round trips before `initNavigation()` wired any nav button and before the ticker's first fetch. On a cold start the page looked dead for 30+ seconds — nav clicks silently dropped, no loading state, and the ticker (the de-facto "app is ready" signal) loaded dead last.

**Changes**
- All pure-DOM wiring (nav included) moves ahead of every network await; ticker + config fetches start immediately in parallel.
- **Auth boot gate**: `loadAgents` waits for the refresh→claim phase, so an early My Agents click can't fetch ahead of the account claim (which would miss the guest Foundation agent and double-provision the starter). `claimAgentsForUser` calls the ungated loader — it *is* the ordering the gate protects. Concurrent early calls coalesce.
- `applyInitialNavigation` skips the saved-page restore if the user already clicked somewhere.
- Preconnect to the API origin + `/health` warmup fetch in the head boot script (cold start begins during JS download); a toast announces "waking up the server" if the ping is still pending after 3s.
- Chart.js CDN tag deferred (~200KB was render-blocking) + SRI hash added; all body scripts deferred (execution order preserved — deferred scripts run in document order).
- My Agents grids ship skeleton cards; every render path overwrites the grid so they self-clear. Cache busters bumped (`app.js?v=57`, `styles.css?v=76`).

**Verification:** new `test_frontend_fast_boot.py` pins boot order, gate wiring, and markup; full suite green. Headless-Chromium smoke: early nav click lands during boot, gate provisions the starter agent on an empty DB, skeletons clear, ticker renders, zero JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)