### PR TITLE
ux(agents): My Agents shelves + marketplace CTA/GitHub link

### DIFF
--- a/dashboard/backend/domain/agents/marketplace.py
+++ b/dashboard/backend/domain/agents/marketplace.py
@@ -20,7 +20,8 @@ def _public_template(raw: Dict[str, Any]) -> Dict[str, Any]:
     pipeline = raw.get("pipeline")
     step_count = len(pipeline) if isinstance(pipeline, list) else 0
     runtime_type = str(raw.get("runtime_type") or "pipeline")
-    return {
+    repo_url = str(raw.get("repo_url") or "").strip()
+    public = {
         "template_id": raw["template_id"],
         "name": raw["name"],
         "model_name": raw.get("model_name") or "local-model",
@@ -36,6 +37,9 @@ def _public_template(raw: Dict[str, Any]) -> Dict[str, Any]:
             else ("simple" if step_count <= 1 else "pipeline")
         ),
     }
+    if repo_url.startswith(("https://github.com/", "http://github.com/")):
+        public["repo_url"] = repo_url
+    return public
 
 
 @lru_cache(maxsize=1)

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -605,6 +605,7 @@ def test_marketplace_listing_and_clone(client):
     assert hedge_fund_card["runtime_type"] == "ai_hedge_fund"
     assert hedge_fund_card["mode"] == "runtime"
     assert hedge_fund_card["model_name"] == "nvidia/nemotron-3-nano-30b-a3b"
+    assert hedge_fund_card["repo_url"] == "https://github.com/virattt/ai-hedge-fund"
 
     browser_session = str(uuid.uuid4())
     headers = {"X-Session-Id": browser_session}

--- a/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
+++ b/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
@@ -65,11 +65,21 @@ def test_robinhood_editor_behavior_is_shared_by_both_runtimes():
     assert "live_trading_enabled: Boolean(liveToggle?.checked)" in editor_state
 
 
-def test_marketplace_copy_label_is_scoped_to_ai_hedge_fund():
-    assert (
-        "const cloneLabel = isAiHedgeFundTemplate "
-        "? 'Copy to My Agents' : 'Add to My Agents';"
-    ) in _APP_JS
+def test_marketplace_cta_label_is_unified():
+    """All marketplace cards share one CTA — no special-case Copy label."""
+    assert "Copy to My Agents" not in _APP_JS
+    assert "const cloneLabel = 'Add to My Agents';" in _APP_JS
+
+
+def test_my_agents_splits_prompting_llms_and_open_agents():
+    """Prompt builtins and AI Hedge Fund agents land on separate shelves."""
+    assert "Foundation Agents" not in _APP_HTML
+    assert "Prompting LLMs" in _APP_HTML
+    assert "Open Agents" in _APP_HTML
+    assert 'id="agentsGridOpen"' in _APP_HTML
+    assert "function isOpenAgent(agent)" in _APP_JS
+    assert "agentsGridOpen" in _APP_JS
+    assert "renderAgentCards(openGrid, openAgents, 'open')" in _APP_JS
 
 
 def test_stored_credential_can_be_removed_from_the_editor():

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -140,11 +140,13 @@ def test_scripts_are_deferred():
 def test_agents_grid_ships_loading_skeleton():
     # Pre-JS, My Agents must show placeholder cards instead of a blank panel.
     builtin_grid_at = APP_HTML.index('id="agentsGridBuiltin"')
+    open_grid_at = APP_HTML.index('id="agentsGridOpen"')
     external_grid_at = APP_HTML.index('id="agentsGridExternal"')
     skeletons = [
         m for m in range(len(APP_HTML)) if APP_HTML.startswith("agent-card--skeleton", m)
     ]
     assert any(builtin_grid_at < at < builtin_grid_at + 2000 for at in skeletons)
+    assert any(open_grid_at < at < open_grid_at + 2000 for at in skeletons)
     assert any(external_grid_at < at < external_grid_at + 2000 for at in skeletons)
     assert ".agent-card--skeleton" in STYLES
 
@@ -172,6 +174,6 @@ def test_slow_boot_notice_is_wired():
 # ---------------------------------------------------------------------------
 
 def test_cache_busters_bumped():
-    # v=61: bumped when the HttpOnly-cookie auth migration (#284) changed app.js
-    assert "app.js?v=63" in APP_HTML
-    assert "styles.css?v=79" in APP_HTML
+    # Floor advances whenever app.js/styles.css change and their ?v= must ship.
+    assert "app.js?v=67" in APP_HTML
+    assert "styles.css?v=80" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_marketplace_placement.py
+++ b/dashboard/backend/tests/test_frontend_marketplace_placement.py
@@ -156,3 +156,17 @@ def test_repeat_visits_do_not_refetch_the_catalog():
     # The cache must be cleared on failure, or one flaky GET pins the error
     # state for the rest of the session.
     assert "marketplaceTemplates = [];" in body
+
+
+def test_marketplace_repo_url_renders_as_github_button():
+    """Open-source templates link out to their GitHub repo from the card meta."""
+    js = _APP_JS.read_text(encoding="utf-8")
+    css = _STYLES_CSS.read_text(encoding="utf-8")
+    catalog = (
+        Path(__file__).resolve().parents[2] / "config" / "marketplace.json"
+    ).read_text(encoding="utf-8")
+    assert "marketplace-repo-btn" in js
+    assert "template.repo_url" in js
+    assert 'href="#icon-github"' in js
+    assert "https://github.com/virattt/ai-hedge-fund" in catalog
+    assert ".marketplace-repo-btn" in css

--- a/dashboard/config/marketplace.json
+++ b/dashboard/config/marketplace.json
@@ -76,6 +76,7 @@
       "category": "Hosted",
       "tags": ["multi-agent", "fundamentals", "first-party"],
       "author": "virattt / Agentic Trading Lab",
+      "repo_url": "https://github.com/virattt/ai-hedge-fund",
       "runtime_type": "ai_hedge_fund",
       "runtime_config": {
         "analysts": [

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=79">
+    <link rel="stylesheet" href="styles.css?v=80">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -898,8 +898,8 @@
                 <div id="agentsCategories">
                     <section class="agents-category" data-category="builtin">
                         <div class="agents-category-head">
-                            <h3 class="agents-category-title">Foundation Agents</h3>
-                            <p class="agents-category-sub">A prompting game — give it money, an instruction, and a model, then backtest.</p>
+                            <h3 class="agents-category-title">Prompting LLMs</h3>
+                            <p class="agents-category-sub">Prompt a LLM with a trading instruction, configure its initial capital, and test in the market.</p>
                         </div>
                         <div id="agentsGridBuiltin" class="agents-grid">
                             <!-- Loading skeletons: visible pre-JS and while the first
@@ -911,7 +911,18 @@
                             <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
                         </div>
                         <div id="agentsGridFooterBuiltin" class="agents-grid-footer" hidden></div>
-                        <p id="agentsEmptyBuiltin" class="control-helper" hidden>No foundation agents yet. Click <strong>Add Agent</strong> to create one.</p>
+                        <p id="agentsEmptyBuiltin" class="control-helper" hidden>No prompting LLMs yet. Click <strong>Add Agent</strong> to create one.</p>
+                    </section>
+                    <section class="agents-category" data-category="open">
+                        <div class="agents-category-head">
+                            <h3 class="agents-category-title">Open Agents</h3>
+                            <p class="agents-category-sub">Open trading agent projects. Add them from Community.</p>
+                        </div>
+                        <div id="agentsGridOpen" class="agents-grid">
+                            <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
+                        </div>
+                        <div id="agentsGridFooterOpen" class="agents-grid-footer" hidden></div>
+                        <p id="agentsEmptyOpen" class="control-helper" hidden>No open agents yet. Add one from Community.</p>
                     </section>
                     <section class="agents-category" data-category="external">
                         <div class="agents-category-head">
@@ -1673,7 +1684,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=23" defer></script>
-    <script src="app.js?v=63" defer></script>
+    <script src="app.js?v=67" defer></script>
     <script src="js/leaderboard.js?v=16" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -468,7 +468,17 @@ let allAgents = [];
 let agentViewMode = 'grid';
 const AGENT_GRID_PAGE_SIZE = 5;
 /** Per-category page index (0-based). Reset on search change. */
-let agentGridPage = { builtin: 0, external: 0 };
+let agentGridPage = { builtin: 0, open: 0, external: 0 };
+
+const AGENT_GRID_FOOTER_IDS = {
+  builtin: 'agentsGridFooterBuiltin',
+  open: 'agentsGridFooterOpen',
+  external: 'agentsGridFooterExternal',
+};
+
+function isOpenAgent(agent) {
+  return (agent?.runtime_type || 'pipeline') === 'ai_hedge_fund';
+}
 
 function agentGridPageCount(total) {
   return Math.max(1, Math.ceil(total / AGENT_GRID_PAGE_SIZE));
@@ -1018,7 +1028,7 @@ function getFilteredAgents() {
 
 function applyAgentFilters(resetPagination = true) {
   if (resetPagination) {
-    agentGridPage = { builtin: 0, external: 0 };
+    agentGridPage = { builtin: 0, open: 0, external: 0 };
   }
   renderAgentCategories(getFilteredAgents());
 }
@@ -1077,17 +1087,17 @@ function renderAgentsError() {
   document.querySelectorAll('.agents-section .agents-grid').forEach((grid) => {
     grid.innerHTML = '';
   });
-  ['agentsGridFooterBuiltin', 'agentsGridFooterExternal'].forEach((id) => {
+  Object.values(AGENT_GRID_FOOTER_IDS).forEach((id) => {
     const footer = document.getElementById(id);
     if (footer) {
       footer.hidden = true;
       footer.innerHTML = '';
     }
   });
-  const builtinEmpty = document.getElementById('agentsEmptyBuiltin');
-  if (builtinEmpty) builtinEmpty.hidden = true;
-  const externalEmpty = document.getElementById('agentsEmptyExternal');
-  if (externalEmpty) externalEmpty.hidden = true;
+  ['agentsEmptyBuiltin', 'agentsEmptyOpen', 'agentsEmptyExternal'].forEach((id) => {
+    const empty = document.getElementById(id);
+    if (empty) empty.hidden = true;
+  });
   if (errorEl) errorEl.hidden = false;
 }
 
@@ -1144,7 +1154,7 @@ function bindAgentCardMenus(grid) {
 }
 
 function renderAgentGridFooter(categoryKey, total, page, pageCount) {
-  const footerId = categoryKey === 'builtin' ? 'agentsGridFooterBuiltin' : 'agentsGridFooterExternal';
+  const footerId = AGENT_GRID_FOOTER_IDS[categoryKey];
   const footer = document.getElementById(footerId);
   if (!footer) return;
   if (pageCount <= 1) {
@@ -1297,9 +1307,10 @@ function renderAgentCards(grid, agents, categoryKey) {
 
 function renderAgentCategories(agents) {
   const builtinGrid = document.getElementById('agentsGridBuiltin');
+  const openGrid = document.getElementById('agentsGridOpen');
   const externalGrid = document.getElementById('agentsGridExternal');
   const errorEl = document.getElementById('agentsErrorState');
-  if (!builtinGrid || !externalGrid) return;
+  if (!builtinGrid || !openGrid || !externalGrid) return;
 
   if (errorEl) errorEl.hidden = true; // a successful render clears any prior error
 
@@ -1308,22 +1319,38 @@ function renderAgentCategories(agents) {
     [...list].sort((a, b) => (b.agent_id === defaultId) - (a.agent_id === defaultId));
 
   // A live search narrows the list: distinguish "no agents at all" (onboarding)
-  // from "none match your search" so we neither mis-say "No foundation agents
-  // yet" nor surface the External onboarding card as if it were a search result.
+  // from "none match your search" so we neither mis-say empty onboarding copy
+  // nor surface the External onboarding card as if it were a search result.
   const searching = !!(document.getElementById('agentSearchInput')?.value || '').trim();
 
-  const builtin = pinDefaultFirst(agents.filter((a) => a.agent_type === 'builtin'));
+  // Prompting LLMs = instruction + model builtins. Open Agents = hosted
+  // runtimes such as AI Hedge Fund (still agent_type=builtin, different shelf).
+  const builtin = pinDefaultFirst(
+    agents.filter((a) => a.agent_type === 'builtin' && !isOpenAgent(a)),
+  );
+  const openAgents = pinDefaultFirst(
+    agents.filter((a) => a.agent_type === 'builtin' && isOpenAgent(a)),
+  );
   const external = pinDefaultFirst(agents.filter((a) => a.agent_type !== 'builtin'));
 
   renderAgentCards(builtinGrid, builtin, 'builtin');
+  renderAgentCards(openGrid, openAgents, 'open');
   renderAgentCards(externalGrid, external, 'external');
 
   const builtinEmpty = document.getElementById('agentsEmptyBuiltin');
   if (builtinEmpty) {
     builtinEmpty.hidden = builtin.length > 0;
     builtinEmpty.innerHTML = searching
-      ? 'No foundation agents match your search.'
-      : 'No foundation agents yet. Click <strong>Add Agent</strong> to create one.';
+      ? 'No prompting LLMs match your search.'
+      : 'No prompting LLMs yet. Click <strong>Add Agent</strong> to create one.';
+  }
+
+  const openEmpty = document.getElementById('agentsEmptyOpen');
+  if (openEmpty) {
+    openEmpty.hidden = openAgents.length > 0;
+    openEmpty.innerHTML = searching
+      ? 'No open agents match your search.'
+      : 'No open agents yet. Add one from Community.';
   }
 
   const externalEmpty = document.getElementById('agentsEmptyExternal');
@@ -1750,15 +1777,29 @@ function renderMarketplaceGrid() {
   templates.forEach((template) => {
     const card = document.createElement('div');
     card.className = 'section-card agent-card marketplace-card';
-    const isAiHedgeFundTemplate = template.runtime_type === 'ai_hedge_fund';
     const modeLabel = template.mode === 'runtime'
       ? 'Hosted runtime'
       : (template.mode === 'pipeline' ? 'Multi-step pipeline' : 'Simple instruction');
-    const cloneLabel = isAiHedgeFundTemplate ? 'Copy to My Agents' : 'Add to My Agents';
+    const cloneLabel = 'Add to My Agents';
     const tags = (template.tags || [])
       .slice(0, 3)
       .map((tag) => `<span class="marketplace-tag">${escapeHtml(tag)}</span>`)
       .join('');
+    const repoLabel = (() => {
+      if (!template.repo_url) return '';
+      try {
+        const path = new URL(template.repo_url).pathname.replace(/^\/+|\/+$/g, '');
+        return path || template.author || 'GitHub';
+      } catch {
+        return template.author || 'GitHub';
+      }
+    })();
+    const authorMeta = template.repo_url
+      ? `<a class="marketplace-repo-btn" href="${escapeHtml(template.repo_url)}" target="_blank" rel="noopener noreferrer" aria-label="Open ${escapeHtml(repoLabel)} on GitHub">
+            <svg class="ui-icon marketplace-repo-icon" aria-hidden="true"><use href="#icon-github"></use></svg>
+            <span>${escapeHtml(repoLabel)}</span>
+          </a>`
+      : `<span>By ${escapeHtml(template.author || 'Community')}</span>`;
     card.innerHTML = `
       <div class="agent-card-top">
         <div class="agent-card-identity">
@@ -1773,7 +1814,7 @@ function renderMarketplaceGrid() {
       <div class="marketplace-card-body">
         <p class="marketplace-card-description">${escapeHtml(template.description || 'Open agent template.')}</p>
         <div class="marketplace-card-meta">
-          <span>By ${escapeHtml(template.author || 'Community')}</span>
+          ${authorMeta}
           ${template.step_count ? `<span>${template.step_count} step${template.step_count === 1 ? '' : 's'}</span>` : ''}
         </div>
         ${tags ? `<div class="marketplace-tag-row">${tags}</div>` : ''}

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9389,8 +9389,36 @@ body.agent-editor-open {
     display: flex;
     flex-wrap: wrap;
     gap: 10px 16px;
+    align-items: center;
     color: var(--text-secondary);
     font-size: 0.82rem;
+}
+
+.marketplace-repo-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px 4px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.85);
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.78rem;
+    font-weight: 600;
+    transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.marketplace-repo-btn:hover {
+    color: #e2e8f0;
+    border-color: rgba(226, 232, 240, 0.45);
+    background: rgba(30, 41, 59, 0.95);
+}
+
+.marketplace-repo-icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
 }
 
 .marketplace-tag-row {


### PR DESCRIPTION
## Summary
- Rename **Foundation Agents** → **Prompting LLMs** and add an **Open Agents** shelf for hosted runtimes (`ai_hedge_fund`), keeping External Agents separate.
- Unify Community marketplace CTAs to **Add to My Agents** (drop the special-case Copy label).
- Add optional `repo_url` on marketplace templates; AI Hedge Fund card links to [virattt/ai-hedge-fund](https://github.com/virattt/ai-hedge-fund) via a GitHub button.

## Test plan
- [ ] Open My Agents: Prompting LLMs / Open Agents / External Agents sections render with the new subtitles
- [ ] Clone AI Hedge Fund from Community → it appears under Open Agents, not Prompting LLMs
- [ ] Marketplace cards all say Add to My Agents; AI Hedge Fund GitHub button opens the repo in a new tab
- [ ] `pytest dashboard/backend/tests/test_ai_hedge_fund_frontend.py dashboard/backend/tests/test_frontend_fast_boot.py dashboard/backend/tests/test_frontend_marketplace_placement.py dashboard/backend/tests/test_agents_api.py::test_marketplace_listing_and_clone -v`


Made with [Cursor](https://cursor.com)