### PR TITLE
fix(deploy): move vercel.json into the Vercel root directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Two step-driven agent surfaces coexist; they are **not peers**:
 ## Deployment
 
 - **Backend** → Render (`render.yaml`): `uvicorn dashboard.backend.app:app`, persistent disk at `/data`, health check `/health`.
-- **Frontend** → Vercel (`vercel.json`): static `dashboard/frontend`.
+- **Frontend** → Vercel (`dashboard/frontend/vercel.json`): static `dashboard/frontend`. The Vercel project's Root Directory is `dashboard/frontend`, so the config **must** live there — a repo-root `vercel.json` is silently ignored (issue #301).
 - **Container** (`Dockerfile`): `WORKDIR /app`; `uvicorn dashboard.backend.app:app`.
 
 ## Merge & branch discipline

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ AgenticTrading/
 ├── orchestration/             # FinAgent multi-agent framework (separate)
 ├── requirements.txt           # Dashboard deps (not root pyproject.toml)
 ├── Dockerfile / render.yaml   # Backend deploy
-└── vercel.json                # Frontend static deploy
+└── dashboard/frontend/vercel.json  # Frontend static deploy (must sit in the Vercel Root Directory)
 ```
 
 ## User Workflow

--- a/dashboard/frontend/vercel.json
+++ b/dashboard/frontend/vercel.json
@@ -1,7 +1,6 @@
 {
   "name": "AgenticTrading Dashboard",
   "cleanUrls": true,
-  "outputDirectory": "dashboard/frontend",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- The Vercel project's Root Directory is `dashboard/frontend` (confirmed via the Vercel API), so the repo-root `vercel.json` was silently ignored — the root cause of #301 and the #283 prod outage.
- Move it to `dashboard/frontend/vercel.json`; drop the now-wrong `outputDirectory` key; update CLAUDE.md/README pointers.

## Verification (post-merge, externally observable)
- `/assets/*` should serve `Cache-Control: ...immutable` and `/` should carry the CSP header — both currently absent because the whole `headers` block never applied.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Z3n28oozR7QRiPaPXfYjj