### PR TITLE
feat(agents): clone/duplicate onto a chosen model

### DIFF
--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -250,6 +250,20 @@ class DuplicateAgentBody(BaseModel):
     model_name: str = Field(min_length=1, max_length=100)
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
 
+    @field_validator("model_name")
+    @classmethod
+    def _reject_blank(cls, value: str) -> str:
+        # Same trap as UpdateAgentBody._reject_blank: ``min_length=1`` counts
+        # the raw length, so a whitespace-only value ("   ") passes it. Unlike
+        # CreateAgentBody.model_name (optional, coerces blank to
+        # "local-model" on purpose), this field is required -- the service's
+        # ``.strip() or source.get("model_name")`` fallback would otherwise
+        # silently reuse the source's own model, defeating the one thing this
+        # action does. Reject it as a 422 instead.
+        if not value.strip():
+            raise ValueError("must not be blank")
+        return value
+
 
 @router.post("/marketplace/{template_id}/clone")
 def clone_marketplace_agent(

--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -238,6 +238,8 @@ def list_marketplace_agents():
 
 class CloneMarketplaceBody(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    # Deliberately unvalidated beyond length -- see clone_marketplace_template.
+    model_name: Optional[str] = Field(default=None, max_length=100)
 
 
 @router.post("/marketplace/{template_id}/clone")
@@ -261,6 +263,7 @@ def clone_marketplace_agent(
             owner_user_id=ctx["user_id"],
             owner_browser_session=ctx["browser_session"],
             name=body.name.strip() if body.name else None,
+            model_name=body.model_name,
         )
     except MarketplaceTemplateNotFoundError:
         raise HTTPException(status_code=404, detail="Marketplace template not found")

--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -33,6 +33,7 @@ from dashboard.backend.domain.agents.credential_store import (
 )
 from dashboard.backend.domain.agents.service import (
     AgentNotFoundError,
+    AgentServiceError,
     MarketplaceTemplateNotFoundError,
     NoExternalRunsError,
     agent_service,
@@ -240,6 +241,14 @@ class CloneMarketplaceBody(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=100)
     # Deliberately unvalidated beyond length -- see clone_marketplace_template.
     model_name: Optional[str] = Field(default=None, max_length=100)
+
+
+class DuplicateAgentBody(BaseModel):
+    """``model_name`` is required here (unlike clone): the whole point of the
+    action is running the same strategy somewhere else."""
+
+    model_name: str = Field(min_length=1, max_length=100)
+    name: Optional[str] = Field(default=None, min_length=1, max_length=100)
 
 
 @router.post("/marketplace/{template_id}/clone")
@@ -627,6 +636,42 @@ def rotate_agent_api_key(
         "agent": agent_service.agent_with_stats(agent),
         "api_key": api_key,
     }
+
+
+@router.post("/{agent_id}/duplicate")
+def duplicate_agent(
+    agent_id: str,
+    body: DuplicateAgentBody,
+    request: Request,
+    authorization: Optional[str] = Header(default=None),
+):
+    """Copy a built-in agent onto a different model ("Run on another model").
+
+    Does not start a backtest: the caller lands on the new agent with Run primed.
+    """
+    ctx = _require_owner_context(request, authorization)
+    _require_agent_access(agent_id, ctx, reclaim_on_session_match=True)
+    cash = float(DEFAULT_AGENT_CASH_ALLOCATION)
+    if ctx["user_id"] and cash > 0:
+        try:
+            portfolio_service.ensure_cash_for_new_agent(ctx["user_id"], cash)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    try:
+        agent = agent_service.duplicate_agent(
+            agent_id=agent_id,
+            model_name=body.model_name,
+            name=body.name.strip() if body.name else None,
+            owner_user_id=ctx["user_id"],
+            owner_browser_session=ctx["browser_session"],
+        )
+    except AgentNotFoundError:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    except AgentServiceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if ctx["user_id"]:
+        portfolio_service.get_or_create_portfolio(ctx["user_id"])
+    return {"agent": agent}
 
 
 @router.post("/{agent_id}/activate")

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -156,6 +156,14 @@ class AgentService:
         if ext_runs:
             latest = sorted(ext_runs, key=lambda r: r.get("created_at") or "", reverse=True)[0]
         result = dict(agent)
+        # repository.create_agent() returns the plaintext api_key on every agent
+        # it mints (any type, not just external), attached directly on the dict
+        # this method receives -- so the shallow copy above would otherwise carry
+        # it into every enriched listing. A route that wants to surface the key
+        # once (create, import-session) pops it off the *raw* agent dict itself,
+        # which this copy does not disturb -- it never removes it from the
+        # source object, only omits it from the enriched copy returned here.
+        result.pop("api_key", None)
         result["run_count"] = len(ext_runs)
         result["latest_run"] = latest
         result["runs"] = sorted(

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -389,6 +389,7 @@ class AgentService:
         owner_user_id: Optional[int],
         owner_browser_session: Optional[str],
         name: Optional[str] = None,
+        model_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Copy a marketplace template into the caller's My Agents list."""
         from dashboard.backend.domain.agents import marketplace as marketplace_mod
@@ -404,9 +405,16 @@ class AgentService:
         runtime_config = normalize_runtime_config(
             runtime_type, template.get("runtime_config") or {}
         )
+        # No whitelist, on purpose: create_agent doesn't validate model_name
+        # either, so rejecting here would be inconsistent, and a Literal would
+        # publish an openapi enum -- the deploy gate #313 had to discharge.
+        # Blank/omitted means "the template's own model".
+        resolved_model = (model_name or "").strip() or str(
+            template.get("model_name") or "local-model"
+        ).strip() or "local-model"
         agent = self.create_agent(
             name=resolved_name,
-            model_name=str(template.get("model_name") or "local-model").strip() or "local-model",
+            model_name=resolved_model,
             owner_user_id=owner_user_id,
             owner_browser_session=owner_browser_session,
             agent_type="builtin",

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -402,6 +402,7 @@ class AgentService:
         runtime_config: Dict[str, Any],
         category: Optional[str],
         pipeline: Optional[List[Dict[str, Any]]],
+        backtest_allocation: Optional[float] = None,
     ) -> Dict[str, Any]:
         """Create a built-in agent and, if the source carried its own pipeline,
         write it in -- the create-then-copy-the-pipeline-then-enrich tail shared
@@ -411,6 +412,14 @@ class AgentService:
         -- those resolutions differ genuinely (template vs. row, three-tier vs.
         two-tier model fallback, different name defaults) and stay put; only the
         mechanical creation sequence below is identical between them.
+
+        ``backtest_allocation`` is simulated capital with no ledger coupling
+        (validated only by ``ge=MIN_BACKTEST_INITIAL_CAPITAL,
+        le=MAX_BACKTEST_INITIAL_CAPITAL``), so it is safe to copy from a
+        source. ``cash_allocation`` is a real ledger debit and must NOT be
+        copied here -- ``create_agent`` below is deliberately not passed one,
+        so it falls back to ``DEFAULT_AGENT_CASH_ALLOCATION`` like any other
+        fresh agent.
         """
         has_own_pipeline = isinstance(pipeline, list) and bool(pipeline)
         agent = self.create_agent(
@@ -422,6 +431,7 @@ class AgentService:
             description=description,
             runtime_type=runtime_type,
             runtime_config=runtime_config,
+            backtest_allocation=backtest_allocation,
             # A source carrying its own pipeline overwrites the seed below, so
             # skip that write. A source WITHOUT one still needs the starter
             # instruction, or the copy lands with an empty Configure screen.
@@ -475,6 +485,8 @@ class AgentService:
             # and those must stamp None rather than reject the clone.
             category=normalize_category(template.get("category")),
             pipeline=template.get("pipeline"),
+            # A catalog template has no backtest allocation of its own.
+            backtest_allocation=None,
         )
 
     def duplicate_agent(
@@ -520,6 +532,11 @@ class AgentService:
             # category must stamp None rather than reject the duplicate.
             category=normalize_category(source.get("category")),
             pipeline=source.get("pipeline"),
+            # Copied (unlike cash_allocation -- see _create_builtin_copy's
+            # docstring) so the two agents' equity curves start from the same
+            # simulated capital and stay comparable. NULL on the source passes
+            # through as None rather than substituting a value.
+            backtest_allocation=source.get("backtest_allocation"),
         )
 
     def list_builtin_agents_with_stats(self) -> List[Dict[str, Any]]:

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -390,6 +390,50 @@ class AgentService:
             agent["pipeline"] = pipeline
         return agent
 
+    def _create_builtin_copy(
+        self,
+        *,
+        name: str,
+        model_name: str,
+        owner_user_id: Optional[int],
+        owner_browser_session: Optional[str],
+        description: Optional[str],
+        runtime_type: str,
+        runtime_config: Dict[str, Any],
+        category: Optional[str],
+        pipeline: Optional[List[Dict[str, Any]]],
+    ) -> Dict[str, Any]:
+        """Create a built-in agent and, if the source carried its own pipeline,
+        write it in -- the create-then-copy-the-pipeline-then-enrich tail shared
+        by ``clone_marketplace_template`` (source: a catalog template) and
+        ``duplicate_agent`` (source: a stored agent row). Callers resolve name,
+        model, runtime, and category from their own source *before* calling this
+        -- those resolutions differ genuinely (template vs. row, three-tier vs.
+        two-tier model fallback, different name defaults) and stay put; only the
+        mechanical creation sequence below is identical between them.
+        """
+        has_own_pipeline = isinstance(pipeline, list) and bool(pipeline)
+        agent = self.create_agent(
+            name=name,
+            model_name=model_name,
+            owner_user_id=owner_user_id,
+            owner_browser_session=owner_browser_session,
+            agent_type="builtin",
+            description=description,
+            runtime_type=runtime_type,
+            runtime_config=runtime_config,
+            # A source carrying its own pipeline overwrites the seed below, so
+            # skip that write. A source WITHOUT one still needs the starter
+            # instruction, or the copy lands with an empty Configure screen.
+            seed_default_pipeline=(
+                runtime_type == PIPELINE_RUNTIME_TYPE and not has_own_pipeline
+            ),
+            category=category,
+        )
+        if has_own_pipeline:
+            agent = self.agents.update_agent(agent["agent_id"], pipeline=pipeline) or agent
+        return self.attach_equity_sparklines([self.agent_with_stats(agent)])[0]
+
     def clone_marketplace_template(
         self,
         *,
@@ -407,8 +451,6 @@ class AgentService:
             raise MarketplaceTemplateNotFoundError()
 
         resolved_name = (name or template.get("name") or "Marketplace Agent").strip()
-        pipeline = template.get("pipeline")
-        has_own_pipeline = isinstance(pipeline, list) and bool(pipeline)
         runtime_type = normalize_runtime_type(template.get("runtime_type"))
         runtime_config = normalize_runtime_config(
             runtime_type, template.get("runtime_config") or {}
@@ -420,29 +462,20 @@ class AgentService:
         resolved_model = (model_name or "").strip() or str(
             template.get("model_name") or "local-model"
         ).strip() or "local-model"
-        agent = self.create_agent(
+        return self._create_builtin_copy(
             name=resolved_name,
             model_name=resolved_model,
             owner_user_id=owner_user_id,
             owner_browser_session=owner_browser_session,
-            agent_type="builtin",
             description=template.get("description"),
             runtime_type=runtime_type,
             runtime_config=runtime_config,
-            # A template carrying its own pipeline overwrites the seed below, so
-            # skip that write. A template WITHOUT one still needs the starter
-            # instruction, or the clone lands with an empty Configure screen.
-            seed_default_pipeline=(
-                runtime_type == PIPELINE_RUNTIME_TYPE and not has_own_pipeline
-            ),
             # Lenient on purpose: the live catalog still carries legacy values
             # ("Foundation", "Advanced", "Hosted") until they're recategorized,
             # and those must stamp None rather than reject the clone.
             category=normalize_category(template.get("category")),
+            pipeline=template.get("pipeline"),
         )
-        if has_own_pipeline:
-            agent = self.agents.update_agent(agent["agent_id"], pipeline=pipeline) or agent
-        return self.attach_equity_sparklines([self.agent_with_stats(agent)])[0]
 
     def duplicate_agent(
         self,
@@ -455,10 +488,8 @@ class AgentService:
     ) -> Dict[str, Any]:
         """Copy an existing built-in agent onto a different model.
 
-        The same two steps as ``clone_marketplace_template`` -- create, then
-        write the pipeline -- so the copy carries the strategy, not just the
-        name. Built-in only: ``create_agent`` mints a one-time plaintext API key
-        for external agents, and duplicating one would open a credential-issuing
+        Built-in only: ``create_agent`` mints a one-time plaintext API key for
+        external agents, and duplicating one would open a credential-issuing
         path this hook has no reason to have.
 
         The generated name collides freely (two copies onto DeepSeek both read
@@ -472,32 +503,24 @@ class AgentService:
             raise AgentServiceError("Only built-in agents can be duplicated")
 
         resolved_name = (name or f"{source.get('name') or 'Agent'} copy").strip()
-        pipeline = source.get("pipeline")
-        has_own_pipeline = isinstance(pipeline, list) and bool(pipeline)
         runtime_type = normalize_runtime_type(source.get("runtime_type"))
         runtime_config = normalize_runtime_config(
             runtime_type, source.get("runtime_config") or {}
         )
-        agent = self.create_agent(
+        return self._create_builtin_copy(
             name=resolved_name,
             model_name=(model_name or "").strip()
             or str(source.get("model_name") or "local-model"),
             owner_user_id=owner_user_id,
             owner_browser_session=owner_browser_session,
-            agent_type="builtin",
             description=source.get("description"),
             runtime_type=runtime_type,
             runtime_config=runtime_config,
-            seed_default_pipeline=(
-                runtime_type == PIPELINE_RUNTIME_TYPE and not has_own_pipeline
-            ),
             # Lenient, matching clone_marketplace_template: a stored legacy
             # category must stamp None rather than reject the duplicate.
             category=normalize_category(source.get("category")),
+            pipeline=source.get("pipeline"),
         )
-        if has_own_pipeline:
-            agent = self.agents.update_agent(agent["agent_id"], pipeline=pipeline) or agent
-        return self.attach_equity_sparklines([self.agent_with_stats(agent)])[0]
 
     def list_builtin_agents_with_stats(self) -> List[Dict[str, Any]]:
         """List all built-in agents (platform-wide) enriched with run stats.

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -436,6 +436,61 @@ class AgentService:
             agent = self.agents.update_agent(agent["agent_id"], pipeline=pipeline) or agent
         return self.attach_equity_sparklines([self.agent_with_stats(agent)])[0]
 
+    def duplicate_agent(
+        self,
+        *,
+        agent_id: str,
+        model_name: str,
+        name: Optional[str] = None,
+        owner_user_id: Optional[int],
+        owner_browser_session: Optional[str],
+    ) -> Dict[str, Any]:
+        """Copy an existing built-in agent onto a different model.
+
+        The same two steps as ``clone_marketplace_template`` -- create, then
+        write the pipeline -- so the copy carries the strategy, not just the
+        name. Built-in only: ``create_agent`` mints a one-time plaintext API key
+        for external agents, and duplicating one would open a credential-issuing
+        path this hook has no reason to have.
+
+        The generated name collides freely (two copies onto DeepSeek both read
+        ``X copy``). Names are not unique anywhere else in this product, and
+        de-duplicating would mean a lookup for a cosmetic gain.
+        """
+        source = self.agents.get_agent(agent_id)
+        if not source:
+            raise AgentNotFoundError()
+        if (source.get("agent_type") or "builtin") != "builtin":
+            raise AgentServiceError("Only built-in agents can be duplicated")
+
+        resolved_name = (name or f"{source.get('name') or 'Agent'} copy").strip()
+        pipeline = source.get("pipeline")
+        has_own_pipeline = isinstance(pipeline, list) and bool(pipeline)
+        runtime_type = normalize_runtime_type(source.get("runtime_type"))
+        runtime_config = normalize_runtime_config(
+            runtime_type, source.get("runtime_config") or {}
+        )
+        agent = self.create_agent(
+            name=resolved_name,
+            model_name=(model_name or "").strip()
+            or str(source.get("model_name") or "local-model"),
+            owner_user_id=owner_user_id,
+            owner_browser_session=owner_browser_session,
+            agent_type="builtin",
+            description=source.get("description"),
+            runtime_type=runtime_type,
+            runtime_config=runtime_config,
+            seed_default_pipeline=(
+                runtime_type == PIPELINE_RUNTIME_TYPE and not has_own_pipeline
+            ),
+            # Lenient, matching clone_marketplace_template: a stored legacy
+            # category must stamp None rather than reject the duplicate.
+            category=normalize_category(source.get("category")),
+        )
+        if has_own_pipeline:
+            agent = self.agents.update_agent(agent["agent_id"], pipeline=pipeline) or agent
+        return self.attach_equity_sparklines([self.agent_with_stats(agent)])[0]
+
     def list_builtin_agents_with_stats(self) -> List[Dict[str, Any]]:
         """List all built-in agents (platform-wide) enriched with run stats.
 

--- a/dashboard/backend/tests/test_agent_duplicate.py
+++ b/dashboard/backend/tests/test_agent_duplicate.py
@@ -168,3 +168,64 @@ def test_duplicate_requires_a_model_name(client, body):
         f"/api/v1/agents/{source['agent_id']}/duplicate", json=body, headers=headers
     )
     assert response.status_code == 422, response.text
+
+
+def test_duplicate_does_not_leak_the_plaintext_api_key(client):
+    """repository.create_agent() mints a plaintext api_key on EVERY agent it
+    creates, built-in included, and attaches it directly on the dict it
+    returns. duplicate_agent only sheds that key on the has_own_pipeline
+    branch, because that branch reassigns ``agent`` from update_agent()'s
+    return value (which never carries the key). A built-in agent with no
+    pipeline of its own -- e.g. one on the ai_hedge_fund runtime -- takes the
+    other branch, and the raw dict (key attached) used to flow straight
+    through agent_with_stats's shallow copy into the response."""
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    source = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "Hedge Fund Source",
+            "model_name": "anthropic/claude-haiku-4-5",
+            "agent_type": "builtin",
+            "runtime_type": "ai_hedge_fund",
+        },
+        headers=headers,
+    )
+    assert source.status_code == 200, source.text
+
+    response = client.post(
+        f"/api/v1/agents/{source.json()['agent']['agent_id']}/duplicate",
+        json={"model_name": "openai/gpt-5.5"},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    assert "api_key" not in response.json()["agent"]
+
+
+def test_create_agent_still_returns_the_one_time_api_key(client):
+    """Guard for the fix above: agent_with_stats now strips api_key from the
+    enriched copy it returns, but POST /api/v1/agents's top-level api_key
+    field pops the key off the *original*, un-enriched dict -- a separate
+    object -- so the one-time reveal must be unaffected."""
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    created = client.post(
+        "/api/v1/agents",
+        json={"name": "Keyed", "model_name": "local-model", "agent_type": "external"},
+        headers=headers,
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["api_key"].startswith("ag_")
+
+
+def test_marketplace_clone_does_not_leak_the_plaintext_api_key(client):
+    """Pre-existing leak, not introduced by this PR: clone_marketplace_template
+    has the identical has_own_pipeline branch as duplicate_agent, and the
+    ``ai-hedge-fund`` template carries no pipeline of its own, so cloning it
+    takes the leaking branch today. Closed by the same agent_with_stats fix."""
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    cloned = client.post(
+        "/api/v1/agents/marketplace/ai-hedge-fund/clone",
+        json={},
+        headers=headers,
+    )
+    assert cloned.status_code == 200, cloned.text
+    assert "api_key" not in cloned.json()["agent"]

--- a/dashboard/backend/tests/test_agent_duplicate.py
+++ b/dashboard/backend/tests/test_agent_duplicate.py
@@ -1,0 +1,170 @@
+"""POST /api/v1/agents/{agent_id}/duplicate -- the "Run on another model" hook.
+
+Copies an existing built-in agent onto a different model, server-side so the
+pipeline copy and the ownership check are one path. It deliberately does NOT
+start a backtest: auto-firing would spend LLM credits on a click the user did
+not frame as "run".
+"""
+
+import uuid
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+
+from dashboard.backend.app import app
+from dashboard.backend.domain.agents.credential_store import AgentCredentialStore
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import dashboard.backend.domain.agents.repository as agent_store_module
+    import dashboard.backend.api.routers.agents as agents_api
+    import dashboard.backend.domain.agents.service as agent_service_module
+    import dashboard.backend.database as db_module
+    import dashboard.backend.domain.brokers.repository as broker_repository
+
+    db_path = tmp_path / "test.db"
+    test_agents = agent_store_module.AgentStore(db_path=db_path)
+    test_credentials = AgentCredentialStore(db_path=db_path)
+    test_db = db_module.BacktestDatabase(db_path=db_path)
+    monkeypatch.setenv(
+        broker_repository._KEY_ENV_VAR, Fernet.generate_key().decode()
+    )
+    monkeypatch.setattr(broker_repository, "_fernet_instance", None)
+    monkeypatch.setattr(agent_store_module, "agent_store", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "agents", test_agents)
+    monkeypatch.setattr(agents_api.agent_service, "db", test_db)
+    monkeypatch.setattr(agents_api, "agent_credential_store", test_credentials)
+    # The service retires runtime-owned credentials on a runtime switch, so it
+    # needs the same store the router writes through.
+    monkeypatch.setattr(
+        agent_service_module, "agent_credential_store", test_credentials
+    )
+    monkeypatch.setattr(db_module, "db", test_db)
+    agents_api._credential_rate_limiter.reset()
+    return TestClient(app)
+
+
+def _create_builtin(client, headers, *, model="anthropic/claude-haiku-4-5"):
+    created = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "Source Agent",
+            "model_name": model,
+            "agent_type": "builtin",
+            "description": "The original.",
+        },
+        headers=headers,
+    )
+    assert created.status_code == 200, created.text
+    return created.json()["agent"]
+
+
+def test_duplicate_copies_the_agent_onto_a_new_model(client):
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    source = _create_builtin(client, headers)
+
+    response = client.post(
+        f"/api/v1/agents/{source['agent_id']}/duplicate",
+        json={"model_name": "deepseek/deepseek-v4-pro", "name": "Source Agent (DeepSeek)"},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    copy = response.json()["agent"]
+    assert copy["agent_id"] != source["agent_id"]
+    assert copy["model_name"] == "deepseek/deepseek-v4-pro"
+    assert copy["name"] == "Source Agent (DeepSeek)"
+    assert copy["description"] == "The original."
+
+
+def test_duplicate_copies_the_pipeline(client):
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    source = _create_builtin(client, headers)
+    pipeline = [
+        {
+            "id": "sub_custom",
+            "presetKey": "simple_instruction",
+            "label": "Trading instruction",
+            "prompt": "Buy only what you would hold for a week.",
+            "outputFormat": "JSON: { \"orders\": [] }",
+        }
+    ]
+    patched = client.patch(
+        f"/api/v1/agents/{source['agent_id']}",
+        json={"pipeline": pipeline},
+        headers=headers,
+    )
+    assert patched.status_code == 200, patched.text
+
+    response = client.post(
+        f"/api/v1/agents/{source['agent_id']}/duplicate",
+        json={"model_name": "qwen/qwen3.7-plus"},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    copy_id = response.json()["agent"]["agent_id"]
+    fetched = client.get(f"/api/v1/agents/{copy_id}", headers=headers).json()["agent"]
+    assert [step["prompt"] for step in fetched["pipeline"]] == [
+        "Buy only what you would hold for a week."
+    ]
+
+
+def test_duplicate_defaults_the_name(client):
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    source = _create_builtin(client, headers)
+    response = client.post(
+        f"/api/v1/agents/{source['agent_id']}/duplicate",
+        json={"model_name": "openai/gpt-5.5"},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["agent"]["name"] == "Source Agent copy"
+
+
+def test_duplicate_rejects_another_owners_agent(client):
+    owner = {"X-Session-Id": str(uuid.uuid4())}
+    attacker = {"X-Session-Id": str(uuid.uuid4())}
+    source = _create_builtin(client, owner)
+    response = client.post(
+        f"/api/v1/agents/{source['agent_id']}/duplicate",
+        json={"model_name": "openai/gpt-5.5"},
+        headers=attacker,
+    )
+    assert response.status_code in (403, 404), response.text
+
+
+def test_duplicate_rejects_an_unknown_agent(client):
+    response = client.post(
+        f"/api/v1/agents/{uuid.uuid4()}/duplicate",
+        json={"model_name": "openai/gpt-5.5"},
+        headers={"X-Session-Id": str(uuid.uuid4())},
+    )
+    assert response.status_code == 404, response.text
+
+
+def test_duplicate_rejects_an_external_agent(client):
+    """External agents mint an API key on create -- not a surface this hook opens."""
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    created = client.post(
+        "/api/v1/agents",
+        json={"name": "Connected", "model_name": "local-model", "agent_type": "external"},
+        headers=headers,
+    )
+    assert created.status_code == 200, created.text
+    response = client.post(
+        f"/api/v1/agents/{created.json()['agent']['agent_id']}/duplicate",
+        json={"model_name": "openai/gpt-5.5"},
+        headers=headers,
+    )
+    assert response.status_code == 400, response.text
+
+
+@pytest.mark.parametrize("body", [{}, {"model_name": ""}])
+def test_duplicate_requires_a_model_name(client, body):
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    source = _create_builtin(client, headers)
+    response = client.post(
+        f"/api/v1/agents/{source['agent_id']}/duplicate", json=body, headers=headers
+    )
+    assert response.status_code == 422, response.text

--- a/dashboard/backend/tests/test_agent_duplicate.py
+++ b/dashboard/backend/tests/test_agent_duplicate.py
@@ -76,6 +76,9 @@ def test_duplicate_copies_the_agent_onto_a_new_model(client):
     assert copy["model_name"] == "deepseek/deepseek-v4-pro"
     assert copy["name"] == "Source Agent (DeepSeek)"
     assert copy["description"] == "The original."
+    # A duplicate never auto-launches a backtest -- the user lands on the copy
+    # with Run primed, not mid-run.
+    assert copy["run_count"] == 0 and copy["latest_run"] is None
 
 
 def test_duplicate_copies_the_pipeline(client):
@@ -108,6 +111,40 @@ def test_duplicate_copies_the_pipeline(client):
     assert [step["prompt"] for step in fetched["pipeline"]] == [
         "Buy only what you would hold for a week."
     ]
+
+
+def test_duplicate_copies_backtest_allocation_but_not_cash_allocation(client):
+    """The one thing a user does with a duplicate is compare its equity curve
+    against the source's -- different starting capital makes those curves
+    incomparable. ``backtest_allocation`` is simulated capital with no ledger
+    coupling, so it is safe to copy. ``cash_allocation`` IS a real ledger debit
+    (the route reserves only DEFAULT_AGENT_CASH_ALLOCATION for it) and must
+    stay un-copied."""
+    headers = {"X-Session-Id": str(uuid.uuid4())}
+    created = client.post(
+        "/api/v1/agents",
+        json={
+            "name": "Source Agent",
+            "model_name": "anthropic/claude-haiku-4-5",
+            "agent_type": "builtin",
+            "cash_allocation": 2500,
+            "backtest_allocation": 2000,
+        },
+        headers=headers,
+    )
+    assert created.status_code == 200, created.text
+    source = created.json()["agent"]
+    assert source["backtest_allocation"] == 2000
+
+    response = client.post(
+        f"/api/v1/agents/{source['agent_id']}/duplicate",
+        json={"model_name": "deepseek/deepseek-v4-pro"},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    copy = response.json()["agent"]
+    assert copy["backtest_allocation"] == 2000
+    assert copy["cash_allocation"] == 1000
 
 
 def test_duplicate_defaults_the_name(client):
@@ -160,7 +197,7 @@ def test_duplicate_rejects_an_external_agent(client):
     assert response.status_code == 400, response.text
 
 
-@pytest.mark.parametrize("body", [{}, {"model_name": ""}])
+@pytest.mark.parametrize("body", [{}, {"model_name": ""}, {"model_name": "   "}])
 def test_duplicate_requires_a_model_name(client, body):
     headers = {"X-Session-Id": str(uuid.uuid4())}
     source = _create_builtin(client, headers)

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -1273,3 +1273,39 @@ def test_builtin_listing_echoes_category(client):
     entry = next(a for a in listing.json()["agents"] if a["agent_id"] == agent_id)
     assert "category" in entry
     assert entry["category"] == "cn_ashares"
+
+
+def test_clone_honours_a_model_name_override(client):
+    """Community's "Choose model" affordance clones a template onto another model."""
+    cloned = client.post(
+        "/api/v1/agents/marketplace/balanced-starter/clone",
+        json={"model_name": "deepseek/deepseek-v4-pro"},
+        headers={"X-Session-Id": str(uuid.uuid4())},
+    )
+    assert cloned.status_code == 200, cloned.text
+    assert cloned.json()["agent"]["model_name"] == "deepseek/deepseek-v4-pro"
+
+
+@pytest.mark.parametrize("blank", [None, "", "   "])
+def test_clone_falls_back_to_the_template_model(client, blank):
+    """Omitted or blank means "use the template's model", not "use empty"."""
+    body = {} if blank is None else {"model_name": blank}
+    cloned = client.post(
+        "/api/v1/agents/marketplace/balanced-starter/clone",
+        json=body,
+        headers={"X-Session-Id": str(uuid.uuid4())},
+    )
+    assert cloned.status_code == 200, cloned.text
+    assert cloned.json()["agent"]["model_name"] == "anthropic/claude-haiku-4-5"
+
+
+def test_clone_does_not_validate_the_model_name(client):
+    """No whitelist here: POST /agents and PATCH /agents/{id} don't have one either,
+    and a Literal would drag in the openapi enum deploy gate #313 discharged."""
+    cloned = client.post(
+        "/api/v1/agents/marketplace/balanced-starter/clone",
+        json={"model_name": "some/unreleased-model"},
+        headers={"X-Session-Id": str(uuid.uuid4())},
+    )
+    assert cloned.status_code == 200, cloned.text
+    assert cloned.json()["agent"]["model_name"] == "some/unreleased-model"

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -104,6 +104,7 @@ EXPECTED_FULL_CONTRACT = {
     ("DELETE", "/api/v1/agents/{agent_id}"),
     ("GET", "/api/v1/agents/{agent_id}"),
     ("PATCH", "/api/v1/agents/{agent_id}"),
+    ("POST", "/api/v1/agents/{agent_id}/duplicate"),
     ("DELETE", "/api/v1/agents/{agent_id}/credentials/financial-datasets"),
     ("GET", "/api/v1/agents/{agent_id}/credentials/financial-datasets"),
     ("PUT", "/api/v1/agents/{agent_id}/credentials/financial-datasets"),

--- a/dashboard/backend/tests/test_router_move.py
+++ b/dashboard/backend/tests/test_router_move.py
@@ -60,6 +60,7 @@ EXPECTED_AGENT_ROUTES = {
     ),
     ("DELETE", "/v1/agents/{agent_id}", "delete_agent"),
     ("POST", "/v1/agents/{agent_id}/rotate-api-key", "rotate_agent_api_key"),
+    ("POST", "/v1/agents/{agent_id}/duplicate", "duplicate_agent"),
     ("POST", "/v1/agents/{agent_id}/activate", "activate_agent"),
 }
 


### PR DESCRIPTION
**Also closes a plaintext-credential leak that is live on `main` today.** Cloning the `ai-hedge-fund` template returns a working agent API key in `agent.api_key`, which the frontend parks in `window.ACTIVE_AGENT`. Verified by running the new guard against the merge-base. Fixed at the shared choke point (`agent_with_stats`), which closes the same hole on the new `duplicate` path.

Two backend additions behind the upcoming Community model facets:

- `POST /api/v1/agents/marketplace/{id}/clone` accepts `model_name` (blank/omitted = template default).
- `POST /api/v1/agents/{agent_id}/duplicate` copies a built-in agent — pipeline and backtest capital included — onto another model. Built-in only; external agents mint an API key on create. It does not start a backtest.

No `model_name` whitelist, matching `POST /agents` and `PATCH /agents/{id}`. No frontend consumes these yet.

Back-compat: zero change for existing callers. The only clone caller posts `{}`; the SDK and Discord bot don't call it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)