### PR TITLE
chore: clear the open CodeQL alerts

### DIFF
--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -1202,7 +1202,13 @@ def test_service_layer_rejects_an_unwhitelisted_category():
     is read back out on the unauthenticated /api/v1/agents/builtin listing, so an
     internal caller writing junk here would publish it.
     """
-    from dashboard.backend.domain.agents.service import agent_service
+    # Module form, not ``from ... import agent_service``: line 19 already imports
+    # this module as a monkeypatch seam, and mixing the two forms is the
+    # inconsistency py/import-and-import-from flags. The alias is resolved here
+    # rather than at each call site only to keep the body below unchanged.
+    import dashboard.backend.domain.agents.service as agent_service_module
+
+    agent_service = agent_service_module.agent_service
 
     with pytest.raises(ValueError, match="unknown category"):
         agent_service.create_agent(

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -179,5 +179,5 @@ def test_slow_boot_notice_is_wired():
 
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
-    assert "app.js?v=73" in APP_HTML
+    assert "app.js?v=74" in APP_HTML
     assert "styles.css?v=84" in APP_HTML

--- a/dashboard/backend/tests/test_onboarding_flow_ux.py
+++ b/dashboard/backend/tests/test_onboarding_flow_ux.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 from dashboard.backend.api.routers.backtests import MAX_BACKTEST_DAYS
 from dashboard.backend.tests._frontend_source import (
-    APP_JS,
     STYLES,
     css_blocks,
     fn_body,

--- a/dashboard/backend/tests/test_users_postgres.py
+++ b/dashboard/backend/tests/test_users_postgres.py
@@ -359,7 +359,7 @@ def test_legacy_plaintext_session_table_is_migrated_postgres(temp_postgres_store
 def test_expired_sessions_are_reclaimed_postgres(temp_postgres_store):
     """Twin of the SQLite sweep tests -- see test_auth.py for the rationale."""
     from dashboard.backend.session_tokens import hash_session_token
-    from dashboard.backend.users import _utcnow, format_stored_timestamp
+    import dashboard.backend.users as users_module
 
     user = temp_postgres_store.create_user("sweep@example.com", "Sweep", "securepass1")
     dead = temp_postgres_store.create_session(user["id"])
@@ -369,7 +369,9 @@ def test_expired_sessions_are_reclaimed_postgres(temp_postgres_store):
             cur.execute(
                 "UPDATE auth_sessions SET expires_at = %s WHERE token_hash = %s",
                 (
-                    format_stored_timestamp(_utcnow() - timedelta(days=1)),
+                    users_module.format_stored_timestamp(
+                        users_module._utcnow() - timedelta(days=1)
+                    ),
                     hash_session_token(dead),
                 ),
             )

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1730,7 +1730,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=26" defer></script>
-    <script src="app.js?v=73" defer></script>
+    <script src="app.js?v=74" defer></script>
     <script src="js/leaderboard.js?v=16" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -6874,7 +6874,12 @@ async function applyAgentRunDeepLink() {
         }
     }
 
-    if (agentId && !agent && agentAuthError) {
+    // agentAuthError can only be set inside the `!agent && agentId` branch above,
+    // and only from the catch — where the `agent = …` assignment never ran. So it
+    // already implies both operands; re-testing them added nothing but made the
+    // guard read as if the URL-supplied agentId decided the outcome. The access
+    // decision is the server's 401/403, not this condition.
+    if (agentAuthError) {
         const signedIn = isSignedIn();
         if (!signedIn) {
             // Park it so a successful sign-in retries — see PENDING_DEEP_LINK_KEY.


### PR DESCRIPTION
Clears the CodeQL board: **15 open on `main` → 0**. 12 fixed here, 2 dismissed by design, 1 was PR-ref-only noise.

Came out of the #310 review — that PR's diff is empty, so every alert on its merge ref was inherited from `main`. Fixing them needed a branch off `main` rather than a push to a contributor's fork.

### Fixed

| Alert | Rule | Sev |
|---|---|---|
| 1214 | `js/user-controlled-bypass` — `app.js:6877` | **high** |
| 1216 | `py/import-and-import-from` — `test_agents_api.py:19` | note |
| 1086/87/89/90/91, 1203–1207 | `py/import-and-import-from` — `test_users_postgres.py` (10) | note |
| 1201 | `py/unused-import` — `test_onboarding_flow_ux.py:15` | note |

**1214 is not a real bypass, but the guard was genuinely redundant.** `agentAuthError` is assigned only inside `if (!agent && agentId)`, and only in the `catch` — where the `agent = …` assignment never ran. So it already implies both other operands. Re-testing the URL-supplied `agentId` made the condition read as if the client decided access; the actual gate is `_require_owner_context` + `_require_agent_access` on `GET /api/v1/agents/{agent_id}`. Simplifying to `if (agentAuthError)` is behaviour-preserving and removes the tainted operand. Fixed at source rather than dismissed because a dismissal re-mints on the next line shift.

The 11 import alerts each trace to a **single** `from X import y` colliding with the module-alias form used everywhere else in the file — one line in `test_users_postgres.py` (whose own docstring says the two forms must not be mixed) and one in `test_agents_api.py`. The module-alias form is the monkeypatch seam and must survive; only the `from` form is expendable.

### Dismissed (by design, on the security tab)

- **1202** `py/cyclic-import` `users_postgres.py:24` — line-shift re-mint of the already-dismissed #1151. `users.py` imports the twin only inside `_build_user_store()` (`users.py:941`); that deferred import *is* the cycle-break.
- **1200** `py/print-during-import` `backtest_hourly_agent.py:66` — operator-facing progress line for a pip install that blocks for seconds. `logger.info()` emits nothing under deployed uvicorn here, so converting it to logging would silence it entirely.

Alert **1216** appeared on `main` but not on #310's merge ref, which was analysed a day earlier — a reminder that a PR merge ref is a snapshot, not live `main`.

### Verification

- `2526 passed, 67 skipped, 0 failed` (full backend suite).
- `node --check dashboard/frontend/app.js` — OK.
- An AST re-implementation of `py/import-and-import-from` reports **0** violations in both edited files, rather than waiting for the post-merge re-scan. It flags 5 residuals elsewhere (`engine.py`, `bridge.py`, `discord_bot.py`, `test_runtime.py`) — the scan is stricter than CodeQL; `engine.py:67` is the documented monkeypatch-seam FP already dismissed as #299, and CodeQL never flagged the other four.
- ⚠️ The 10 `test_users_postgres.py` sites are in the `@pg_only` tier, which **skips locally**. Confirm CI by the skip count collapsing, not by a green tick. The changed line's two attributes were checked directly against the module.

`app.js?v=73 → v=74`, with the `test_cache_busters_bumped` floor moved to match.
