### PR TITLE
feat(community): spread the catalog across vendors

### DIFF
--- a/dashboard/backend/tests/test_marketplace_catalog_models.py
+++ b/dashboard/backend/tests/test_marketplace_catalog_models.py
@@ -1,0 +1,52 @@
+"""Every catalog template must run on a model the platform actually offers.
+
+A template on an unlisted model is invisible trouble: it clones fine, then the
+Run Backtest picker cannot represent its model. The only exception is a hosted
+runtime, whose model is a property of the runtime rather than a user choice.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from dashboard.backend.tests._frontend_source import js_const
+
+_CATALOG = json.loads(
+    (Path(__file__).resolve().parents[3] / "dashboard/config/marketplace.json").read_text(
+        encoding="utf-8"
+    )
+)["templates"]
+
+_SUPPORTED_SLUGS = set(re.findall(r"slug:\s*'([^']+)'", js_const("SUPPORTED_MODELS")))
+
+_EXPECTED_NEW = {
+    "contrarian-dip-buyer": ("openai/gpt-5.5", "us_stocks"),
+    "sector-rotator": ("google/gemini-3.1-pro-preview", "us_stocks"),
+    "volatility-guard": ("deepseek/deepseek-v4-pro", "us_stocks"),
+    "ashare-momentum-t1": ("qwen/qwen3.7-plus", "cn_ashares"),
+}
+
+
+@pytest.mark.parametrize("template", _CATALOG, ids=lambda t: t["template_id"])
+def test_every_template_runs_a_supported_or_hosted_model(template):
+    if template.get("runtime_type"):
+        return  # hosted runtime: its model is not user-selectable
+    assert template["model_name"] in _SUPPORTED_SLUGS, (
+        f"{template['template_id']} runs {template['model_name']!r}, "
+        "which is not in SUPPORTED_MODELS"
+    )
+
+
+@pytest.mark.parametrize("template_id,expected", sorted(_EXPECTED_NEW.items()))
+def test_new_templates_are_present_with_their_pairings(template_id, expected):
+    found = next((t for t in _CATALOG if t["template_id"] == template_id), None)
+    assert found is not None, f"{template_id} missing from marketplace.json"
+    assert (found["model_name"], found["category"]) == expected
+
+
+def test_catalog_covers_every_pickable_vendor():
+    """The facet is decorative if most of its chips are empty."""
+    vendors = {t["model_name"].split("/", 1)[0] for t in _CATALOG}
+    assert {"anthropic", "openai", "google", "deepseek", "qwen"} <= vendors

--- a/dashboard/config/marketplace.json
+++ b/dashboard/config/marketplace.json
@@ -140,6 +140,90 @@
           "outputFormat": "JSON: { \"orders\": [{ \"symbol\": \"...\", \"side\": \"buy|sell|hold\", \"qty\": number, \"order_type\": \"market|limit\", \"limit_price\": number|null, \"reason\": \"...\" }] }"
         }
       ]
+    },
+    {
+      "template_id": "contrarian-dip-buyer",
+      "name": "Contrarian Dip Buyer",
+      "model_name": "openai/gpt-5.5",
+      "description": "Buys stocks that have sold off hard and trims them back once they have recovered. The opposite instinct to a momentum strategy.",
+      "category": "us_stocks",
+      "tags": [
+        "contrarian",
+        "mean reversion"
+      ],
+      "author": "Agentic Trading Lab",
+      "pipeline": [
+        {
+          "id": "sub_contrarian_dip",
+          "presetKey": "simple_instruction",
+          "label": "Trading instruction",
+          "prompt": "Look for stocks that have fallen well below where they were trading recently and buy those, in small pieces rather than all at once. Sell back into strength once a position has recovered. Do not chase stocks that are already running.",
+          "outputFormat": "JSON: { \"orders\": [{ \"symbol\": \"...\", \"side\": \"buy|sell|hold\", \"qty\": number, \"order_type\": \"market|limit\", \"limit_price\": number|null, \"reason\": \"...\" }] }"
+        }
+      ]
+    },
+    {
+      "template_id": "sector-rotator",
+      "name": "Sector Rotator",
+      "model_name": "google/gemini-3.1-pro-preview",
+      "description": "Concentrates into whichever part of the market is leading, and moves on when leadership changes.",
+      "category": "us_stocks",
+      "tags": [
+        "rotation",
+        "trend"
+      ],
+      "author": "Agentic Trading Lab",
+      "pipeline": [
+        {
+          "id": "sub_sector_rotator",
+          "presetKey": "simple_instruction",
+          "label": "Trading instruction",
+          "prompt": "Group the available stocks by the kind of business they are in. Put most of the money into the group that has been performing best, and hold two or three names from it rather than one. When a different group takes the lead, sell out of the old one before building the new position.",
+          "outputFormat": "JSON: { \"orders\": [{ \"symbol\": \"...\", \"side\": \"buy|sell|hold\", \"qty\": number, \"order_type\": \"market|limit\", \"limit_price\": number|null, \"reason\": \"...\" }] }"
+        }
+      ]
+    },
+    {
+      "template_id": "volatility-guard",
+      "name": "Volatility Guard",
+      "model_name": "deepseek/deepseek-v4-pro",
+      "description": "Holds a steady portfolio in calm markets and cuts exposure when prices start swinging. Runs on the only model that has beaten the passive baselines on our leaderboard.",
+      "category": "us_stocks",
+      "tags": [
+        "risk management",
+        "defensive"
+      ],
+      "author": "Agentic Trading Lab",
+      "pipeline": [
+        {
+          "id": "sub_volatility_guard",
+          "presetKey": "simple_instruction",
+          "label": "Trading instruction",
+          "prompt": "Judge how violently prices have been moving lately compared with earlier in the period. While things are calm, stay invested across several stocks. When the swings get noticeably larger, sell part of every position and hold the cash rather than switching stocks. Rebuild the positions gradually once the market settles down. Protecting the money matters more here than catching every rally.",
+          "outputFormat": "JSON: { \"orders\": [{ \"symbol\": \"...\", \"side\": \"buy|sell|hold\", \"qty\": number, \"order_type\": \"market|limit\", \"limit_price\": number|null, \"reason\": \"...\" }] }"
+        }
+      ]
+    },
+    {
+      "template_id": "ashare-momentum-t1",
+      "name": "A-Share Momentum (T+1)",
+      "model_name": "qwen/qwen3.7-plus",
+      "description": "Rides the strongest Chinese A-shares while respecting that market's rule that shares bought today cannot be sold until the next trading day.",
+      "category": "cn_ashares",
+      "tags": [
+        "a-shares",
+        "momentum"
+      ],
+      "author": "Agentic Trading Lab",
+      "pipeline": [
+        {
+          "id": "sub_ashare_momentum",
+          "presetKey": "simple_instruction",
+          "label": "Trading instruction",
+          "prompt": "Buy the Chinese A-shares that have been climbing most steadily and hold them while they keep leading. Shares bought today cannot be sold until the next trading day, so only buy what you are happy to still own tomorrow, and plan any exit at least a day ahead. Sell a position once it stops leading.",
+          "outputFormat": "JSON: { \"orders\": [{ \"symbol\": \"...\", \"side\": \"buy|sell|hold\", \"qty\": number, \"order_type\": \"market|limit\", \"limit_price\": number|null, \"reason\": \"...\" }] }"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Catalog goes 7 → 11 templates and stops being a Claude monoculture: one each on GPT-5.5, Gemini 3.1 Pro, DeepSeek V4 Pro and Qwen3.7 Plus. China A-Share goes 1 → 2.

Content only — `marketplace.json` plus one new test file. No route, schema, or existing template changed; the four objects are a pure append.

A new guard pins every template's model to `SUPPORTED_MODELS` (hosted runtimes excepted, since their model is a property of the runtime rather than a user choice), so a future template cannot land on a model the Run Backtest picker has no option for. It reads the list out of `app.js` rather than restating it, so the two cannot drift.

Two pairings are deliberate: Qwen (Alibaba) on the thin A-share shelf, DeepSeek on the risk strategy because it is the only leaderboard LLM that beat the passive baselines.

Prerequisite for the Community vendor facets. Full backend suite: 2569 passed, 67 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
