### PR TITLE
fix(app): send CSRF token on agent editor Save

### DIFF
--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -173,5 +173,5 @@ def test_slow_boot_notice_is_wired():
 
 def test_cache_busters_bumped():
     # v=61: bumped when the HttpOnly-cookie auth migration (#284) changed app.js
-    assert "app.js?v=62" in APP_HTML
+    assert "app.js?v=63" in APP_HTML
     assert "styles.css?v=79" in APP_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1672,8 +1672,8 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
-    <script src="js/agent-editor.js?v=22" defer></script>
-    <script src="app.js?v=62" defer></script>
+    <script src="js/agent-editor.js?v=23" defer></script>
+    <script src="app.js?v=63" defer></script>
     <script src="js/leaderboard.js?v=16" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -2401,6 +2401,9 @@ function csrfHeaders() {
   return token ? { 'X-CSRF-Token': token } : {};
 }
 window.csrfHeaders = csrfHeaders;
+// Classic-script `const API` is not a window property; agent-editor and others
+// look up window.API.patch for credentialed mutating calls.
+window.API = API;
 
 
 const AuthAPI = {

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -827,11 +827,17 @@
 
     async function requestWithHeaders(extraHeaders) {
       if (window.API?.patch) {
-        return window.API.patch(endpoint, payload, extraHeaders);
+        return window.API.patch(endpoint, payload, {
+          ...authHeaders(),
+          ...extraHeaders,
+        });
       }
+      // window.API is a const in app.js and is not on `window` unless exported —
+      // this fallback is the live prod path. It must send X-CSRF-Token whenever
+      // the session cookie is present (#285), same as Robinhood / credential calls.
       const headers = {
         'Content-Type': 'application/json',
-        'x-session-id': window.SESSION_ID,
+        ...authHeaders(),
         ...extraHeaders,
       };
       const response = await fetch(endpoint, {


### PR DESCRIPTION
## Summary

After #285 landed, saving an agent in the editor showed:

> Saved locally; server update failed: CSRF token missing or invalid

**This was not a missing cookie.** Re-login correctly minted `__Host-atl_session` + `__Host-atl_csrf`. The bug was that Save never sent `X-CSRF-Token`.

### What went wrong

1. `#285` requires double-submit CSRF on mutating requests that carry the session cookie: cookie `__Host-atl_csrf` / `atl_csrf` **and** header `X-CSRF-Token`.
2. `agent-editor.js` `patchAgent()` prefers `window.API?.patch`, then falls back to a raw `fetch`.
3. `app.js` declares `const API = {…}` in a classic script — that does **not** create `window.API`. So the preferred path never ran in prod.
4. The fallback built headers with only `x-session-id` / `x-browser-id` — **no CSRF**. Robinhood / Financial Datasets paths already used `authHeaders()` and were fine; only Save was broken.
5. Backend correctly returned `403 {"detail":"CSRF token missing or invalid"}`; the editor surfaced it as the toast above and kept a local-only copy.

### Fix

- Fallback (and `window.API.patch` when present) spreads `authHeaders()` so Save sends `X-CSRF-Token`.
- Export `window.API = API` so the intended helper path works.
- Bump cache-busters: `agent-editor.js?v=23`, `app.js?v=63`.

## Test plan

- [ ] Open Agents → edit any agent → Save: no CSRF toast; server persists name/description/allocations
- [ ] DevTools → Network on the PATCH: request has `X-CSRF-Token` matching `__Host-atl_csrf`
- [ ] Console: `typeof window.API?.patch === 'function'` after load
- [ ] Hard-refresh `/app` after deploy (`/app` may still be cached up to 1h until #305)


Made with [Cursor](https://cursor.com)