### PR TITLE
fix(backtest): one model vocabulary, no stale submissions

### DIFF
--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -179,5 +179,5 @@ def test_slow_boot_notice_is_wired():
 
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
-    assert "app.js?v=74" in APP_HTML
+    assert "app.js?v=75" in APP_HTML
     assert "styles.css?v=84" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_model_vocabulary.py
+++ b/dashboard/backend/tests/test_frontend_model_vocabulary.py
@@ -14,7 +14,7 @@ import subprocess
 
 import pytest
 
-from dashboard.backend.tests._frontend_source import APP_HTML, APP_JS, fn_body, js_const
+from dashboard.backend.tests._frontend_source import APP_HTML, fn_body, js_const
 
 EXPECTED_MODELS = [
     ("anthropic/claude-haiku-4-5", "Claude Haiku 4.5", "anthropic"),
@@ -40,6 +40,18 @@ def test_model_selects_carry_no_hardcoded_options(select_id):
     assert "<option" not in _select_markup(select_id), (
         f"#{select_id} still hardcodes options; build it from SUPPORTED_MODELS"
     )
+
+
+def test_the_populator_fills_both_pickers():
+    """populateSupportedModelSelects must write into #modelSelect AND
+    #builtinAgentModel -- dropping either line ships an empty picker silently.
+    For #builtinAgentModel specifically, an empty select means
+    submitCreateBuiltinAgent's `|| 'anthropic/claude-haiku-4-5'` fallback puts
+    every new built-in agent on Haiku with no error.
+    """
+    body = fn_body("function populateSupportedModelSelects")
+    for select_id in ("modelSelect", "builtinAgentModel"):
+        assert f"getElementById('{select_id}')" in body
 
 
 def test_supported_models_are_the_six_runnable_models():

--- a/dashboard/backend/tests/test_frontend_model_vocabulary.py
+++ b/dashboard/backend/tests/test_frontend_model_vocabulary.py
@@ -34,6 +34,18 @@ def _select_markup(select_id: str) -> str:
     return APP_HTML[open_tag:close]
 
 
+def _strip_js_comments(source: str) -> str:
+    """`source` with `//` and `/* */` comments removed.
+
+    A comment can restate the very code it defers ("// TODO: wire up
+    createPicker.innerHTML = html later"), so a raw `in`/`re.search` over the
+    function body would be satisfied by the comment instead of live code and
+    pass against a picker that ships empty. Matches this suite's convention
+    (see test_frontend_shelves.py / test_app_copy_register.py).
+    """
+    return re.sub(r"//[^\n]*", "", re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL))
+
+
 @pytest.mark.parametrize("select_id", ["modelSelect", "builtinAgentModel"])
 def test_model_selects_carry_no_hardcoded_options(select_id):
     """Neither picker may hold its own option list -- that is how they drifted."""
@@ -44,14 +56,23 @@ def test_model_selects_carry_no_hardcoded_options(select_id):
 
 def test_the_populator_fills_both_pickers():
     """populateSupportedModelSelects must write into #modelSelect AND
-    #builtinAgentModel -- dropping either line ships an empty picker silently.
+    #builtinAgentModel -- both looked up AND assigned. Two ways this ships an
+    empty picker silently: the lookup+assignment lines being deleted outright,
+    or the lookup surviving while its .innerHTML assignment is dropped (e.g.
+    left as a TODO) -- a bare substring check on the id would miss the second,
+    and even the assignment check alone is fooled by a comment that names the
+    deferred code, so comments are stripped first.
     For #builtinAgentModel specifically, an empty select means
     submitCreateBuiltinAgent's `|| 'anthropic/claude-haiku-4-5'` fallback puts
     every new built-in agent on Haiku with no error.
     """
-    body = fn_body("function populateSupportedModelSelects")
+    body = _strip_js_comments(fn_body("function populateSupportedModelSelects"))
     for select_id in ("modelSelect", "builtinAgentModel"):
-        assert f"getElementById('{select_id}')" in body
+        bound = re.search(rf"(\w+)\s*=\s*document\.getElementById\('{select_id}'\)", body)
+        assert bound, f"{select_id} is never looked up in the populator"
+        assert re.search(rf"{bound.group(1)}\.innerHTML\s*=", body), (
+            f"{select_id} is looked up but never written to -- it would ship empty"
+        )
 
 
 def test_supported_models_are_the_six_runnable_models():

--- a/dashboard/backend/tests/test_frontend_model_vocabulary.py
+++ b/dashboard/backend/tests/test_frontend_model_vocabulary.py
@@ -1,0 +1,80 @@
+"""Guards for the single frontend source of truth for runnable models.
+
+app.html used to carry two hand-maintained model <option> lists that drifted
+apart: the backtest picker offered six models this platform does not run, and
+omitted four it does. Both selects are now built from SUPPORTED_MODELS in
+app.js. /app has no JS test harness, so -- per this suite's convention
+(_frontend_source) -- the contract is asserted against the shipped source, and
+behaviour is asserted by running the real functions under node.
+"""
+
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from dashboard.backend.tests._frontend_source import APP_HTML, APP_JS, fn_body, js_const
+
+EXPECTED_MODELS = [
+    ("anthropic/claude-haiku-4-5", "Claude Haiku 4.5", "anthropic"),
+    ("anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6", "anthropic"),
+    ("openai/gpt-5.5", "GPT-5.5", "openai"),
+    ("google/gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", "google"),
+    ("deepseek/deepseek-v4-pro", "DeepSeek V4 Pro", "deepseek"),
+    ("qwen/qwen3.7-plus", "Qwen3.7 Plus", "qwen"),
+]
+
+
+def _select_markup(select_id: str) -> str:
+    """The <select id="..."> element's own markup, up to its closing tag."""
+    start = APP_HTML.index(f'id="{select_id}"')
+    open_tag = APP_HTML.rindex("<select", 0, start)
+    close = APP_HTML.index("</select>", start)
+    return APP_HTML[open_tag:close]
+
+
+@pytest.mark.parametrize("select_id", ["modelSelect", "builtinAgentModel"])
+def test_model_selects_carry_no_hardcoded_options(select_id):
+    """Neither picker may hold its own option list -- that is how they drifted."""
+    assert "<option" not in _select_markup(select_id), (
+        f"#{select_id} still hardcodes options; build it from SUPPORTED_MODELS"
+    )
+
+
+def test_supported_models_are_the_six_runnable_models():
+    source = js_const("SUPPORTED_MODELS")
+    found = re.findall(
+        r"slug:\s*'([^']+)',\s*label:\s*'([^']+)',\s*vendor:\s*'([^']+)'", source
+    )
+    assert found == EXPECTED_MODELS
+
+
+def test_retired_models_are_gone_from_the_frontend():
+    """The six models the old picker offered that this platform cannot run."""
+    for retired in (
+        "claude-opus-4.7",
+        "gpt-5.2",
+        "gpt-5-mini",
+        "deepseek-v4-flash",
+        "gemini-3.5-flash",
+        "gemini-2.5-pro",
+    ):
+        assert retired not in APP_HTML, f"{retired} still offered in app.html"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_model_options_html_renders_every_supported_model():
+    script = f"""
+function escapeHtml(s) {{ return String(s); }}
+{js_const("SUPPORTED_MODELS")}
+{fn_body("function modelOptionsHtml")}
+console.log(modelOptionsHtml(SUPPORTED_MODELS));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    html = result.stdout
+    for slug, label, _vendor in EXPECTED_MODELS:
+        assert f'<option value="{slug}">{label}</option>' in html

--- a/dashboard/backend/tests/test_frontend_model_vocabulary.py
+++ b/dashboard/backend/tests/test_frontend_model_vocabulary.py
@@ -78,3 +78,82 @@ console.log(modelOptionsHtml(SUPPORTED_MODELS));
     html = result.stdout
     for slug, label, _vendor in EXPECTED_MODELS:
         assert f'<option value="{slug}">{label}</option>' in html
+
+
+_FAKE_SELECT = """
+class FakeOption {
+  constructor(value, text) { this.value = value; this.textContent = text; this.dataset = {}; }
+}
+class FakeSelect {
+  constructor(values) {
+    this.options = values.map((v) => new FakeOption(v, v));
+    this.value = values[0] || '';
+  }
+  appendChild(option) { this.options.push(option); }
+  querySelectorAll(selector) {
+    if (selector !== 'option[data-injected-model]') throw new Error('unexpected: ' + selector);
+    const self = this;
+    const matches = this.options.filter((o) => o.dataset.injectedModel);
+    matches.forEach((o) => { o.remove = () => {
+      self.options = self.options.filter((x) => x !== o);
+    }; });
+    return matches;
+  }
+}
+"""
+
+
+def _run_sync_harness(body: str) -> str:
+    script = f"""
+{_FAKE_SELECT}
+let SELECT = null;
+const document = {{
+  getElementById: (id) => (id === 'modelSelect' ? SELECT : null),
+  createElement: () => new FakeOption('', ''),
+}};
+function formatAgentModelLabel(m) {{ return String(m); }}
+{fn_body("function normalizeBacktestModelId")}
+{fn_body("function findBacktestModelOption")}
+{fn_body("function syncModelSelectFromAgent")}
+{body}
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_unrepresentable_model_is_injected_not_left_stale():
+    """The regression: agent B's run must never submit agent A's model."""
+    out = _run_sync_harness(
+        # Agent A leaves qwen in the select; agent B runs a legacy model.
+        "SELECT = new FakeSelect(['anthropic/claude-haiku-4-5', 'qwen/qwen3.7-plus']);"
+        "SELECT.value = 'qwen/qwen3.7-plus';"
+        "syncModelSelectFromAgent({model_name: 'gpt-5.2'});"
+        "console.log(SELECT.value);"
+    )
+    assert out == "gpt-5.2"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_injected_options_do_not_accumulate():
+    out = _run_sync_harness(
+        "SELECT = new FakeSelect(['anthropic/claude-haiku-4-5']);"
+        "syncModelSelectFromAgent({model_name: 'gpt-5.2'});"
+        "syncModelSelectFromAgent({model_name: 'local-model'});"
+        "console.log(SELECT.options.map((o) => o.value).join(','));"
+    )
+    assert out == "anthropic/claude-haiku-4-5,local-model"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_representable_model_selects_its_own_option():
+    out = _run_sync_harness(
+        "SELECT = new FakeSelect(['anthropic/claude-haiku-4-5', 'qwen/qwen3.7-plus']);"
+        "SELECT.value = 'qwen/qwen3.7-plus';"
+        "syncModelSelectFromAgent({model_name: 'anthropic/claude-haiku-4-5'});"
+        "console.log(SELECT.value + '|' + SELECT.options.length);"
+    )
+    assert out == "anthropic/claude-haiku-4-5|2"

--- a/dashboard/backend/tests/test_frontend_model_vocabulary.py
+++ b/dashboard/backend/tests/test_frontend_model_vocabulary.py
@@ -99,6 +99,15 @@ class FakeSelect {
     }; });
     return matches;
   }
+  // A real <select>'s value setter silently resolves to '' when the assigned
+  // string matches no current <option>. Mirror that here so a future edit that
+  // sets .value before the matching option exists (e.g. reordering appendChild
+  // and the .value assignment) shows up as a blank value in this fake too,
+  // instead of the fake accepting any string unconditionally.
+  get value() { return this._value; }
+  set value(v) {
+    this._value = this.options.some((o) => o.value === v) ? v : '';
+  }
 }
 """
 

--- a/dashboard/backend/tests/test_ifind_ashare_frontend.py
+++ b/dashboard/backend/tests/test_ifind_ashare_frontend.py
@@ -218,22 +218,24 @@ def test_backtest_capital_input_stays_removed_default_unchanged(html, js):
     assert re.search(r"DEFAULT_AGENT_CASH_ALLOCATION\s*=\s*1000", js)
 
 
-def test_ifind_model_dropdown_keeps_all_nine_models_available(html):
-    model_options = re.findall(
-        r'<option\s+value="([^"]+)">[^<]+</option>',
-        re.search(r'<select[^>]+id="modelSelect"[^>]*>(.*?)</select>', html, re.S).group(1),
+def test_ifind_model_dropdown_is_populated_from_supported_models(html, js):
+    """This used to pin nine hardcoded <option>s here -- six models the platform
+    cannot run, in a bare-slug format ('gpt-5.2') the rest of the app does not
+    use, while #builtinAgentModel used namespaced slugs. Both pickers now build
+    from SUPPORTED_MODELS in app.js; the vocabulary itself is pinned by
+    test_frontend_model_vocabulary.py.
+
+    What still matters *here* is that the picker is never left empty: on the
+    iFinD A-share path it is the live rule-based-vs-LLM decision-source control,
+    so the populator has to be wired into boot, not merely defined.
+    """
+    assert re.search(r'<select[^>]*id="modelSelect"[^>]*>\s*</select>', html)
+    assert "function populateSupportedModelSelects" in js
+    assert js.count("populateSupportedModelSelects()") >= 1
+    # Wired into the pure-DOM boot block, not left merely defined.
+    assert js.index("setupTickerScrollControls();") < js.index(
+        "populateSupportedModelSelects();"
     )
-    assert model_options == [
-        "claude-haiku-4.5",
-        "claude-sonnet-4.6",
-        "claude-opus-4.7",
-        "gpt-5.2",
-        "gpt-5-mini",
-        "deepseek-v4-flash",
-        "deepseek-v4-pro",
-        "gemini-3.5-flash",
-        "gemini-2.5-pro",
-    ]
 
 
 def test_run_config_shows_ifind_source_universe_count_timeframe_and_decision(html, js):

--- a/dashboard/backend/tests/test_ifind_ashare_frontend.py
+++ b/dashboard/backend/tests/test_ifind_ashare_frontend.py
@@ -231,7 +231,6 @@ def test_ifind_model_dropdown_is_populated_from_supported_models(html, js):
     """
     assert re.search(r'<select[^>]*id="modelSelect"[^>]*>\s*</select>', html)
     assert "function populateSupportedModelSelects" in js
-    assert js.count("populateSupportedModelSelects()") >= 1
     # Wired into the pure-DOM boot block, not left merely defined.
     assert js.index("setupTickerScrollControls();") < js.index(
         "populateSupportedModelSelects();"

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -357,17 +357,10 @@
                     <label for="modelSelect">Model</label>
                     <p id="runBacktestModelReadonly" class="run-backtest-readonly" hidden>—</p>
                     <p id="modelSelectHint" class="control-helper">Set on the agent in Configure — this backtest always runs the agent's saved model.</p>
-                    <select class="control-select" id="modelSelect" hidden>
-                        <option value="claude-haiku-4.5">Claude Haiku 4.5</option>
-                        <option value="claude-sonnet-4.6">Claude Sonnet 4.6</option>
-                        <option value="claude-opus-4.7">Claude Opus 4.7</option>
-                        <option value="gpt-5.2">GPT-5.2</option>
-                        <option value="gpt-5-mini">GPT-5 mini</option>
-                        <option value="deepseek-v4-flash">DeepSeek V4 Flash</option>
-                        <option value="deepseek-v4-pro">DeepSeek V4 Pro</option>
-                        <option value="gemini-3.5-flash">Gemini 3.5 Flash</option>
-                        <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
-                    </select>
+                    <!-- Options are written by populateSupportedModelSelects() from
+                         SUPPORTED_MODELS in app.js. Do not hardcode them here: this
+                         list and #builtinAgentModel's drifted apart once already. -->
+                    <select class="control-select" id="modelSelect" hidden></select>
                 </div>
 
                 <select id="backtestAgentSelect" hidden aria-hidden="true">
@@ -795,14 +788,10 @@
                 </label>
                 <label class="auth-field">
                     <span>Model</span>
-                    <select id="builtinAgentModel">
-                        <option value="anthropic/claude-haiku-4-5">Claude Haiku 4.5</option>
-                        <option value="anthropic/claude-sonnet-4-6">Claude Sonnet 4.6</option>
-                        <option value="openai/gpt-5.5">GPT-5.5</option>
-                        <option value="google/gemini-3.1-pro-preview">Gemini 3.1 Pro Preview</option>
-                        <option value="deepseek/deepseek-v4-pro">DeepSeek V4 Pro</option>
-                        <option value="qwen/qwen3.7-plus">Qwen3.7 Plus</option>
-                    </select>
+                    <!-- Options are written by populateSupportedModelSelects() in app.js.
+                         js/agent-editor.js clones this select's options for the Configure
+                         screen's picker, at editor-open time, so it inherits them too. -->
+                    <select id="builtinAgentModel"></select>
                 </label>
                 <label class="auth-field">
                     <span>Description (optional)</span>
@@ -1730,7 +1719,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=26" defer></script>
-    <script src="app.js?v=74" defer></script>
+    <script src="app.js?v=75" defer></script>
     <script src="js/leaderboard.js?v=16" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1683,8 +1683,9 @@ function resolveBacktestModelRequest(modelSelect, agent) {
   if (agentOption?.value === selectedModel && agent?.model_name) {
     return agent.model_name;
   }
-  // A model the nine-option list cannot represent still belongs to the agent:
-  // without this the run submits whatever value a previous agent left behind.
+  // Belt-and-braces since syncModelSelectFromAgent started injecting an option
+  // for unrepresentable models: on the hidden path the agent's saved model wins
+  // outright, whatever the select happens to hold.
   if (agent?.model_name && !backtestModelPickerIsLiveControl()) {
     return agent.model_name;
   }
@@ -1707,13 +1708,34 @@ function syncBacktestModelFieldMode() {
       : formatAgentModelLabel(runBacktestModalAgent?.model_name));
 }
 
+/**
+ * Point the picker at this agent's model.
+ *
+ * A model the curated list cannot represent (a legacy value like 'gpt-5.2' or
+ * 'local-model') is INJECTED as its own option rather than left unmatched.
+ * Leaving it unmatched is a silent-wrong-value bug, not a cosmetic one: on the
+ * live iFinD path resolveBacktestModelRequest returns the select's current
+ * value, so the run would submit whatever the previously-selected agent left
+ * there, recorded under this agent's name. js/agent-editor.js does the same
+ * thing for the Configure picker.
+ */
 function syncModelSelectFromAgent(agent) {
   const modelSelect = document.getElementById('modelSelect');
   if (!modelSelect || !agent?.model_name) return;
+  // Drop the previous agent's injected option first, so injections cannot pile
+  // up across agent switches and cannot be matched as if they were curated.
+  modelSelect.querySelectorAll('option[data-injected-model]').forEach((option) => option.remove());
   const option = findBacktestModelOption(modelSelect, agent.model_name);
   if (option) {
     modelSelect.value = option.value;
+    return;
   }
+  const injected = document.createElement('option');
+  injected.value = agent.model_name;
+  injected.textContent = formatAgentModelLabel(agent.model_name);
+  injected.dataset.injectedModel = 'true';
+  modelSelect.appendChild(injected);
+  modelSelect.value = agent.model_name;
 }
 
 function getSelectedBacktestAgent() {

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -497,6 +497,46 @@ const MARKET_LABELS = {
 // opens), never at its own module-init time -- the same rule window.API follows.
 window.AGENT_SHELF_LABELS = MARKET_LABELS;
 
+/** Every model a user can actually pick and run here. The single source for
+ * both model <select> elements: the Run Backtest picker (#modelSelect, live
+ * only on the iFinD A-share path) and the Create Built-in picker
+ * (#builtinAgentModel, which the Configure editor clones its own options from).
+ *
+ * These lists were hand-maintained separately and drifted: the backtest picker
+ * offered six models this platform does not run and omitted four it does, and
+ * an agent on an unlisted model silently submitted the *previous* agent's
+ * selection (see syncModelSelectFromAgent). Declaration order is display order.
+ *
+ * The AI Hedge Fund runtime's Nemotron is deliberately absent: it is a property
+ * of a hosted runtime, not a user choice, and syncBacktestModelFieldMode
+ * already renders that case as "AI Hedge Fund — hosted runtime". */
+const SUPPORTED_MODELS = [
+  { slug: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5', vendor: 'anthropic' },
+  { slug: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6', vendor: 'anthropic' },
+  { slug: 'openai/gpt-5.5', label: 'GPT-5.5', vendor: 'openai' },
+  { slug: 'google/gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview', vendor: 'google' },
+  { slug: 'deepseek/deepseek-v4-pro', label: 'DeepSeek V4 Pro', vendor: 'deepseek' },
+  { slug: 'qwen/qwen3.7-plus', label: 'Qwen3.7 Plus', vendor: 'qwen' },
+];
+
+/** Pure: no DOM, so the guards can run it under node. */
+function modelOptionsHtml(models) {
+  return models
+    .map((model) => `<option value="${escapeHtml(model.slug)}">${escapeHtml(model.label)}</option>`)
+    .join('');
+}
+
+/** Fill both model pickers. Runs once, in the pure-DOM boot block, which is
+ * before syncIFindModelControl can prepend #modelSelect's "Rule-based" option
+ * -- calling this again later would wipe that option out. */
+function populateSupportedModelSelects() {
+  const html = modelOptionsHtml(SUPPORTED_MODELS);
+  const backtestPicker = document.getElementById('modelSelect');
+  if (backtestPicker) backtestPicker.innerHTML = html;
+  const createPicker = document.getElementById('builtinAgentModel');
+  if (createPicker) createPicker.innerHTML = html;
+}
+
 // My Agents' JS-driven sections, in display order. `match` delegates to
 // agentShelfKey so every agent resolves to exactly one shelf by construction
 // rather than by predicates staying mutually exclusive as they're edited.
@@ -3954,6 +3994,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initNavigation();
     setupTickerResizeHandler();
     setupTickerScrollControls();
+    populateSupportedModelSelects();
 
     // Setup time period buttons
     document.querySelectorAll('.time-btn').forEach(btn => {


### PR DESCRIPTION
The Run Backtest picker offered six models this platform cannot run and omitted four it can — and it used bare slugs (`claude-haiku-4.5`) where the Create Built-in picker used namespaced ones (`anthropic/claude-haiku-4-5`). The two lists were hand-maintained and had drifted in both vocabulary and slug format. Both `<select>` elements now build from one `SUPPORTED_MODELS` list in `app.js`.

Also closes a silent-wrong-value path: on the iFinD A-share route — the only place the picker is a live control — an agent whose model matched no option submitted the *previously selected* agent's model, recorded under this agent's name. It is now injected as its own option.

**Behaviour change worth knowing:** on that live path a legacy model (`local-model`, `gpt-5.2`) now reaches the gateway as itself and may fail, where before it silently ran under a different agent's runnable model. Configure is unaffected — `agent-editor.js` already injects an unlisted current value, so no saved agent loses or rewrites its model.

Incidentally fixes a latent wire-format bug: `backtest_harness.py` expects `provider/model` ids, so the old bare slugs were the wrong form on the live path.

Prerequisite for the Community model-vendor facets and the Qwen A-share template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)