### PR TITLE
fix(leaderboard): clear curve emphasis when pointer leaves a line

### DIFF
--- a/dashboard/backend/tests/test_frontend_leaderboard_hover.py
+++ b/dashboard/backend/tests/test_frontend_leaderboard_hover.py
@@ -1,0 +1,245 @@
+"""Guards for the leaderboard equity chart's hover gate (js/leaderboard.js).
+
+The chart emphasizes one curve and dims the rest while the pointer is on a line.
+Getting the *gate* wrong is invisible to every other test in the suite, and two
+of the ways to get it wrong are not obvious from reading the code:
+
+* Measuring to the nearest **data point** rather than to the rendered line looks
+  right on the Contest board (162 samples per curve, ~4px apart) and breaks the
+  Daily board (8 samples, ~97px apart), where most of every segment then sits
+  further than the hit radius from either endpoint. `resolveHoverTarget` is
+  therefore exercised below at Daily-board spacing.
+* Chart.js only fires `onHover` inside `chartArea`, and `chart.update()` replays
+  the last in-plot event. Emphasis driven from `onHover` consequently sticks in
+  the 120px endpoint-label gutter *and* re-arms itself when cleared. The fix is
+  to take Chart.js out of event handling entirely (`events: []`) and drive hover
+  from a canvas pointer listener; the source guards below hold that in place,
+  since restoring either default would silently bring the bug back.
+
+The behavioural cases run the real extracted functions under node against a stub
+chart, following the convention set by test_frontend_xss_guards.py.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_LEADERBOARD_JS = (
+    Path(__file__).resolve().parents[2] / "frontend" / "js" / "leaderboard.js"
+)
+_SRC = _LEADERBOARD_JS.read_text(encoding="utf-8")
+
+# Daily-board geometry: 8 samples across a ~606px plot.
+_POINT_SPACING = 97.0
+_PLOT_LEFT = 74.0
+_PLOT_RIGHT = 680.0
+
+
+def _extract_function(name: str) -> str:
+    """The source of ``function <name>(...) { ... }``, brace-matched.
+
+    Extracted rather than restated so a rename or deletion fails these tests
+    instead of leaving them passing against a copy that no longer ships.
+    """
+    marker = f"function {name}("
+    start = _SRC.index(marker)
+    depth = 0
+    index = _SRC.index("{", _SRC.index(")", start))
+    while True:
+        if _SRC[index] == "{":
+            depth += 1
+        elif _SRC[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return _SRC[start : index + 1]
+        index += 1
+
+
+def _hit_radius_const() -> str:
+    line = next(
+        ln for ln in _SRC.splitlines() if ln.startswith("const HOVER_HIT_RADIUS_PX")
+    )
+    return line
+
+
+def _run_node(script: str):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available")
+    harness = "\n".join(
+        [
+            _hit_radius_const(),
+            _extract_function("resolveHoverTarget"),
+            _extract_function("nearestDataIndex"),
+            # Stub chart: straight segments between evenly spaced samples, which
+            # is what Chart.js' LineElement.interpolate returns for tension 0.
+            """
+function makeChart(curves, hidden = []) {
+  const area = { left: %(left)s, right: %(right)s, top: 0, bottom: 400 };
+  const metas = curves.map((ys) => {
+    const data = ys.map((y, i) => ({ x: area.left + i * %(spacing)s, y }));
+    return {
+      data,
+      dataset: {
+        interpolate({ x }) {
+          for (let i = 1; i < data.length; i++) {
+            if (x >= data[i - 1].x && x <= data[i].x) {
+              const t = (x - data[i - 1].x) / (data[i].x - data[i - 1].x);
+              return { x, y: data[i - 1].y + t * (data[i].y - data[i - 1].y) };
+            }
+          }
+          return undefined;
+        },
+      },
+    };
+  });
+  return {
+    chartArea: area,
+    data: { datasets: curves.map((_, i) => ({ label: 'curve' + i })) },
+    isDatasetVisible: (i) => !hidden.includes(i),
+    getDatasetMeta: (i) => metas[i],
+  };
+}
+"""
+            % {"left": _PLOT_LEFT, "right": _PLOT_RIGHT, "spacing": _POINT_SPACING},
+            script,
+        ]
+    )
+    proc = subprocess.run(
+        [node, "-e", harness], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_hit_radius_is_a_declared_constant():
+    assert "const HOVER_HIT_RADIUS_PX" in _SRC
+
+
+def test_on_curve_between_sparse_points_is_a_hit():
+    """The Daily-board case: cursor on the line, ~48px from either sample."""
+    result = _run_node(
+        """
+const chart = makeChart([[100, 200, 100, 200, 100, 200, 100, 200]]);
+const x = chart.chartArea.left + %(spacing)s * 1.5;   // midway between samples 1 and 2
+const y = 150;                                        // exactly on the line there
+const target = resolveHoverTarget(chart, x, y);
+console.log(JSON.stringify({
+  hit: target ? target.datasetIndex : null,
+  distance: target ? target.distance : null,
+  gapToNearestSample: %(spacing)s / 2,
+}));
+"""
+        % {"spacing": _POINT_SPACING}
+    )
+    assert result["hit"] == 0, (
+        "hovering directly on the line must emphasize it even when the nearest "
+        f"data point is {result['gapToNearestSample']}px away"
+    )
+    assert result["distance"] < 1
+
+
+def test_off_curve_beyond_the_radius_is_a_miss():
+    result = _run_node(
+        """
+const chart = makeChart([[100, 100, 100, 100, 100, 100, 100, 100]]);
+const x = chart.chartArea.left + %(spacing)s * 1.5;
+console.log(JSON.stringify({
+  justInside: resolveHoverTarget(chart, x, 100 + HOVER_HIT_RADIUS_PX - 1) !== null,
+  justOutside: resolveHoverTarget(chart, x, 100 + HOVER_HIT_RADIUS_PX + 1) !== null,
+}));
+"""
+        % {"spacing": _POINT_SPACING}
+    )
+    assert result["justInside"] is True
+    assert result["justOutside"] is False
+
+
+def test_endpoint_label_gutter_is_never_a_hit():
+    """Right of chartArea is the reserved label gutter, not part of the plot."""
+    result = _run_node(
+        """
+const chart = makeChart([[100, 100, 100, 100, 100, 100, 100, 100]]);
+const a = chart.chartArea;
+console.log(JSON.stringify({
+  insidePlot: resolveHoverTarget(chart, a.right - 5, 100) !== null,
+  inGutter: resolveHoverTarget(chart, a.right + 40, 100) !== null,
+  farGutter: resolveHoverTarget(chart, a.right + 110, 100) !== null,
+  abovePlot: resolveHoverTarget(chart, a.right - 50, a.top - 5) !== null,
+}));
+"""
+    )
+    assert result["insidePlot"] is True
+    assert result["inGutter"] is False
+    assert result["farGutter"] is False
+    assert result["abovePlot"] is False
+
+
+def test_nearest_curve_wins_and_hidden_series_are_ignored():
+    result = _run_node(
+        """
+const flat = (v) => [v, v, v, v, v, v, v, v];
+const chart = makeChart([flat(100), flat(130)]);
+const x = chart.chartArea.left + %(spacing)s * 1.5;
+const hiddenChart = makeChart([flat(100), flat(130)], [1]);
+console.log(JSON.stringify({
+  nearTop: resolveHoverTarget(chart, x, 104).datasetIndex,
+  nearBottom: resolveHoverTarget(chart, x, 126).datasetIndex,
+  hiddenIgnored: resolveHoverTarget(hiddenChart, x, 126),
+}));
+"""
+        % {"spacing": _POINT_SPACING}
+    )
+    assert result["nearTop"] == 0
+    assert result["nearBottom"] == 1
+    assert result["hiddenIgnored"] is None, "a hidden curve must not be hoverable"
+
+
+def test_target_carries_the_nearest_sample_index_for_the_tooltip():
+    """The tooltip reads `_raw[dataIndex]`, so the index must track the pointer."""
+    result = _run_node(
+        """
+const chart = makeChart([[100, 100, 100, 100, 100, 100, 100, 100]]);
+const a = chart.chartArea;
+console.log(JSON.stringify({
+  nearFirst: resolveHoverTarget(chart, a.left + 5, 100).dataIndex,
+  nearThird: resolveHoverTarget(chart, a.left + %(spacing)s * 2 + 3, 100).dataIndex,
+}));
+"""
+        % {"spacing": _POINT_SPACING}
+    )
+    assert result["nearFirst"] == 0
+    assert result["nearThird"] == 2
+
+
+def test_chartjs_event_handling_stays_disabled():
+    """`events: []` is what stops onHover replay from re-arming a cleared hover."""
+    assert "events: []" in _SRC
+    assert "hover: { mode: null }" in _SRC
+    assert "onHover(" not in _SRC, (
+        "hover must not be driven from Chart.js' onHover: it never fires in the "
+        "label gutter, and chart.update() replays the last in-plot event"
+    )
+
+
+def test_hover_is_driven_by_canvas_pointer_events():
+    assert "addEventListener('pointermove', handleCanvasPointerMove)" in _SRC
+    assert "addEventListener('pointerleave', clearChartHoverEmphasis)" in _SRC
+
+
+def test_builtin_point_hover_marker_is_off():
+    """Chart.js' marker ignores the proximity gate; hoverMarkerPlugin replaces it."""
+    assert "pointHoverRadius: 0" in _SRC
+    assert "id: 'hoverMarker'" in _SRC
+
+
+def test_idle_chart_does_not_auto_emphasize_the_leader():
+    body = _extract_function("getEmphasisLabel")
+    assert "selectedLeaderboardEntry" in body
+    assert "getEntryKind" not in body, (
+        "idle view must show every curve at its kind weight; only an explicit "
+        "row selection is emphasized"
+    )

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1543,7 +1543,7 @@
                         <canvas id="equityCurvesChart"></canvas>
                     </div>
                     <div id="equityCurvesLegend" class="chart-legend-custom"></div>
-                    <div class="chart-hint">Click a legend item to show/hide a curve • Hover to emphasize • Click a row to select a team</div>
+                    <div class="chart-hint">Click a legend item to show/hide a curve • Hover a curve to emphasize • Click a row to select a team</div>
                 </section>
             </div>
 

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -15,14 +15,18 @@ let leaderboardListenersInitialized = false;
 let hiddenSeries = new Set();
 let hiddenInitialized = false;
 let hoveredDatasetIndex = null;
-let canvasLeaveBound = false;
+// Pixel position on the hovered curve directly under the pointer, or null. Kept
+// alongside the index so the hover dot sits on the line rather than snapping to
+// the nearest data point — on the Daily board those are ~97px apart.
+let hoveredPoint = null;
+let canvasPointerBound = false;
 const selectedBenchmarkLabel = 'SPY';
 /** Expanded groups in the Show-on-Chart picker: model | baseline | index */
 let curvePickerExpanded = new Set();
 let curvePickerOutsideBound = false;
-// Max pixel distance from a data point before hover emphasis clears. Without
-// this, Chart.js `nearest` + `intersect:false` keeps a curve selected anywhere
-// inside the canvas — including empty plot space and the label gutter.
+// Max vertical distance from a curve before hover emphasis clears. Without it,
+// Chart.js `nearest` + `intersect:false` keeps a curve selected anywhere inside
+// the canvas — including empty plot space and the label gutter.
 const HOVER_HIT_RADIUS_PX = 16;
 
 // Stable per-series style presets. `kind` drives width/opacity hierarchy:
@@ -681,7 +685,7 @@ function selectLeaderboardTeam(entryId) {
   renderEquityCurvesChart();
 }
 
-function getEmphasisLabel(_orderedEntries) {
+function getEmphasisLabel() {
   // Only an explicit row/detail selection stays emphasized when the pointer is
   // idle. Do not auto-emphasize the current leader — idle view shows the whole
   // figure with every visible curve at its kind weight.
@@ -691,34 +695,130 @@ function getEmphasisLabel(_orderedEntries) {
   return null;
 }
 
-/** Dataset under the pointer only when inside the plot and within hit radius. */
-function resolveHoveredDatasetIndex(chart, event) {
-  const x = event?.x;
-  const y = event?.y;
+/**
+ * The curve under the pointer at canvas pixel (x, y), or null.
+ *
+ * Distance is measured to the *rendered line* — `LineElement.interpolate` gives
+ * the curve's y at the pointer's x — rather than to the nearest data point. A
+ * point-distance test only works on a dense series: the Daily board plots 8
+ * points per curve (~97px apart at typical widths), so a 16px radius around the
+ * points rejects roughly two thirds of every segment while the cursor is
+ * sitting directly on the line.
+ */
+function resolveHoverTarget(chart, x, y) {
   if (x == null || y == null) return null;
   const area = chart.chartArea;
   if (!area) return null;
   if (x < area.left || x > area.right || y < area.top || y > area.bottom) {
     return null;
   }
-  const hits = chart.getElementsAtEventForMode(
-    event,
-    'nearest',
-    { intersect: false, axis: 'xy' },
-    true,
-  );
-  if (!hits.length) return null;
-  const el = hits[0].element;
-  if (!el || el.x == null || el.y == null) return null;
-  if (Math.hypot(el.x - x, el.y - y) > HOVER_HIT_RADIUS_PX) return null;
-  return hits[0].datasetIndex;
+
+  let best = null;
+  chart.data.datasets.forEach((ds, i) => {
+    if (!chart.isDatasetVisible(i)) return;
+    const line = chart.getDatasetMeta(i).dataset;
+    if (!line || typeof line.interpolate !== 'function') return;
+    // Undefined past the ends of the series; an array where several segments
+    // cross this x (spanGaps can leave a curve in more than one piece).
+    const found = line.interpolate({ x }, 'x');
+    if (!found) return;
+    (Array.isArray(found) ? found : [found]).forEach((pt) => {
+      if (!pt || !Number.isFinite(pt.y)) return;
+      const distance = Math.abs(pt.y - y);
+      if (!best || distance < best.distance) {
+        best = { datasetIndex: i, x: pt.x, y: pt.y, distance };
+      }
+    });
+  });
+
+  if (!best || best.distance > HOVER_HIT_RADIUS_PX) return null;
+  // The tooltip reads real samples (`_raw[dataIndex]`), so pair the interpolated
+  // position with the closest actual point on that curve.
+  best.dataIndex = nearestDataIndex(chart.getDatasetMeta(best.datasetIndex), x);
+  return best.dataIndex < 0 ? null : best;
+}
+
+/** Index of the closest non-skipped point of `meta` to canvas x. */
+function nearestDataIndex(meta, x) {
+  let index = -1;
+  let smallest = Infinity;
+  (meta.data || []).forEach((point, i) => {
+    if (point.skip) return;
+    const dx = Math.abs(point.x - x);
+    if (dx < smallest) {
+      smallest = dx;
+      index = i;
+    }
+  });
+  return index;
+}
+
+/** Commit a resolved hover target (or null) to the chart, redrawing on change. */
+function applyHoverTarget(chart, target) {
+  const index = target ? target.datasetIndex : null;
+  const sameSpot =
+    (hoveredPoint?.x ?? null) === (target?.x ?? null) &&
+    (hoveredPoint?.y ?? null) === (target?.y ?? null);
+  if (index === hoveredDatasetIndex && sameSpot) return;
+  const curveChanged = index !== hoveredDatasetIndex;
+
+  // State first: setActiveElements rebuilds the tooltip synchronously, and
+  // `tooltip.filter` reads hoveredDatasetIndex while it does.
+  hoveredDatasetIndex = index;
+  hoveredPoint = target ? { x: target.x, y: target.y } : null;
+
+  // The tooltip is driven from here rather than by Chart.js (see `events: []`),
+  // so it can never disagree with the emphasis about which curve is hovered.
+  if (chart.tooltip) {
+    chart.tooltip.setActiveElements(
+      target ? [{ datasetIndex: target.datasetIndex, index: target.dataIndex }] : [],
+      target ? { x: target.x, y: target.y } : undefined,
+    );
+  }
+
+  if (curveChanged) {
+    // Every dataset's colour and width changed — needs a real update pass.
+    styleDatasets(chart);
+    chart.update('none');
+    return;
+  }
+  // Only the marker slid along the curve already emphasized: repaint is enough.
+  // `update('none')` here would re-run the whole pipeline on every mousemove.
+  chart.render();
 }
 
 function clearChartHoverEmphasis() {
-  if (hoveredDatasetIndex == null || !equityCurvesChartInstance) return;
+  if (hoveredDatasetIndex == null && hoveredPoint == null) return;
+  // Clear the state even with no live chart, so a stale index can never dim the
+  // wrong series after the next render rebuilds the dataset array.
+  const chart = equityCurvesChartInstance;
   hoveredDatasetIndex = null;
-  styleDatasets(equityCurvesChartInstance);
-  equityCurvesChartInstance.update('none');
+  hoveredPoint = null;
+  if (!chart) return;
+  if (chart.tooltip) chart.tooltip.setActiveElements([], undefined);
+  styleDatasets(chart);
+  chart.update('none');
+}
+
+/**
+ * Single source of truth for chart hover: every pointer position on the canvas.
+ *
+ * Chart.js' own `onHover` cannot do this job. It only fires while the pointer
+ * is inside `chartArea` (plus `_minPadding`, a couple of px of dataset
+ * overflow), so the 120px endpoint-label gutter reserved by
+ * `layout.padding.right` never reaches the proximity gate — emphasis would
+ * stick on whichever curve was hovered last. Worse, `chart.update()` replays
+ * the last in-plot event, so clearing from `onHover` re-emphasized the curve
+ * the clear had just dropped. Handling the DOM event directly sidesteps both.
+ */
+function handleCanvasPointerMove(event) {
+  const chart = equityCurvesChartInstance;
+  if (!chart || !chart.chartArea) return;
+  const rect = chart.canvas.getBoundingClientRect();
+  applyHoverTarget(
+    chart,
+    resolveHoverTarget(chart, event.clientX - rect.left, event.clientY - rect.top),
+  );
 }
 
 function styleDatasets(chart) {
@@ -763,6 +863,30 @@ const selectedGlowPlugin = {
     if (ds && ds.label === chart.$emphasisLabel && hoveredDatasetIndex == null) {
       chart.ctx.restore();
     }
+  },
+};
+
+// Dot marking the exact spot on the hovered curve. Chart.js' own point-hover
+// styling is off (`hover: { mode: null }`): it tracks the nearest *data point*
+// on the nearest curve regardless of our proximity gate, so it kept marking a
+// curve out in empty plot space, and on a sparse board it snapped up to half a
+// segment away from the cursor.
+const hoverMarkerPlugin = {
+  id: 'hoverMarker',
+  afterDatasetsDraw(chart) {
+    if (hoveredDatasetIndex == null || !hoveredPoint) return;
+    const ds = chart.data.datasets[hoveredDatasetIndex];
+    if (!ds) return;
+    const { ctx } = chart;
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(hoveredPoint.x, hoveredPoint.y, 4, 0, Math.PI * 2);
+    ctx.fillStyle = (ds._style && ds._style.color) || '#e5e7eb';
+    ctx.strokeStyle = 'rgba(15, 23, 42, 0.9)';
+    ctx.lineWidth = 2;
+    ctx.fill();
+    ctx.stroke();
+    ctx.restore();
   },
 };
 
@@ -892,7 +1016,13 @@ async function renderEquityCurvesChart() {
   const { times, days, curves, initials } = equityCurvesData;
   const axisLabels = times || days;
   const orderedEntries = (leaderboardPayload?.entries || []);
-  const emphasisLabel = getEmphasisLabel(orderedEntries);
+  const emphasisLabel = getEmphasisLabel();
+
+  // Hover state is a position into the dataset array about to be rebuilt, and
+  // rank changes or a legend toggle reorder it. Drop it rather than carry an
+  // index that now points at a different series.
+  hoveredDatasetIndex = null;
+  hoveredPoint = null;
 
   const datasets = [];
   orderedEntries.forEach((entry) => {
@@ -914,7 +1044,8 @@ async function renderEquityCurvesChart() {
       borderDash: style.dash || [],
       borderCapStyle: 'round',
       pointRadius: 0,
-      pointHoverRadius: 4,
+      // Marker comes from hoverMarkerPlugin, which honours the proximity gate.
+      pointHoverRadius: 0,
       tension: 0.1,
       fill: false,
       // Series use different hour grids (e.g. SPY :30 vs LLM :00). On a shared
@@ -934,30 +1065,22 @@ async function renderEquityCurvesChart() {
   equityCurvesChartInstance = new Chart(ctx, {
     type: 'line',
     data: { labels: axisLabels, datasets },
-    plugins: [selectedGlowPlugin, endpointLabelPlugin],
+    plugins: [selectedGlowPlugin, hoverMarkerPlugin, endpointLabelPlugin],
     options: {
       responsive: true,
       maintainAspectRatio: false,
       layout: { padding: { right: 120, top: 8 } },
-      // 'nearest' across BOTH axes (no axis:'x') so hover targets the single
-      // line under the cursor instead of every series sharing that x-position.
-      // Proximity is enforced in onHover / tooltip.filter — bare intersect:false
-      // would keep a curve selected across empty plot space.
-      interaction: { mode: 'nearest', intersect: false, axis: 'xy' },
-      onHover(event, _els, chart) {
-        const idx = resolveHoveredDatasetIndex(chart, event);
-        if (idx !== hoveredDatasetIndex) {
-          hoveredDatasetIndex = idx;
-          styleDatasets(chart);
-          chart.update('none');
-        }
-      },
+      // Chart.js does no interaction resolution of its own: hover, the marker
+      // and the tooltip are all driven from handleCanvasPointerMove, which is
+      // the only path that sees the endpoint-label gutter. Leaving the built-in
+      // handling on would light up curves the proximity gate has rejected, and
+      // its replay of the last in-plot event on every `update()` would undo the
+      // clear that moving into the gutter had just performed.
+      events: [],
+      hover: { mode: null },
       plugins: {
         legend: { display: false },
         tooltip: {
-          mode: 'nearest',
-          intersect: false,
-          axis: 'xy',
           position: 'nearest',
           backgroundColor: 'rgba(15, 23, 42, 0.96)',
           borderColor: 'rgba(148, 163, 184, 0.25)',
@@ -966,8 +1089,9 @@ async function renderEquityCurvesChart() {
           bodyColor: '#cbd5e1',
           padding: 10,
           displayColors: false,
-          // onHover runs before tooltip plugins; only show a tip while a curve
-          // is actually under the pointer (same gate as dimming).
+          // Belt-and-braces: the active element is set explicitly by
+          // applyHoverTarget, so this only bites if Chart.js event handling is
+          // ever switched back on above.
           filter(item) {
             return hoveredDatasetIndex != null && item.datasetIndex === hoveredDatasetIndex;
           },
@@ -1044,9 +1168,13 @@ async function renderEquityCurvesChart() {
   styleDatasets(equityCurvesChartInstance);
   equityCurvesChartInstance.update('none');
 
-  if (!canvasLeaveBound) {
-    canvas.addEventListener('mouseleave', clearChartHoverEmphasis);
-    canvasLeaveBound = true;
+  if (!canvasPointerBound) {
+    // Pointer events, not mouse events: `events: []` turned off Chart.js' own
+    // touchstart/touchmove handling, and these cover mouse, touch and pen in
+    // one pair. Bound once — the canvas outlives each destroy/recreate cycle.
+    canvas.addEventListener('pointermove', handleCanvasPointerMove);
+    canvas.addEventListener('pointerleave', clearChartHoverEmphasis);
+    canvasPointerBound = true;
   }
 
   buildCustomLegend(equityCurvesChartInstance);

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -20,6 +20,10 @@ const selectedBenchmarkLabel = 'SPY';
 /** Expanded groups in the Show-on-Chart picker: model | baseline | index */
 let curvePickerExpanded = new Set();
 let curvePickerOutsideBound = false;
+// Max pixel distance from a data point before hover emphasis clears. Without
+// this, Chart.js `nearest` + `intersect:false` keeps a curve selected anywhere
+// inside the canvas — including empty plot space and the label gutter.
+const HOVER_HIT_RADIUS_PX = 16;
 
 // Stable per-series style presets. `kind` drives width/opacity hierarchy:
 //   benchmark -> neutral gray, dotted / dash-dot, understated
@@ -677,12 +681,44 @@ function selectLeaderboardTeam(entryId) {
   renderEquityCurvesChart();
 }
 
-function getEmphasisLabel(orderedEntries) {
+function getEmphasisLabel(_orderedEntries) {
+  // Only an explicit row/detail selection stays emphasized when the pointer is
+  // idle. Do not auto-emphasize the current leader — idle view shows the whole
+  // figure with every visible curve at its kind weight.
   if (selectedLeaderboardEntry) {
     return selectedLeaderboardEntry.model || selectedLeaderboardEntry.team_name;
   }
-  const leadTeam = orderedEntries.find((e) => getEntryKind(e) === 'team');
-  return leadTeam ? (leadTeam.model || leadTeam.team_name) : null;
+  return null;
+}
+
+/** Dataset under the pointer only when inside the plot and within hit radius. */
+function resolveHoveredDatasetIndex(chart, event) {
+  const x = event?.x;
+  const y = event?.y;
+  if (x == null || y == null) return null;
+  const area = chart.chartArea;
+  if (!area) return null;
+  if (x < area.left || x > area.right || y < area.top || y > area.bottom) {
+    return null;
+  }
+  const hits = chart.getElementsAtEventForMode(
+    event,
+    'nearest',
+    { intersect: false, axis: 'xy' },
+    true,
+  );
+  if (!hits.length) return null;
+  const el = hits[0].element;
+  if (!el || el.x == null || el.y == null) return null;
+  if (Math.hypot(el.x - x, el.y - y) > HOVER_HIT_RADIUS_PX) return null;
+  return hits[0].datasetIndex;
+}
+
+function clearChartHoverEmphasis() {
+  if (hoveredDatasetIndex == null || !equityCurvesChartInstance) return;
+  hoveredDatasetIndex = null;
+  styleDatasets(equityCurvesChartInstance);
+  equityCurvesChartInstance.update('none');
 }
 
 function styleDatasets(chart) {
@@ -710,7 +746,7 @@ function styleDatasets(chart) {
   });
 }
 
-// Subtle glow only on the emphasized (selected/leading) curve.
+// Subtle glow only on the explicitly selected curve (row click), not on hover.
 const selectedGlowPlugin = {
   id: 'selectedGlow',
   beforeDatasetDraw(chart, args) {
@@ -905,11 +941,11 @@ async function renderEquityCurvesChart() {
       layout: { padding: { right: 120, top: 8 } },
       // 'nearest' across BOTH axes (no axis:'x') so hover targets the single
       // line under the cursor instead of every series sharing that x-position.
-      interaction: { mode: 'nearest', intersect: false },
+      // Proximity is enforced in onHover / tooltip.filter — bare intersect:false
+      // would keep a curve selected across empty plot space.
+      interaction: { mode: 'nearest', intersect: false, axis: 'xy' },
       onHover(event, _els, chart) {
-        let idx = null;
-        const hits = chart.getElementsAtEventForMode(event, 'nearest', { intersect: false }, true);
-        if (hits.length) idx = hits[0].datasetIndex;
+        const idx = resolveHoveredDatasetIndex(chart, event);
         if (idx !== hoveredDatasetIndex) {
           hoveredDatasetIndex = idx;
           styleDatasets(chart);
@@ -921,6 +957,7 @@ async function renderEquityCurvesChart() {
         tooltip: {
           mode: 'nearest',
           intersect: false,
+          axis: 'xy',
           position: 'nearest',
           backgroundColor: 'rgba(15, 23, 42, 0.96)',
           borderColor: 'rgba(148, 163, 184, 0.25)',
@@ -929,6 +966,11 @@ async function renderEquityCurvesChart() {
           bodyColor: '#cbd5e1',
           padding: 10,
           displayColors: false,
+          // onHover runs before tooltip plugins; only show a tip while a curve
+          // is actually under the pointer (same gate as dimming).
+          filter(item) {
+            return hoveredDatasetIndex != null && item.datasetIndex === hoveredDatasetIndex;
+          },
           callbacks: {
             title(items) {
               if (!items.length) return '';
@@ -1003,13 +1045,7 @@ async function renderEquityCurvesChart() {
   equityCurvesChartInstance.update('none');
 
   if (!canvasLeaveBound) {
-    canvas.addEventListener('mouseleave', () => {
-      if (hoveredDatasetIndex != null && equityCurvesChartInstance) {
-        hoveredDatasetIndex = null;
-        styleDatasets(equityCurvesChartInstance);
-        equityCurvesChartInstance.update('none');
-      }
-    });
+    canvas.addEventListener('mouseleave', clearChartHoverEmphasis);
     canvasLeaveBound = true;
   }
 


### PR DESCRIPTION
## Summary
- Leaderboard equity chart only emphasizes a curve when the pointer is near it (within the plot + hit radius); empty plot space and the right-side label gutter no longer stick on a single series.
- Tooltip uses the same proximity gate; idle view no longer auto-emphasizes the current leader (row click still selects).

## Test plan
- [ ] Open Competition Leaderboard equity chart
- [ ] Hover directly on a curve → that curve emphasizes, others dim, tooltip shows
- [ ] Move pointer into empty plot space → all curves return to equal/global view, tooltip clears
- [ ] Move pointer into the right endpoint-label gutter / outside the canvas → no single-curve sticky emphasis
- [ ] Click a table row → that team stays emphasized until another selection; hover still temporarily overrides


Made with [Cursor](https://cursor.com)