### PR TITLE
feat(community): browse and clone agents by AI model

### DIFF
--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -179,5 +179,5 @@ def test_slow_boot_notice_is_wired():
 
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
-    assert "app.js?v=75" in APP_HTML
-    assert "styles.css?v=84" in APP_HTML
+    assert "app.js?v=76" in APP_HTML
+    assert "styles.css?v=85" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -403,3 +403,95 @@ console.log(JSON.stringify(cardHtml.map((html) => html.includes('marketplace-lic
     assert result.returncode == 0, result.stderr
     # In catalog order: open-weight DeepSeek, closed-weight Claude, unknown vendor.
     assert json.loads(result.stdout) == [True, False, False]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_closed_card_differs_from_open_card_by_exactly_the_badge():
+    """"Absence is not a negative claim" is a stronger promise than "no badge
+    with this exact class and text" -- the two tests above enumerate two
+    guessed forbidden strings ("Closed-source", "Proprietary"), which cannot
+    rule out a differently-worded, differently-classed marker on closed cards
+    (e.g. a `.marketplace-vendor-note` span reading "Vendor-locked model").
+
+    This renders the REAL renderMarketplaceGrid twice, over two templates that
+    are identical except for `model_name` (one open-weight, one closed-weight),
+    and diffs the emitted HTML directly: stripping the open-source badge out of
+    the open card's HTML must yield the closed card's HTML exactly, modulo the
+    one legitimately-differing "Powered by X" label. Any extra marker on the
+    closed card -- of any name or wording -- breaks that equality.
+    """
+    script = f"""
+{fn_body("function escapeHtml")}
+{fn_body("function agentRobotIcon")}
+const MARKET_LABELS = {{ us_stocks: 'U.S.', cn_ashares: 'China A-Share' }};
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+{fn_body("function modelVendorLicence")}
+{fn_body("function formatModelProviderLabel")}
+
+function renderMarketplaceCategoryChips() {{}}
+function renderMarketplaceVendorChips() {{}}
+
+let currentTemplates;
+function getFilteredMarketplaceTemplates() {{ return currentTemplates; }}
+let document;
+
+{fn_body("function renderMarketplaceGrid")}
+
+function renderOneCard(modelName) {{
+  const cardHtml = [];
+  const grid = {{
+    innerHTML: '',
+    appendChild(card) {{ cardHtml.push(card.innerHTML); }},
+    querySelectorAll() {{ return []; }},
+  }};
+  document = {{
+    getElementById(id) {{ return id === 'marketplaceGrid' ? grid : null; }},
+    createElement() {{ return {{ className: '', innerHTML: '' }}; }},
+  }};
+  // Identical in every field except model_name -- the only legitimate
+  // difference between the two cards is the licence and the model label.
+  // A shared tag keeps the tag-row wrapper div present on BOTH cards, so the
+  // only thing that can differ inside it is the badge span itself -- with no
+  // tags, the wrapper disappears entirely on the closed card (no badge, no
+  // tags -> nothing to wrap) and that wrapper's absence would itself count as
+  // a "difference", masking whether an extra marker was also added.
+  currentTemplates = [
+    {{ template_id: 'x', category: 'us_stocks', name: 'Same Template',
+       model_name: modelName, tags: ['sample'], author: 'Community' }},
+  ];
+  renderMarketplaceGrid();
+  return cardHtml[0];
+}}
+
+const openHtml = renderOneCard('deepseek/deepseek-v4-pro');
+const closedHtml = renderOneCard('anthropic/claude-haiku-4-5');
+
+const BADGE = '<span class="marketplace-licence-badge">Open-source model</span>';
+const openHasBadge = openHtml.includes(BADGE);
+const closedHasBadge = closedHtml.includes('marketplace-licence-badge');
+// Strip only the exact badge span (proves it was actually there) and
+// normalise only the one known-legitimate difference (the model label) --
+// a blanket strip would hide any other marker instead of catching it.
+const openWithoutBadge = openHtml.split(BADGE).join('')
+  .replace('Powered by DeepSeek', 'POWERED_BY_MODEL');
+const closedNormalized = closedHtml.replace('Powered by Claude', 'POWERED_BY_MODEL');
+
+console.log(JSON.stringify({{
+  openHasBadge,
+  closedHasBadge,
+  equalAfterNormalizing: openWithoutBadge === closedNormalized,
+}}));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["openHasBadge"] is True
+    assert data["closedHasBadge"] is False
+    assert data["equalAfterNormalizing"] is True, (
+        "closed card must be byte-identical to the open card minus the badge "
+        "(modulo the model label) -- any other marker on the closed card is a "
+        "negative claim about someone else's product"
+    )

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -126,3 +126,88 @@ console.log(JSON.stringify([
     )
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == ["", "", "", "qwen", "", "open", "closed", ""]
+
+
+def test_vendor_chip_container_exists_in_the_community_view():
+    community = APP_HTML[
+        APP_HTML.index('<div id="communityView"') : APP_HTML.index('<div id="accountView"')
+    ]
+    assert 'id="marketplaceVendorChips"' in community
+    assert 'id="marketplaceCategoryChips"' in community
+    assert community.index('id="marketplaceCategoryChips"') < community.index(
+        'id="marketplaceVendorChips"'
+    ), "market row must render above the vendor row"
+
+
+def test_vendor_chips_are_derived_not_hardcoded():
+    """Chips come from MODEL_VENDORS intersected with the loaded catalog, so a
+    vendor with no templates never ships an empty chip."""
+    body = fn_body("function renderMarketplaceVendorChips")
+    assert "MODEL_VENDORS" in body
+    assert "marketplaceTemplates" in body
+    for literal in ("'anthropic'", "'openai'", "'deepseek'", "'qwen'"):
+        assert literal not in body, f"{literal} hardcoded in the chip builder"
+
+
+def test_vendor_chips_are_built_once_then_toggled():
+    """renderMarketplaceGrid runs on every search keystroke; rebuilding innerHTML
+    per keystroke would blow away the focused chip."""
+    body = fn_body("function renderMarketplaceVendorChips")
+    assert "existing.length !== chips.length" in body
+
+
+def test_three_empty_states_stay_distinguishable():
+    body = fn_body("function marketplaceEmptyHtml")
+    assert "No templates match your search." in body
+    assert "No templates match both filters" in body
+    assert "marketplace-clear-filters" in body
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_empty_state_precedence():
+    script = f"""
+function escapeHtml(s) {{ return String(s); }}
+const MARKET_LABELS = {{ us_stocks: 'U.S.', cn_ashares: 'China A-Share' }};
+{js_const("MODEL_VENDORS")}
+{fn_body("function marketplaceEmptyHtml")}
+const out = [
+  marketplaceEmptyHtml({{searching: true, categoryFilter: 'us_stocks', vendorFilter: 'qwen'}}),
+  marketplaceEmptyHtml({{searching: false, categoryFilter: 'us_stocks', vendorFilter: 'qwen'}}),
+  marketplaceEmptyHtml({{searching: false, categoryFilter: 'us_stocks', vendorFilter: 'all'}}),
+  marketplaceEmptyHtml({{searching: false, categoryFilter: 'all', vendorFilter: 'all'}}),
+];
+console.log(JSON.stringify(out));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    search_empty, both, one_chip, none_at_all = json.loads(result.stdout)
+    # A typed query wins: clearing the chips would not bring anything back.
+    assert search_empty == "No templates match your search."
+    assert "both filters" in both and "marketplace-clear-filters" in both
+    assert "U.S." in one_chip and "both filters" not in one_chip
+    assert none_at_all == "No templates match your search."
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_unknown_vendor_survives_the_all_chip_and_only_that_chip():
+    script = f"""
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+const templates = [
+  {{template_id: 'a', model_name: 'qwen/qwen3.7-plus'}},
+  {{template_id: 'b', model_name: 'totally/unknown'}},
+];
+function visible(filter) {{
+  return templates
+    .filter((t) => filter === 'all' || modelVendorKey(t.model_name) === filter)
+    .map((t) => t.template_id);
+}}
+console.log(JSON.stringify([visible('all'), visible('qwen')]));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [["a", "b"], ["a"]]

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -1,0 +1,128 @@
+"""Guards for the Community model-vendor facet.
+
+The vendor axis is a pure derivation from `model_name` -- no column, no
+migration. MODEL_VENDORS is its single source of truth: chip order, display
+label and open/closed licence all come from one table, so a badge cannot drift
+from the vendor it describes. A wrong badge is a factual claim about someone
+else's product.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dashboard.backend.tests._frontend_source import APP_HTML, APP_JS, fn_body, js_const
+
+_CATALOG = json.loads(
+    (Path(__file__).resolve().parents[3] / "dashboard/config/marketplace.json").read_text(
+        encoding="utf-8"
+    )
+)["templates"]
+
+EXPECTED_VENDORS = [
+    ("anthropic", "anthropic/", "Claude", "closed"),
+    ("openai", "openai/", "GPT", "closed"),
+    ("google", "google/", "Gemini", "closed"),
+    ("deepseek", "deepseek/", "DeepSeek", "open"),
+    ("qwen", "qwen/", "Qwen", "open"),
+    ("nvidia", "nvidia/nemotron", "NVIDIA Nemotron", "open"),
+    ("meta", "meta-llama/", "Llama", "open"),
+    ("xai", "x-ai/", "Grok", "closed"),
+]
+
+
+def _vendor_rows():
+    return re.findall(
+        r"key:\s*'([^']+)',\s*prefix:\s*'([^']+)',\s*label:\s*'([^']+)',\s*licence:\s*'([^']+)'",
+        js_const("MODEL_VENDORS"),
+    )
+
+
+def test_vendor_table_is_pinned_including_licence():
+    assert _vendor_rows() == EXPECTED_VENDORS
+
+
+def test_every_catalog_model_matches_a_vendor_prefix():
+    """The highest-value guard: a template on an unmatched prefix renders as
+    "AI-powered" with no chip and no badge, which is otherwise invisible."""
+    prefixes = [row[1] for row in _vendor_rows()]
+    for template in _CATALOG:
+        model = template["model_name"].lower()
+        assert any(model.startswith(p) for p in prefixes), (
+            f"{template['template_id']} runs {model!r}, which matches no MODEL_VENDORS prefix"
+        )
+
+
+def test_every_supported_model_matches_a_vendor_prefix():
+    prefixes = [row[1] for row in _vendor_rows()]
+    for slug in re.findall(r"slug:\s*'([^']+)'", js_const("SUPPORTED_MODELS")):
+        assert any(slug.lower().startswith(p) for p in prefixes), slug
+
+
+def test_supported_model_vendor_fields_agree_with_the_vendor_table():
+    """SUPPORTED_MODELS carries its own `vendor` key; it must not drift."""
+    by_prefix = {row[1]: row[0] for row in _vendor_rows()}
+    pairs = re.findall(
+        r"slug:\s*'([^']+)',\s*label:\s*'[^']+',\s*vendor:\s*'([^']+)'",
+        js_const("SUPPORTED_MODELS"),
+    )
+    for slug, vendor in pairs:
+        expected = next(k for p, k in by_prefix.items() if slug.lower().startswith(p))
+        assert vendor == expected, f"{slug} is tagged {vendor!r}, table says {expected!r}"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_provider_label_output_is_unchanged():
+    """These six strings ship on cards today. The refactor must not touch them."""
+    script = f"""
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+{fn_body("function formatModelProviderLabel")}
+const cases = ['anthropic/claude-haiku-4-5', 'nvidia/nemotron-3-nano-30b-a3b',
+               'deepseek/deepseek-v4-pro', 'openai/gpt-5.5',
+               'google/gemini-3.1-pro-preview', 'qwen/qwen3.7-plus',
+               'totally/unknown', ''];
+console.log(JSON.stringify(cases.map(formatModelProviderLabel)));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == [
+        "Powered by Claude",
+        "Powered by NVIDIA Nemotron",
+        "Powered by DeepSeek",
+        "Powered by GPT",
+        "Powered by Gemini",
+        "Powered by Qwen",
+        "AI-powered",
+        "AI-powered",
+    ]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_unknown_vendor_resolves_to_empty_string():
+    """Same contract as agentMarketKey: unknown stays visible under All and is
+    excluded only by an explicit chip -- never hidden, never defaulted."""
+    script = f"""
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+{fn_body("function agentVendorKey")}
+{fn_body("function modelVendorLicence")}
+console.log(JSON.stringify([
+  modelVendorKey('totally/unknown'), modelVendorKey(null), modelVendorKey('local-model'),
+  agentVendorKey({{model_name: 'qwen/qwen3.7-plus'}}), agentVendorKey(null),
+  modelVendorLicence('deepseek/deepseek-v4-pro'),
+  modelVendorLicence('anthropic/claude-haiku-4-5'),
+  modelVendorLicence('totally/unknown'),
+]));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == ["", "", "", "qwen", "", "open", "closed", ""]

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -786,3 +786,39 @@ def test_entering_community_resets_the_vendor_filter():
         "without it the vendor chip leaks across visits and strands the "
         "empty-shelf deep links on an empty grid"
     )
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_duplicate_name_never_exceeds_the_backend_cap():
+    """DuplicateAgentBody.name is max_length=100. An over-long generated name
+    fails validation, and API.request JSON.stringify's the non-string `detail`,
+    so the raw Pydantic array -- including the user's own agent name -- renders
+    in the modal's error line. Trim the base, never the vendor suffix."""
+    script = f"""
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+{fn_body("function duplicateAgentName")}
+const long = 'Q'.repeat(95);
+const out = [
+  duplicateAgentName({{name: long}}, 'deepseek/deepseek-v4-pro'),
+  duplicateAgentName({{name: 'Momentum Alpha'}}, 'deepseek/deepseek-v4-pro'),
+  duplicateAgentName({{name: 'Z'.repeat(200)}}, 'totally/unknown'),
+];
+console.log(JSON.stringify(out.map((s) => [s.length, s.endsWith(')')])));
+"""
+    result = subprocess.run(["node", "-e", script], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    for length, ends_with_vendor in json.loads(result.stdout):
+        assert length <= 100, f"generated a {length}-char name; backend caps at 100"
+        assert ends_with_vendor, "the vendor suffix was trimmed instead of the base name"
+
+
+def test_model_picker_accessible_name_contains_its_visible_label():
+    """WCAG 2.5.3 Label in Name (Level A): a voice-control user saying
+    "click Choose model" must be able to activate the button."""
+    grid = fn_body("function renderMarketplaceGrid")
+    match = re.search(r'aria-label="([^"]*)"[^>]*>Choose model', grid)
+    assert match, "the model-picker button lost its aria-label or its visible text"
+    assert match.group(1).lower().startswith("choose model"), (
+        f"accessible name {match.group(1)!r} does not contain the visible label 'Choose model'"
+    )

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -495,3 +495,157 @@ console.log(JSON.stringify({{
         "(modulo the model label) -- any other marker on the closed card is a "
         "negative claim about someone else's product"
     )
+
+
+def test_primary_clone_cta_is_unchanged():
+    """The conversion click keeps its label and its one-click behaviour."""
+    grid = fn_body("function renderMarketplaceGrid")
+    assert "const cloneLabel = 'Add to My Agents';" in grid
+    assert "marketplace-clone-btn" in grid
+
+
+def test_model_choice_is_a_secondary_affordance():
+    grid = fn_body("function renderMarketplaceGrid")
+    assert "marketplace-clone-model-btn" in grid
+    assert "Choose model" in grid
+    assert "SUPPORTED_MODELS" in grid
+
+
+def test_clone_sends_the_chosen_model():
+    body = fn_body("async function cloneMarketplaceTemplate")
+    assert "model_name" in body
+
+
+def test_clone_menu_changes_only_the_model():
+    """A second half-Configure inside a clone menu is how two editing surfaces
+    start drifting apart. Name, capital and pipeline stay in Configure."""
+    grid = fn_body("function renderMarketplaceGrid")
+    menu_start = grid.index("marketplace-model-menu")
+    menu = grid[menu_start : menu_start + 800]
+    for forbidden in ("cash_allocation", "backtest_allocation", "pipeline", "rename"):
+        assert forbidden not in menu
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_model_picker_gated_on_runtime_type_not_truthiness():
+    """`runtime_type` is always present and always truthy -- server-defaulted
+    to 'pipeline' for every ordinary template (marketplace.py:
+    `str(raw.get("runtime_type") or "pipeline")`). A gate written as
+    `template.runtime_type ? '' : (...)` is therefore false for EVERY
+    template and would hide the picker everywhere while looking correct on a
+    substring-only test. The AI Hedge Fund runtime hardcodes its own model
+    (infrastructure/ai_hedge_fund/adapter.py) and never reads the stored
+    value, so offering a picker there would let a user "choose" a model that
+    is silently ignored.
+
+    This executes the REAL renderMarketplaceGrid over one ordinary
+    (runtime_type: 'pipeline') template and one hosted (runtime_type:
+    'ai_hedge_fund') template and checks which cards actually get a picker."""
+    script = f"""
+{fn_body("function escapeHtml")}
+{fn_body("function agentRobotIcon")}
+const MARKET_LABELS = {{ us_stocks: 'U.S.' }};
+{js_const("MODEL_VENDORS")}
+{js_const("SUPPORTED_MODELS")}
+{fn_body("function modelVendorKey")}
+{fn_body("function modelVendorLicence")}
+{fn_body("function formatModelProviderLabel")}
+{fn_body("function normalizeBacktestModelId")}
+
+function renderMarketplaceCategoryChips() {{}}
+function renderMarketplaceVendorChips() {{}}
+
+const marketplaceTemplates = [
+  {{ template_id: 'ordinary', category: 'us_stocks', name: 'Ordinary Template',
+     model_name: 'anthropic/claude-haiku-4-5', tags: [], author: 'Community',
+     runtime_type: 'pipeline' }},
+  {{ template_id: 'hosted', category: 'us_stocks', name: 'Hosted Template',
+     model_name: 'nvidia/nemotron-3-nano-30b-a3b', tags: [], author: 'Community',
+     runtime_type: 'ai_hedge_fund' }},
+];
+function getFilteredMarketplaceTemplates() {{ return marketplaceTemplates; }}
+let marketplaceCloneInFlight = false;
+
+const cardHtml = [];
+const grid = {{
+  innerHTML: '',
+  appendChild(card) {{ cardHtml.push(card.innerHTML); }},
+  querySelectorAll() {{ return []; }},
+}};
+const document = {{
+  getElementById(id) {{ return id === 'marketplaceGrid' ? grid : null; }},
+  createElement() {{ return {{ className: '', innerHTML: '' }}; }},
+}};
+
+{fn_body("function renderMarketplaceGrid")}
+renderMarketplaceGrid();
+
+console.log(JSON.stringify(cardHtml.map((html) => ({{
+  hasModelBtn: html.includes('marketplace-clone-model-btn'),
+  hasModelMenu: html.includes('marketplace-model-menu'),
+  hasPrimaryBtn: html.includes('marketplace-clone-btn'),
+}}))));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    ordinary, hosted = json.loads(result.stdout)
+    # Ordinary template: both the picker button AND its menu render.
+    assert ordinary["hasModelBtn"] is True
+    assert ordinary["hasModelMenu"] is True
+    assert ordinary["hasPrimaryBtn"] is True
+    # Hosted template: the primary "Add to My Agents" CTA still renders, but
+    # neither the picker button nor its menu markup does -- a hidden button
+    # with live menu markup is dead weight, not a fix.
+    assert hosted["hasModelBtn"] is False
+    assert hosted["hasModelMenu"] is False
+    assert hosted["hasPrimaryBtn"] is True
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_clone_posts_the_chosen_model_and_omits_it_by_default():
+    """Executes the REAL cloneMarketplaceTemplate (not a reimplementation).
+    test_clone_sends_the_chosen_model only checks that the string
+    "model_name" appears somewhere in the function's source -- that would
+    pass even if the value were read but never sent, or appeared only in a
+    comment. This captures the actual POST body under a stubbed API.post for
+    both call shapes: a chosen model (the secondary menu's path) and the
+    parameter omitted (the primary CTA's path, whose behaviour must be
+    byte-for-byte unchanged: `{{}}`, never a model_name)."""
+    script = f"""
+const posted = [];
+const API = {{
+  post: async (url, body) => {{
+    posted.push(body);
+    return {{ agent: {{ agent_id: 'a1' }} }};
+  }},
+}};
+const API_BASE = '';
+function applyActiveAgent(agent) {{}}
+async function loadAgents() {{}}
+function switchPlaygroundTab(tab) {{}}
+const window = {{}};
+
+{fn_body("async function cloneMarketplaceTemplate")}
+
+(async () => {{
+  // Real templates always carry a model_name (marketplace.py defaults it to
+  // "local-model"), so it is present here too -- a mutation that falls back
+  // to template.model_name instead of truly omitting the key must produce a
+  // visibly wrong body, not one that happens to serialize the same as {{}}.
+  await cloneMarketplaceTemplate({{ template_id: 't1', model_name: 'anthropic/claude-haiku-4-5' }}, 'openai/gpt-5.5');
+  await cloneMarketplaceTemplate({{ template_id: 't1', model_name: 'anthropic/claude-haiku-4-5' }});
+  console.log(JSON.stringify(posted));
+}})();
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    posted = json.loads(result.stdout)
+    assert posted == [{"model_name": "openai/gpt-5.5"}, {}], (
+        "a chosen model must be sent as {model_name: ...}; an omitted model "
+        "must post an empty body exactly as before -- the primary CTA's "
+        "one-click behaviour must not change"
+    )

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -328,3 +328,78 @@ console.log(JSON.stringify(container.querySelectorAll().map((b) => b.dataset.mar
     # MODEL_VENDORS (anthropic, deepseek, qwen), not the catalog's insertion
     # order (qwen, anthropic, deepseek).
     assert keys == ["all", "anthropic", "deepseek", "qwen"]
+
+
+def test_only_open_weight_models_get_a_badge():
+    """Closed models get NOTHING. A "Closed" label reads as a warning about
+    someone else's product; absence is not a negative claim."""
+    grid = fn_body("function renderMarketplaceGrid")
+    assert "modelVendorLicence" in grid
+    assert "Open-source model" in grid
+    assert "Closed-source" not in APP_JS
+    assert "Proprietary" not in APP_JS
+
+
+def test_licence_badge_has_a_style_rule():
+    from dashboard.backend.tests._frontend_source import css_blocks
+
+    assert css_blocks(".marketplace-licence-badge"), "badge has no styles.css rule"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_shipped_grid_badges_only_open_weight_cards():
+    """Lifts the REAL renderMarketplaceGrid (not a reimplementation) against a
+    synthetic catalog with one open-weight, one closed-weight and one
+    unknown-vendor template. The two tests above only substring-check
+    renderMarketplaceGrid's source text, so a polarity bug (badging closed
+    models instead of open ones) or a "computed but never rendered" bug
+    (licenceBadge assigned but not interpolated into the tag row) would both
+    pass them silently. This test executes the shipped card template and
+    checks the actual HTML each template produces."""
+    script = f"""
+{fn_body("function escapeHtml")}
+{fn_body("function agentRobotIcon")}
+const MARKET_LABELS = {{ us_stocks: 'U.S.', cn_ashares: 'China A-Share' }};
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+{fn_body("function modelVendorLicence")}
+{fn_body("function formatModelProviderLabel")}
+
+// Collaborators renderMarketplaceGrid calls that render other UI regions --
+// stubbed as no-ops so this test stays scoped to the card template.
+function renderMarketplaceCategoryChips() {{}}
+function renderMarketplaceVendorChips() {{}}
+
+function getFilteredMarketplaceTemplates() {{
+  return [
+    {{ template_id: 'open1', category: 'us_stocks', name: 'Open Template',
+       model_name: 'deepseek/deepseek-v4-pro', tags: [], author: 'Community' }},
+    {{ template_id: 'closed1', category: 'us_stocks', name: 'Closed Template',
+       model_name: 'anthropic/claude-haiku-4-5', tags: [], author: 'Community' }},
+    {{ template_id: 'unknown1', category: 'us_stocks', name: 'Unknown Template',
+       model_name: 'totally/unknown', tags: [], author: 'Community' }},
+  ];
+}}
+
+const cardHtml = [];
+const grid = {{
+  innerHTML: '',
+  appendChild(card) {{ cardHtml.push(card.innerHTML); }},
+  querySelectorAll() {{ return []; }},
+}};
+const document = {{
+  getElementById(id) {{ return id === 'marketplaceGrid' ? grid : null; }},
+  createElement() {{ return {{ className: '', innerHTML: '' }}; }},
+}};
+
+{fn_body("function renderMarketplaceGrid")}
+renderMarketplaceGrid();
+
+console.log(JSON.stringify(cardHtml.map((html) => html.includes('marketplace-licence-badge'))));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    # In catalog order: open-weight DeepSeek, closed-weight Claude, unknown vendor.
+    assert json.loads(result.stdout) == [True, False, False]

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -211,3 +211,120 @@ console.log(JSON.stringify([visible('all'), visible('qwen')]));
     )
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout) == [["a", "b"], ["a"]]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_shipped_filter_ands_market_and_vendor_not_or():
+    """Lifts the REAL getFilteredMarketplaceTemplates (not a reimplementation) --
+    the six chip/empty-state tests above never execute this function, so a
+    regression that drops the vendor filter or ORs it with the market filter
+    passed the whole suite until this test existed."""
+    script = f"""
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+const document = {{ getElementById: () => null }};
+const marketplaceTemplates = [
+  {{ template_id: 't1', category: 'us_stocks', model_name: 'anthropic/claude-haiku-4-5' }},
+  {{ template_id: 't2', category: 'us_stocks', model_name: 'qwen/qwen3.7-plus' }},
+  {{ template_id: 't3', category: 'cn_ashares', model_name: 'anthropic/claude-haiku-4-5' }},
+  {{ template_id: 't4', category: 'cn_ashares', model_name: 'qwen/qwen3.7-plus' }},
+  {{ template_id: 't5', category: 'us_stocks', model_name: 'totally/unknown' }},
+];
+let marketplaceCategoryFilter = 'all';
+let marketplaceVendorFilter = 'all';
+
+{fn_body("function getFilteredMarketplaceTemplates")}
+
+function ids() {{ return getFilteredMarketplaceTemplates().map((t) => t.template_id); }}
+
+const results = {{}};
+marketplaceCategoryFilter = 'us_stocks'; marketplaceVendorFilter = 'all';
+results.marketOnly = ids();
+
+marketplaceCategoryFilter = 'all'; marketplaceVendorFilter = 'qwen';
+results.vendorOnly = ids();
+
+marketplaceCategoryFilter = 'us_stocks'; marketplaceVendorFilter = 'qwen';
+results.both = ids();
+
+marketplaceCategoryFilter = 'all'; marketplaceVendorFilter = 'anthropic';
+results.vendorExplicit = ids();
+
+console.log(JSON.stringify(results));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    # Market filter alone: both known-vendor templates plus the unknown-vendor
+    # one -- unknown must stay visible when no vendor chip narrows it.
+    assert set(data["marketOnly"]) == {"t1", "t2", "t5"}
+    # Vendor filter alone: both markets, only the matching vendor.
+    assert set(data["vendorOnly"]) == {"t2", "t4"}
+    # Both together must be the INTERSECTION (t2 only), not the union
+    # (which would also include t1, t4, t5).
+    assert data["both"] == ["t2"], "market+vendor must AND, not OR"
+    # An explicit vendor chip excludes the unknown-vendor template -- it is
+    # visible only under vendor 'all'.
+    assert set(data["vendorExplicit"]) == {"t1", "t3"}
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_shipped_vendor_chip_order_follows_model_vendors_not_catalog_order():
+    """Lifts the REAL renderMarketplaceVendorChips against a synthetic DOM and a
+    catalog whose insertion order is deliberately scrambled relative to
+    MODEL_VENDORS. test_vendor_chips_are_derived_not_hardcoded only substring
+    -checks the function's source text, so it never actually executes this and
+    can't tell catalog order from MODEL_VENDORS order."""
+    script = f"""
+function escapeHtml(s) {{ return String(s); }}
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+
+function makeContainer() {{
+  let buttons = [];
+  return {{
+    querySelectorAll() {{ return buttons; }},
+    set innerHTML(html) {{
+      buttons = [];
+      const re = /data-marketplace-vendor="([^"]*)"/g;
+      let m;
+      while ((m = re.exec(html))) {{
+        buttons.push({{
+          dataset: {{ marketplaceVendor: m[1] }},
+          classList: {{ toggle() {{}} }},
+          setAttribute() {{}},
+        }});
+      }}
+    }},
+  }};
+}}
+const container = makeContainer();
+const document = {{ getElementById: (id) => (id === 'marketplaceVendorChips' ? container : null) }};
+
+// MODEL_VENDORS order is anthropic, openai, google, deepseek, qwen, nvidia,
+// meta, xai. This catalog is inserted qwen, anthropic, deepseek -- scrambled
+// on purpose -- plus one unknown-vendor template and no openai template.
+const marketplaceTemplates = [
+  {{ template_id: 'a', model_name: 'qwen/qwen3.7-plus' }},
+  {{ template_id: 'b', model_name: 'anthropic/claude-haiku-4-5' }},
+  {{ template_id: 'c', model_name: 'deepseek/deepseek-v4-pro' }},
+  {{ template_id: 'd', model_name: 'totally/unknown' }},
+];
+let marketplaceVendorFilter = 'all';
+
+{fn_body("function renderMarketplaceVendorChips")}
+renderMarketplaceVendorChips();
+
+console.log(JSON.stringify(container.querySelectorAll().map((b) => b.dataset.marketplaceVendor)));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    keys = json.loads(result.stdout)
+    # 'openai' has no template so it must not get a chip; order must follow
+    # MODEL_VENDORS (anthropic, deepseek, qwen), not the catalog's insertion
+    # order (qwen, anthropic, deepseek).
+    assert keys == ["all", "anthropic", "deepseek", "qwen"]

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -649,3 +649,115 @@ const window = {{}};
         "must post an empty body exactly as before -- the primary CTA's "
         "one-click behaviour must not change"
     )
+
+
+def test_duplicate_action_only_on_agents_that_have_run():
+    """"Run on another model" is a follow-on offer, not a first action."""
+    body = fn_body("function renderAgentCardActions")
+    assert "agent-duplicate-model-btn" in body
+    assert "'backtested'" in body and "'paper'" in body
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_duplicate_action_gated_on_type_status_and_runtime():
+    """test_duplicate_action_only_on_agents_that_have_run only checks that the
+    literal strings 'backtested' and 'paper' appear somewhere in the
+    function's source -- that stays green even if the gate is built wrong:
+    an inverted runtime check, a dropped status check, a dropped agent_type
+    check, or a dropped runtime check entirely all leave those substrings in
+    place. This lifts the REAL renderAgentCardActions and checks which
+    agent/status combinations actually render the button.
+
+    Must fail under each of:
+    - M1 (inverted runtime predicate): `!agent.runtime_type` instead of
+      `=== 'pipeline'`. runtime_type is always present and always truthy
+      (server-defaulted to 'pipeline' for every ordinary agent -- see
+      domain/agents/repository.py), so `!agent.runtime_type` is false for
+      EVERY ordinary agent and hides the button everywhere. A presence
+      assertion on the ordinary pipeline case is the only thing that catches
+      this -- an absence-only test cannot.
+    - M2 (runtime gate dropped): the button appears on an ai_hedge_fund agent.
+    - M3 (status gate dropped): the button appears on a draft agent.
+    - M4 (agent_type gate dropped): the button appears on an external agent.
+    """
+    script = f"""
+{fn_body("function escapeHtml")}
+{fn_body("function renderAgentCardActions")}
+
+function hasBtn(agent, statusKey) {{
+  return renderAgentCardActions(agent, statusKey).includes('agent-duplicate-model-btn');
+}}
+
+const pipeline = {{ agent_id: 'a1', agent_type: 'builtin', runtime_type: 'pipeline' }};
+const hosted = {{ agent_id: 'a2', agent_type: 'builtin', runtime_type: 'ai_hedge_fund' }};
+const external = {{ agent_id: 'a3', agent_type: 'external', runtime_type: 'pipeline' }};
+
+console.log(JSON.stringify({{
+  pipelineBacktested: hasBtn(pipeline, 'backtested'),
+  pipelinePaper: hasBtn(pipeline, 'paper'),
+  pipelineDraft: hasBtn(pipeline, 'draft'),
+  hostedBacktested: hasBtn(hosted, 'backtested'),
+  externalBacktested: hasBtn(external, 'backtested'),
+}}));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    # Ordinary built-in agent that has actually run: the button must be there.
+    assert data["pipelineBacktested"] is True
+    assert data["pipelinePaper"] is True
+    # Not yet run: no follow-on offer yet.
+    assert data["pipelineDraft"] is False
+    # Hosted runtime hardcodes its own model -- offering a picker would be a
+    # false statement about which model actually runs.
+    assert data["hostedBacktested"] is False
+    # External agents authenticate via API key; duplicating one would mint a
+    # new key through a hook that has no reason to do that.
+    assert data["externalBacktested"] is False
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_duplicate_offers_every_model_except_the_current_one():
+    script = f"""
+{js_const("SUPPORTED_MODELS")}
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+{fn_body("function duplicateModelChoices")}
+console.log(JSON.stringify([
+  duplicateModelChoices({{model_name: 'qwen/qwen3.7-plus'}}).map((m) => m.slug),
+  duplicateModelChoices({{model_name: 'local-model'}}).map((m) => m.slug).length,
+]));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    without_qwen, legacy_count = json.loads(result.stdout)
+    assert "qwen/qwen3.7-plus" not in without_qwen
+    assert len(without_qwen) == 5
+    # A legacy/hosted model isn't in the list, so nothing is filtered out.
+    assert legacy_count == 6
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_duplicate_name_uses_the_vendor_label():
+    script = f"""
+{js_const("MODEL_VENDORS")}
+{fn_body("function modelVendorKey")}
+{fn_body("function duplicateAgentName")}
+console.log(duplicateAgentName({{name: 'Momentum Alpha'}}, 'deepseek/deepseek-v4-pro'));
+"""
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "Momentum Alpha (DeepSeek)"
+
+
+def test_duplicate_does_not_start_a_backtest():
+    """Auto-firing spends LLM credits on a click the user did not frame as run."""
+    body = fn_body("async function submitDuplicateAgent")
+    for forbidden in ("runBacktest(", "openRunBacktestModal("):
+        assert forbidden not in body

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -761,3 +761,28 @@ def test_duplicate_does_not_start_a_backtest():
     body = fn_body("async function submitDuplicateAgent")
     for forbidden in ("runBacktest(", "openRunBacktestModal("):
         assert forbidden not in body
+
+
+def test_entering_community_resets_the_vendor_filter():
+    """A vendor left selected on one visit must not leak into the next.
+
+    `marketplaceCategoryFilter` already resets here, under a comment explaining
+    exactly this hazard. The vendor filter was added later and initially did not,
+    so returning to Community via the nav tab stayed filtered -- and the My Agents
+    empty-shelf deep link (which rides in with a category) then ANDed against the
+    stale vendor and landed the user on an empty grid.
+
+    Scoped to the `page === 'community'` branch on purpose: a reset anywhere else
+    in the function would not fix the leak, so it must not satisfy this guard.
+    """
+    body = fn_body("function navigateToPage")
+    start = body.index("page === 'community'")
+    branch = body[start : body.index("page === 'account'", start)]
+    assert re.search(r"marketplaceCategoryFilter\s*=", branch), (
+        "the category reset vanished from the community branch"
+    )
+    assert re.search(r"marketplaceVendorFilter\s*=\s*'all'", branch), (
+        "entering Community must reset marketplaceVendorFilter to 'all'; "
+        "without it the vendor chip leaks across visits and strands the "
+        "empty-shelf deep links on an empty grid"
+    )

--- a/dashboard/backend/tests/test_frontend_select_contrast.py
+++ b/dashboard/backend/tests/test_frontend_select_contrast.py
@@ -42,6 +42,7 @@ _COVERED_CLASSES = {"control-select", "filter-select", "agent-editor-model-selec
 # <select>s covered by a descendant rule rather than their own class.
 _DESCENDANT_COVERED_IDS = {
     "builtinAgentModel",  # inside <label class="auth-field"> -> `.auth-field select`
+    "duplicateAgentModel",  # inside <label class="auth-field"> -> `.auth-field select`
 }
 
 # The only <select> that is never rendered: no code path clears its `hidden`

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1602,9 +1602,10 @@
                 </div>
             </div>
             <p class="control-helper">Every test here uses simulated money. Real money is involved only if you explicitly connect a brokerage account and turn on live trading.</p>
-            <div id="marketplaceCategoryChips" class="marketplace-category-chips" role="group" aria-label="Filter templates by category"></div>
+            <div id="marketplaceCategoryChips" class="marketplace-category-chips" role="group" aria-label="Filter templates by market"></div>
+            <div id="marketplaceVendorChips" class="marketplace-category-chips marketplace-vendor-chips" role="group" aria-label="Filter templates by AI model"></div>
             <div id="marketplaceGrid" class="agents-grid marketplace-grid"></div>
-            <p id="marketplaceEmptyState" class="control-helper" hidden>No templates match your search.</p>
+            <p id="marketplaceEmptyState" class="control-helper" hidden></p>
             <p id="marketplaceErrorState" class="control-helper" hidden style="color:#f87171;">Couldn't load the marketplace. Check your connection and try again.</p>
         </div>
     </div>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -808,6 +808,25 @@
         </div>
     </div>
 
+    <div id="duplicateAgentModal" class="auth-modal" hidden>
+        <div class="auth-modal-backdrop" id="duplicateAgentModalBackdrop"></div>
+        <div class="auth-modal-panel" role="dialog" aria-labelledby="duplicateAgentModalTitle">
+            <button id="duplicateAgentModalClose" class="auth-modal-close" type="button" aria-label="Close">×</button>
+            <h2 id="duplicateAgentModalTitle" class="auth-modal-title">Run on another model</h2>
+            <p class="auth-modal-subtitle">Makes a copy of this agent — same strategy, same instructions — running on a different AI model, so you can compare them side by side. Nothing runs until you press Run Backtest.</p>
+            <form id="duplicateAgentForm" class="auth-form">
+                <label class="auth-field">
+                    <span>Model</span>
+                    <!-- Options are written by openDuplicateAgentModal(): the list
+                         excludes the agent's own model, so it cannot be built here. -->
+                    <select id="duplicateAgentModel"></select>
+                </label>
+                <p id="duplicateAgentError" class="auth-error" hidden></p>
+                <button id="duplicateAgentSubmit" class="auth-submit-btn" type="submit">Create the copy</button>
+            </form>
+        </div>
+    </div>
+
     <div id="agentCredentialsModal" class="auth-modal" hidden>
         <div class="auth-modal-backdrop" id="agentCredentialsModalBackdrop"></div>
         <div class="auth-modal-panel" role="dialog" aria-labelledby="agentCredentialsModalTitle">

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=84">
+    <link rel="stylesheet" href="styles.css?v=85">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -1739,7 +1739,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=26" defer></script>
-    <script src="app.js?v=75" defer></script>
+    <script src="app.js?v=76" defer></script>
     <script src="js/leaderboard.js?v=16" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1956,6 +1956,9 @@ let marketplaceLoadInFlight = null;
  * shelf's empty-state Community button (via navigateToPage's options). */
 let marketplaceCategoryFilter = 'all';
 
+/** 'all' or one of MODEL_VENDORS' keys. ANDs with marketplaceCategoryFilter. */
+let marketplaceVendorFilter = 'all';
+
 /** The model-vendor axis: who makes a model, and how it is licensed.
  *
  * Promoted from a submeta label lookup into the source of truth for the whole
@@ -2029,6 +2032,15 @@ function setMarketplaceCategoryFilter(category) {
   renderMarketplaceGrid();
 }
 
+/** Select a vendor chip and re-render. Mirrors setMarketplaceCategoryFilter,
+ * including the reset-to-'all' fallback for an unrecognized key. */
+function setMarketplaceVendorFilter(vendorKey) {
+  marketplaceVendorFilter = MODEL_VENDORS.some((vendor) => vendor.key === vendorKey)
+    ? vendorKey
+    : 'all';
+  renderMarketplaceGrid();
+}
+
 /** Chip row above the marketplace grid: 'All' plus one chip per market, built
  * from MARKET_LABELS rather than a second hardcoded list. Built from the label
  * map rather than AGENT_SHELVES because Community filters templates by
@@ -2057,11 +2069,67 @@ function renderMarketplaceCategoryChips() {
   });
 }
 
+/** Second chip row: 'All' plus one chip per vendor PRESENT IN THE CATALOG.
+ *
+ * Deliberately asymmetric with the market row, which is hardcoded from
+ * MARKET_LABELS: markets are a closed, backend-validated enum, vendors are
+ * open-ended. Hardcoding all of MODEL_VENDORS would ship chips that can never
+ * match anything. Order still comes from MODEL_VENDORS, not from catalog order,
+ * so the row does not reshuffle when a template is added. */
+function renderMarketplaceVendorChips() {
+  const container = document.getElementById('marketplaceVendorChips');
+  if (!container) return;
+  const present = new Set(marketplaceTemplates.map((t) => modelVendorKey(t.model_name)));
+  const chips = [
+    { key: 'all', label: 'All models' },
+    ...MODEL_VENDORS.filter((vendor) => present.has(vendor.key)).map((vendor) => ({
+      key: vendor.key,
+      label: vendor.label,
+    })),
+  ];
+  // Build once, then only toggle state -- same reason as the market row: this
+  // runs from renderMarketplaceGrid, which is bound to the search box's `input`.
+  const existing = container.querySelectorAll('[data-marketplace-vendor]');
+  if (existing.length !== chips.length) {
+    container.innerHTML = chips
+      .map((chip) => `<button type="button" class="marketplace-category-chip" data-marketplace-vendor="${escapeHtml(chip.key)}" aria-pressed="false">${escapeHtml(chip.label)}</button>`)
+      .join('');
+  }
+  container.querySelectorAll('[data-marketplace-vendor]').forEach((button) => {
+    const active = button.dataset.marketplaceVendor === marketplaceVendorFilter;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-pressed', String(active));
+  });
+}
+
+/** Empty-state copy. Three cases, deliberately worded apart -- the same concern
+ * stocksEmptyHtml records for My Agents.
+ *
+ * A typed query wins over the facet case: when a search is what emptied the
+ * grid, offering "Clear filters" sends the user to fix the wrong thing. */
+function marketplaceEmptyHtml({ searching, categoryFilter, vendorFilter }) {
+  if (searching) return 'No templates match your search.';
+  if (categoryFilter !== 'all' && vendorFilter !== 'all') {
+    return `No templates match both filters. <button type="button" class="marketplace-clear-filters">Clear filters</button>`;
+  }
+  if (categoryFilter !== 'all') {
+    return `No ${escapeHtml(MARKET_LABELS[categoryFilter] || '')} templates yet.`;
+  }
+  if (vendorFilter !== 'all') {
+    const vendor = MODEL_VENDORS.find((entry) => entry.key === vendorFilter);
+    return `No ${escapeHtml(vendor?.label || '')} templates yet.`;
+  }
+  return 'No templates match your search.';
+}
+
 function getFilteredMarketplaceTemplates() {
   const query = (document.getElementById('marketplaceSearchInput')?.value || '').trim().toLowerCase();
   let list = marketplaceTemplates.slice();
   if (marketplaceCategoryFilter !== 'all') {
     list = list.filter((template) => String(template.category || '').toLowerCase() === marketplaceCategoryFilter);
+  }
+  if (marketplaceVendorFilter !== 'all') {
+    list = list.filter((template) => modelVendorKey(template.model_name) === marketplaceVendorFilter);
   }
   if (query) {
     list = list.filter((template) => {
@@ -2089,15 +2157,27 @@ function renderMarketplaceGrid() {
   if (!grid) return;
 
   renderMarketplaceCategoryChips();
+  renderMarketplaceVendorChips();
   if (errorEl) errorEl.hidden = true;
   const templates = getFilteredMarketplaceTemplates();
   grid.innerHTML = '';
 
   if (!templates.length) {
-    // Show the empty message once the catalog has actually loaded and the
-    // filter narrowed it to zero; keep it hidden before the first load so
-    // it doesn't flash while marketplaceTemplates is still empty.
-    if (emptyEl) emptyEl.hidden = marketplaceTemplates.length === 0;
+    // Keep it hidden before the first load, so it doesn't flash while
+    // marketplaceTemplates is still empty.
+    if (emptyEl) {
+      emptyEl.hidden = marketplaceTemplates.length === 0;
+      emptyEl.innerHTML = marketplaceEmptyHtml({
+        searching: Boolean((document.getElementById('marketplaceSearchInput')?.value || '').trim()),
+        categoryFilter: marketplaceCategoryFilter,
+        vendorFilter: marketplaceVendorFilter,
+      });
+      emptyEl.querySelector('.marketplace-clear-filters')?.addEventListener('click', () => {
+        marketplaceCategoryFilter = 'all';
+        marketplaceVendorFilter = 'all';
+        renderMarketplaceGrid();
+      });
+    }
     return;
   }
   if (emptyEl) emptyEl.hidden = true;
@@ -7289,6 +7369,11 @@ function initNavigation() {
       const chipBtn = event.target.closest('[data-marketplace-category]');
       if (!chipBtn) return;
       setMarketplaceCategoryFilter(chipBtn.dataset.marketplaceCategory);
+    });
+    document.getElementById('marketplaceVendorChips')?.addEventListener('click', (event) => {
+        const chip = event.target.closest('[data-marketplace-vendor]');
+        if (!chip) return;
+        setMarketplaceVendorFilter(chip.dataset.marketplaceVendor);
     });
     document.getElementById('agentsCategories')?.addEventListener('click', (event) => {
       const marketChip = event.target.closest('[data-agent-market]');

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1956,29 +1956,62 @@ let marketplaceLoadInFlight = null;
  * shelf's empty-state Community button (via navigateToPage's options). */
 let marketplaceCategoryFilter = 'all';
 
-/** Model slug prefix -> "Powered by <provider>" label for the marketplace
- * card submeta. Matched by prefix, not exact slug, so a new model version
- * under an already-known provider doesn't need a new table entry. The raw
- * slug itself never renders on the card -- an unmatched prefix falls back to
- * the glossary's generic "AI-powered" rather than leaking it. */
-const MODEL_PROVIDER_LABELS = [
-  { prefix: 'anthropic/', label: 'Powered by Claude' },
-  { prefix: 'nvidia/nemotron', label: 'Powered by NVIDIA Nemotron' },
-  { prefix: 'deepseek/', label: 'Powered by DeepSeek' },
-  { prefix: 'openai/', label: 'Powered by GPT' },
-  // Not in today's catalog, but all four are already on the leaderboard, so a
-  // template using one is a config change away -- cheaper to cover the whole
-  // set now than to notice a card reading "AI-powered" after the fact.
-  { prefix: 'google/', label: 'Powered by Gemini' },
-  { prefix: 'qwen/', label: 'Powered by Qwen' },
-  { prefix: 'x-ai/', label: 'Powered by Grok' },
-  { prefix: 'meta-llama/', label: 'Powered by Llama' },
+/** The model-vendor axis: who makes a model, and how it is licensed.
+ *
+ * Promoted from a submeta label lookup into the source of truth for the whole
+ * axis -- Community's vendor chips, the open-source badge and the card submeta
+ * all derive from this one table, so a badge cannot drift from the vendor it
+ * describes. A wrong badge is a factual claim about someone else's product.
+ *
+ * Matched by PREFIX, not exact slug, so a new model version under a known
+ * vendor needs no entry here. Declaration order is chip order, mirroring how
+ * MARKET_LABELS' key order mirrors the AgentCategory Literal.
+ *
+ * All eight are listed even though only six are pickable: a card whose model
+ * matches nothing renders as the generic "AI-powered" with no chip and no
+ * badge, which is invisible until someone notices. The chip ROW is still
+ * derived from what the loaded catalog actually contains (see
+ * renderMarketplaceVendorChips), so listing a vendor here never ships an
+ * empty chip. */
+const MODEL_VENDORS = [
+  { key: 'anthropic', prefix: 'anthropic/', label: 'Claude', licence: 'closed' },
+  { key: 'openai', prefix: 'openai/', label: 'GPT', licence: 'closed' },
+  { key: 'google', prefix: 'google/', label: 'Gemini', licence: 'closed' },
+  { key: 'deepseek', prefix: 'deepseek/', label: 'DeepSeek', licence: 'open' },
+  { key: 'qwen', prefix: 'qwen/', label: 'Qwen', licence: 'open' },
+  // "NVIDIA Nemotron", not "Nemotron": this label also feeds
+  // formatModelProviderLabel, whose shipped output must not change.
+  { key: 'nvidia', prefix: 'nvidia/nemotron', label: 'NVIDIA Nemotron', licence: 'open' },
+  { key: 'meta', prefix: 'meta-llama/', label: 'Llama', licence: 'open' },
+  { key: 'xai', prefix: 'x-ai/', label: 'Grok', licence: 'closed' },
 ];
 
-function formatModelProviderLabel(modelName) {
+/** Vendor key for a model slug, or '' when the platform genuinely doesn't know.
+ *
+ * '' is not a bug and must never hide the template: it stays visible under the
+ * All chip and is excluded only by an explicit vendor chip -- the same contract
+ * agentMarketKey documents for markets. */
+function modelVendorKey(modelName) {
   const raw = String(modelName || '').trim().toLowerCase();
-  const match = MODEL_PROVIDER_LABELS.find((entry) => raw.startsWith(entry.prefix));
-  return match ? match.label : 'AI-powered';
+  if (!raw) return '';
+  return (MODEL_VENDORS.find((vendor) => raw.startsWith(vendor.prefix)) || {}).key || '';
+}
+
+/** modelVendorKey for an agent record. The agent-facing twin of agentMarketKey. */
+function agentVendorKey(agent) {
+  return modelVendorKey(agent?.model_name);
+}
+
+/** 'open' | 'closed' | '' -- '' when the vendor is unknown. */
+function modelVendorLicence(modelName) {
+  const key = modelVendorKey(modelName);
+  return (MODEL_VENDORS.find((vendor) => vendor.key === key) || {}).licence || '';
+}
+
+function formatModelProviderLabel(modelName) {
+  const key = modelVendorKey(modelName);
+  const vendor = MODEL_VENDORS.find((entry) => entry.key === key);
+  return vendor ? `Powered by ${vendor.label}` : 'AI-powered';
 }
 
 /** Select a Community category chip and re-render, without a route or API

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1085,6 +1085,20 @@ function renderAgentCardActions(agent, statusKey) {
     agent.agent_type === 'builtin'
       ? ''
       : `<button class="agent-menu-item agent-rotate-key-btn" type="button" data-agent-id="${id}">New access key</button>`;
+  // Only once the user has actually run this agent: "try it on another model"
+  // is a follow-on offer, not a first action. Built-in only -- duplicating an
+  // external agent would mint an API key (see the backend's duplicate route).
+  // Also excludes hosted runtimes (runtime_type !== 'pipeline'): ai_hedge_fund
+  // hardcodes its own model and never reads the stored value, so duplicating
+  // it onto a chosen model would display a model that isn't actually running.
+  // runtime_type is always present and truthy (server-defaulted to
+  // 'pipeline'), so this MUST be an equality check, never a truthiness test.
+  const duplicate =
+    agent.agent_type === 'builtin' &&
+    agent.runtime_type === 'pipeline' &&
+    (statusKey === 'backtested' || statusKey === 'paper')
+      ? `<button class="agent-menu-item agent-duplicate-model-btn" type="button" data-agent-id="${id}">Run on another model</button>`
+      : '';
   return `
     <div class="agent-card-actions agent-card-actions--status">
       ${configure}
@@ -1096,10 +1110,83 @@ function renderAgentCardActions(agent, statusKey) {
         <div class="agent-menu-dropdown" hidden>
           <button class="agent-menu-item agent-set-default-btn" type="button" data-agent-id="${id}">Set as default</button>
           ${rotate}
+          ${duplicate}
           <button class="agent-menu-item agent-menu-item--danger agent-delete-btn" type="button" data-agent-id="${id}">Delete</button>
         </div>
       </div>
     </div>`;
+}
+
+/** SUPPORTED_MODELS minus the agent's current model -- an entry that duplicates
+ * an agent onto the model it already runs is a no-op the user has to reason
+ * about. A legacy or hosted-runtime model isn't in the list, so nothing is
+ * filtered out and the full six are offered. */
+function duplicateModelChoices(agent) {
+  const current = String(agent?.model_name || '').trim().toLowerCase();
+  return SUPPORTED_MODELS.filter((model) => model.slug.toLowerCase() !== current).map(
+    (model) => ({ slug: model.slug, label: model.label }),
+  );
+}
+
+/** "Momentum Alpha (DeepSeek)". Collides freely: two copies onto DeepSeek read
+ * the same. Names are not unique anywhere else in this product, and
+ * de-duplicating would mean a lookup for a cosmetic gain. */
+function duplicateAgentName(agent, modelSlug) {
+  const vendor = MODEL_VENDORS.find((entry) => entry.key === modelVendorKey(modelSlug));
+  return `${agent?.name || 'Agent'} (${vendor?.label || 'new model'})`;
+}
+
+let duplicateAgentSource = null;
+
+function openDuplicateAgentModal(agent) {
+  const modal = document.getElementById('duplicateAgentModal');
+  const select = document.getElementById('duplicateAgentModel');
+  const error = document.getElementById('duplicateAgentError');
+  if (!modal || !select || !agent) return;
+  duplicateAgentSource = agent;
+  select.innerHTML = duplicateModelChoices(agent)
+    .map((model) => `<option value="${escapeHtml(model.slug)}">${escapeHtml(model.label)}</option>`)
+    .join('');
+  if (error) { error.hidden = true; error.textContent = ''; }
+  modal.hidden = false;
+}
+
+function closeDuplicateAgentModal() {
+  const modal = document.getElementById('duplicateAgentModal');
+  if (modal) modal.hidden = true;
+  duplicateAgentSource = null;
+}
+
+/** Lands the user on the new agent with Run primed. Deliberately does NOT start
+ * a backtest: auto-firing would spend LLM credits on a click the user framed as
+ * "make a copy". */
+async function submitDuplicateAgent() {
+  const agent = duplicateAgentSource;
+  const select = document.getElementById('duplicateAgentModel');
+  const error = document.getElementById('duplicateAgentError');
+  const submit = document.getElementById('duplicateAgentSubmit');
+  if (!agent || !select?.value) return;
+  if (submit) submit.disabled = true;
+  try {
+    const data = await API.post(
+      `${API_BASE}/api/v1/agents/${encodeURIComponent(agent.agent_id)}/duplicate`,
+      { model_name: select.value, name: duplicateAgentName(agent, select.value) },
+    );
+    const created = data?.agent;
+    if (!created?.agent_id) throw new Error('Copy failed — no agent returned');
+    closeDuplicateAgentModal();
+    applyActiveAgent(created);
+    await loadAgents();
+    showAppToast(`${created.name} is ready. Press Run Backtest to compare them.`);
+    highlightAgentCard(created.agent_id);
+  } catch (err) {
+    if (error) {
+      error.textContent = err.message || `Couldn't create the copy. Please try again.`;
+      error.hidden = false;
+    }
+  } finally {
+    if (submit) submit.disabled = false;
+  }
 }
 
 function renderAgentRunningActions(agent) {
@@ -1394,6 +1481,14 @@ function renderAgentCards(grid, agents, categoryKey) {
       } finally {
         btn.disabled = false;
       }
+    });
+  });
+
+  grid.querySelectorAll('.agent-duplicate-model-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const agent = visibleAgents.find((a) => a.agent_id === btn.dataset.agentId);
+      if (!agent) return;
+      openDuplicateAgentModal(agent);
     });
   });
 
@@ -7458,6 +7553,12 @@ function initNavigation() {
     document.getElementById('createBuiltinAgentModalClose')?.addEventListener('click', closeCreateBuiltinAgentModal);
     document.getElementById('createBuiltinAgentModalBackdrop')?.addEventListener('click', closeCreateBuiltinAgentModal);
     document.getElementById('createBuiltinAgentForm')?.addEventListener('submit', submitCreateBuiltinAgent);
+    document.getElementById('duplicateAgentModalClose')?.addEventListener('click', closeDuplicateAgentModal);
+    document.getElementById('duplicateAgentModalBackdrop')?.addEventListener('click', closeDuplicateAgentModal);
+    document.getElementById('duplicateAgentForm')?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        submitDuplicateAgent();
+    });
     document.getElementById('agentCredentialsModalClose')?.addEventListener('click', closeAgentCredentialsModal);
     document.getElementById('agentCredentialsModalBackdrop')?.addEventListener('click', closeAgentCredentialsModal);
 

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1133,7 +1133,16 @@ function duplicateModelChoices(agent) {
  * de-duplicating would mean a lookup for a cosmetic gain. */
 function duplicateAgentName(agent, modelSlug) {
   const vendor = MODEL_VENDORS.find((entry) => entry.key === modelVendorKey(modelSlug));
-  return `${agent?.name || 'Agent'} (${vendor?.label || 'new model'})`;
+  const suffix = ` (${vendor?.label || 'new model'})`;
+  // 100 mirrors DuplicateAgentBody.name's max_length and both name inputs'
+  // maxlength. A 95-char agent would otherwise generate an over-length copy,
+  // and API.request JSON.stringify's the non-string 422 `detail`, so the raw
+  // Pydantic array renders in the modal's error line. Inlined rather than a
+  // module constant because the guards lift this function body into node on
+  // its own -- an outside reference would be undefined there.
+  // Trim the base, never the suffix: the vendor is the point of the name.
+  const base = String(agent?.name || 'Agent').slice(0, 100 - suffix.length).trimEnd();
+  return `${base}${suffix}`;
 }
 
 let duplicateAgentSource = null;
@@ -2333,7 +2342,7 @@ function renderMarketplaceGrid() {
         <div class="marketplace-clone-split">
           <button class="agent-card-cta marketplace-clone-btn" type="button" data-template-id="${escapeHtml(template.template_id)}">${cloneLabel}</button>
           ${template.runtime_type === 'pipeline' ? `
-          <button class="agent-card-cta marketplace-clone-model-btn" type="button" data-template-id="${escapeHtml(template.template_id)}" aria-haspopup="true" aria-expanded="false" aria-label="Add on a different model">Choose model ▾</button>
+          <button class="agent-card-cta marketplace-clone-model-btn" type="button" data-template-id="${escapeHtml(template.template_id)}" aria-haspopup="true" aria-expanded="false" aria-label="Choose model — add this template on a different model">Choose model ▾</button>
           <div class="marketplace-model-menu" hidden>
             ${SUPPORTED_MODELS.map((model) => `<button type="button" class="agent-menu-item marketplace-model-option" data-template-id="${escapeHtml(template.template_id)}" data-model-slug="${escapeHtml(model.slug)}"${normalizeBacktestModelId(model.slug) === normalizeBacktestModelId(template.model_name) ? ' aria-current="true"' : ''}>${escapeHtml(model.label)}</button>`).join('')}
           </div>` : ''}

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -2191,6 +2191,11 @@ function renderMarketplaceGrid() {
     const cloneLabel = 'Add to My Agents';
     const categoryLabel = MARKET_LABELS[String(template.category || '').toLowerCase()] || 'General';
     const modelLabel = formatModelProviderLabel(template.model_name);
+    // Open weights get a badge; closed models get nothing. Licence comes from
+    // MODEL_VENDORS so it cannot drift from the vendor it describes.
+    const licenceBadge = modelVendorLicence(template.model_name) === 'open'
+      ? '<span class="marketplace-licence-badge">Open-source model</span>'
+      : '';
     const tags = (template.tags || [])
       .slice(0, 3)
       .map((tag) => `<span class="marketplace-tag">${escapeHtml(tag)}</span>`)
@@ -2227,7 +2232,7 @@ function renderMarketplaceGrid() {
           ${authorMeta}
           ${template.step_count ? `<span>${template.step_count} step${template.step_count === 1 ? '' : 's'}</span>` : ''}
         </div>
-        ${tags ? `<div class="marketplace-tag-row">${tags}</div>` : ''}
+        ${(licenceBadge || tags) ? `<div class="marketplace-tag-row">${licenceBadge}${tags}</div>` : ''}
       </div>
       <div class="agent-card-actions agent-card-actions--status">
         <button class="agent-card-cta marketplace-clone-btn" type="button" data-template-id="${escapeHtml(template.template_id)}">${cloneLabel}</button>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -2235,7 +2235,14 @@ function renderMarketplaceGrid() {
         ${(licenceBadge || tags) ? `<div class="marketplace-tag-row">${licenceBadge}${tags}</div>` : ''}
       </div>
       <div class="agent-card-actions agent-card-actions--status">
-        <button class="agent-card-cta marketplace-clone-btn" type="button" data-template-id="${escapeHtml(template.template_id)}">${cloneLabel}</button>
+        <div class="marketplace-clone-split">
+          <button class="agent-card-cta marketplace-clone-btn" type="button" data-template-id="${escapeHtml(template.template_id)}">${cloneLabel}</button>
+          ${template.runtime_type === 'pipeline' ? `
+          <button class="agent-card-cta marketplace-clone-model-btn" type="button" data-template-id="${escapeHtml(template.template_id)}" aria-haspopup="true" aria-expanded="false" aria-label="Add on a different model">Choose model ▾</button>
+          <div class="marketplace-model-menu" hidden>
+            ${SUPPORTED_MODELS.map((model) => `<button type="button" class="agent-menu-item marketplace-model-option" data-template-id="${escapeHtml(template.template_id)}" data-model-slug="${escapeHtml(model.slug)}"${normalizeBacktestModelId(model.slug) === normalizeBacktestModelId(template.model_name) ? ' aria-current="true"' : ''}>${escapeHtml(model.label)}</button>`).join('')}
+          </div>` : ''}
+        </div>
       </div>`;
     grid.appendChild(card);
   });
@@ -2257,6 +2264,37 @@ function renderMarketplaceGrid() {
         marketplaceCloneInFlight = false;
         btn.disabled = false;
         btn.textContent = prevLabel;
+      }
+    });
+  });
+
+  grid.querySelectorAll('.marketplace-clone-model-btn').forEach((btn) => {
+    btn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const menu = btn.parentElement?.querySelector('.marketplace-model-menu');
+      if (!menu) return;
+      const opening = menu.hidden;
+      // Close every other card's menu first: two open menus overlap.
+      grid.querySelectorAll('.marketplace-model-menu').forEach((el) => { el.hidden = true; });
+      grid.querySelectorAll('.marketplace-clone-model-btn').forEach((el) => el.setAttribute('aria-expanded', 'false'));
+      menu.hidden = !opening;
+      btn.setAttribute('aria-expanded', String(opening));
+    });
+  });
+
+  grid.querySelectorAll('.marketplace-model-option').forEach((option) => {
+    option.addEventListener('click', async () => {
+      const template = marketplaceTemplates.find((item) => item.template_id === option.dataset.templateId);
+      if (!template || marketplaceCloneInFlight) return;
+      marketplaceCloneInFlight = true;
+      option.disabled = true;
+      try {
+        await cloneMarketplaceTemplate(template, option.dataset.modelSlug);
+      } catch (error) {
+        alert(error.message || `Couldn't add this template. Please try again.`);
+      } finally {
+        marketplaceCloneInFlight = false;
+        option.disabled = false;
       }
     });
   });
@@ -2304,10 +2342,12 @@ async function loadMarketplace() {
   return marketplaceLoadInFlight;
 }
 
-async function cloneMarketplaceTemplate(template) {
+/** `modelName` omitted means the template's own model -- the primary CTA's
+ * path, whose behaviour is deliberately unchanged. */
+async function cloneMarketplaceTemplate(template, modelName) {
   const data = await API.post(
     `${API_BASE}/api/v1/agents/marketplace/${encodeURIComponent(template.template_id)}/clone`,
-    {},
+    modelName ? { model_name: modelName } : {},
   );
   const agent = data?.agent;
   if (!agent?.agent_id) {

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -7397,6 +7397,11 @@ function navigateToPage(page, options = {}) {
             // set on one visit would leak into the next, unrelated visit made
             // through the plain nav tab, the most common entry path.
             marketplaceCategoryFilter = MARKET_LABELS[options.communityCategory] ? options.communityCategory : 'all';
+            // The vendor chip resets for the same reason, and nothing rides in
+            // via options: a vendor left selected on one visit would AND with an
+            // incoming category and strand the empty-shelf deep links on an
+            // empty grid.
+            marketplaceVendorFilter = 'all';
             if (communityView) communityView.style.display = 'block';
             loadMarketplace();
         } else if (page === 'account') {

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9631,6 +9631,12 @@ body.agent-editor-open {
     margin: 4px 0 16px;
 }
 
+/* Second facet row (model vendor). Pulled up under the market row so the two
+   read as one stacked filter block rather than two unrelated controls. */
+.marketplace-vendor-chips {
+    margin-top: -8px;
+}
+
 .marketplace-category-chip {
     display: inline-flex;
     align-items: center;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9651,6 +9651,48 @@ body.agent-editor-open {
     border: 1px solid rgba(34, 197, 94, 0.35);
 }
 
+/* Split CTA: the primary Add button keeps its weight; the model picker is a
+   quieter sibling so it cannot compete with the conversion click. */
+.marketplace-clone-split {
+    position: relative;
+    display: flex;
+    gap: 6px;
+    width: 100%;
+}
+
+.marketplace-clone-split .marketplace-clone-btn {
+    flex: 1 1 auto;
+}
+
+.marketplace-clone-model-btn {
+    flex: 0 0 auto;
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+}
+
+.marketplace-clone-model-btn:hover {
+    color: var(--text-primary);
+    border-color: var(--info-color);
+}
+
+.marketplace-model-menu {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 6px);
+    z-index: 20;
+    min-width: 200px;
+    padding: 6px;
+    border-radius: 10px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.marketplace-model-menu[hidden] {
+    display: none !important;
+}
+
 .marketplace-category-chip {
     display: inline-flex;
     align-items: center;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9637,6 +9637,20 @@ body.agent-editor-open {
     margin-top: -8px;
 }
 
+/* Open-weight marker. Sits in the tag row so it wraps with the tags rather
+   than competing with the mode chip for the card's top-right corner. */
+.marketplace-licence-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--success-color);
+    background: rgba(34, 197, 94, 0.12);
+    border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
 .marketplace-category-chip {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
Community gains a model-vendor chip row that ANDs with the market row, an `Open-source model` badge, and two ways to make another agent on a different model: `Choose model ▾` beside the clone CTA, and `Run on another model` on any agent already backtested or paper-trading. Neither auto-starts a run.

The vendor axis is derived from `model_name` — no column, no migration. One table (`MODEL_VENDORS`) owns vendor identity, chip order and open/closed licence, so a badge cannot drift from the vendor it describes. `formatModelProviderLabel` was refactored onto it with byte-identical output — verified by running the old and new implementations over 29 inputs and diffing.

**Both hooks are hidden on the hosted `ai-hedge-fund` entry.** That runtime hardcodes its own model and never reads the stored value, so offering a choice there would display a model the agent does not run. Gated on `runtime_type === 'pipeline'` — an equality check, not a truthiness test: `runtime_type` is server-defaulted and always truthy, so `!runtime_type` would have hidden the feature everywhere while looking correct.

Closed-weight models get **nothing** — no badge, no label. A "closed" marker is a negative claim about someone else's product. Enforced by a differential render (open vs closed card must differ by exactly the badge), not by enumerating forbidden strings.

Verified in a real browser against a scratch DB: 18/18 checks — both chip rows, derived vendor chips in table order, AND filtering, the three empty states, Clear filters resetting both rows, badges only on open-weight cards, the picker absent on the hosted card and present on all others. Zero console errors, zero page errors.

Also fixed, found by the whole-branch review:
- The vendor filter leaked across visits. `marketplaceCategoryFilter` already resets on entry to Community; the vendor filter was added later and missed it, so the My Agents empty-shelf deep link ANDed against a stale vendor and landed on an empty grid.
- A 95-character agent name generated a 106-character copy name, failing the backend's 100-char cap; the raw Pydantic 422 body — including the user's agent name — rendered in the modal's error line.
- The picker's `aria-label` overrode its visible text, so voice control could not activate it (WCAG 2.5.3, Level A).

Screen-reader copy change: the market chip row's `aria-label` becomes "Filter templates by market", matching the shipped rename of categories to markets.

Known follow-ups, deliberately not in scope: the model menu has no outside-click dismissal; closing the duplicate modal mid-request does not stop the in-flight create (the copy is already committed server-side at that point, so "cancel" was never a cancel — the honest fix is blocking the close, not aborting); the duplicate modal's focus/Escape handling is at parity with the sibling create modal but below `runBacktestModal`.

Cache busters: `app.js` 75→76, `styles.css` 84→85, with the guard that pins them. `agent-editor.js` untouched — no task edits that file.

Full backend suite: 2585 passed, 67 skipped, 0 failed. Committed seed DB byte-identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
