### PR TITLE
ux: guide sign-in through to a first backtest

### DIFF
--- a/dashboard/backend/tests/test_onboarding_flow_ux.py
+++ b/dashboard/backend/tests/test_onboarding_flow_ux.py
@@ -1,0 +1,273 @@
+"""Guards for the sign-in -> My Agents -> configure -> backtest flow (2026-08-03).
+
+Every contract here was found by measuring the *rendered* page in headless
+Chromium, not by reading source, and each one reverts silently: a colour that
+drops under the contrast floor, a base rule deleted as redundant, or a client
+limit that drifts from the server's still render a page that looks fine in a
+diff. So they are asserted against the shipped bytes, per this suite's
+frontend convention (`_frontend_source`).
+"""
+
+import re
+from pathlib import Path
+
+from dashboard.backend.api.routers.backtests import MAX_BACKTEST_DAYS
+from dashboard.backend.tests._frontend_source import (
+    APP_JS,
+    STYLES,
+    css_blocks,
+    fn_body,
+)
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_INDEX_HTML = (_FRONTEND / "index.html").read_text(encoding="utf-8")
+_EDITOR_JS = (_FRONTEND / "js" / "agent-editor.js").read_text(encoding="utf-8")
+
+# WCAG 2.1 AA for normal-weight body text.
+_AA_CONTRAST = 4.5
+
+
+def _css_var(name: str) -> str:
+    """The first value of a `--custom-property` in styles.css."""
+    match = re.search(rf"{re.escape(name)}:\s*(#[0-9a-fA-F]{{3,8}})", STYLES)
+    assert match, f"{name} is no longer a hex custom property in styles.css"
+    return match.group(1)
+
+
+def _declaration(block: str, prop: str) -> str:
+    """A property's value from inside one already-sliced CSS block.
+
+    Comment-stripped first: three of the blocks below carry a rationale comment
+    that names the very colour being replaced (`white on #00bfff measures
+    2.12:1`), and a naive search finds that mention instead of the live
+    declaration -- the guard would then read the *rejected* value and fail on
+    correct code.
+    """
+    body = re.sub(r"/\*.*?\*/", "", block, flags=re.DOTALL)
+    match = re.search(rf"(?<![-\w]){re.escape(prop)}:\s*([^;}}]+)", body)
+    assert match, f"no {prop} declaration in block: {body[:120]}"
+    return match.group(1).strip()
+
+
+def _code_only(source: str) -> str:
+    """`source` with its JS comments removed.
+
+    Both fixes below are explained in a comment that *names the behaviour being
+    replaced* ("used to go to '?view=home'"), so a `not in` assertion over raw
+    source reads the rationale and reports a regression that is not there. The
+    inverse is the real hazard: an `in` assertion satisfied by a comment passes
+    after the code it describes has been deleted.
+    """
+    return re.sub(r"//[^\n]*", "", re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL))
+
+
+def _slice_fn(source: str, signature: str) -> str:
+    """`fn_body` for a file other than app.js (index.html's inline script)."""
+    start = source.index(signature)
+    depth, index = 0, source.index("{", source.index(")", start))
+    while True:
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+        index += 1
+
+
+def _relative_luminance(hex_colour: str) -> float:
+    raw = hex_colour.lstrip("#")
+    if len(raw) == 3:
+        raw = "".join(channel * 2 for channel in raw)
+    channels = []
+    for offset in (0, 2, 4):
+        value = int(raw[offset : offset + 2], 16) / 255
+        channels.append(
+            value / 12.92 if value <= 0.03928 else ((value + 0.055) / 1.055) ** 2.4
+        )
+    red, green, blue = channels
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+
+def _contrast(foreground: str, background: str) -> float:
+    first = _relative_luminance(foreground)
+    second = _relative_luminance(background)
+    lighter, darker = max(first, second), min(first, second)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def test_contrast_helper_agrees_with_the_wcag_reference_pairs():
+    """Anchor the maths, so the ratio assertions below cannot pass vacuously.
+
+    A luminance function with a transposed coefficient or a missing gamma step
+    still returns a plausible number for any input, and every threshold check
+    built on it would keep passing. Black-on-white is 21:1 exactly, and the
+    white-on-#00bfff pair these fixes replace is the documented 2.12:1.
+    """
+    assert round(_contrast("#000000", "#ffffff"), 2) == 21.0
+    assert round(_contrast("#ffffff", "#00bfff"), 2) == 2.12
+
+
+def test_primary_cyan_buttons_clear_the_aa_contrast_floor():
+    """`.auth-submit` paints the submit control at every step of this flow.
+
+    The sign-in modal, the Run Backtest modal and both create-agent modals all
+    use it, and it shipped as white on --info-color: 2.12:1, less than half the
+    AA floor.
+    """
+    blocks = css_blocks(".auth-submit-btn")
+    assert len(blocks) == 1, "expected one base .auth-submit-btn rule"
+    # Pin the fill too: the ratio below is only meaningful while the button is
+    # still painted on --info-color.
+    assert _declaration(blocks[0], "background") == "var(--info-color)"
+    ratio = _contrast(_declaration(blocks[0], "color"), _css_var("--info-color"))
+    assert ratio >= _AA_CONTRAST, f"{ratio:.2f}:1"
+
+
+def test_active_subtab_clears_the_aa_contrast_floor():
+    """The My Agents / Backtest / Paper Trading switch -- the most-used control
+    in the flow -- had the same white-on-cyan pairing."""
+    blocks = css_blocks(".subtab-btn.active")
+    assert len(blocks) == 1
+    assert _declaration(blocks[0], "background") == "var(--info-color)"
+    ratio = _contrast(_declaration(blocks[0], "color"), _css_var("--info-color"))
+    assert ratio >= _AA_CONTRAST, f"{ratio:.2f}:1"
+
+
+def test_form_controls_inherit_the_page_font():
+    """Without this base rule the UA stylesheet wins and controls render Arial.
+
+    Measured before the fix: 15 of the 16 buttons on My Agents plus the search
+    input painted in Arial while the prose beside them used the app font. The
+    cause is an *absence*, so nothing in the file points at it -- which is
+    exactly why a later reader can delete the rule as redundant.
+    """
+    blocks = css_blocks("button,\ninput,\nselect,\ntextarea")
+    assert len(blocks) == 1, "the form-control font base rule is gone"
+    assert _declaration(blocks[0], "font-family") == "inherit"
+
+
+def test_the_subtab_bar_is_not_the_smallest_text_on_the_page():
+    """It was 11px in a 26px target, under a 14px/32px top nav, while being the
+    primary in-product navigation."""
+    blocks = css_blocks(".subtab-btn")
+    assert blocks, "no .subtab-btn rule"
+    assert int(_declaration(blocks[0], "font-size").removesuffix("px")) >= 13
+
+
+def test_configure_panel_headings_outrank_the_section_card_default():
+    """`.section-card h3 { font-size: 12px }` beat these single-class rules.
+
+    All three panel titles in Configure therefore painted *smaller than their
+    own body text*. The fix is specificity, so the guard has to check the
+    qualified selector still exists -- an unqualified rule with the right
+    font-size looks correct and renders at 12px.
+    """
+    default = css_blocks(".section-card h3")
+    assert default, "no .section-card h3 rule to override"
+    overridden = int(_declaration(default[0], "font-size").removesuffix("px"))
+
+    for title in (
+        "agent-capital-title",
+        "agent-editor-history-title",
+        "agent-editor-intro-title",
+    ):
+        blocks = css_blocks(f".section-card .{title}")
+        assert len(blocks) == 1, f".{title} is no longer qualified by .section-card"
+        size = int(_declaration(blocks[0], "font-size").removesuffix("px"))
+        assert size > overridden, f".{title} renders at {size}px"
+
+
+def test_the_instruction_field_is_sized_in_px_like_the_rest_of_the_app():
+    """`rem` resolves against the 16px html root; the app is sized off a 14px
+    body, so `0.95rem` painted this field at a fractional 15.2px."""
+    blocks = css_blocks(".agent-editor-simple textarea")
+    assert blocks, "no .agent-editor-simple textarea rule"
+    assert _declaration(blocks[0], "font-size").endswith("px")
+
+
+def test_run_backtest_submit_is_pinned_in_view():
+    """The panel's content runs ~1080px, so the CTA rendered at y=1045 on a
+    1440x900 screen -- past the fold, with nothing indicating the panel scrolls."""
+    blocks = css_blocks(".run-backtest-modal-panel > #runBacktestModalSubmit")
+    assert len(blocks) == 1, "the Run Backtest submit is no longer pinned"
+    assert _declaration(blocks[0], "position") == "sticky"
+
+
+def test_the_flow_controls_have_a_visible_focus_style():
+    """styles.css carried eight bare `outline: none` resets and zero
+    `:focus-visible` rules, so keyboard users could not see their position."""
+    for selector in (".subtab-btn", ".agent-card-cta", ".home-btn"):
+        assert f"{selector}:focus-visible" in STYLES, f"{selector} has no focus style"
+
+
+def test_both_auth_paths_land_the_user_on_my_agents():
+    """The two sign-in surfaces are separate code (the landing page has no build
+    step and cannot import app.js), so each needs its own assertion.
+
+    Sign-up used to go to Home -- a second marketing hero carrying the button
+    the user had just clicked -- and sign-in navigated nowhere at all.
+    """
+    landing = _code_only(_slice_fn(_INDEX_HTML, "function goToDashboardLoggedIn"))
+    assert "?view=agents" in landing
+    assert "?view=home" not in landing
+    # The '?view=' wins on boot; this write keeps a later bare /app visit off
+    # the tab the user was last on while logged out.
+    assert "'nav-state'" in landing
+    assert "playgroundTab: 'agents'" in landing
+
+    # Only the post-authentication branch, not all of initAuthUI: the sign-*out*
+    # handler in the same function navigates Home and rightly so, so a whole-body
+    # `not in` would forbid correct code.
+    body = _code_only(fn_body("function initAuthUI"))
+    prefix = body[: body.index("claimAgentsForUser()")]
+    on_success = prefix[prefix.rindex("closeAuthModal();") :]
+    assert "navigateToPage('agents')" in on_success
+    # The destination used to fork on sign-up vs sign-in; it no longer does.
+    assert "authMode === 'signup'" not in on_success
+
+
+def test_the_client_backtest_span_check_mirrors_the_server_constant():
+    """A client limit that drifts from the server's is worse than none: the
+    modal closes, then a 422 arrives with the dates no longer on screen."""
+    body = fn_body("async function runBacktest")
+    match = re.search(r"const MAX_BACKTEST_DAYS = (\d+);", body)
+    assert match, "runBacktest no longer range-checks the window client-side"
+    assert int(match.group(1)) == MAX_BACKTEST_DAYS
+
+
+def test_the_period_helper_states_the_limit_rather_than_inviting_the_error():
+    from dashboard.backend.tests._frontend_source import APP_HTML
+
+    assert f"up to {MAX_BACKTEST_DAYS} days" in APP_HTML
+    assert "any range you have data for" not in APP_HTML
+
+
+def test_editor_status_messages_also_reach_the_toast():
+    """Every caller of showSaveStatus is a click in the editor's sticky header,
+    but the element it writes to renders 920px below the fold and has no
+    aria-live -- so 'Save changes before Run Backtest' was invisible and the
+    primary CTA read as dead. Asserted inside the function so a stray call
+    elsewhere in the file cannot satisfy it."""
+    start = _EDITOR_JS.index("function showSaveStatus")
+    end = _EDITOR_JS.index("\n  function ", start + 1)
+    assert "window.showAppToast" in _EDITOR_JS[start:end]
+
+
+def test_no_untranslated_strings_remain_in_the_served_frontend():
+    """My Agents shipped a Chinese pagination footer and legend toggle in an
+    otherwise all-English UI. The sweep covers the whole served tree, so it also
+    catches a *new* untranslated string rather than only a revert of these two.
+
+    `assets/` is excluded: it is the built landing bundle, whose source of truth
+    is dashboard/landing (see test_frontend_bundle_integrity).
+    """
+    cjk = re.compile(r"[一-鿿]")
+    offenders = [
+        path.relative_to(_FRONTEND).as_posix()
+        for pattern in ("*.js", "*.html", "*.css")
+        for path in _FRONTEND.rglob(pattern)
+        if "assets" not in path.parts
+        and cjk.search(path.read_text(encoding="utf-8", errors="ignore"))
+    ]
+    assert offenders == []

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=75">
+    <link rel="stylesheet" href="styles.css?v=76">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
     (function () {
@@ -247,7 +247,7 @@
 
                 <div class="control-group">
                     <label>Period</label>
-                    <p class="control-helper">Pre-filled with a recent window that has full market data. Change it to any range you have data for.</p>
+                    <p class="control-helper">Pre-filled with a recent window that has full market data. You can pick any window up to 31 days.</p>
                     <div class="date-range-inputs">
                         <div class="date-input-wrapper">
                             <input type="date" id="startDate" value="2026-04-15" class="date-input">
@@ -1643,8 +1643,8 @@
     <script src="market-events/MarketEventCard.js"></script>
     <script src="market-events/MarketEventFeed.js"></script>
     <script src="js/portfolio.js?v=15"></script>
-    <script src="js/agent-editor.js?v=17"></script>
-    <script src="app.js?v=56"></script>
+    <script src="js/agent-editor.js?v=18"></script>
+    <script src="app.js?v=57"></script>
     <script src="js/leaderboard.js?v=16"></script>
     <script src="home-page.js?v=36"></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1642,7 +1642,7 @@
     <script src="market-events/marketEventRelativeTime.js"></script>
     <script src="market-events/MarketEventCard.js"></script>
     <script src="market-events/MarketEventFeed.js"></script>
-    <script src="js/portfolio.js?v=15"></script>
+    <script src="js/portfolio.js?v=16"></script>
     <script src="js/agent-editor.js?v=18"></script>
     <script src="app.js?v=57"></script>
     <script src="js/leaderboard.js?v=16"></script>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1152,9 +1152,9 @@ function renderAgentGridFooter(categoryKey, total, page, pageCount) {
   const atStart = page <= 0;
   const atEnd = page >= pageCount - 1;
   footer.innerHTML = `
-    <button type="button" class="agents-grid-footer-btn agents-grid-footer-btn--nav" data-agent-grid-prev="${categoryKey}" aria-label="上一页" ${atStart ? 'disabled' : ''}>←</button>
-    <span class="agents-grid-footer-count">第 ${page + 1} / ${pageCount} 页 · 共 ${total} 个</span>
-    <button type="button" class="agents-grid-footer-btn agents-grid-footer-btn--nav" data-agent-grid-next="${categoryKey}" aria-label="下一页" ${atEnd ? 'disabled' : ''}>→</button>`;
+    <button type="button" class="agents-grid-footer-btn agents-grid-footer-btn--nav" data-agent-grid-prev="${categoryKey}" aria-label="Previous page" ${atStart ? 'disabled' : ''}>←</button>
+    <span class="agents-grid-footer-count">Page ${page + 1} of ${pageCount} · ${total} total</span>
+    <button type="button" class="agents-grid-footer-btn agents-grid-footer-btn--nav" data-agent-grid-next="${categoryKey}" aria-label="Next page" ${atEnd ? 'disabled' : ''}>→</button>`;
 }
 
 function renderAgentCards(grid, agents, categoryKey) {

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -3312,11 +3312,14 @@ function initAuthUI(options = {}) {
       // post-sign-in housekeeping and must not hold the modal open — a slow or
       // hung backend used to leave the popup up over an already-signed-in UI.
       closeAuthModal();
-      // First-time accounts should greet on Home, not a leftover My Agents tab
-      // from browsing while logged out (nav-state restore).
-      if (authMode === 'signup') {
-        navigateToPage('home');
-      }
+      // Land on My Agents after either sign-up or sign-in, matching the landing
+      // page's goToDashboardLoggedIn. Sign-up used to go to Home (a second
+      // marketing hero); sign-in used to navigate nowhere at all, so the only
+      // confirmation it had worked was the header avatar swapping in, and the
+      // user was left on whatever page they happened to be reading.
+      // navigateToPage maps 'agents' → playground + the 'agents' subtab itself.
+      navigateToPage('agents');
+      showAppToast(`Signed in as ${data.user?.display_name || data.user?.email || 'your account'}`);
       claimAgentsForUser()
         .then(() => {
           // If we arrived here from a Discord deep link that needed this account
@@ -5802,8 +5805,7 @@ async function runBacktest() {
     const startDate = startDateInput.value;
     const endDate = endDateInput.value;
     
-    if (!startDate || !endDate) {
-        const msg = 'Please select both start and end dates.';
+    const showModalError = (msg) => {
         const err = document.getElementById('runBacktestModalError');
         if (err && !document.getElementById('runBacktestModal')?.hidden) {
             err.textContent = msg;
@@ -5811,6 +5813,30 @@ async function runBacktest() {
         } else {
             console.warn(msg);
         }
+    };
+
+    if (!startDate || !endDate) {
+        showModalError('Please select both start and end dates.');
+        return;
+    }
+
+    // Mirror the server's MAX_BACKTEST_DAYS (api/routers/backtests.py) here so an
+    // over-long window is caught while the modal is still open and the dates are
+    // still on screen. Without this the only feedback is a 422 that arrives after
+    // the modal has closed, and the helper copy used to actively invite the
+    // mistake ("Change it to any range you have data for").
+    const MAX_BACKTEST_DAYS = 31;
+    const spanDays = Math.round(
+        (Date.parse(`${endDate}T00:00:00Z`) - Date.parse(`${startDate}T00:00:00Z`)) / 86400000,
+    );
+    if (Number.isFinite(spanDays) && spanDays < 0) {
+        showModalError('The end date must be on or after the start date.');
+        return;
+    }
+    if (Number.isFinite(spanDays) && spanDays > MAX_BACKTEST_DAYS) {
+        showModalError(
+            `Pick a window of ${MAX_BACKTEST_DAYS} days or fewer — that range is ${spanDays} days.`,
+        );
         return;
     }
 

--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -303,20 +303,27 @@
           return data;
         }
 
-        function goToDashboardLoggedIn(user, token, options) {
-          options = options || {};
+        function goToDashboardLoggedIn(user, token) {
           try {
             localStorage.setItem(AUTH_TOKEN_KEY, token);
             localStorage.setItem(AUTH_USER_KEY, JSON.stringify(user));
-            // New accounts should land on Home, not a leftover My Agents tab
-            // from browsing the dashboard while logged out.
+            // Land authenticated users on My Agents, for both sign-up and
+            // sign-in. Sign-up used to go to '?view=home', which is a second
+            // marketing hero -- the same "Talk to Agents / Test Trading Ideas"
+            // pitch and a "Get Started" button the user had just clicked. Sign-in
+            // used to go to a bare '/app', which restores whatever tab was last
+            // visited while logged out, so a returning user could land on
+            // Competition. Neither put anyone near their agent.
             // 'nav-state' must match app.js's NAV_STATE_KEY -- this landing
             // page has no build step to share that constant across the split.
-            if (options.goHome) {
-              localStorage.setItem('nav-state', JSON.stringify({ page: 'home' }));
-            }
+            // The '?view=' below already wins over saved nav-state on boot; this
+            // write keeps a *later* bare '/app' visit off the stale tab too.
+            localStorage.setItem(
+              'nav-state',
+              JSON.stringify({ page: 'playground', playgroundTab: 'agents' })
+            );
           } catch (e) { /* ignore */ }
-          window.location.href = options.goHome ? (APP_URL + '?view=home') : APP_URL;
+          window.location.href = APP_URL + '?view=agents';
         }
 
         function initAuthModal() {
@@ -371,9 +378,7 @@
                     email: email,
                     password: password,
                   });
-              goToDashboardLoggedIn(data.user, data.token, {
-                goHome: authMode === 'signup',
-              });
+              goToDashboardLoggedIn(data.user, data.token);
             } catch (error) {
               if (errorEl) {
                 errorEl.textContent = error.message || 'Something went wrong.';

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -664,6 +664,20 @@
   }
 
   function showSaveStatus(message, isError) {
+    // Toast as well as write the inline note. #agentEditorSaveStatus lives at
+    // the bottom of the editor's left column, but every one of this function's
+    // callers is a click on a control in the sticky header (Save, Run Backtest,
+    // Run Live, Connect/Disconnect Robinhood). Measured live at 1440x900: the
+    // header button sits at y=14 and this element renders at y=934 -- 920px
+    // below the fold in a 900px viewport, and it carries no aria-live. So
+    // "Save changes before Run Backtest" and "Agent name is required" both
+    // landed somewhere nobody was looking, and the button read as dead.
+    // #appToast is role="status" aria-live="polite", so this reaches sighted
+    // and screen-reader users both. Done here rather than at the 16 call sites
+    // so no future message can regress to inline-only.
+    if (typeof window.showAppToast === 'function') {
+      window.showAppToast(message);
+    }
     const el = document.getElementById('agentEditorSaveStatus');
     if (!el) return;
     el.hidden = false;

--- a/dashboard/frontend/js/portfolio.js
+++ b/dashboard/frontend/js/portfolio.js
@@ -356,7 +356,7 @@ function renderAllocationLegend(legendEl, slices) {
     const toggleHtml = needsExpand
         ? `<div class="allocation-legend-toggle-row">
             <button type="button" class="allocation-legend-toggle" data-allocation-legend-toggle aria-expanded="${expanded ? 'true' : 'false'}">
-                ${expanded ? '收起' : `展开全部 (${agentCount})`}
+                ${expanded ? 'Show less' : `Show all (${agentCount})`}
             </button>
            </div>`
         : '';

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9,6 +9,24 @@
     box-sizing: border-box;
 }
 
+/*
+ * Form controls do not inherit the page font: the UA stylesheet gives every
+ * `button`/`input`/`select` its own default (Arial here) and every `textarea`
+ * `monospace`. With no base rule, 15 of the 16 buttons on My Agents and the
+ * plain-English "Trading instruction" textarea painted in a different typeface
+ * than the text around them -- the single widest typographic inconsistency in
+ * the app. `font-family` only, deliberately: `font: inherit` would also reset
+ * size/weight, and the controls that set those want to keep them. The mono
+ * fields (.agent-capital-input, .date-input, .control-select, ...) declare
+ * `font-family: var(--font-mono)` on a class, so they still win over this.
+ */
+button,
+input,
+select,
+textarea {
+    font-family: inherit;
+}
+
 :root {
     /* 10jqka-inspired dark theme - professional trading */
     --bg-primary: #0a0e27;
@@ -511,7 +529,14 @@ a.header-brand:hover .title-section h1 {
     border: none;
     border-radius: 6px;
     background: var(--info-color);
-    color: #fff;
+    /*
+     * Dark on cyan, not #fff: white on --info-color (#00bfff) measures 2.12:1,
+     * under the WCAG AA 4.5:1 floor. This rule paints the primary button of the
+     * sign-in modal, the Run Backtest modal and both create-agent modals -- i.e.
+     * the submit control at every step of this flow. #041018 measures ~9:1 and
+     * matches how the same cyan is already paired on .home-btn-primary.
+     */
+    color: #041018;
     font-weight: 700;
     font-size: 13px;
     cursor: pointer;
@@ -4468,6 +4493,35 @@ a.header-brand:hover .title-section h1 {
     width: min(560px, calc(100vw - 32px));
     max-height: calc(100vh - 48px);
     overflow: auto;
+    /* Column layout so the submit button can be pinned to the bottom below. */
+    display: flex;
+    flex-direction: column;
+}
+
+/*
+ * Pin the primary CTA. The panel's content runs ~1080px tall, so on a 1440x900
+ * screen the "▶ Run Backtest" button rendered at y=1045 -- 145px past the fold
+ * (measured live), and worse on a 1366x768 laptop. The panel scrolls, but
+ * nothing said so, so the payoff action of the whole product was invisible on
+ * open. Sticky keeps it in view at every scroll position.
+ */
+.run-backtest-modal-panel > #runBacktestModalSubmit {
+    position: sticky;
+    bottom: 0;
+    margin-top: auto;
+    /* Opaque: the content scrolls underneath this button. Matches .auth-submit. */
+    background-color: var(--info-color);
+    box-shadow: 0 -8px 16px -8px rgba(0, 0, 0, 0.6);
+}
+
+/*
+ * Reclaim ~170px of that overflow at the source: two preset cards each
+ * reserving 180px for three short lines is what pushed the CTA off-screen.
+ * Scoped to this modal so the roomier cards elsewhere are untouched.
+ */
+.run-backtest-modal .preset-card {
+    min-height: 0;
+    padding: 12px;
 }
 
 .run-backtest-modal-body {
@@ -8129,8 +8183,19 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     background: rgba(34, 211, 238, 0.1);
 }
 
+/*
+ * A neutral treatment, not a faded primary. `opacity: 0.45` over the solid
+ * cyan fill left the permanently-disabled "Run Paper Trading" button sitting
+ * next to the real "Run Backtest" as the same shape and colour at a slightly
+ * different brightness -- the action row squint-tested as two cyan CTAs, which
+ * halved the pull of the one action this flow exists to drive. The blend also
+ * dropped the label to roughly 3:1 against its own fill.
+ */
 .agent-card-cta--disabled {
-    opacity: 0.45;
+    opacity: 1;
+    background: rgba(148, 163, 184, 0.10);
+    border-color: var(--border-color);
+    color: var(--text-muted);
     cursor: not-allowed;
 }
 
@@ -8337,26 +8402,54 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 }
 
 .subtab-btn {
-    padding: 7px 16px;
+    /*
+     * 13px/9px, not 11px/7px: this bar is the primary navigation *inside* the
+     * product (My Agents / Backtest / Paper Trading), yet it was the smallest
+     * interactive text on the page -- 11px in a 26px-tall target, against a
+     * 14px/32px top nav. 13px + 9px padding brings it to ~32px, matching the
+     * nav above it.
+     */
+    padding: 9px 16px;
     border: none;
     background: transparent;
     color: var(--text-secondary);
     border-radius: 3px;
-    font-size: 11px;
+    font-size: 13px;
     font-weight: 700;
     cursor: pointer;
-    transition: all 0.15s;
+    /* Enumerated, not `all`: `all` also animates layout properties. */
+    transition: background-color 0.15s ease, color 0.15s ease;
     white-space: nowrap;
 }
 
 .subtab-btn.active {
     background: var(--info-color);
-    color: white;
+    /*
+     * Dark on cyan, not white: white on --info-color (#00bfff) measures 2.12:1,
+     * below the WCAG AA 4.5:1 floor, on the most-used control in the flow.
+     * #041018 measures ~9:1 and matches how the same cyan is already paired
+     * with a dark foreground on .home-btn-primary / .agent-card-cta.
+     */
+    color: #041018;
 }
 
 .subtab-btn:hover:not(.active) {
     color: var(--text-primary);
     background: var(--bg-hover);
+}
+
+/*
+ * styles.css had zero `:focus-visible` rules and eight bare `outline: none`
+ * resets, and this bar had no focus style of any kind -- keyboard users could
+ * not see which tab they were on. Scoped to the flow's controls rather than a
+ * global reset so it cannot disturb unrelated views.
+ */
+.subtab-btn:focus-visible,
+.agent-card-cta:focus-visible,
+.agent-view-btn:focus-visible,
+.home-btn:focus-visible {
+    outline: 2px solid var(--home-accent-cyan);
+    outline-offset: 2px;
 }
 
 .overview-grid {
@@ -8569,10 +8662,12 @@ body.agent-editor-open {
     margin-bottom: 12px;
 }
 
-.agent-capital-title {
+/* Beat `.section-card h3 { font-size: 12px }` (higher specificity). */
+.section-card .agent-capital-title {
     margin: 0 0 12px;
     font-size: 17px;
     font-weight: 700;
+    letter-spacing: normal;
     color: var(--text-primary);
 }
 
@@ -8780,10 +8875,12 @@ body.agent-editor-open {
     gap: 12px;
 }
 
-.agent-editor-history-title {
+/* Beat `.section-card h3 { font-size: 12px }` (higher specificity). */
+.section-card .agent-editor-history-title {
     margin: 0;
     font-size: 15px;
     font-weight: 700;
+    letter-spacing: normal;
     color: var(--text-primary);
 }
 
@@ -8878,10 +8975,12 @@ body.agent-editor-open {
     font-size: 12px;
 }
 
-.agent-editor-intro-title {
+/* Beat `.section-card h3 { font-size: 12px }` (higher specificity). */
+.section-card .agent-editor-intro-title {
     margin: 0 0 6px;
     font-size: 15px;
     font-weight: 700;
+    letter-spacing: normal;
     color: var(--text-primary);
 }
 
@@ -9313,7 +9412,13 @@ body.agent-editor-open {
     border: 1px solid var(--border-color);
     border-radius: 8px;
     color: var(--text-primary);
-    font-size: 0.95rem;
+    /*
+     * 14px, not `0.95rem`: `rem` resolves against the 16px html root while the
+     * whole app is sized off the 14px body, so 0.95rem painted this field at
+     * 15.2px -- a fractional size (blurry sub-pixel text) on a different scale
+     * from every other control.
+     */
+    font-size: 14px;
     line-height: 1.5;
     padding: 10px 12px;
     margin-top: 10px;


### PR DESCRIPTION
Sign-in now lands on My Agents, and the flow from there to a first backtest is legible. Frontend only.

Found by driving the real flow in headless Chromium and reading computed styles, so these are measured, not inferred:

| | before | after |
|---|---|---|
| controls painting in Arial while prose used the app font | 15 of 16 buttons + search | 0 |
| active subtab / every modal submit (white on `--info-color`) | 2.12:1 | 9.06:1 |
| Configure's 3 panel headings (`.section-card h3` outranked them) | 12px, under their own 14px body | 17/15/15px |
| "Trading instruction" — the flow's main input | monospace, 15.2px | app font, 14px |
| Run Backtest submit on 1440x900 | y=1045, past the fold | pinned |
| subtab bar, the primary in-product nav | 11px / 26px | 13px / 32px |
| `:focus-visible` rules in styles.css | 0 | flow controls covered |

Behaviour: sign-up used to land on Home (a second marketing hero with the button just clicked) and sign-in navigated nowhere, so the only confirmation was the avatar swapping in. Both now go to My Agents. The 31-day backtest limit is stated and checked client-side against the server's `MAX_BACKTEST_DAYS` instead of arriving as a 422 after the modal closes. Two Chinese strings on My Agents (pagination footer, allocation legend) are translated.

The one that needed a browser: `showSaveStatus` writes to an element that renders at y=934 in a 900px viewport with no `aria-live`, so "Save changes before Run Backtest" was 920px below the button that triggered it and the CTA read as dead. Fixed at the function, covering all 16 callers.

`test_onboarding_flow_ux.py` pins the contracts that revert silently. Mutation-tested: six reverts each kill exactly one case. Suite 2236 passed / 0 failed.

**Merge note for #295** (`perf/frontend-fast-boot`): both branches independently bump `app.js` to `?v=57` and `styles.css` to `?v=76`, so whichever lands second ships with a cache-buster that already went out — bump to `v=58`/`v=77` when resolving. `app.html`'s script block conflicts textually; keep #295's deferred tags and apply these version numbers on top. `app.js` itself merges cleanly (different functions).

Still open, not addressed here: a mid-run backtest failure writes its error into a panel the user has been navigated away from, and the auth modal has no focus trap.
