### PR TITLE
fix(deploy): re-land same-origin API via Vercel rewrites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,6 +152,12 @@ DATABASE_PATH=dashboard/storage/data/backtest.db
 # connection. Leave unset for local dev -- falls back to DATABASE_PATH.
 # USERS_DATABASE_URL=postgresql://user:password@host/dbname
 
+# Browser origins allowed to call the API cross-origin (comma-separated).
+# Same-origin Vercel traffic uses vercel.json rewrites and does not need this.
+# When unset, CORS stays `*` with credentials disabled. Never enable
+# allow_credentials with `*`.
+# ATL_FRONTEND_ORIGINS=https://your-frontend.vercel.app
+
 # Session token hashing + lifetimes (account auth). SESSION_HASH_SECRET is the
 # HMAC key for auth_sessions.token_hash. It is REQUIRED whenever RENDER is set
 # or ATL_ENV=production: the app refuses to start without it, rather than

--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, RedirectResponse
 from pathlib import Path
+import os
 
 import dashboard.backend.database as _database
 from dashboard.backend.paths import FRONTEND_DIR
@@ -58,6 +59,31 @@ app = FastAPI(
 app.add_exception_handler(ApiError, api_error_handler)
 app.add_exception_handler(RequestValidationError, validation_error_handler)
 
+
+def _cors_allow_origins() -> list[str]:
+    """Browser origins allowed to call this API cross-origin.
+
+    Same-origin Vercel→rewrite traffic does not need CORS. External agent
+    browsers and legacy split-origin frontends still do. When
+    ``ATL_FRONTEND_ORIGINS`` is unset we keep ``*`` (credentials remain
+    disabled). When set, only that allowlist (+ local dev hosts) is used —
+    never combine ``*`` with ``allow_credentials=True``.
+    """
+    raw = (os.getenv("ATL_FRONTEND_ORIGINS") or "").strip()
+    locals_ = [
+        "http://localhost:8000",
+        "http://127.0.0.1:8000",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+    if not raw:
+        return ["*"]
+    origins = [part.strip().rstrip("/") for part in raw.split(",") if part.strip()]
+    for host in locals_:
+        if host not in origins:
+            origins.append(host)
+    return origins
+
 # Compress JSON responses when the client accepts it. Equity curves and agent
 # lists run to hundreds of KB uncompressed; minimum_size skips tiny payloads
 # where the gzip header would cost more than it saves.
@@ -80,11 +106,12 @@ app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=6)
 # Enable CORS for frontend
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_allow_origins(),
     allow_credentials=False,
-    # PATCH backs the agent Configure screen's Save. Frontend and API are
-    # separate origins in prod, so a method absent here fails at the preflight
-    # even though the route exists (test_cors_preflight_allows_every_routed_method).
+    # PATCH backs the agent Configure screen's Save. Cross-origin callers
+    # (and pre-proxy split-origin frontends) need the method listed here or
+    # the browser fails at preflight even though the route exists
+    # (test_cors_preflight_allows_every_routed_method).
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["content-type", "authorization", "x-session-id", "x-browser-id", "x-api-key", "accept"],
     # x-ratelimit-*/retry-after: the v2 spec promises these to agent clients;

--- a/dashboard/backend/tests/integrations/test_strategy_html_api_base.py
+++ b/dashboard/backend/tests/integrations/test_strategy_html_api_base.py
@@ -1,11 +1,7 @@
-"""MEDIUM #6 — strategy.html must resolve the API base the way app.js does.
+"""strategy.html must resolve the API base the way app.js does.
 
-strategy.html is a standalone shared-link page (no app.js include). It used
-``const API = location.origin`` unconditionally, which is correct locally
-(frontend + backend share ``localhost:8000``) but wrong on Vercel, where the
-static frontend and the API are on different origins — every API call would hit
-the frontend host and 404. It also hardcoded fixed default dates. These source
-checks run without a browser (the page has no JS test harness).
+strategy.html is a standalone shared-link page (no app.js include). Same-origin
+locally; empty base on Vercel so backend paths hit vercel.json rewrites.
 """
 
 from pathlib import Path
@@ -19,14 +15,13 @@ def _source() -> str:
     return _STRATEGY_HTML.read_text(encoding="utf-8")
 
 
-def test_strategy_html_uses_hosted_api_base_off_origin():
+def test_strategy_html_uses_same_origin_api_base_off_localhost():
     src = _source()
-    # The broken bare-origin assignment is gone.
     assert "const API = location.origin" not in src
-    # Same localhost-vs-hosted resolution as app.js.
-    assert "https://agentictrading.onrender.com" in src
+    assert "https://agentictrading.onrender.com" not in src
     assert 'window.location.hostname === "localhost"' in src
     assert 'window.location.hostname === "127.0.0.1"' in src
+    assert ': ""' in src or ": ''" in src
 
 
 def test_strategy_html_no_hardcoded_default_dates():

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -18,7 +18,7 @@ from dashboard.backend.api.routers import config as config_canon
 from dashboard.backend.api.routers import health as health_canon
 from dashboard.backend.api.routers import market as market_canon
 from dashboard.backend import middleware as middleware_mod
-from dashboard.backend.app import app
+from dashboard.backend.app import app, _cors_allow_origins
 
 _BACKEND = Path(__file__).resolve().parents[1]
 _APP_FILE = _BACKEND / "app.py"
@@ -416,3 +416,63 @@ def test_app_first_party_imports_are_canonical():
     first_party = {m for m in modules if "backend" in m or m.startswith("dashboard")}
     for m in first_party:
         assert m.startswith("dashboard.backend"), m
+
+
+# ---------------------------------------------------------------------------
+# CORS allowlist resolution (same-origin migration)
+# ---------------------------------------------------------------------------
+
+def test_cors_allow_origins_defaults_to_wildcard_when_unset(monkeypatch):
+    """Unset must reproduce the pre-migration default exactly.
+
+    Same-origin Vercel traffic goes through the ``vercel.json`` rewrites and
+    never preflights, so the allowlist exists for the split-origin callers that
+    remain. Anything other than ``["*"]`` here silently 403s them at the
+    preflight on a deploy where the env var was never set -- which is the
+    default state of the Render dashboard.
+    """
+    monkeypatch.delenv("ATL_FRONTEND_ORIGINS", raising=False)
+    assert _cors_allow_origins() == ["*"]
+
+    monkeypatch.setenv("ATL_FRONTEND_ORIGINS", "   ")
+    assert _cors_allow_origins() == ["*"]
+
+
+def test_cors_allow_origins_parses_allowlist_and_adds_local_hosts(monkeypatch):
+    monkeypatch.setenv(
+        "ATL_FRONTEND_ORIGINS",
+        "https://example.vercel.app/, , https://second.example",
+    )
+    origins = _cors_allow_origins()
+
+    # Compared as a whole list, not with ``in``: membership on a list is exact,
+    # but CodeQL reads ``"https://host" in x`` as a substring URL check and
+    # raises py/incomplete-url-substring-sanitization. An exact list comparison
+    # is both alert-free and the stronger assertion -- it pins order and
+    # rejects extra entries.
+    #
+    # The trailing slash must be stripped: a browser's Origin header never
+    # carries one, so an unstripped entry never matches and the allowlist
+    # silently fails shut. The blank segment from the doubled comma must not
+    # survive as an origin.
+    assert origins == [
+        "https://example.vercel.app",
+        "https://second.example",
+        "http://localhost:8000",
+        "http://127.0.0.1:8000",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+
+
+def test_cors_wildcard_is_never_mixed_into_an_explicit_allowlist(monkeypatch):
+    """``*`` plus a real allowlist is the shape that becomes unsafe.
+
+    Starlette rejects ``allow_origins=["*"]`` combined with
+    ``allow_credentials=True``, but only when the wildcard is the *whole* list.
+    A list that merely contains ``"*"`` alongside named origins matches every
+    origin while looking restricted, so a later flip of ``allow_credentials``
+    would hand credentialed responses to any site.
+    """
+    monkeypatch.setenv("ATL_FRONTEND_ORIGINS", "https://example.vercel.app")
+    assert "*" not in _cors_allow_origins()

--- a/dashboard/backend/tests/test_frontend_api_base.py
+++ b/dashboard/backend/tests/test_frontend_api_base.py
@@ -1,17 +1,13 @@
-"""Split-origin API-base guard for the static frontend.
+"""Same-origin API-base guard for the static frontend.
 
-In production the frontend and the API live on **different origins** -- Vercel
-serves ``dashboard/frontend`` statically, Render serves the FastAPI app -- so a
-script that resolves its API base to ``window.location.origin`` addresses every
-``/api/...`` call to the static host.  ``vercel.json`` has no ``/api`` rewrite,
-so those requests come back as Vercel's *HTML* 404 page and surface as a JSON
-parse error (``Unexpected token 'T', "The page c"...``) rather than a clean
-404.  That is exactly how ``js/agent-editor.js`` shipped a Configure screen
-whose save silently could not reach the backend.
+Production serves ``dashboard/frontend`` on Vercel and proxies backend paths
+to Render via ``vercel.json`` rewrites. Scripts must therefore use an empty
+API base (root-relative URLs) off localhost — not a hardcoded Render origin,
+and not a bare ``window.location.origin`` assignment that would skip the
+localhost special-case.
 
-The contract is on every file that *defines* a base; the files that merely read
-the global ``API_BASE`` from ``app.js`` inherit a correct value.  ``API`` is
-matched too because ``strategy.html`` names its base that.
+Local uvicorn still uses ``window.location.origin`` so ``localhost:8000`` keeps
+working without the Vercel rewrite layer.
 """
 
 import re
@@ -34,11 +30,15 @@ _DEFINITION = re.compile(r"(?:const|let|var)\s+(?:API_BASE|API)\s*=\s*([^;]{0,30
 _BARE_ORIGIN = re.compile(r"(?:API_BASE|API)\s*=\s*window\.location\.origin\s*;")
 
 # Anchored to the exact quoted literal, not a bare substring: a check like
-# ``"onrender.com" in initializer`` would also pass for a typo'd host such as
-# ``'https://evil.example/onrender.com'`` (CodeQL: py/incomplete-url-substring
+# ``"localhost" in initializer`` would also pass for a typo'd host such as
+# ``'https://evil.example/localhost'`` (CodeQL: py/incomplete-url-substring
 # -sanitization). Quote-delimiting the literal makes the match exact.
 _LOCALHOST_LITERAL = re.compile(r"""['"]localhost['"]""")
-_ONRENDER_HOST_LITERAL = re.compile(r"""['"]https://agentictrading\.onrender\.com['"]""")
+# Matching quote pairs only: ``['"]{2}`` also matches the mixed adjacency `'"`,
+# so an initializer that merely abuts two differently-quoted strings would
+# false-pass as "uses an empty API base".
+_EMPTY_PROD_BASE = re.compile(r"""(?:''|"")""")
+_LEGACY_ONRENDER = re.compile(r"""['"]https://agentictrading\.onrender\.com['"]""")
 
 
 def _definitions():
@@ -58,14 +58,17 @@ def test_the_known_api_base_definers_are_still_matched():
     assert {"app.js", "js/agent-editor.js", "index.html", "strategy.html"} <= definers
 
 
-def test_every_api_base_definition_targets_the_backend_off_localhost():
+def test_every_api_base_definition_uses_same_origin_off_localhost():
     for name, initializer in _definitions():
         assert _LOCALHOST_LITERAL.search(initializer), (
             f"{name}: the API base must special-case local development"
         )
-        assert _ONRENDER_HOST_LITERAL.search(initializer), (
-            f"{name}: the API base must point at the hosted backend when not on "
-            "localhost -- the Vercel origin serves no /api routes"
+        assert _EMPTY_PROD_BASE.search(initializer), (
+            f"{name}: off localhost the API base must be '' (Vercel rewrites "
+            "backend paths to Render; see vercel.json)"
+        )
+        assert not _LEGACY_ONRENDER.search(initializer), (
+            f"{name}: hardcoded Render origin regresses same-origin cookie auth"
         )
 
 

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -172,5 +172,6 @@ def test_slow_boot_notice_is_wired():
 # ---------------------------------------------------------------------------
 
 def test_cache_busters_bumped():
-    assert "app.js?v=59" in APP_HTML
+    # v=60: bumped when the same-origin API re-land (#302 follow-up) changed app.js
+    assert "app.js?v=60" in APP_HTML
     assert "styles.css?v=79" in APP_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1672,8 +1672,8 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=16" defer></script>
-    <script src="js/agent-editor.js?v=18" defer></script>
-    <script src="app.js?v=59" defer></script>
+    <script src="js/agent-editor.js?v=19" defer></script>
+    <script src="app.js?v=60" defer></script>
     <script src="js/leaderboard.js?v=16" defer></script>
     <script src="home-page.js?v=36" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -2373,7 +2373,7 @@ const API = {
 
 const API_BASE = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
     ? window.location.origin
-    : 'https://agentictrading.onrender.com';
+    : '';
 
 const AUTH_TOKEN_KEY = 'auth-token';
 const AUTH_USER_KEY = 'auth-user';

--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -140,7 +140,7 @@
         var host = window.location.hostname;
         var API_BASE = (host === 'localhost' || host === '127.0.0.1')
           ? window.location.origin
-          : 'https://agentictrading.onrender.com';
+          : '';
 
         function clearAuth() {
           try {
@@ -229,7 +229,7 @@
         var host = window.location.hostname;
         var API_BASE = (host === 'localhost' || host === '127.0.0.1')
           ? window.location.origin
-          : 'https://agentictrading.onrender.com';
+          : '';
 
         var authMode = 'signup';
 

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -42,13 +42,12 @@
     ['valuation_analyst', 'Valuation'],
   ];
   // Match app.js: same-origin locally, hosted backend everywhere else. In
-  // production the static frontend (Vercel) and the API (Render) are different
-  // origins, so a bare location.origin sends every /api call to the static host
-  // -- which answers with an HTML 404 page, not JSON.
+  // Same-origin API base. Local uvicorn serves the backend; production Vercel
+  // rewrites API paths to Render (see vercel.json). Empty string = root-relative.
   const API_BASE =
     window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
       ? window.location.origin
-      : 'https://agentictrading.onrender.com';
+      : '';
 
   // The simple-instruction contract (preset key + trading-actions output format)
   // has a single source of truth in app.js, published on `window`. app.js loads

--- a/dashboard/frontend/strategy.html
+++ b/dashboard/frontend/strategy.html
@@ -99,12 +99,11 @@
   <script>
     const params = new URLSearchParams(location.search);
     const code = params.get("code");
-    // Match app.js: same-origin locally, hosted backend on Vercel (where the
-    // static frontend and the API live on different origins, so location.origin
-    // would point at the frontend and every API call would 404).
+    // Match app.js: same-origin locally; empty base on Vercel so /api and
+    // other backend paths hit vercel.json rewrites to Render.
     const API = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
         ? window.location.origin
-        : "https://agentictrading.onrender.com";
+        : "";
 
     const $ = (id) => document.getElementById(id);
     const metaEl = $("meta");

--- a/dashboard/frontend/vercel.json
+++ b/dashboard/frontend/vercel.json
@@ -50,12 +50,61 @@
           "value": "public, max-age=0, must-revalidate"
         }
       ]
+    },
+    {
+      "source": "/(api|paper|backtest|runs|config|admin|ticker|health|compare)(/.*)?",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
     }
   ],
   "rewrites": [
     {
       "source": "/app",
       "destination": "/app.html"
+    },
+    {
+      "source": "/api/:path*",
+      "destination": "https://agentictrading.onrender.com/api/:path*"
+    },
+    {
+      "source": "/paper/:path*",
+      "destination": "https://agentictrading.onrender.com/paper/:path*"
+    },
+    {
+      "source": "/backtest/:path*",
+      "destination": "https://agentictrading.onrender.com/backtest/:path*"
+    },
+    {
+      "source": "/runs/:path*",
+      "destination": "https://agentictrading.onrender.com/runs/:path*"
+    },
+    {
+      "source": "/runs",
+      "destination": "https://agentictrading.onrender.com/runs"
+    },
+    {
+      "source": "/config/:path*",
+      "destination": "https://agentictrading.onrender.com/config/:path*"
+    },
+    {
+      "source": "/admin/:path*",
+      "destination": "https://agentictrading.onrender.com/admin/:path*"
+    },
+    {
+      "source": "/ticker",
+      "destination": "https://agentictrading.onrender.com/ticker"
+    },
+    {
+      "source": "/health",
+      "destination": "https://agentictrading.onrender.com/health"
+    },
+    {
+      "source": "/compare",
+      "destination": "https://agentictrading.onrender.com/compare"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Reverts the revert `9ad484e`, re-landing #283 now that #302 fixed the root cause (#301): the rewrites/headers land in `dashboard/frontend/vercel.json`, which the Vercel project actually reads.
- Cache busters bump to `app.js?v=60` / `agent-editor.js?v=19`; the #295 guard test pin moves with them.
- Same-origin `API_BASE = ''` in prod; all backend routes proxied via Vercel rewrites with `no-store`.

## Test plan
- [x] Full backend suite: 2315 passed (1 known local-only iFind `.env` failure, unrelated)
- [ ] Post-merge: `https://agentic-trading-lab.vercel.app/api/health` returns 200 **through the rewrite** (was `x-vercel-error: NOT_FOUND` last time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Z3n28oozR7QRiPaPXfYjj