### PR TITLE
fix(backtest): lower max initial capital to $3,000

### DIFF
--- a/dashboard/backend/domain/backtesting/constants.py
+++ b/dashboard/backend/domain/backtesting/constants.py
@@ -18,7 +18,7 @@ Capital scale (product):
   backtests must not read or write this field.
 - Backtest / protocol simulation capital: floor ``MIN_BACKTEST_INITIAL_CAPITAL``
   ($1), default ``INITIAL_CAPITAL`` ($1,000), max
-  ``MAX_BACKTEST_INITIAL_CAPITAL`` ($10,000). Chosen per run via
+  ``MAX_BACKTEST_INITIAL_CAPITAL`` ($3,000). Chosen per run via
   ``config.initial_cash`` / ``--initial-capital``, resolved by
   ``resolve_initial_capital()`` below, which only ever looks at the value
   passed in for *that* run — it does not read the agent row. The per-agent
@@ -40,7 +40,7 @@ INITIAL_CAPITAL = 1000
 MIN_BACKTEST_INITIAL_CAPITAL = 1
 
 # Hard cap on simulation capital for a single backtest / protocol run.
-MAX_BACKTEST_INITIAL_CAPITAL = 10_000
+MAX_BACKTEST_INITIAL_CAPITAL = 3_000
 
 # Account portfolio equity ($10k). Real ledger budget for signed-in users.
 DEFAULT_PORTFOLIO_EQUITY = 10_000

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -79,11 +79,11 @@ def test_create_accepts_backtest_allocation(client):
     headers = _headers()
     resp = client.post(
         "/api/v1/agents",
-        json={"name": "alpha", "agent_type": "builtin", "backtest_allocation": 5000},
+        json={"name": "alpha", "agent_type": "builtin", "backtest_allocation": 2500},
         headers=headers,
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["agent"]["backtest_allocation"] == 5000
+    assert resp.json()["agent"]["backtest_allocation"] == 2500
 
 
 def test_patch_updates_backtest_allocation(client):
@@ -94,11 +94,11 @@ def test_patch_updates_backtest_allocation(client):
 
     resp = client.patch(
         f"/api/v1/agents/{created['agent_id']}",
-        json={"backtest_allocation": 7500},
+        json={"backtest_allocation": 2500},
         headers=headers,
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["agent"]["backtest_allocation"] == 7500
+    assert resp.json()["agent"]["backtest_allocation"] == 2500
 
 
 def test_patch_backtest_allocation_alone_is_not_no_fields_to_update(client):
@@ -116,7 +116,7 @@ def test_patch_backtest_allocation_alone_is_not_no_fields_to_update(client):
     assert resp.status_code != 400
 
 
-@pytest.mark.parametrize("bad", [0, -100, 10001])
+@pytest.mark.parametrize("bad", [0, -100, 3001])
 def test_backtest_allocation_out_of_range_is_rejected(client, bad):
     headers = _headers()
     resp = client.post(
@@ -138,12 +138,12 @@ def test_backtest_allocation_does_not_change_the_paper_sleeve(client):
 
     updated = client.patch(
         f"/api/v1/agents/{created['agent_id']}",
-        json={"backtest_allocation": 9000},
+        json={"backtest_allocation": 2500},
         headers=headers,
     ).json()["agent"]
 
     assert updated["cash_allocation"] == 1000
-    assert updated["backtest_allocation"] == 9000
+    assert updated["backtest_allocation"] == 2500
 
 
 @pytest.fixture
@@ -223,12 +223,12 @@ def test_signed_in_combined_patch_moves_only_the_real_sleeve(authed_client):
     updated = authed_client.patch(
         f"/api/v1/agents/{agent_id}",
         headers=headers,
-        json={"cash_allocation": 2500, "backtest_allocation": 6000},
+        json={"cash_allocation": 2500, "backtest_allocation": 2000},
     )
     assert updated.status_code == 200, updated.text
     agent = updated.json()["agent"]
     assert agent["cash_allocation"] == 2500
-    assert agent["backtest_allocation"] == 6000
+    assert agent["backtest_allocation"] == 2000
 
     after = authed_client.get("/api/v1/portfolio", headers=headers).json()["portfolio"]
     assert after["cash_available"] == before["cash_available"] - 1500

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -486,11 +486,11 @@ def test_cash_allocation_cap_is_three_thousand(client):
     )
 
     assert MAX_AGENT_CASH_ALLOCATION == 3_000
-    assert MAX_BACKTEST_INITIAL_CAPITAL == 10_000
+    assert MAX_BACKTEST_INITIAL_CAPITAL == 3_000
     # Clamp behavior follows the backtest capital constant (not the sleeve max).
     assert resolve_initial_capital(3_000) == 3_000.0
-    assert resolve_initial_capital(10_000) == 10_000.0
-    assert resolve_initial_capital(50_000) == 10_000.0
+    assert resolve_initial_capital(10_000) == 3_000.0
+    assert resolve_initial_capital(50_000) == 3_000.0
     assert resolve_initial_capital(None) == 1_000.0
 
     browser_session = str(uuid.uuid4())

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -175,5 +175,5 @@ def test_slow_boot_notice_is_wired():
 
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
-    assert "app.js?v=67" in APP_HTML
+    assert "app.js?v=68" in APP_HTML
     assert "styles.css?v=80" in APP_HTML

--- a/dashboard/backend/tests/test_my_agents_capital_ui.py
+++ b/dashboard/backend/tests/test_my_agents_capital_ui.py
@@ -38,8 +38,8 @@ def test_capital_inputs_are_no_longer_in_the_editor_header():
 
 
 def test_capital_limits_are_stated_next_to_each_field():
-    assert "max $3,000" in _APP_HTML
-    assert "max $10,000" in _APP_HTML
+    assert _APP_HTML.count("max $3,000") >= 2
+    assert "max $10,000" not in _APP_HTML
 
 
 def test_editor_state_carries_backtest_allocation():

--- a/dashboard/backend/tests/test_my_agents_card_ui.py
+++ b/dashboard/backend/tests/test_my_agents_card_ui.py
@@ -52,7 +52,7 @@ def _run_node(script: str) -> str:
 def _harness(body: str) -> str:
     """Real functions lifted from app.js, with their few dependencies stubbed."""
     return f"""
-const MAX_BACKTEST_ALLOCATED_CAPITAL = 10000;
+const MAX_BACKTEST_ALLOCATED_CAPITAL = 3000;
 const DEFAULT_AGENT_CASH_ALLOCATION = 1000;
 function escapeHtml(s) {{ return String(s); }}
 function formatAgentCashAllocation(v) {{ return '$' + Number(v).toLocaleString(); }}
@@ -66,13 +66,13 @@ def test_card_shows_both_capitals():
     out = _run_node(
         _harness(
             "console.log(renderAgentAllocatedCapitalHero("
-            "{cash_allocation: 1000, backtest_allocation: 5000}));"
+            "{cash_allocation: 1000, backtest_allocation: 2500}));"
         )
     )
     assert "Paper Trading" in out
     assert "Backtesting" in out
     assert "$1,000" in out
-    assert "$5,000" in out
+    assert "$2,500" in out
 
 
 def test_card_backtest_capital_falls_back_to_the_sleeve():

--- a/dashboard/backend/tests/test_protocol_api.py
+++ b/dashboard/backend/tests/test_protocol_api.py
@@ -534,7 +534,7 @@ def test_create_run_accepts_independent_initial_cash(client):
                 "start_date": "2026-04-15",
                 "end_date": "2026-04-16",
                 "symbols": ["AAPL", "MSFT"],
-                "initial_cash": 5000,
+                "initial_cash": 2500,
             },
         },
         headers={"X-API-Key": key},

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -916,7 +916,7 @@
                     <section class="agents-category" data-category="open">
                         <div class="agents-category-head">
                             <h3 class="agents-category-title">Open Agents</h3>
-                            <p class="agents-category-sub">Open trading agent projects. Add them from Community.</p>
+                            <p class="agents-category-sub">Open-source trading agents.</p>
                         </div>
                         <div id="agentsGridOpen" class="agents-grid">
                             <div class="section-card agent-card agent-card--skeleton" aria-hidden="true"></div>
@@ -998,8 +998,8 @@
                                 <span class="agent-capital-note">Reserved from My Portfolio. Real sleeve.</span>
                             </label>
                             <label class="agent-capital-field" for="agentEditorBacktestAllocation">
-                                <span class="agent-capital-label">Backtesting <span class="agent-capital-max">max $10,000</span></span>
-                                <input id="agentEditorBacktestAllocation" class="agent-capital-input" type="number" min="1" max="10000" step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
+                                <span class="agent-capital-label">Backtesting <span class="agent-capital-max">max $3,000</span></span>
+                                <input id="agentEditorBacktestAllocation" class="agent-capital-input" type="number" min="1" max="3000" step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
                                 <span class="agent-capital-note">Simulated only. Never spends real cash.</span>
                             </label>
                         </div>
@@ -1683,8 +1683,8 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
-    <script src="js/agent-editor.js?v=23" defer></script>
-    <script src="app.js?v=67" defer></script>
+    <script src="js/agent-editor.js?v=24" defer></script>
+    <script src="app.js?v=68" defer></script>
     <script src="js/leaderboard.js?v=16" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -182,7 +182,7 @@ function showAppToast(message) {
 const MAX_AGENT_CASH_ALLOCATION = 3000;
 const DEFAULT_AGENT_CASH_ALLOCATION = 1000;
 /** Simulated cash ceiling for a single backtest run — unrelated to the paper sleeve above. */
-const MAX_BACKTEST_ALLOCATED_CAPITAL = 10000;
+const MAX_BACKTEST_ALLOCATED_CAPITAL = 3000;
 const DEFAULT_PORTFOLIO_EQUITY = 10000;
 const AGENT_CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
 

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -593,8 +593,8 @@
       if (!Number.isFinite(value) || value < 1) {
         throw new Error('Backtest Allocated Capital must be at least $1.');
       }
-      if (value > 10000) {
-        throw new Error('Backtest Allocated Capital cannot exceed $10,000.');
+      if (value > 3000) {
+        throw new Error('Backtest Allocated Capital cannot exceed $3,000.');
       }
       backtest_allocation = Math.round(value);
     } else {
@@ -603,7 +603,7 @@
       // through to the default rather than becoming an unsaveable value.
       backtest_allocation =
         Number.isFinite(Number(cash_allocation)) && Number(cash_allocation) > 0
-          ? Math.min(Math.round(Number(cash_allocation)), 10000)
+          ? Math.min(Math.round(Number(cash_allocation)), 3000)
           : 1000;
     }
     const modelSelect = document.getElementById('agentEditorModelSelect');
@@ -739,7 +739,7 @@
         const value = Number(raw);
         if (Number.isFinite(value) && value > 0) { resolved = value; break; }
       }
-      backtestInput.value = String(Math.min(Math.round(resolved), 10000));
+      backtestInput.value = String(Math.min(Math.round(resolved), 3000));
     }
     if (meta) {
       meta.textContent = agent.agent_type === 'builtin' ? 'Built-in agent' : 'External agent';


### PR DESCRIPTION
## Summary
- Lower `MAX_BACKTEST_INITIAL_CAPITAL` from \$10,000 to \$3,000 (backend clamp, agents API `backtest_allocation`, Configure UI, and editor validation).
- Shorten Open Agents subtitle to **Open-source trading agents.** (follow-up after #309).

## Test plan
- [ ] Configure → Backtesting field shows max \$3,000; values above 3000 are rejected
- [ ] Protocol/API create-run with `initial_cash` > 3000 returns 400; 2500–3000 succeeds
- [ ] `pytest dashboard/backend/tests/test_agents_api.py::test_cash_allocation_cap_is_three_thousand dashboard/backend/tests/test_agent_backtest_allocation.py dashboard/backend/tests/test_protocol_api.py::test_reject_nondefault_initial_cash dashboard/backend/tests/test_protocol_api.py::test_create_run_accepts_independent_initial_cash dashboard/backend/tests/test_my_agents_capital_ui.py dashboard/backend/tests/test_my_agents_card_ui.py -v`


Made with [Cursor](https://cursor.com)