### PR TITLE
docs: participatory competition pivot spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-08-09-participatory-competition-phase-0-1.md
+++ b/docs/superpowers/plans/2026-08-09-participatory-competition-phase-0-1.md
@@ -2,7 +2,50 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> # ⚠ Status: reconciled 2026-08-15 — DO NOT EXECUTE TASKS 5, 7 OR 8 AS WRITTEN
+>
+> This plan was written on 2026-08-09. Six days later PR #352 (`7db504d`) and
+> PR #357 (`60fa01f`) shipped a leaderboard redesign and a leaderboard-first
+> landing page. Neither was written against this plan, and between them they
+> delivered part of Phase 1 by other means — in one case in the **opposite**
+> direction.
+>
+> **Nothing in Phase 0 has been implemented.** Verified 2026-08-15 against
+> `origin/main` @ `88c7b8c`, and across every ref in the repo: no branch anywhere
+> adds `strategy_prompt` to `llm_agent.py`.
+>
+> ## Task status
+>
+> | # | Task | Status | Evidence checked 2026-08-15 |
+> |---|---|---|---|
+> | 1 | `LLMAgentStrategy` forwards `strategy_prompt` | **TODO — valid as written** | No `strategy_prompt` or `_run_decision_loop` in `llm_agent.py`; the loop is still inlined in `run()` |
+> | 2 | Instruction-sensitivity probe script | **TODO — valid** | `dashboard/scripts/probe_instruction_sensitivity.py` absent |
+> | 3 | Run the probe, record the gate | **TODO — blocked on spend approval** | `docs/superpowers/probe-results/` does not exist |
+> | 4 | Six Open Track seed entries | **TODO — valid** | `leaderboard.json` still holds exactly 12 entries (5 baselines + 7 Model); no `label: "Open Track"`, `authored_by` or `strategy_prompt` anywhere |
+> | 5 | `landing/src/lib/leaderboard.ts` | **BLOCKED — premise withdrawn** | Needed only if the landing page fetches live data. #357 chose labelled sample data instead. Do not build until that decision is reopened |
+> | 6 | `landing/src/lib/analytics.ts` | **TODO — still valid** | No `track()` import anywhere in `landing/src/`; `<Analytics />` is mount-only. Independent of the board-data decision |
+> | 7 | `Race` renders the live board | **SUPERSEDED — and partly reversed** | See the task's own status note. Its guard test would now *delete* a guard #357 added deliberately |
+> | 8 | Promote the board above the fold | **DONE, by different means — one loose end** | `BoardPreview` mounted at `Hero.tsx:144`. `Race` never moved and is still last. Loose end: `FooterCTA.tsx:10` still says `Talk → Test → Race` |
+> | 9 | Social share card (`og:image`) | **TODO — valid, unchanged** | `index.html` still declares `twitter:card="summary_large_image"` with no image — the exact "worst of both" state the task describes |
+> | 10 | Community→Agent Marketplace, Teams→Traders | **TODO — valid, line numbers moved** | `app.html:243` `Community`, `:1691` `<h2>Community</h2>`, `:1433` `Participating Teams`, `:1439` `Season hasn't started yet` |
+> | 11 | Rebuild the shipped landing bundle | **MECHANICAL — only if landing source changes** | #357 already rebuilt it (`index-XgaRai2O.js`). Re-run only after touching `dashboard/landing/src/` |
+> | 12 | Full verification and PR | **Rewrite** — scope is now Tasks 1–4, 6, 9, 10 | — |
+>
+> **What is actually left of Phase 1:** the seed field (1–4), funnel events (6),
+> `og:image` (9), and the two renames (10). That is a materially smaller PR than
+> the one this plan describes, and it no longer touches the landing page's data
+> path at all.
+>
+> **Line numbers throughout this document are as of 2026-08-09** unless a task's
+> status note gives a newer one. Re-verify before editing.
+
 **Goal:** Prove that a trading instruction measurably changes a pinned LLM's backtest return, then ship a landing page whose hero is the real leaderboard showing most models losing to buy-and-hold, with a CTA inviting visitors to beat them.
+
+> **Half of this goal is met and half changed shape (2026-08-15).** The board *is*
+> the hero and the CTA *is* in place — #357 did that. But the landing hero shows
+> labelled **illustrative** numbers, not the real board; the real board is on the
+> `/app` home screen. The first clause — proving an instruction moves the return —
+> is untouched and remains the whole point of Phase 0.
 
 **Architecture:** Phase 0 adds one two-line capability to `LLMAgentStrategy` (`strategy_prompt` reaches the prompt builder) and uses it to run a 12-run sensitivity probe across two models. If the probe passes, the five surviving instructions become permanent house-authored seed entries in `leaderboard.json`, and Phase 1 wires the landing page's existing `Race` section to the live leaderboard API, promotes it above the fold, and instruments the funnel. **No new database tables, no new routes, no user-submitted entries.**
 
@@ -21,7 +64,8 @@ Every task's requirements implicitly include this section.
 - **Any test importing an optional dep (`vnpy`, `discord`) must `importorskip`.** An unguarded import raises during *collection*, and a collection error aborts the whole pytest session — 0 tests run, and the deploy hook that gates on backend tests never fires.
 - **Frontend cache-busters:** every touched `/app` asset needs its own `?v=` bump in `dashboard/frontend/app.html` — they are versioned independently, not globally. **The landing bundle needs none**: Vite asset names are content-hashed, and the hash is the cache bust.
 - **Merging to Open-Finance-Lab `main` auto-deploys prod.** A CI job hits the Render deploy hook once backend tests pass on `main`.
-- **PR #326 is open and touches `dashboard/frontend/js/leaderboard.js`.** Rebase onto it before starting Phase 1 frontend work; do not resolve conflicts by discarding its hover-gate fixes.
+- ~~**PR #326 is open and touches `dashboard/frontend/js/leaderboard.js`.** Rebase onto it before starting Phase 1 frontend work; do not resolve conflicts by discarding its hover-gate fixes.~~ **Void — #326 merged 2026-08-09.** The live hazard is now different: `js/leaderboard.js` went 1,037 → 1,600 lines across #326, #352 and #357, so every line reference into it in this plan is stale.
+- **Cache-buster collisions are the recurring merge hazard on this repo.** Two PRs bumping the same `?v=` produce a conflict that resolves silently to the *lower* number if taken carelessly. Resolve upward, always.
 - **`OPENROUTER_API_KEY` must be set locally** for Phase 0. Nemotron and DeepSeek are reached through OpenRouter, which is never auto-selected (`providers/__init__.py:11`). Unset, every probe run silently falls back to rule-based and the probe measures nothing.
 - **Copy rule:** user-facing text says **"instruction"**, never "strategy" (`domain/strategies/` is an existing product noun) and never "prompt". Entrants are **"traders"**, never "teams".
 - **Never claim the market is easy to beat.** Headline numbers are stated against the house instruction's curve; beating the market is a separate, scarce badge.
@@ -61,10 +105,30 @@ Every task's requirements implicitly include this section.
 # PHASE 0 — The Gate
 
 **This is not a PR. It is a decision.** The entire design rests on an unverified
-assumption: that better instructions produce better returns on a 30B nano model
-whose prompt is dominated by an unconditional `SAFE_TRADING_PROMPT`
-(`validator.py:545-664`). If instruction quality does not move the return, the
-leaderboard ranks noise and Phase 2 must not be built.
+assumption: that better instructions produce better returns on a 30B nano model.
+If instruction quality does not move the return, the leaderboard ranks noise and
+Phase 2 must not be built.
+
+> **Premise correction, 2026-08-15.** This paragraph originally justified the
+> gate by saying the model's prompt "is dominated by an unconditional
+> `SAFE_TRADING_PROMPT` (`validator.py:545-664`)". **That is not what the code
+> does.** A caller-supplied instruction *replaces* the `SAFE_TRADING_PROMPT`
+> strategy body; only a fixed execution-contract scaffold is concatenated after
+> it — `CUSTOM_STRATEGY_OUTPUT_CONTRACT` (`validator.py:667-711`), joined by
+> `create_custom_prompt` (`:730`), in place since `edc186b`, 2026-06-26. The
+> instruction owns the whole strategy slot.
+>
+> The gate still matters — the open question is whether a nano model *acts* on
+> instruction content — but two things change in how you read the result:
+>
+> - **A flat spread is more damning than this plan assumed.** There is no
+>   prompt-dilution fix to try next; "the model ignores the instruction" is what
+>   is left.
+> - **The control is the load-bearing measurement**, not the spread. A nonsense
+>   control still yields a valid run, so a control landing mid-pack means the
+>   model responds to *having* a strategy body rather than to its content — which
+>   passes a naive spread check while the board ranks noise. Task 3's gate table
+>   already encodes this; do not relax it.
 
 Task 1's code ships in Phase 1 regardless. Tasks 2–3 are throwaway measurement.
 
@@ -81,10 +145,17 @@ Task 1's code ships in Phase 1 regardless. Tasks 2–3 are throwaway measurement
 - Produces: `LLMAgentStrategy(config)` now reads `config["strategy_prompt"]` into `self.strategy_prompt: str | None` (empty/whitespace-only → `None`) and passes it as the `strategy_prompt=` keyword to `PortfolioManager.make_trading_decision_with_llm`. Every later task and both later phases depend on this exact attribute name and this exact keyword.
 
 **Why this is two lines:** `make_trading_decision_with_llm` already declares
-`strategy_prompt: str = None` (`portfolio_manager.py:233`) and already threads it
-to `create_prompt(custom_prompt=strategy_prompt)` (`:453`). The house path simply
-never passes it, so `custom_prompt` is always `None`. No downstream signature
-changes.
+`strategy_prompt: str = None` (`portfolio_manager.py:233` — **`:245` as of
+2026-08-15**) and already threads it to
+`create_prompt(custom_prompt=strategy_prompt)` (`:453` — **`:462-465`**). The
+house path simply never passes it, so `custom_prompt` is always `None`. No
+downstream signature changes.
+
+> **Re-verified 2026-08-15 and still true.** The wiring is intact, the method is
+> still one method with one `if pipeline:` branch (`:440`), and `llm_agent.py`
+> still passes neither argument. `self.temperature` remains at `llm_agent.py:81`,
+> exactly where Step 3 says to insert. This task is unaffected by #352/#357 and
+> is the one piece of Phase 0/1 that can be executed exactly as written.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -560,7 +631,7 @@ check while the leaderboard still ranks noise.
 | Outcome | Action |
 |---|---|
 | Nemotron spread ≥1pp **and** control is an outlier | **PASS.** Proceed to Phase 1 as written. |
-| Nemotron flat, DeepSeek spread ≥1pp | **PASS with contingency.** Pin DeepSeek. Per the spec, the budget holds and the grant shrinks: Replay attempts 5 → 1. Update the spec's cost tables and every `nvidia/nemotron-3-nano-30b-a3b` reference in Task 4 before proceeding. |
+| Nemotron flat, DeepSeek spread ≥1pp | **PASS with contingency.** Pin DeepSeek. Per the spec, the budget holds and the grant shrinks: Competition attempts 5 → 1. Update the spec's cost tables and every `nvidia/nemotron-3-nano-30b-a3b` reference in Task 4 before proceeding. |
 | Both flat, **or** the control scores mid-pack on both | **FAIL. Stop.** The instruction axis does not exist. Phase 1's hero chart would advertise a competition that cannot be won on merit. Report back rather than proceeding. |
 
 - [ ] **Step 4: Commit the result**
@@ -582,8 +653,17 @@ otherwise** — the `#homeGetStartedBtn` dead-CTA failure is the thing this desi
 exists to fix, so a CTA that leads nowhere is a Phase 1 bug, not a Phase 2
 placeholder.
 
-**Before starting:** `git fetch origin && git rebase origin/main`, and rebase
-onto PR #326 if it has not yet merged.
+**Before starting:** `git fetch origin && git rebase origin/main`. ~~and rebase
+onto PR #326 if it has not yet merged.~~ (#326 merged 2026-08-09.)
+
+> **Scope reduced 2026-08-15.** Phase 1 as described below is larger than what is
+> left to do. #352/#357 delivered the above-the-fold board and rewrote the
+> landing's data story; Tasks 5, 7 and 8 are withdrawn, superseded or done. The
+> remaining PR is **Tasks 1–4, 6, 9 and 10**, and it no longer touches the
+> landing page's data path. The paragraph below still describes the phase's
+> *purpose* correctly, and the dead-CTA principle in it is worth keeping — it is
+> now the standard the shipped page is being held to, not a change this phase
+> makes.
 
 ---
 
@@ -808,6 +888,23 @@ git commit -m "feat(leaderboard): seed the Open Track with six house-authored en
 
 ### Task 5: Typed leaderboard client for the landing page
 
+> ## ⛔ BLOCKED 2026-08-15 — premise withdrawn, do not build
+>
+> This module exists solely to let the landing page fetch the live board. PR #357
+> decided the landing page ships **labelled sample data** instead
+> (`BoardPreview.tsx`), and put the live board on the `/app` home screen, which
+> fetches through `home-page.js:1518` and needs nothing from here.
+>
+> There is a real argument for that choice, not just an accident: the landing is
+> served from Vercel while the API is on Render's **free tier, which spins down**,
+> so an above-the-fold cross-origin fetch to a cold backend is the weakest
+> possible first impression.
+>
+> **Build this only if the sample-vs-live decision is deliberately reopened** —
+> and if it is, budget for the cold-start problem first, because a spinner or an
+> error card above the fold is worse than an honest labelled sample. Tasks 6, 9
+> and 10 do not depend on this one.
+
 **Files:**
 - Create: `dashboard/landing/src/lib/leaderboard.ts`
 
@@ -1025,6 +1122,36 @@ git commit -m "feat(landing): funnel event wrapper"
 ---
 
 ### Task 7: `Race` renders the live board
+
+> ## ⛔ SUPERSEDED 2026-08-15 — and its guard test is now *wrong*
+>
+> PR #357 resolved this task in the opposite direction, deliberately.
+>
+> **What shipped instead:** the chart moved out of `Race.tsx` into a new
+> `BoardPreview.tsx` mounted in the hero, and it renders `SAMPLE_CURVES` /
+> `SAMPLE_STANDINGS` — hardcoded illustrative numbers — under a visible
+> "Illustrative example" badge. `Race.tsx` keeps the full standings table and
+> imports `SAMPLE_STANDINGS` from `BoardPreview`.
+>
+> **Why the guard below must not be written as specified.** Step 1 creates
+> `test_landing_race_copy.py` asserting `"Illustrative" not in RACE` and that
+> `SAMPLE_CURVES`/`SAMPLE_STANDINGS` are gone. Main now ships the inverse
+> assertion:
+> `test_landing_copy_register.py::test_illustrative_example_label_appears_at_least_twice`
+> counts `"Illustrative example"` in the **shipped bundle** and requires ≥ 2.
+> Implementing this task means deleting that guard. That is a decision to make
+> explicitly with the person who added it, not a step to execute.
+>
+> **One detail worth preserving if this is ever revisited.** `BoardPreview.tsx`
+> spells the label out as a literal in each card rather than sharing an exported
+> constant, and says so in a comment. That is not sloppiness: esbuild collapses a
+> shared constant to a single string literal, so the DRY version renders the label
+> on both cards while the bundle-level guard drops from 3 hits to 1. Do not
+> "clean it up".
+>
+> The parts of this task that are *not* superseded — the CTA naming the beatable
+> number rather than the market, and the ban on "strategy"/"teams" in user-facing
+> copy — remain live requirements and are already honoured by the shipped copy.
 
 **Files:**
 - Modify: `dashboard/landing/src/components/home/Race.tsx`
@@ -1355,6 +1482,28 @@ git commit -m "feat(landing): Race renders the live leaderboard"
 
 ### Task 8: Promote the board above the fold and renumber the storyline
 
+> ## ✅ DONE 2026-08-15 by different means — one loose end remains
+>
+> PR #357 achieved the goal without the reorder this task specifies.
+>
+> | Step | Status |
+> |---|---|
+> | Move `Race` under `Hero` in `landing-page.tsx` | **Not done, and not needed.** The chart was extracted into `BoardPreview` and mounted at `Hero.tsx:144` instead. Section order is unchanged: `Hero → WhyCare → Talk → Test → Race` |
+> | `Talk` keeps `01`, `Test` keeps `02` | **Done** — `Talk.tsx:13`, `Test.tsx:143` |
+> | The board drops its `03 — Race` line | **Done** — no `03 —` remains anywhere in `landing/src/` |
+> | `FooterCTA.tsx:10`: `Talk → Test → Race` → `Race → Talk → Test` | **⚠ NOT DONE** |
+>
+> **The loose end is real and small.** `FooterCTA.tsx:10` is now the only place on
+> the page asserting a sequence the page no longer has — the board is the frame,
+> and `Race` lost its number, but the footer still narrates `Talk → Test → Race`.
+> Worth fixing whenever the landing source is next touched; it forces a bundle
+> rebuild (Task 11), so it is not worth a PR of its own.
+>
+> **The sign-off this task required never happened.** The `01/02/03` sequence is
+> Allan's copy, and #357 renumbered it without asking. That is water under the
+> bridge, but if the footer line is changed, mention it rather than slipping a
+> second unreviewed copy edit past the same person.
+
 **Files:**
 - Modify: `dashboard/landing/src/pages/landing-page.tsx:18-22`
 - Modify: `dashboard/landing/src/components/home/Talk.tsx:12`
@@ -1417,6 +1566,19 @@ git commit -m "feat(landing): promote the leaderboard above the fold"
 
 ### Task 9: Social share card
 
+> **✅ Still valid, unchanged, and still worth doing. Re-verified 2026-08-15:**
+> `index.html` declares `twitter:card="summary_large_image"` and supplies no
+> image — the exact state this task describes. `dashboard/frontend/images/`
+> contains five logo variants plus `snapshot.png`, and no `og-card.png`. The
+> `<head>` runs to `:22`, with the description/OG/Twitter meta tags at `:7-14`;
+> insert after `:14` as the task says.
+>
+> One addition: if the card is produced by screenshotting the hero, note the hero
+> now shows **illustrative** numbers. A share card built from sample data and
+> presented as a result would be the dishonesty the badge exists to prevent.
+> Either shoot the `/app` board (live data) or keep the card to product name +
+> hook sentence with no numbers on it.
+
 **Files:**
 - Create: `dashboard/frontend/images/og-card.png` (1200×630)
 - Modify: `dashboard/frontend/index.html:9-14`
@@ -1475,6 +1637,32 @@ git commit -m "feat(landing): social share card"
 ---
 
 ### Task 10: Rename Community → Agent Marketplace, Teams → Traders
+
+> **✅ Still valid. Every line number below moved — use these instead
+> (verified 2026-08-15 against `origin/main` @ `88c7b8c`):**
+>
+> | This task says | Actual | Current content |
+> |---|---|---|
+> | `app.html:195` | **`:243`** | `<button class="mode-btn" data-mode="community">Community</button>` |
+> | `app.html:1600` | **`:1691`** | `<h2 class="page-title">Community</h2>` |
+> | `app.html:1403-1410` | **`:1428-1439`** | the participants empty state |
+> | `Participating Teams` subtab | **`:1433`** | `data-competition-tab="participants">Participating Teams<` |
+>
+> **The subtab roster changed under this task.** PR #352 replaced the Daily
+> Leaderboard subtab with Live Trading, so the four are now `leaderboard`,
+> `live`, `participants`, `about` (`:1431-1434`). This does not change what Task
+> 10 renames, but Step 3's empty-state replacement copy needs a rewrite: it
+> currently says *"The Ranking board shows AI models and baseline strategies
+> only"*, which describes one board when there are now two. Suggested:
+>
+> > `No traders yet` / `Traders will appear here when the season opens. Both
+> > boards currently show AI models, baseline strategies and house-authored
+> > instructions.`
+>
+> Also note `:1439` still reads *"Season hasn't started yet"* — which is now
+> **accidentally accurate** for Live Trading's Season 0, on a panel that belongs
+> to the Competition tab. Rename it anyway; two boards make "the season" ambiguous
+> and that ambiguity is worth removing, not preserving.
 
 **Files:**
 - Modify: `dashboard/frontend/app.html:195`, `:1600`, `:1403-1410`
@@ -1558,6 +1746,18 @@ git commit -m "ux(app): Agent Marketplace and Participating Traders"
 
 ### Task 11: Rebuild the shipped landing bundle
 
+> **Mechanical, and conditional. Run this only if `dashboard/landing/src/` was
+> touched.** With Tasks 5, 7 and 8 withdrawn or done, the reduced Phase 1 (1–4,
+> 6, 9, 10) changes React source only in Task 6 (`lib/analytics.ts`), so the
+> rebuild is needed only if that module is actually imported by a component. Task
+> 9 edits `index.html`'s `<head>` by hand and Task 10 edits `app.html`, neither of
+> which is Vite output.
+>
+> #357 already rebuilt the bundle (current: `index-XgaRai2O.js`,
+> `index-BbJpUuy3.css`). The four hand-written auth blocks survived that rebuild,
+> which is evidence the procedure below works — follow it exactly rather than
+> improvising, and let `test_frontend_bundle_integrity.py` confirm it.
+
 **Files:**
 - Modify: `dashboard/frontend/index.html` (asset hashes only)
 - Modify/Create/Delete: `dashboard/frontend/assets/*`
@@ -1619,6 +1819,16 @@ git commit -m "build(landing): refresh shipped bundle"
 ---
 
 ### Task 12: Full verification and PR
+
+> **The PR body in Step 4 is stale — rewrite it.** It advertises "`Race` renders
+> the live board, promoted above the fold", which is now either superseded or
+> already shipped. The reduced Phase 1 ships: C1, the six seed entries, funnel
+> events, `og:image`, and the two `/app` renames. Say that instead, and keep the
+> title short per the repo's convention.
+>
+> The verification steps themselves (Steps 1–3, 5) are unchanged and still
+> correct. Step 2's expectation holds with extra force: the reduced scope adds no
+> routes, so a golden-set failure means something unintended was added.
 
 - [ ] **Step 1: Full backend suite**
 
@@ -1695,19 +1905,19 @@ result means the deploy reset it and the entries could not recompute.
 
 Each gets its own plan, written when its prerequisites resolve.
 
-**Phase 2 (Replay qualifier)** is blocked on the Task 3 gate. Its pinned model,
-attempt grant and cost tables all change if the probe forces DeepSeek, so
+**Phase 2 (Competition qualifier)** is blocked on the Task 3 gate. Its pinned
+model, attempt grant and cost tables all change if the probe forces DeepSeek, so
 detailed tasks written now would be discarded. It covers C3/C4/C5/C7,
 `leaderboard_entries` + `leaderboard_attempts` with Postgres twins, the attempt
 ledger, email verification at signup, the checklist card, the Submit action, the
 two-worker queue, and graduation into Loop A.
 
-**Phase 3 (Forward Seasons)** is blocked on Phase 2 — Forward entry requires a
-completed Replay attempt. It covers C8, `forward_positions`, derived weekly
-seasons, the Friday result email, the share-card download, and the notification
-channel abstraction with Discord stubbed.
+**Phase 3 (Live Trading seasons)** is blocked on Phase 2 — Live Trading entry
+requires a completed Competition attempt. It covers C8, `forward_positions`,
+derived **two-week** seasons, the season-close email, the share-card download,
+and the notification channel abstraction with Discord stubbed.
 
-Two items to carry into Phase 2's planning:
+Four items to carry into planning:
 
 1. **Worker concurrency against issue #202**, which reports blocking sync I/O on
    exactly the leaderboard routes. The spec says two workers; that must be
@@ -1715,3 +1925,16 @@ Two items to carry into Phase 2's planning:
 2. **`BREVO_API_KEY` becomes a hard signup dependency** once verification gates
    account creation. It must be set in Render *before* that PR merges, or every
    signup breaks.
+3. **Added 2026-08-15 — consider pulling C8 out of Phase 3 and landing it
+   first.** The Live Trading board is already in prod as a Season 0 preview that
+   has never advanced. C8 against the existing house roster needs no user
+   entries, no ledger, and nothing from Phase 2, and it does not depend on the
+   Phase 0 gate — whether *instructions* move returns is a separate question from
+   whether the board can advance. The Phase 2→3 ordering constraint is about user
+   entry, and a house-only advance has no users in it. See §Rollout in the spec
+   for the invariants it must respect and the cost question it must answer first.
+4. **Added 2026-08-15 — the instruction-lock trade-off is reopened.** The
+   two-week cadence doubles how long a user waits to correct a bad instruction,
+   and the original "user's call" decision rested on a one-week season. Resolve
+   it in Phase 3 planning (one pre-advance edit? a mid-season re-entry slot?)
+   rather than inheriting a decision made under different terms.

--- a/docs/superpowers/plans/2026-08-09-participatory-competition-phase-0-1.md
+++ b/docs/superpowers/plans/2026-08-09-participatory-competition-phase-0-1.md
@@ -38,6 +38,21 @@
 >
 > **Line numbers throughout this document are as of 2026-08-09** unless a task's
 > status note gives a newer one. Re-verify before editing.
+>
+> ## Read these three before starting Phase 2
+>
+> - **`docs/superpowers/specs/2026-08-15-live-trading-leaderboard-ui.md`** — the
+>   newer board-side spec. Authoritative over the companion design doc on the
+>   boards' UI and payload contract; that doc stays authoritative on user entry.
+> - **Issue #354** — the Live Trading season engine (C8), already filed.
+> - **Issue #355** — two open design questions that **explicitly block this PR and
+>   Phase 2**: whether the qualifier gate survives now that the practice board is
+>   unranked, and what `instruction_sha256` config-freeze means for user-owned
+>   editable entries.
+>
+> **Phase 0 (Tasks 1–3) is not blocked by #355.** It measures whether instructions
+> move returns, which is upstream of every question in that issue and answers none
+> of them. It can proceed the moment the spend is approved.
 
 **Goal:** Prove that a trading instruction measurably changes a pinned LLM's backtest return, then ship a landing page whose hero is the real leaderboard showing most models losing to buy-and-hold, with a CTA inviting visitors to beat them.
 

--- a/docs/superpowers/plans/2026-08-09-participatory-competition-phase-0-1.md
+++ b/docs/superpowers/plans/2026-08-09-participatory-competition-phase-0-1.md
@@ -1,0 +1,1717 @@
+# Participatory Competition — Phase 0 (Gate) + Phase 1 (Evidence) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove that a trading instruction measurably changes a pinned LLM's backtest return, then ship a landing page whose hero is the real leaderboard showing most models losing to buy-and-hold, with a CTA inviting visitors to beat them.
+
+**Architecture:** Phase 0 adds one two-line capability to `LLMAgentStrategy` (`strategy_prompt` reaches the prompt builder) and uses it to run a 12-run sensitivity probe across two models. If the probe passes, the five surviving instructions become permanent house-authored seed entries in `leaderboard.json`, and Phase 1 wires the landing page's existing `Race` section to the live leaderboard API, promotes it above the fold, and instruments the funnel. **No new database tables, no new routes, no user-submitted entries.**
+
+**Tech Stack:** Python 3.13 / FastAPI / pytest (backend); vanilla JS + Chart.js (`/app`); Vite + React + recharts + Tailwind (`dashboard/landing`, built into `dashboard/frontend`); SQLite + optional Neon Postgres; Vercel (frontend) + Render (backend).
+
+**Spec:** `docs/superpowers/specs/2026-08-09-participatory-competition-design.md`
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **Never `git add -A` in this repo.** A bare backend import runs lazy `CREATE TABLE`/`ALTER` statements against the committed prod seed database `dashboard/storage/data/backtest.db`. Always stage explicit paths. Before every commit, run `git status --short` and confirm `dashboard/storage/data/` is absent.
+- **Run everything from the repo root.** The backend is the `dashboard.backend` package; `python dashboard/backend/app.py` does not work.
+- **Route-contract freeze golden sets must be updated in the same commit as any new route.** The sets are `EXPECTED_LEADERBOARD_ROUTES` (`dashboard/backend/tests/test_router_move.py:112`) and `EXPECTED_FULL_CONTRACT` (`dashboard/backend/tests/test_app_composition.py:56`). They drift independently. *Phase 1 adds no routes, so this should not fire — if it does, you have added a route this plan did not call for.*
+- **Postgres twin parity:** `test_store_twin_parity.py` compares column **names** only and cannot see f-string DDL. `NOT NULL` and type divergence are invisible to it and must be checked by hand. *Phase 1 adds no tables.*
+- **Any test importing an optional dep (`vnpy`, `discord`) must `importorskip`.** An unguarded import raises during *collection*, and a collection error aborts the whole pytest session — 0 tests run, and the deploy hook that gates on backend tests never fires.
+- **Frontend cache-busters:** every touched `/app` asset needs its own `?v=` bump in `dashboard/frontend/app.html` — they are versioned independently, not globally. **The landing bundle needs none**: Vite asset names are content-hashed, and the hash is the cache bust.
+- **Merging to Open-Finance-Lab `main` auto-deploys prod.** A CI job hits the Render deploy hook once backend tests pass on `main`.
+- **PR #326 is open and touches `dashboard/frontend/js/leaderboard.js`.** Rebase onto it before starting Phase 1 frontend work; do not resolve conflicts by discarding its hover-gate fixes.
+- **`OPENROUTER_API_KEY` must be set locally** for Phase 0. Nemotron and DeepSeek are reached through OpenRouter, which is never auto-selected (`providers/__init__.py:11`). Unset, every probe run silently falls back to rule-based and the probe measures nothing.
+- **Copy rule:** user-facing text says **"instruction"**, never "strategy" (`domain/strategies/` is an existing product noun) and never "prompt". Entrants are **"traders"**, never "teams".
+- **Never claim the market is easy to beat.** Headline numbers are stated against the house instruction's curve; beating the market is a separate, scarce badge.
+
+---
+
+## File Structure
+
+**Phase 0**
+
+| File | Responsibility |
+|---|---|
+| `dashboard/backend/domain/leaderboard/strategies/llm_agent.py` (modify) | Accept and forward `strategy_prompt` |
+| `dashboard/backend/tests/domain/leaderboard/test_llm_agent_instruction.py` (create) | Guard that the instruction reaches the call and that omission preserves today's behaviour |
+| `dashboard/scripts/probe_instruction_sensitivity.py` (create) | Standalone probe: N instructions × M models, prints a spread table. Builds configs in memory so the probe never pollutes `leaderboard.json` |
+| `docs/superpowers/probe-results/2026-08-09-instruction-sensitivity.md` (create) | The recorded gate decision |
+
+**Phase 1**
+
+| File | Responsibility |
+|---|---|
+| `dashboard/config/leaderboard.json` (modify) | Six new house-authored Open Track entries carrying `strategy_prompt` |
+| `dashboard/backend/tests/domain/leaderboard/test_seed_entries.py` (create) | Guard seed entries are labelled, pinned to Nemotron, and carry instructions |
+| `dashboard/landing/src/lib/leaderboard.ts` (create) | Typed fetch + shaping of `/api/v1/leaderboard` for recharts. Sole owner of the API contract on the landing side |
+| `dashboard/landing/src/lib/analytics.ts` (create) | Thin `trackEvent()` wrapper over `@vercel/analytics`, with the event-name union |
+| `dashboard/landing/src/components/home/Race.tsx` (modify) | Render live data; own its loading/error/empty states |
+| `dashboard/landing/src/pages/landing-page.tsx` (modify) | Promote `Race` above `WhyCare` |
+| `dashboard/landing/src/components/home/Talk.tsx`, `Test.tsx`, `FooterCTA.tsx` (modify) | Storyline renumber |
+| `dashboard/frontend/index.html` (modify) | `og:image`; rebuilt bundle asset hashes; auth layer preserved verbatim |
+| `dashboard/frontend/images/og-card.png` (create) | Static 1200×630 share image |
+| `dashboard/frontend/app.html` (modify) | Community→Agent Marketplace; Teams→Traders |
+| `dashboard/backend/tests/test_frontend_marketplace_placement.py` (modify) | Follow the rename |
+| `dashboard/backend/tests/test_landing_race_copy.py` (create) | Guard the CTA sentence and the absence of "Illustrative" |
+
+---
+
+# PHASE 0 — The Gate
+
+**This is not a PR. It is a decision.** The entire design rests on an unverified
+assumption: that better instructions produce better returns on a 30B nano model
+whose prompt is dominated by an unconditional `SAFE_TRADING_PROMPT`
+(`validator.py:545-664`). If instruction quality does not move the return, the
+leaderboard ranks noise and Phase 2 must not be built.
+
+Task 1's code ships in Phase 1 regardless. Tasks 2–3 are throwaway measurement.
+
+---
+
+### Task 1: `LLMAgentStrategy` accepts an instruction (change C1)
+
+**Files:**
+- Modify: `dashboard/backend/domain/leaderboard/strategies/llm_agent.py:45-89` and `:176-182`
+- Test: `dashboard/backend/tests/domain/leaderboard/test_llm_agent_instruction.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `LLMAgentStrategy(config)` now reads `config["strategy_prompt"]` into `self.strategy_prompt: str | None` (empty/whitespace-only → `None`) and passes it as the `strategy_prompt=` keyword to `PortfolioManager.make_trading_decision_with_llm`. Every later task and both later phases depend on this exact attribute name and this exact keyword.
+
+**Why this is two lines:** `make_trading_decision_with_llm` already declares
+`strategy_prompt: str = None` (`portfolio_manager.py:233`) and already threads it
+to `create_prompt(custom_prompt=strategy_prompt)` (`:453`). The house path simply
+never passes it, so `custom_prompt` is always `None`. No downstream signature
+changes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/backend/tests/domain/leaderboard/test_llm_agent_instruction.py`:
+
+```python
+"""C1: an Open Track entry's instruction must reach the shared prompt builder.
+
+`make_trading_decision_with_llm` already accepts `strategy_prompt` and threads it
+into `create_prompt(custom_prompt=...)`. The house path never passed it, so every
+leaderboard entry ran the bare SAFE_TRADING_PROMPT. These guard that the wire is
+connected and, just as importantly, that omitting the key preserves today's
+behaviour for the seven published Model Track entries.
+"""
+
+import pytest
+
+from dashboard.backend.domain.leaderboard.strategies.llm_agent import LLMAgentStrategy
+
+BASE_CONFIG = {
+    "strategy": "llm_agent",
+    "model_id": "nvidia/nemotron-3-nano-30b-a3b",
+    "integration": "openrouter",
+    "temperature": 0,
+    "reasoning_effort": "none",
+    "mode": "safe_trading",
+    "symbols": [],
+}
+
+
+def test_instruction_is_read_from_config():
+    strategy = LLMAgentStrategy({**BASE_CONFIG, "strategy_prompt": "Buy the dip."})
+    assert strategy.strategy_prompt == "Buy the dip."
+
+
+def test_missing_instruction_is_none_not_empty_string():
+    """The published Model Track entries carry no `strategy_prompt` key.
+
+    `None` and `""` are NOT interchangeable downstream: `create_prompt` branches on
+    truthiness, so an empty string would take the same branch as None today but
+    silently diverge if that branch is ever tightened to `is not None`.
+    """
+    strategy = LLMAgentStrategy(dict(BASE_CONFIG))
+    assert strategy.strategy_prompt is None
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\n\t "])
+def test_blank_instruction_collapses_to_none(blank):
+    strategy = LLMAgentStrategy({**BASE_CONFIG, "strategy_prompt": blank})
+    assert strategy.strategy_prompt is None
+
+
+def test_instruction_is_stripped():
+    strategy = LLMAgentStrategy({**BASE_CONFIG, "strategy_prompt": "  Hold cash.  "})
+    assert strategy.strategy_prompt == "Hold cash."
+
+
+def test_instruction_is_passed_to_the_decision_call(monkeypatch):
+    """The attribute existing is not the contract — reaching the call site is."""
+    import dashboard.backend.domain.leaderboard.strategies.llm_agent as mod
+
+    seen = {}
+
+    class FakeManager:
+        cash = 10_000.0
+        trades = []
+        equity_history = [{"equity": 10_000.0}]
+        llm_calls = 0
+        llm_decisions = 0
+        input_tokens = 0
+        output_tokens = 0
+
+        def __init__(self, **kwargs):
+            pass
+
+        def get_portfolio_state(self, market_data, price_cache, ts):
+            return {}
+
+        def make_trading_decision_with_llm(self, state, client, **kwargs):
+            seen.update(kwargs)
+            return {"actions": []}
+
+        def execute_actions(self, actions, market_data, ts):
+            pass
+
+        def update_equity(self, market_data, price_cache, ts):
+            pass
+
+        def get_equity_curve(self):
+            return [{"timestamp": "2026-04-15T14:00:00", "equity": 10_000.0}]
+
+    monkeypatch.setattr(mod, "PortfolioManager", FakeManager)
+
+    strategy = LLMAgentStrategy({**BASE_CONFIG, "strategy_prompt": "Rotate weekly."})
+    strategy._run_decision_loop(
+        client=object(),
+        timestamps=["2026-04-15T14:00:00"],
+        symbols=["AAPL"],
+        data={},
+        price_cache={},
+        initial_capital=10_000.0,
+    )
+
+    assert seen.get("strategy_prompt") == "Rotate weekly."
+```
+
+> **Note for the implementer:** the last test calls `_run_decision_loop`, which
+> does **not exist yet**. Extracting the loop currently inlined in `run()`
+> (`llm_agent.py:145-200`) into a named method is part of Step 3 — the loop is
+> otherwise unreachable without live market data and an LLM client, and an
+> untestable call site is exactly where a silently-dropped keyword hides. Keep
+> the extraction pure: move the code, change nothing else.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pytest dashboard/backend/tests/domain/leaderboard/test_llm_agent_instruction.py -v
+```
+
+Expected: `test_instruction_is_read_from_config` FAILS with
+`AttributeError: 'LLMAgentStrategy' object has no attribute 'strategy_prompt'`,
+and `test_instruction_is_passed_to_the_decision_call` FAILS with
+`AttributeError: ... has no attribute '_run_decision_loop'`.
+
+- [ ] **Step 3: Implement**
+
+In `llm_agent.py`, immediately after `self.temperature = temperature` (`:81`),
+add:
+
+```python
+        # C1: the Open Track's competing variable. Absent on the seven published
+        # Model Track entries, which must keep producing their existing curves —
+        # so blank collapses to None rather than "".
+        self.strategy_prompt = (self.config.get("strategy_prompt") or "").strip() or None
+```
+
+Then extract the decision loop from `run()` into a method, and add the keyword.
+The loop currently at `:165-187` becomes:
+
+```python
+    def _run_decision_loop(
+        self,
+        client,
+        timestamps,
+        symbols,
+        data,
+        price_cache,
+        initial_capital,
+    ):
+        """One decision per timestamp, executed against a fresh PortfolioManager.
+
+        Extracted from run() so the strategy_prompt hand-off is reachable in a
+        test without live bars or an LLM client.
+        """
+        profile = get_market_profile(ALPACA)
+        manager = PortfolioManager(
+            initial_capital=initial_capital,
+            t_plus_one_enabled=profile.t_plus_one_enabled,
+        )
+        total = len(timestamps)
+
+        for i, ts in enumerate(timestamps):
+            market_data = {}
+            for sym in symbols:
+                df = data.get(sym)
+                if df is not None and ts in df.index:
+                    market_data[sym] = df.loc[ts]
+
+            state = manager.get_portfolio_state(market_data, price_cache, ts)
+            state["timestamp"] = ts
+
+            if client is not None:
+                decision = manager.make_trading_decision_with_llm(
+                    state,
+                    client,
+                    mode=self.mode,
+                    model=self.model_id or default_model_name(self.integration),
+                    strategy_prompt=self.strategy_prompt,
+                    temperature=self.temperature,
+                )
+            else:
+                decision = manager.make_trading_decision(state)
+
+            manager.execute_actions(decision.get("actions", []), market_data, ts)
+            manager.update_equity(market_data, price_cache, ts)
+
+            if (i + 1) % 25 == 0 or (i + 1) == total:
+                equity = (
+                    manager.equity_history[-1]["equity"]
+                    if manager.equity_history
+                    else initial_capital
+                )
+                print(f"      step {i + 1}/{total} · equity ${equity:,.0f} · calls {manager.llm_calls}")
+
+        return manager
+```
+
+Replace the inlined loop in `run()` with a call to it, keeping the existing
+post-loop bookkeeping (`curve`, `_num_trades`, `llm_calls`, `llm_decisions`,
+`decision_steps`, token counters) reading from the returned `manager`.
+
+- [ ] **Step 4: Run the new test**
+
+```bash
+pytest dashboard/backend/tests/domain/leaderboard/test_llm_agent_instruction.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Run the leaderboard suite to prove the extraction changed nothing**
+
+```bash
+pytest dashboard/backend/tests/domain/leaderboard/ dashboard/backend/tests/test_leaderboard_api.py -v
+```
+
+Expected: all pass. **A failure here means the extraction was not pure** — the
+published Model Track curves depend on this loop.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git status --short   # confirm dashboard/storage/data/ is NOT listed
+git add dashboard/backend/domain/leaderboard/strategies/llm_agent.py \
+        dashboard/backend/tests/domain/leaderboard/test_llm_agent_instruction.py
+git commit -m "feat(leaderboard): LLMAgentStrategy forwards strategy_prompt (C1)"
+```
+
+---
+
+### Task 2: The instruction-sensitivity probe script
+
+**Files:**
+- Create: `dashboard/scripts/probe_instruction_sensitivity.py`
+
+**Interfaces:**
+- Consumes: `LLMAgentStrategy.strategy_prompt` from Task 1.
+- Produces: `PROBE_INSTRUCTIONS: list[tuple[str, str]]` — `(slug, instruction_text)`. Task 4 imports this exact name to build the seed config entries, so the five non-control instructions must never be edited in one place only.
+
+**Why a script and not config entries:** the probe runs 6 instructions × 2 models
+= 12 runs, but only 5 Nemotron instructions survive into `leaderboard.json`.
+Adding 12 temporary entries to a config file that feeds the prod board is an
+invitation to commit them by accident.
+
+- [ ] **Step 1: Write the script**
+
+Create `dashboard/scripts/probe_instruction_sensitivity.py`:
+
+```python
+"""Does a trading instruction actually change what the model does?
+
+The participatory-competition design assumes instruction quality maps to return
+on a pinned model. Nobody has measured it. This runs deliberately opposite
+instructions through the leaderboard harness and prints the spread.
+
+    python dashboard/scripts/probe_instruction_sensitivity.py
+
+Costs about $4.97 at 2026-08 prices (6 instructions x 2 models, ~160 LLM calls
+each). Requires OPENROUTER_API_KEY -- without it every run silently falls back to
+rule-based and the spread is meaningless, so we assert on it up front.
+
+GATE: if the spread across these instructions is under ~1pp on both models, the
+instruction axis does not exist and Phase 2 must not be built.
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dashboard.backend.domain.leaderboard.service import load_leaderboard_config
+from dashboard.backend.domain.leaderboard.strategies.registry import get_strategy
+
+# The five that become the Phase 1 seed field, plus one control that never ships.
+PROBE_INSTRUCTIONS: list[tuple[str, str]] = [
+    (
+        "aggressive_momentum",
+        "Concentrate in the strongest recent performers. Add to positions that "
+        "are rising and cut losers quickly. Prefer a small number of large "
+        "positions over broad diversification.",
+    ),
+    (
+        "defensive_cash",
+        "Preserve capital above all. Hold a large cash position, buy only when a "
+        "stock is clearly oversold, and take profits early. Never hold more than "
+        "half the portfolio in equities.",
+    ),
+    (
+        "equal_weight_hold",
+        "Spread the money evenly across many of the available stocks on the first "
+        "opportunity, then hold. Do not react to short-term moves.",
+    ),
+    (
+        "contrarian_reversion",
+        "Buy what has fallen the most and sell what has risen the most. Assume "
+        "prices revert toward their recent average.",
+    ),
+    (
+        "verbose_analytical",
+        "Before each decision, weigh trend, momentum and valuation signals against "
+        "each other. Act only when at least two signals agree. Explain the reason "
+        "for every order.",
+    ),
+    # CONTROL — never seeded to the board. If this scores like the others, the
+    # model is ignoring the instruction and the axis is dead.
+    (
+        "control_nonsense",
+        "The weather is pleasant today. Consider the colour blue. Bananas are a "
+        "type of fruit that grows in warm climates.",
+    ),
+]
+
+PROBE_MODELS: list[tuple[str, dict]] = [
+    (
+        "nemotron",
+        {
+            "model_id": "nvidia/nemotron-3-nano-30b-a3b",
+            "integration": "openrouter",
+            "temperature": 0,
+            "reasoning_effort": "none",
+        },
+    ),
+    (
+        "deepseek",
+        {
+            "model_id": "deepseek/deepseek-v4-pro",
+            "integration": "openrouter",
+            "temperature": 0,
+            "reasoning_effort": "none",
+        },
+    ),
+]
+
+SEEDABLE = [slug for slug, _ in PROBE_INSTRUCTIONS if not slug.startswith("control_")]
+
+
+def main() -> int:
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        print("FATAL: OPENROUTER_API_KEY is unset. Every run would silently fall")
+        print("back to rule-based and the probe would measure nothing.")
+        return 2
+
+    cfg = load_leaderboard_config()
+    results: dict[str, dict[str, float]] = {}
+
+    for model_slug, model_cfg in PROBE_MODELS:
+        results[model_slug] = {}
+        for slug, instruction in PROBE_INSTRUCTIONS:
+            print(f"\n=== {model_slug} / {slug} ===")
+            strategy = get_strategy(
+                {
+                    "strategy": "llm_agent",
+                    "mode": "safe_trading",
+                    "symbols": [],
+                    "strategy_prompt": instruction,
+                    **model_cfg,
+                }
+            )
+            curve = strategy.run(
+                start_date=cfg["start_date"],
+                end_date=cfg["end_date"],
+                reference_start_date=cfg["reference_start_date"],
+                initial_capital=cfg["initial_capital"],
+            )
+            first = curve[0]["equity"]
+            last = curve[-1]["equity"]
+            ret = (last / first - 1.0) * 100.0
+            coverage = (
+                strategy.llm_decisions / strategy.decision_steps
+                if strategy.decision_steps
+                else 0.0
+            )
+            results[model_slug][slug] = ret
+            print(f"  return {ret:+.2f}%  llm coverage {coverage:.1%}")
+            if coverage < 0.95:
+                print("  WARNING: below the H6 threshold — this run could not publish.")
+
+    print("\n" + "=" * 60)
+    print("SPREAD")
+    print("=" * 60)
+    verdict_pass = False
+    for model_slug in results:
+        rets = list(results[model_slug].values())
+        spread = max(rets) - min(rets)
+        stdev = statistics.pstdev(rets)
+        print(f"\n{model_slug}: spread {spread:.2f}pp, stdev {stdev:.2f}pp")
+        for slug, ret in sorted(results[model_slug].items(), key=lambda kv: -kv[1]):
+            marker = "  (control)" if slug.startswith("control_") else ""
+            print(f"   {ret:+7.2f}%  {slug}{marker}")
+        if spread >= 1.0:
+            verdict_pass = True
+
+    print("\n" + "=" * 60)
+    if verdict_pass:
+        print("GATE: PASS — at least one model separates instructions by >=1pp.")
+    else:
+        print("GATE: FAIL — no model separates instructions. Do NOT build Phase 2.")
+    print("=" * 60)
+    return 0 if verdict_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Verify the script's own wiring without spending money**
+
+```bash
+python -c "
+from dashboard.scripts.probe_instruction_sensitivity import PROBE_INSTRUCTIONS, SEEDABLE
+assert len(PROBE_INSTRUCTIONS) == 6, PROBE_INSTRUCTIONS
+assert len(SEEDABLE) == 5, SEEDABLE
+assert all(t.strip() for _, t in PROBE_INSTRUCTIONS)
+print('OK', SEEDABLE)
+"
+```
+
+Expected: `OK ['aggressive_momentum', 'defensive_cash', 'equal_weight_hold', 'contrarian_reversion', 'verbose_analytical']`
+
+- [ ] **Step 3: Confirm the fatal guard fires**
+
+```bash
+env -u OPENROUTER_API_KEY python dashboard/scripts/probe_instruction_sensitivity.py; echo "exit=$?"
+```
+
+Expected: the FATAL message and `exit=2`. **Do not skip this** — a probe that
+silently measures rule-based fallback would produce a confident, meaningless
+verdict.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git status --short
+git add dashboard/scripts/probe_instruction_sensitivity.py
+git commit -m "chore(leaderboard): instruction-sensitivity probe script"
+```
+
+---
+
+### Task 3: Run the probe and record the gate decision
+
+**Files:**
+- Create: `docs/superpowers/probe-results/2026-08-09-instruction-sensitivity.md`
+
+**Interfaces:**
+- Consumes: Task 2's script.
+- Produces: the pass/fail decision, and — on a Nemotron-fails/DeepSeek-passes result — the pinned model for every later task.
+
+**This task spends real money (~$4.97).** Confirm with the repo owner before
+running.
+
+- [ ] **Step 1: Run the probe**
+
+```bash
+python dashboard/scripts/probe_instruction_sensitivity.py 2>&1 | tee /tmp/probe.log
+```
+
+Runtime is roughly 30–60 minutes: 12 runs × ~160 sequential LLM calls.
+
+- [ ] **Step 2: Record the result**
+
+Create `docs/superpowers/probe-results/2026-08-09-instruction-sensitivity.md`
+containing: the full spread table from stdout, the H6 coverage per run, the
+verdict, and — critically — **where the control landed**. A control that scores
+mid-pack is the single most informative outcome: it means the model responds to
+*having* an instruction rather than to its content, which passes a naive spread
+check while the leaderboard still ranks noise.
+
+- [ ] **Step 3: Apply the gate**
+
+| Outcome | Action |
+|---|---|
+| Nemotron spread ≥1pp **and** control is an outlier | **PASS.** Proceed to Phase 1 as written. |
+| Nemotron flat, DeepSeek spread ≥1pp | **PASS with contingency.** Pin DeepSeek. Per the spec, the budget holds and the grant shrinks: Replay attempts 5 → 1. Update the spec's cost tables and every `nvidia/nemotron-3-nano-30b-a3b` reference in Task 4 before proceeding. |
+| Both flat, **or** the control scores mid-pack on both | **FAIL. Stop.** The instruction axis does not exist. Phase 1's hero chart would advertise a competition that cannot be won on merit. Report back rather than proceeding. |
+
+- [ ] **Step 4: Commit the result**
+
+```bash
+git status --short
+git add docs/superpowers/probe-results/2026-08-09-instruction-sensitivity.md
+git commit -m "docs: instruction-sensitivity probe results and gate decision"
+```
+
+---
+
+# PHASE 1 — Evidence and Measurement (one PR)
+
+Ships the hook without shipping the competition: the landing hero becomes the
+real board, the Open Track gets a visible field of house-authored entries, and
+the funnel is instrumented. **No user can enter yet, and the UI must not pretend
+otherwise** — the `#homeGetStartedBtn` dead-CTA failure is the thing this design
+exists to fix, so a CTA that leads nowhere is a Phase 1 bug, not a Phase 2
+placeholder.
+
+**Before starting:** `git fetch origin && git rebase origin/main`, and rebase
+onto PR #326 if it has not yet merged.
+
+---
+
+### Task 4: Seed the Open Track with six house-authored entries
+
+**Files:**
+- Modify: `dashboard/config/leaderboard.json`
+- Test: `dashboard/backend/tests/domain/leaderboard/test_seed_entries.py` (create)
+
+**Interfaces:**
+- Consumes: `PROBE_INSTRUCTIONS`/`SEEDABLE` (Task 2), `strategy_prompt` support (Task 1).
+- Produces: six config entries with `id` values `open_house_reference`, `open_seed_aggressive_momentum`, `open_seed_defensive_cash`, `open_seed_equal_weight_hold`, `open_seed_contrarian_reversion`, `open_seed_verbose_analytical`, each carrying `"label": "Open Track"` and `"authored_by": "Agentic Trading Lab"`. Task 5 filters the API payload on `label == "Open Track"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/backend/tests/domain/leaderboard/test_seed_entries.py`:
+
+```python
+"""Phase 1 ships an Open Track field of house-authored entries.
+
+A board with one row is not a board, and an unlabelled house entry sitting among
+what will later be user entries is dishonest. These guard both.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+CONFIG = json.loads(
+    (Path(__file__).resolve().parents[4] / "config" / "leaderboard.json").read_text(
+        encoding="utf-8"
+    )
+)
+ENTRIES = CONFIG["strategies"]
+OPEN_TRACK = [e for e in ENTRIES if e.get("label") == "Open Track"]
+
+PINNED_MODEL_ID = "nvidia/nemotron-3-nano-30b-a3b"
+
+# Deliberately literal rather than imported from the probe script:
+# dashboard/scripts/ is NOT a Python package (no __init__.py), so
+# `from dashboard.scripts.probe_instruction_sensitivity import SEEDABLE` raises
+# ModuleNotFoundError at collection — and a collection error aborts the whole
+# pytest session, not just this file. The config is the source of truth once
+# seeded; the probe script is throwaway measurement.
+SEEDABLE = [
+    "aggressive_momentum",
+    "defensive_cash",
+    "equal_weight_hold",
+    "contrarian_reversion",
+    "verbose_analytical",
+]
+
+
+def test_open_track_has_a_house_reference_plus_five_seeds():
+    assert len(OPEN_TRACK) == 6, [e["id"] for e in OPEN_TRACK]
+    assert any(e["id"] == "open_house_reference" for e in OPEN_TRACK)
+
+
+def test_every_seed_slug_from_the_probe_is_present():
+    seeded = {e["id"] for e in OPEN_TRACK}
+    for slug in SEEDABLE:
+        assert f"open_seed_{slug}" in seeded, slug
+
+
+def test_every_open_track_entry_carries_an_instruction():
+    for entry in OPEN_TRACK:
+        assert entry.get("strategy_prompt", "").strip(), entry["id"]
+
+
+def test_every_open_track_entry_is_labelled_house_authored():
+    """Seeds must never be mistakable for user entries."""
+    for entry in OPEN_TRACK:
+        assert entry.get("authored_by") == "Agentic Trading Lab", entry["id"]
+
+
+def test_every_open_track_entry_is_pinned_to_the_season_model():
+    """A silent switch to a frontier model would multiply spend ~190x."""
+    for entry in OPEN_TRACK:
+        assert entry["strategy"] == "llm_agent", entry["id"]
+        assert entry["model_id"] == PINNED_MODEL_ID, entry["id"]
+        assert entry["integration"] == "openrouter", entry["id"]
+        assert entry["temperature"] == 0, entry["id"]
+
+
+def test_model_track_entries_still_carry_no_instruction():
+    """The seven published curves must not change. C1 reads this key; if one
+    appeared on a Model Track entry, its next re-deploy would produce a
+    different curve under the same published name."""
+    model_track = [e for e in ENTRIES if e.get("label") == "Model"]
+    assert len(model_track) == 7, [e["id"] for e in model_track]
+    for entry in model_track:
+        assert "strategy_prompt" not in entry, entry["id"]
+
+
+@pytest.mark.parametrize("entry", OPEN_TRACK, ids=lambda e: e["id"])
+def test_open_track_ids_do_not_collide_with_the_lb_run_prefix(entry):
+    assert not entry["id"].startswith("lb_"), entry["id"]
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+pytest dashboard/backend/tests/domain/leaderboard/test_seed_entries.py -v
+```
+
+Expected: FAIL — `assert 0 == 6`.
+
+- [ ] **Step 3: Add the six entries**
+
+Append to the `strategies` array in `dashboard/config/leaderboard.json`. The
+house reference uses the **existing** house behaviour expressed as an explicit
+instruction — this is what makes it the bar being challenged:
+
+```json
+    {
+      "id": "open_house_reference",
+      "name": "House instruction",
+      "label": "Open Track",
+      "authored_by": "Agentic Trading Lab",
+      "model": "Nemotron 3 Nano 30B",
+      "provider": "NVIDIA",
+      "strategy": "llm_agent",
+      "integration": "openrouter",
+      "model_id": "nvidia/nemotron-3-nano-30b-a3b",
+      "reasoning_effort": "none",
+      "temperature": 0,
+      "mode": "safe_trading",
+      "symbols": [],
+      "auto_compute": false,
+      "strategy_prompt": "Manage the portfolio prudently. Diversify across strong stocks, size positions sensibly, and avoid concentrating risk in any single name."
+    },
+    {
+      "id": "open_seed_aggressive_momentum",
+      "name": "Aggressive momentum",
+      "label": "Open Track",
+      "authored_by": "Agentic Trading Lab",
+      "model": "Nemotron 3 Nano 30B",
+      "provider": "NVIDIA",
+      "strategy": "llm_agent",
+      "integration": "openrouter",
+      "model_id": "nvidia/nemotron-3-nano-30b-a3b",
+      "reasoning_effort": "none",
+      "temperature": 0,
+      "mode": "safe_trading",
+      "symbols": [],
+      "auto_compute": false,
+      "strategy_prompt": "Concentrate in the strongest recent performers. Add to positions that are rising and cut losers quickly. Prefer a small number of large positions over broad diversification."
+    }
+```
+
+…and the same shape for `open_seed_defensive_cash`, `open_seed_equal_weight_hold`,
+`open_seed_contrarian_reversion` and `open_seed_verbose_analytical`, with
+`strategy_prompt` copied **verbatim** from `PROBE_INSTRUCTIONS` and `name` set to
+"Defensive cash", "Equal weight & hold", "Contrarian reversion" and
+"Weighted signals" respectively.
+
+> **Verbatim matters:** the probe's measured returns are only evidence for these
+> entries if the strings are byte-identical. If you retype rather than copy, the
+> recorded probe results no longer describe what ships.
+
+- [ ] **Step 4: Run the test**
+
+```bash
+pytest dashboard/backend/tests/domain/leaderboard/test_seed_entries.py -v
+```
+
+Expected: 11 passed.
+
+- [ ] **Step 5: Deploy the six curves**
+
+```bash
+for id in open_house_reference open_seed_aggressive_momentum open_seed_defensive_cash \
+          open_seed_equal_weight_hold open_seed_contrarian_reversion open_seed_verbose_analytical; do
+  python dashboard/scripts/deploy_leaderboard_model.py --entry "$id"
+done
+```
+
+Cost: ~$0.43, or $0 if you reuse the Phase 0 Nemotron runs. Each must report a
+published curve; an H6 rejection here means that instruction cannot seed the
+board — drop it and note why in the probe-results doc rather than lowering the
+threshold.
+
+- [ ] **Step 6: Verify the API serves them and the seed DB was not mutated**
+
+```bash
+git status --short   # dashboard/storage/data/ MUST NOT appear
+python -c "
+from dashboard.backend.domain.leaderboard.service import get_leaderboard
+p = get_leaderboard()
+open_track = [e for e in p['entries'] if e.get('team_badge') == 'Open Track' or 'open_' in str(e.get('entry_id'))]
+print(len(open_track), [e.get('entry_id') for e in open_track])
+"
+```
+
+- [ ] **Step 7: Verify the existing `/app` board still styles correctly**
+
+The six new entries appear on the existing `/app` Competition board too, carrying
+a `team_badge` value (`Open Track`) that `LEADERBOARD_STYLES` has no preset for.
+That is safe by design — `getSeriesStyle` (`js/leaderboard.js:99-106`) falls
+through to `{ color: getTeamColor(entry_id), kind: 'team' }`, which is the
+correct tier for an entrant. Confirm it rather than assume it:
+
+```bash
+uvicorn dashboard.backend.app:app --reload
+```
+
+Load `http://localhost:8000/app?view=leaderboard` and confirm the six entries
+render as solid coloured `team`-tier lines with distinct colours, appear in the
+curve picker, and do not collide visually with the seven grey model lines.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git status --short
+git add dashboard/config/leaderboard.json \
+        dashboard/backend/tests/domain/leaderboard/test_seed_entries.py
+git commit -m "feat(leaderboard): seed the Open Track with six house-authored entries"
+```
+
+---
+
+### Task 5: Typed leaderboard client for the landing page
+
+**Files:**
+- Create: `dashboard/landing/src/lib/leaderboard.ts`
+
+**Interfaces:**
+- Consumes: `GET /api/v1/leaderboard` (unchanged; no auth).
+- Produces:
+  - `type BoardEntry = { entryId: string; name: string; badge: string; rank: number; returnPct: number; curve: { t: string; equity: number }[] }`
+  - `type BoardState = { status: "loading" | "ok" | "error" | "empty"; entries: BoardEntry[]; message?: string }`
+  - `fetchBoard(signal?: AbortSignal): Promise<BoardEntry[]>`
+  - `toRechartsSeries(entries: BoardEntry[]): { rows: Record<string, number | string>[]; keys: string[] }`
+  - `selectHeroSeries(entries: BoardEntry[]): BoardEntry[]`
+
+  Task 6 imports all five names exactly as spelled here.
+
+**Isolation requirement:** this module owns the API contract for the landing
+side. `Race.tsx` must not call `fetch` directly, so a contract change touches one
+file.
+
+- [ ] **Step 1: Write the module**
+
+Create `dashboard/landing/src/lib/leaderboard.ts`:
+
+```ts
+/**
+ * The landing page's sole consumer of GET /api/v1/leaderboard.
+ *
+ * Same-origin by design: the Vercel rewrite proxies /api/* to Render, and the
+ * CSP on both origins allows connect-src 'self'. MarketTicker.tsx hardcodes
+ * https://agentictrading.onrender.com instead — do not copy that; it defeats the
+ * rewrite and pins the frontend to one backend hostname.
+ */
+
+export type BoardEntry = {
+  entryId: string;
+  name: string;
+  badge: string;
+  rank: number;
+  returnPct: number;
+  curve: { t: string; equity: number }[];
+};
+
+export type BoardState = {
+  status: "loading" | "ok" | "error" | "empty";
+  entries: BoardEntry[];
+  message?: string;
+};
+
+const FETCH_TIMEOUT_MS = 45_000;
+
+export async function fetchBoard(signal?: AbortSignal): Promise<BoardEntry[]> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  signal?.addEventListener("abort", () => controller.abort());
+  try {
+    const res = await fetch("/api/v1/leaderboard?period=contest", {
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const raw = Array.isArray(data?.entries) ? data.entries : [];
+    return raw
+      .filter((e: any) => Array.isArray(e?.equity_curve) && e.equity_curve.length > 0)
+      .map((e: any) => ({
+        entryId: String(e.entry_id ?? ""),
+        name: String(e.model ?? e.team_name ?? e.entry_id ?? "Entry"),
+        badge: String(e.team_badge ?? ""),
+        rank: Number(e.rank ?? 0),
+        returnPct: Number(e.cumulative_return ?? 0),
+        curve: e.equity_curve.map((p: any) => ({
+          t: String(p.timestamp),
+          equity: Number(p.equity),
+        })),
+      }));
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * The hero shows at most 8 lines: the market baseline, the house instruction,
+ * and the top Open Track entries. The seven Model Track models are returned too
+ * but the chart renders them as one thin grey cluster — see Race.tsx.
+ */
+export function selectHeroSeries(entries: BoardEntry[]): BoardEntry[] {
+  const byId = (id: string) => entries.find((e) => e.entryId === id);
+  const baseline = byId("buy_hold_djia") ?? byId("djia_index");
+  const house = byId("open_house_reference");
+  const openTrack = entries
+    .filter((e) => e.entryId.startsWith("open_seed_"))
+    .sort((a, b) => b.returnPct - a.returnPct)
+    .slice(0, 3);
+  const models = entries.filter((e) => e.badge === "Model");
+  return [...models, ...(baseline ? [baseline] : []), ...(house ? [house] : []), ...openTrack];
+}
+
+/**
+ * recharts wants one row per x-value with a key per series. Curves are merged on
+ * the timestamp string rather than by array index: entries tick at different
+ * minutes, so index-merging silently misaligns them (the same reason
+ * buildEquityCurvesFromEntries in js/leaderboard.js merges on a time key).
+ */
+export function toRechartsSeries(entries: BoardEntry[]): {
+  rows: Record<string, number | string>[];
+  keys: string[];
+} {
+  const axis = new Set<string>();
+  for (const e of entries) for (const p of e.curve) axis.add(p.t);
+  const sorted = [...axis].sort();
+  const keys = entries.map((e) => e.entryId);
+  const rows = sorted.map((t) => {
+    const row: Record<string, number | string> = { t };
+    for (const e of entries) {
+      const point = e.curve.find((p) => p.t === t);
+      if (point) row[e.entryId] = point.equity;
+    }
+    return row;
+  });
+  return { rows, keys };
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd dashboard/landing && npx tsc --noEmit
+```
+
+Expected: no errors. (Run `npm install` first if `node_modules` is absent.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git status --short
+git add dashboard/landing/src/lib/leaderboard.ts
+git commit -m "feat(landing): typed leaderboard client"
+```
+
+---
+
+### Task 6: Funnel instrumentation
+
+**Files:**
+- Create: `dashboard/landing/src/lib/analytics.ts`
+
+**Interfaces:**
+- Consumes: `@vercel/analytics` (already a dependency, `package.json:75`; already mounted at `App.tsx:30`).
+- Produces: `trackEvent(name: FunnelEvent, props?: Record<string, string | number>): void` and `type FunnelEvent = "landing_view" | "board_interact" | "cta_click"`. Task 7 calls `trackEvent`.
+
+**Deviation from the spec, deliberate:** the spec calls for a *first-party
+beacon* in Phase 1. A beacon needs somewhere to write, and Phase 1's defining
+constraint is **no new tables**. Rather than smuggle a table into the phase that
+was scoped to avoid them, Phase 1 uses the `@vercel/analytics` custom-event API
+that is already installed and already mounted, and Phase 2 adds the first-party
+beacon alongside the tables it is already creating. If you disagree with this
+trade, the alternative is pulling one `analytics_events` table plus a
+`POST /api/v1/events` route (and its two golden-set updates) into Phase 1.
+
+**Scope note:** the spec lists six funnel events. Three are landing-side and
+ship here. `signup_complete`, `instruction_saved` and `attempt_submitted` are
+`/app`-side, where the React bundle does not run — they arrive with Phase 2's
+first-party beacon, alongside the tables that phase already adds. Phase 1
+therefore under-counts ad-blocking visitors; that is acceptable because Phase 1's
+question is comparative (does the new hero convert better than the old page) and
+the undercount applies equally to both.
+
+- [ ] **Step 1: Verify custom events are actually available**
+
+Open the Vercel project dashboard → Analytics. Confirm **Web Analytics is
+enabled** and that custom events are included on the current plan.
+
+**If custom events are not available, stop and report back** rather than
+shipping calls that silently no-op — the fallback is Phase 2's first-party
+beacon pulled forward, which is a different task with a backend route and a
+golden-set update.
+
+- [ ] **Step 2: Write the module**
+
+Create `dashboard/landing/src/lib/analytics.ts`:
+
+```ts
+import { track } from "@vercel/analytics";
+
+/**
+ * The landing half of the Phase 1 funnel. Deliberately three events, not ten:
+ * the question is "does the board convert a visitor into a signup", and every
+ * event beyond that is noise nobody will read.
+ *
+ * The /app half (signup_complete, instruction_saved, attempt_submitted) lands
+ * with Phase 2's first-party beacon — the React bundle does not run on /app.
+ */
+export type FunnelEvent = "landing_view" | "board_interact" | "cta_click";
+
+export function trackEvent(
+  name: FunnelEvent,
+  props?: Record<string, string | number>,
+): void {
+  try {
+    track(name, props);
+  } catch {
+    // Analytics must never break the page. A blocked or failed beacon is an
+    // expected condition, not an error worth surfacing.
+  }
+}
+```
+
+- [ ] **Step 3: Typecheck and commit**
+
+```bash
+cd dashboard/landing && npx tsc --noEmit
+cd ../.. && git status --short
+git add dashboard/landing/src/lib/analytics.ts
+git commit -m "feat(landing): funnel event wrapper"
+```
+
+---
+
+### Task 7: `Race` renders the live board
+
+**Files:**
+- Modify: `dashboard/landing/src/components/home/Race.tsx`
+- Test: `dashboard/backend/tests/test_landing_race_copy.py` (create)
+
+**Interfaces:**
+- Consumes: `fetchBoard`, `selectHeroSeries`, `toRechartsSeries`, `BoardState` (Task 5); `trackEvent` (Task 6).
+- Produces: a `Race` section that owns its own loading, error and empty states.
+
+**Isolation requirement (spec §Isolation contract):** a failed board fetch must
+render *inside this section only*. It must never throw to a parent, blank the
+page, or block the rest of the landing from rendering.
+
+- [ ] **Step 1: Write the copy guard first**
+
+Create `dashboard/backend/tests/test_landing_race_copy.py`:
+
+```python
+"""Guards on the shipped landing source for the Phase 1 hook.
+
+Asserted against the React source rather than the built bundle: the bundle is
+minified and its identifiers are mangled, so a source assertion is the only one
+that survives a rebuild. test_frontend_bundle_integrity.py separately guards that
+the bundle and source agree on CTA labels.
+"""
+
+from pathlib import Path
+
+RACE = (
+    Path(__file__).resolve().parents[2]
+    / "landing"
+    / "src"
+    / "components"
+    / "home"
+    / "Race.tsx"
+).read_text(encoding="utf-8")
+
+
+def test_the_illustrative_badge_is_gone():
+    """The data is real now. Leaving the badge would understate it; leaving the
+    badge AND real data would be a lie in the other direction."""
+    assert "Illustrative" not in RACE
+
+
+def test_sample_data_is_gone():
+    for dead in ("SAMPLE_CURVES", "SAMPLE_STANDINGS"):
+        assert dead not in RACE, dead
+
+
+def test_the_cta_names_the_beatable_number_not_the_market():
+    """Spec: rank against the house instruction, never imply the market is easy
+    to beat."""
+    assert "buy-and-hold" in RACE
+    assert "instruction" in RACE
+
+
+def test_copy_avoids_the_reserved_product_nouns():
+    """'strategy' collides with domain/strategies/; 'teams' contradicts one
+    entrant = one person."""
+    for line in RACE.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(("<p", "<h2", "<h3", "<li", "{\"")):
+            continue
+        assert "your strategy" not in stripped.lower(), stripped
+        assert "teams" not in stripped.lower(), stripped
+
+
+def test_race_does_not_fetch_directly():
+    """The API contract lives in lib/leaderboard.ts so a change touches one file."""
+    assert "fetch(" not in RACE
+    assert "from \"@/lib/leaderboard\"" in RACE
+
+
+def test_race_renders_its_own_error_state():
+    """Isolation contract: one failed fetch must not blank the page."""
+    assert "error" in RACE
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+pytest dashboard/backend/tests/test_landing_race_copy.py -v
+```
+
+Expected: multiple failures — `SAMPLE_CURVES` present, "Illustrative" present.
+
+- [ ] **Step 3: Rewrite `Race.tsx`**
+
+Replace the sample constants and the component body. Keep the existing
+`Button`/`PRIMARY_LANDING_CTA` usage, the card chrome and the Tailwind classes;
+change the data source, the copy, and add the states:
+
+```tsx
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Medal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+} from "recharts";
+import { PRIMARY_LANDING_CTA } from "@/lib/cta";
+import {
+  fetchBoard, selectHeroSeries, toRechartsSeries,
+  type BoardEntry, type BoardState,
+} from "@/lib/leaderboard";
+import { trackEvent } from "@/lib/analytics";
+
+/** Model Track entries render as one thin grey cluster; Open Track entries are bold. */
+const OPEN_TRACK_COLORS = ["#22d3ee", "#a78bfa", "#fbbf24"];
+const HOUSE_COLOR = "#f97316";
+const BASELINE_COLOR = "#94a3b8";
+const MODEL_CLUSTER_COLOR = "#475569";
+
+function styleFor(entry: BoardEntry, openTrackIndex: number) {
+  if (entry.entryId === "open_house_reference") {
+    return { stroke: HOUSE_COLOR, strokeWidth: 2.5, dash: undefined, opacity: 1 };
+  }
+  if (entry.entryId.startsWith("open_seed_")) {
+    return {
+      stroke: OPEN_TRACK_COLORS[openTrackIndex % OPEN_TRACK_COLORS.length],
+      strokeWidth: 2.5, dash: undefined, opacity: 1,
+    };
+  }
+  if (entry.badge === "Model") {
+    return { stroke: MODEL_CLUSTER_COLOR, strokeWidth: 1, dash: undefined, opacity: 0.35 };
+  }
+  return { stroke: BASELINE_COLOR, strokeWidth: 1.5, dash: "4 4", opacity: 0.9 };
+}
+
+export function Race() {
+  const [state, setState] = useState<BoardState>({ status: "loading", entries: [] });
+  const interacted = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchBoard()
+      .then((entries) => {
+        if (cancelled) return;
+        setState(
+          entries.length
+            ? { status: "ok", entries }
+            : { status: "empty", entries: [], message: "The board has no published entries yet." },
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({
+          status: "error",
+          entries: [],
+          message: "The leaderboard is temporarily unavailable.",
+        });
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const hero = useMemo(() => selectHeroSeries(state.entries), [state.entries]);
+  const { rows } = useMemo(() => toRechartsSeries(hero), [hero]);
+
+  const standings = useMemo(
+    () =>
+      hero
+        .filter((e) => e.entryId.startsWith("open_") || e.badge === "Model")
+        .sort((a, b) => b.returnPct - a.returnPct)
+        .slice(0, 5),
+    [hero],
+  );
+
+  function onChartInteract() {
+    if (interacted.current) return;
+    interacted.current = true;
+    trackEvent("board_interact");
+  }
+
+  let openTrackSeen = 0;
+
+  return (
+    <section id="race" className="py-24 bg-muted/20 border-y border-border scroll-mt-40">
+      <div className="container mx-auto px-6">
+        <div className="grid lg:grid-cols-2 gap-12 items-start mb-12">
+          <div>
+            <h2 className="text-3xl md:text-4xl font-bold mb-3">
+              Most models lost to buy-and-hold
+            </h2>
+            <p className="text-foreground/80 mb-6 text-lg">
+              We gave seven frontier models the same house instruction and one month of
+              real market data. Six of them finished behind simply buying and holding.
+              Can you beat them with a better instruction?
+            </p>
+            <ul className="space-y-2 mb-8 text-sm text-foreground/80">
+              <li>· Real hourly market data — no real money at risk</li>
+              <li>· One pinned model, so the instruction is the only variable</li>
+              <li>· Same window, same starting cash, same rules for every entry</li>
+            </ul>
+            <Button
+              size="lg"
+              type="button"
+              data-landing-auth={PRIMARY_LANDING_CTA.authMode}
+              onClick={() => trackEvent("cta_click", { placement: "race" })}
+              className="bg-primary text-primary-foreground hover:bg-primary/90"
+            >
+              {PRIMARY_LANDING_CTA.label}
+            </Button>
+          </div>
+
+          <div className="bg-card border border-card-border rounded-xl shadow-xl p-6">
+            <div className="flex items-center justify-between mb-2 border-b border-border pb-4 gap-3">
+              <h3 className="text-xl font-bold flex items-center gap-2 min-w-0">
+                <Medal className="w-5 h-5 text-primary shrink-0" />
+                Standings
+              </h3>
+            </div>
+            <div className="space-y-2 mt-4">
+              {state.status === "loading" && (
+                <p className="text-sm text-muted-foreground p-3">Loading the board…</p>
+              )}
+              {(state.status === "error" || state.status === "empty") && (
+                <p className="text-sm text-muted-foreground p-3">{state.message}</p>
+              )}
+              {state.status === "ok" && standings.map((item, i) => {
+                const isOpen = item.entryId.startsWith("open_");
+                return (
+                  <div
+                    key={item.entryId}
+                    className={`grid grid-cols-12 items-center p-3 border rounded-lg ${
+                      isOpen ? "bg-primary/10 border-primary/40" : "bg-background border-border"
+                    }`}
+                  >
+                    <div className="col-span-2 font-mono font-bold text-muted-foreground">#{i + 1}</div>
+                    <div className="col-span-7 font-medium truncate pr-2">
+                      {item.name}
+                      <span className="ml-2 text-xs font-mono text-muted-foreground">
+                        {isOpen ? "instruction" : "model"}
+                      </span>
+                    </div>
+                    <div className={`col-span-3 text-right font-mono font-bold ${
+                      item.returnPct >= 0 ? "text-positive" : "text-destructive"
+                    }`}>
+                      {item.returnPct >= 0 ? "+" : ""}{item.returnPct.toFixed(2)}%
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-card border border-card-border rounded-xl shadow-xl p-6 md:p-8">
+          <h3 className="text-lg font-bold mb-6">Leaderboard</h3>
+          <div className="h-[320px] md:h-[400px] w-full" onMouseEnter={onChartInteract}>
+            {state.status !== "ok" ? (
+              <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
+                {state.status === "loading" ? "Loading the board…" : state.message}
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={rows} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
+                  <XAxis dataKey="t" stroke="hsl(var(--muted-foreground))" fontSize={12}
+                         tickLine={false} axisLine={false} tickFormatter={(v: string) => v.slice(5, 10)} />
+                  <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} tickLine={false}
+                         axisLine={false} domain={["auto", "auto"]} tickFormatter={(v) => `$${v}`} />
+                  <Tooltip contentStyle={{
+                    backgroundColor: "hsl(var(--card))",
+                    borderColor: "hsl(var(--border))",
+                    borderRadius: "8px",
+                  }} />
+                  {hero.map((entry) => {
+                    const isOpenSeed = entry.entryId.startsWith("open_seed_");
+                    const style = styleFor(entry, isOpenSeed ? openTrackSeen++ : 0);
+                    return (
+                      <Line
+                        key={entry.entryId}
+                        type="linear"
+                        dataKey={entry.entryId}
+                        name={entry.name}
+                        stroke={style.stroke}
+                        strokeWidth={style.strokeWidth}
+                        strokeDasharray={style.dash}
+                        strokeOpacity={style.opacity}
+                        connectNulls
+                        dot={false}
+                      />
+                    );
+                  })}
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the guard and the typechecker**
+
+```bash
+pytest dashboard/backend/tests/test_landing_race_copy.py -v
+cd dashboard/landing && npx tsc --noEmit
+```
+
+Expected: 6 passed; no TS errors.
+
+- [ ] **Step 5: Verify against a live backend**
+
+```bash
+# terminal 1
+uvicorn dashboard.backend.app:app --reload
+# terminal 2
+cd dashboard/landing && npm run dev
+```
+
+Confirm, in the browser: the chart renders real curves; the Model Track lines are
+a faint grey cluster while Open Track lines are bold; **stop the backend and
+reload** — the Race section must show its own error text while every other
+section still renders.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git status --short
+git add dashboard/landing/src/components/home/Race.tsx \
+        dashboard/backend/tests/test_landing_race_copy.py
+git commit -m "feat(landing): Race renders the live leaderboard"
+```
+
+---
+
+### Task 8: Promote the board above the fold and renumber the storyline
+
+**Files:**
+- Modify: `dashboard/landing/src/pages/landing-page.tsx:18-22`
+- Modify: `dashboard/landing/src/components/home/Talk.tsx:12`
+- Modify: `dashboard/landing/src/components/home/Test.tsx:143`
+- Modify: `dashboard/landing/src/components/home/FooterCTA.tsx:10`
+
+**Interfaces:**
+- Consumes: Task 7's `Race`.
+- Produces: section order `Hero → Race → WhyCare → Talk → Test`.
+
+**Sign-off required:** the `01 — Talk / 02 — Test / 03 — Race` sequence is
+Allan's copy (`WhyCare.tsx:5` comments on the numbering deliberately, and
+`FooterCTA.tsx:10` restates it). **Confirm with the repo owner before
+committing.** Promoting Race makes it the frame rather than step three, so it
+loses its number and Talk/Test keep 01/02 — the sequence is not deleted.
+
+- [ ] **Step 1: Reorder**
+
+In `landing-page.tsx`, move `<Race />` to sit directly after `<Hero />`:
+
+```tsx
+      <main>
+        <Hero />
+        <Race />
+        <WhyCare />
+        <Talk />
+        <Test />
+      </main>
+```
+
+- [ ] **Step 2: Renumber**
+
+`Race.tsx` already dropped its `03 — Race` line in Task 7. Leave `Talk.tsx:12`
+(`01 — Talk`) and `Test.tsx:143` (`02 — Test`) as they are — they remain correct.
+In `FooterCTA.tsx:10`, change `Talk → Test → Race` to `Race → Talk → Test`.
+
+- [ ] **Step 3: Verify no orphaned numbering**
+
+```bash
+command grep -rn "03 —\|Talk → Test → Race" dashboard/landing/src/
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Visual check**
+
+`npm run dev`, then confirm the chart is visible without scrolling at 1280×800,
+and that the `#race` anchor in `Navbar.tsx:9` still scrolls correctly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git status --short
+git add dashboard/landing/src/pages/landing-page.tsx \
+        dashboard/landing/src/components/home/FooterCTA.tsx
+git commit -m "feat(landing): promote the leaderboard above the fold"
+```
+
+---
+
+### Task 9: Social share card
+
+**Files:**
+- Create: `dashboard/frontend/images/og-card.png` (1200×630)
+- Modify: `dashboard/frontend/index.html:9-14`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `og:image` / `twitter:image` meta tags.
+
+Today `index.html:12` declares `twitter:card="summary_large_image"` and supplies
+**no image** — the worst of both, since it requests a large card and gives the
+crawler nothing. Dynamic per-entry images are rejected in the spec: Render's free
+tier spins down and link-preview crawlers abandon in seconds, so most first
+shares would render nothing.
+
+- [ ] **Step 1: Produce the image**
+
+A 1200×630 PNG carrying the product name and the hook sentence
+("Most models lost to buy-and-hold"). Screenshot the new hero chart at
+1200×630 if no designed asset exists. Keep it under 300 KB.
+
+- [ ] **Step 2: Add the tags**
+
+In `index.html`, after line 14:
+
+```html
+    <meta property="og:image" content="https://agentictrading.com/images/og-card.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:image" content="https://agentictrading.com/images/og-card.png" />
+```
+
+> Absolute URLs are required — crawlers do not resolve relative `og:image`
+> paths. Replace the host with the production domain if it differs from
+> `agentictrading.com`; check the Vercel project's assigned domain first.
+
+- [ ] **Step 3: Verify the asset resolves**
+
+```bash
+python - <<'PY'
+from pathlib import Path
+html = Path("dashboard/frontend/index.html").read_text(encoding="utf-8")
+assert 'og:image' in html and 'twitter:image' in html
+assert Path("dashboard/frontend/images/og-card.png").is_file()
+print("OK", Path("dashboard/frontend/images/og-card.png").stat().st_size, "bytes")
+PY
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git status --short
+git add dashboard/frontend/index.html dashboard/frontend/images/og-card.png
+git commit -m "feat(landing): social share card"
+```
+
+---
+
+### Task 10: Rename Community → Agent Marketplace, Teams → Traders
+
+**Files:**
+- Modify: `dashboard/frontend/app.html:195`, `:1600`, `:1403-1410`
+- Modify: `dashboard/backend/tests/test_frontend_marketplace_placement.py:117-137`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: user-visible strings only.
+
+**Do not rename** the `community` page key, `#communityView`, the `NAV_VIEW_MAP`
+entries (`app.html:28-44`) or the `nav-state` localStorage value — live bookmarks
+break for no user-visible gain. `?view=marketplace` already exists as a legacy
+alias pointing at `community`, so this rename makes that alias the accurate one.
+
+- [ ] **Step 1: Update the guard first**
+
+`test_frontend_marketplace_placement.py::test_community_page_header_matches_the_nav_button`
+(`:117-137`) asserts the nav button text equals the page `<h2>`. It passes only
+if **both** move. Add an explicit assertion that the new label is in place:
+
+```python
+def test_nav_and_page_title_say_agent_marketplace():
+    """They must move together — the pre-existing matching guard passes if both
+    stay 'Community', so it cannot detect a half-done rename on its own."""
+    from ._frontend_source import APP_HTML
+
+    assert 'data-mode="community">Agent Marketplace<' in APP_HTML
+    assert '<h2 class="page-title">Agent Marketplace</h2>' in APP_HTML
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+pytest dashboard/backend/tests/test_frontend_marketplace_placement.py -v
+```
+
+Expected: the new test FAILS.
+
+- [ ] **Step 3: Apply the renames**
+
+| File:line | From | To |
+|---|---|---|
+| `app.html:195` | `data-mode="community">Community<` | `data-mode="community">Agent Marketplace<` |
+| `app.html:1600` | `<h2 class="page-title">Community</h2>` | `<h2 class="page-title">Agent Marketplace</h2>` |
+| `app.html:1406` | `Season hasn't started yet` | `No traders yet` |
+| `app.html:1407` | `Participating teams will appear here when the contest season opens. The Ranking board shows AI models and baseline strategies only.` | `Traders will appear here when the season opens. The board currently shows AI models, baseline strategies and house-authored instructions.` |
+| `app.html` (subtab) | `data-competition-tab="participants">Participating Teams<` | `data-competition-tab="participants">Participating Traders<` |
+
+Leave `data-competition-tab="participants"` and `#competitionParticipantsPanel`
+unchanged — identifiers, not copy.
+
+- [ ] **Step 4: Bump the cache-buster**
+
+`app.html` itself is not versioned, but any touched asset is. This task edits
+only `app.html`, so **no `?v=` bump is required.** Confirm you did not edit
+`app.js`, `styles.css` or `js/leaderboard.js`:
+
+```bash
+git diff --name-only
+```
+
+Expected: only `app.html` and the test file.
+
+- [ ] **Step 5: Run the frontend guards**
+
+```bash
+pytest dashboard/backend/tests/test_frontend_marketplace_placement.py -v
+command grep -c "Participating Teams" dashboard/frontend/app.html   # expect 0
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git status --short
+git add dashboard/frontend/app.html \
+        dashboard/backend/tests/test_frontend_marketplace_placement.py
+git commit -m "ux(app): Agent Marketplace and Participating Traders"
+```
+
+---
+
+### Task 11: Rebuild the shipped landing bundle
+
+**Files:**
+- Modify: `dashboard/frontend/index.html` (asset hashes only)
+- Modify/Create/Delete: `dashboard/frontend/assets/*`
+
+**Interfaces:**
+- Consumes: Tasks 6–9.
+- Produces: the deployed landing page.
+
+The shipped page is the Vite build **plus four hand-written auth blocks with no
+React counterpart**. Losing any of them breaks signup silently — the page renders
+and the button does nothing.
+
+- [ ] **Step 1: Build**
+
+```bash
+cd dashboard/landing && npm run build
+```
+
+- [ ] **Step 2: Copy the new assets and remove the superseded ones**
+
+```bash
+cp dist/public/assets/* ../frontend/assets/
+# then delete the PREVIOUS index-*.js / index-*.css from ../frontend/assets/
+```
+
+- [ ] **Step 3: Repoint the tags, preserving the auth layer**
+
+In `dashboard/frontend/index.html`, update the `<script>` and `<link>` to the new
+content-hashed filenames. **Keep verbatim:** the auth-gate `<script>` in `<head>`,
+the `#landingAuthModal` markup, `<style id="landing-auth-patch">`, and the
+end-of-body auth `<script>`. No `?v=` cache-buster — the content hash is the bust.
+
+- [ ] **Step 4: Run the integrity guard**
+
+```bash
+pytest dashboard/backend/tests/test_frontend_bundle_integrity.py -v
+```
+
+Expected: all pass. This checks every `/assets/...` reference resolves, no
+superseded bundle is left behind, the four auth markers survive, and the shipped
+bundle carries the current CTA label from `lib/cta.ts`.
+
+- [ ] **Step 5: Browser verification**
+
+Load `/` and confirm: each section renders exactly once; the board is above the
+fold; the modal opens in **signup** mode from every **Start Free** button and in
+**login** mode from the navbar **Sign in** (widen past 1024px — that control is
+`lg:`-gated); the only console error is the `/_vercel/insights/script.js` 404,
+which is expected off Vercel.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git status --short
+git add dashboard/frontend/index.html dashboard/frontend/assets
+git commit -m "build(landing): refresh shipped bundle"
+```
+
+---
+
+### Task 12: Full verification and PR
+
+- [ ] **Step 1: Full backend suite**
+
+```bash
+pytest dashboard/backend/tests/ -q
+```
+
+Expected: green. A red test is a real regression — the suite is green
+end-to-end. **Exception:** if `test_deleted_shim_is_not_importable` fails with
+`DID NOT RAISE ModuleNotFoundError`, that is stale bytecode, not a regression:
+
+```bash
+rm -rf dashboard/backend/engines dashboard/backend/services
+```
+
+- [ ] **Step 2: Confirm the route contract did not move**
+
+```bash
+pytest dashboard/backend/tests/test_router_move.py dashboard/backend/tests/test_app_composition.py -q
+```
+
+Expected: green **without** editing any golden set. Phase 1 adds no routes; if
+these fail, a route was added that this plan did not call for.
+
+- [ ] **Step 3: Confirm the prod seed DB is untouched**
+
+```bash
+git status --short
+git diff --stat origin/main -- dashboard/storage/
+```
+
+Expected: no output from the second command.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin feat/participatory-competition-phase-1
+gh pr create --title "feat: leaderboard-first landing + Open Track seed field" --body "$(cat <<'EOF'
+Phase 1 of the participatory competition design. Display only — no user entries yet.
+
+- C1: `LLMAgentStrategy` forwards `strategy_prompt`
+- Six house-authored Open Track seed entries, gated on the instruction-sensitivity probe
+- `Race` renders the live board, promoted above the fold
+- Funnel events, `og:image`, Community→Agent Marketplace, Teams→Traders
+
+Spec: `docs/superpowers/specs/2026-08-09-participatory-competition-design.md`
+Probe: `docs/superpowers/probe-results/2026-08-09-instruction-sensitivity.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Post-merge prod verification**
+
+Merging to Open-Finance-Lab `main` auto-deploys. After the deploy completes:
+
+```bash
+curl -s https://agentictrading.onrender.com/api/v1/leaderboard | python -c "
+import json,sys
+p=json.load(sys.stdin)
+ids=[e.get('entry_id') for e in p['entries']]
+print('open track:', [i for i in ids if str(i).startswith('open_')])
+"
+```
+
+Expected: six `open_*` ids. **If empty, `OPENROUTER_API_KEY` is unset in the
+Render dashboard** — the seeds' curves come from the committed DB, so an empty
+result means the deploy reset it and the entries could not recompute.
+
+---
+
+## Deferred: Phases 2 and 3
+
+Each gets its own plan, written when its prerequisites resolve.
+
+**Phase 2 (Replay qualifier)** is blocked on the Task 3 gate. Its pinned model,
+attempt grant and cost tables all change if the probe forces DeepSeek, so
+detailed tasks written now would be discarded. It covers C3/C4/C5/C7,
+`leaderboard_entries` + `leaderboard_attempts` with Postgres twins, the attempt
+ledger, email verification at signup, the checklist card, the Submit action, the
+two-worker queue, and graduation into Loop A.
+
+**Phase 3 (Forward Seasons)** is blocked on Phase 2 — Forward entry requires a
+completed Replay attempt. It covers C8, `forward_positions`, derived weekly
+seasons, the Friday result email, the share-card download, and the notification
+channel abstraction with Discord stubbed.
+
+Two items to carry into Phase 2's planning:
+
+1. **Worker concurrency against issue #202**, which reports blocking sync I/O on
+   exactly the leaderboard routes. The spec says two workers; that must be
+   measured, not assumed.
+2. **`BREVO_API_KEY` becomes a hard signup dependency** once verification gates
+   account creation. It must be set in Render *before* that PR merges, or every
+   signup breaks.

--- a/docs/superpowers/specs/2026-08-09-participatory-competition-design.md
+++ b/docs/superpowers/specs/2026-08-09-participatory-competition-design.md
@@ -1,227 +1,287 @@
-# Participatory competition: an Open Track users can enter
+# Participatory competition: two boards users can enter
 
-**Date:** 2026-08-09
+**Date:** 2026-08-09 (rewritten same day after a design grilling)
 **Status:** Design approved, pending implementation plan
 
 ## Goal
 
-Give ATL a hook. Today a new visitor reads a tagline and lands on an empty
-My Agents page with no stated objective; users report not knowing what the
-platform wants from them. This design makes the **leaderboard the objective**:
-a visitor sees a live board of models trading, is told the house instruction
-lost money, and is invited to write a better one.
+Give ATL a hook that makes people **come** and **stay**.
+
+Today a visitor reads a tagline, scrolls past four sections, and lands on an
+empty My Agents page with no stated objective; users report not knowing what the
+platform wants from them. This design makes the leaderboard the objective: a
+visitor sees a live board of named frontier models mostly *losing* to
+buy-and-hold, and is invited to beat them with one instruction.
 
 The differentiator is participation. Researched 2026-08-08: nof1.ai's Alpha
 Arena is spectator-only (nof1 picks the models and writes the single shared
-prompt) and has been dormant since its Season 1.5 ended 2025-12-03, with no
-Season 2 as of 2026-08. TradeRank built a public Agent Builder and disabled it.
-StrategyArena takes external strategies but is explicitly educational
-simulation. **No public LLM-trading leaderboard currently accepts
-user-submitted, prompt-defined agents.**
+prompt) and has been dormant since Season 1.5 ended 2025-12-03. TradeRank built
+a public Agent Builder and disabled it. StrategyArena takes external strategies
+but is explicitly educational simulation. **No public LLM-trading leaderboard
+currently accepts user-submitted, prompt-defined agents.**
 
 Alpha Arena varies the *model* across one shared prompt. This design does the
-inverse: one shared model, N user instructions. That axis is unoccupied, and it
+inverse: one pinned model, N user instructions. That axis is unoccupied, and it
 is also the cheap one.
+
+### Come, and stay — the two mechanisms, named
+
+- **Come** is the Replay board: seven named frontier models, six of which lost
+  to buy-and-hold over a real month, on one chart above the fold, with a CTA
+  that points at a specific beatable number.
+- **Stay** is the weekly Forward Season cycle: submit Monday, watch the board
+  move daily, get a result email Friday, next season opens Monday.
+
+A fixed replay alone cannot produce a return visit — the race ends the moment
+you submit. That is why there are two boards and not one.
 
 ## Decisions taken
 
 | Decision | Choice | Why |
 |---|---|---|
-| Season window | Fixed historical month, re-runs capped by the attempt budget | Simplest to ship; no waiting for real time to pass |
-| Board display | Best attempt only; attempt count in entry detail | User's call — a losing attempt never has to be worn |
+| Board count | Two: Replay (perpetual) + Forward Season (weekly) | Replay is the argument; Forward is the habit |
+| Replay window | The existing fixed month, never reset | A fixed replay's result never changes; resetting deletes history and re-charges for the same curve |
+| Forward substrate | **Simulated** forward execution on real bars | Decouples the season from broker paper trading, which does not exist |
+| Forward cadence | One week, Mon open → Fri close | Locked instructions cost little when the next season is days away |
+| Instruction lock | Locks when the run begins | User's call; the weekly cadence is what makes it survivable |
 | Competition axis | One pinned model, instructions compete | One variable; predictable cost; the unoccupied axis |
-| Season 1 model | Nemotron 3 Nano 30B | Cheapest by 10x, and the house lost with it — the prompt carries the signal |
-| Funding | Platform pays | No credit system exists yet |
-| Attempt budget | Per-entry consumable balance | Is the credit ledger v0; billing tops it up later with no migration |
+| Season 1 model | Nemotron 3 Nano 30B, `temperature: 0` | Cheapest by 10×, and the house lost with it — the prompt carries the signal |
+| Entry shape | An agent with **exactly one** pipeline step | Matches how the product already stores instructions |
+| Attempts | 5 lifetime on Replay; Forward is a slot, not a ledger | Under a locked forward run there is nothing to spend a second attempt on |
+| Abuse control | Email verification at **account creation** + a hard global monthly spend ceiling | Accounts are free and instant; attempts cost real money |
+| Funding | Platform pays, capped at $50/month | No credit system exists yet |
+| Graduation | Carry the instruction text only into Loop A | Loop A cannot reproduce season conditions; pretending otherwise invites bug reports |
 
-### The look-ahead trade-off, recorded deliberately
+### The look-ahead trade-off, resolved rather than accepted
 
-A fixed historical window means entrants can iterate against a known outcome,
-and the current contest window (2026-04-15 → 2026-05-15) may fall inside the
-training data of competing models. This was raised and accepted: the board
-measures prompt engineering against a fixed replay, not alpha discovery, and
-should be described that way in user-facing copy.
+The earlier draft accepted that a fixed historical window lets entrants iterate
+against a known outcome, and that the window may sit inside competing models'
+training data. **The Forward Season resolves this** rather than merely
+disclosing it: it runs on bars that do not exist when the instruction locks.
 
-Two facts materially reduce the risk and are load-bearing:
+Replay keeps the known-outcome property and is therefore explicitly positioned
+as a **qualifier**, not the competitive board. Its purpose is evidence (the
+hero chart) and practice (the cheap, repeatable loop). A Replay rank is a score
+against a fixed replay; a Forward rank is a forecast. User-facing copy must say
+so.
+
+Two facts still reduce Replay's gameability and are load-bearing:
 
 1. **Nemotron is pinned to `temperature: 0`** — uniquely among the seven house
    entries, which otherwise run at provider default. Verified at
-   `dashboard/config/leaderboard.json` (`"temperature": 0`,
-   `"reasoning_effort": "none"`) and plumbed for real:
-   `llm_agent.py:53-81` validates the value (finite, 0–1, rejects bools,
-   rejects combining with extended thinking) and `llm_agent.py:181` passes it
-   into the call. Re-running an unchanged instruction therefore returns a
-   near-identical curve, so repeated attempts cannot mine sampling variance
-   the way they could on a default-temperature model.
-   This is *near*-deterministic, not bitwise: providers still vary through
-   batching and MoE routing. Do not document it as reproducible.
-2. **`instruction_sha256` is recorded per attempt** (see Data model), so two
-   attempts sharing a hash are visibly re-runs rather than iterations.
-
-The attempt cap therefore exists to bound cost and iteration count, not to stop
-variance mining.
+   `dashboard/config/leaderboard.json`, and plumbed for real: `llm_agent.py`
+   validates the value (finite, 0–1, rejects bools, rejects combining with
+   extended thinking) and passes it into the call at `:176-182`. Re-running an
+   unchanged instruction therefore returns a near-identical curve, so repeated
+   attempts cannot mine sampling variance. This is *near*-deterministic, not
+   bitwise: providers still vary through batching and MoE routing. Do not
+   document it as reproducible.
+2. **`instruction_sha256` is recorded per attempt**, so two attempts sharing a
+   hash are visibly re-runs rather than iterations.
 
 ## Background: verified state of the code
 
-Verified 2026-08-08/09 against `origin/main` @ `45ccbc0`. The local checkout was
-seven commits behind at the time of writing; read leaderboard files at
-`origin/main`.
+Verified 2026-08-08/09 against `origin/main` @ `45ccbc0`.
+
+### There is one trading harness and two drivers
+
+**This corrects the previous draft**, which claimed the paths "do not share a
+template" and were "not interchangeable". That framing was wrong, and it argued
+against a change that is in fact small.
+
+Both paths construct the **same `PortfolioManager`** from
+`domain/backtesting/portfolio_manager.py` — `engine.py:36,861` and
+`llm_agent.py:27,153` — and drive it through the same four calls:
+`get_portfolio_state` → `make_trading_decision_with_llm` → `execute_actions`
+→ `update_equity`. Order fills, cash accounting, position tracking, T+1
+settlement and trade records are **already identical**.
+
+`make_trading_decision_with_llm` (`portfolio_manager.py:227-238`) is **one
+method with one branch**:
+
+- `if pipeline:` (`:428`) → `run_pipeline_decision` with `PIPELINE_SYSTEM_PROMPT`
+  and a per-step `outputFormat` contract;
+- `else:` (`:453`) → `create_prompt(custom_prompt=strategy_prompt)` with
+  `SYSTEM_PROMPT` + `SAFE_TRADING_PROMPT`.
+
+The house path passes neither `strategy_prompt` nor `pipeline`, so
+`custom_prompt` is always `None`. **C1 fixes that in two lines.**
+
+The divergences that remain are **parametric, not architectural**: which bars
+are fed (warm-up from `reference_start_date`, the `+1 day` end bump, the engine's
+80%-symbol-coverage filter), the capital cap, `llm_agent.py:152` hardcoding
+`get_market_profile(ALPACA)`, the `market` snapshot key, and retry/rescue
+behaviour (the house retries 4× with a reasoning-disabled rescue; the pipeline
+falls back to rule-based on first unparseable response).
+
+### The pipeline trap
+
+In ATL today, **a trading instruction is structurally a one-step pipeline.**
+Every marketplace template — including the simplest, "Balanced Starter" — stores
+its instruction as `pipeline: [{presetKey: "simple_instruction", prompt: …,
+outputFormat: …}]`, and `domain/agents/service.py:380` seeds
+`default_starter_pipeline()` into every new pipeline-runtime agent.
+
+So `if pipeline:` is **true for essentially every user agent**, including
+single-instruction ones. "A pipeline-less user agent already matches the house
+path" is technically true and practically vacuous — the product does not create
+pipeline-less agents. This is why C7 (below) exists.
 
 ### What already exists and is better than assumed
 
-- **The board is a one-month backtest already.** `leaderboard.json` fixes
+- **The Replay board is a one-month backtest already.** `leaderboard.json` fixes
   `initial_capital: 10000`, `start_date: 2026-04-15`, `end_date: 2026-05-15`,
-  `reference_start_date: 2026-03-15` (indicator warm-up, no in-window
-  look-ahead). 12 entries live in prod: 5 baselines + 7 LLM models.
+  `reference_start_date: 2026-03-15`. 12 entries live in prod: 5 baselines +
+  7 LLM models.
 - **The chart is the most developed frontend in the repo.**
   `dashboard/frontend/js/leaderboard.js` (1,037 lines): three visual tiers by
-  `kind` (benchmark / strategy / model, differing in width, dash and alpha),
-  a hand-built custom legend (`buildCustomLegend`, `:810-847`) with Chart.js's
-  own legend disabled, a grouped curve picker with per-group checkboxes
-  (`renderCurvePicker`, `:185-230`) driving a shared `hiddenSeries` set,
-  endpoint labels with collision avoidance in a reserved 120px gutter
-  (`endpointLabelPlugin`, `:735-808`), a %/$ toggle, and tooltips carrying rank
-  and delta-vs-SPY.
+  `kind` (benchmark / strategy / model / **team**), a hand-built custom legend
+  (`buildCustomLegend`, `:810-847`) with Chart.js's own legend disabled, a
+  grouped curve picker (`renderCurvePicker`, `:185-230`) driving a shared
+  `hiddenSeries` set, endpoint labels with collision avoidance in a reserved
+  120px gutter (`endpointLabelPlugin`, `:735-808`), a %/$ toggle, and tooltips
+  carrying rank and delta-vs-SPY. User entries map to the existing `team` tier,
+  which already has a stable per-`entry_id` colour assignment.
 - **`buildEquityCurvesFromEntries` (`:477-512`) merges every entry onto one
   shared hour-precision time axis**, not by array index — because SPY ticks at
-  `:30` and LLM agents at `:00`. Built for 12 entries, this is exactly what
-  makes an N-entry board tractable.
+  `:30` and LLM agents at `:00`.
 - **The board is already fully public.** No auth dependency on
   `GET /api/v1/leaderboard`; `middleware.py:47-49` exempts `/api/*` from session
-  enforcement; `applyInitialNavigation()` runs regardless of sign-in state.
-  A logged-out visitor already sees the whole Competition tab.
-- **Deep links exist**: `?view=contest|daily|competition|leaderboard|participants|about`
-  via `NAV_VIEW_MAP` (`app.html:28-44`).
-- **PR #325 is merged** (`45ccbc0`), shipping `POST /api/v1/leaderboard/daily/refresh`
-  (secret-gated, 202 + background thread, rate-limited 20/hr), a nightly GitHub
-  Actions cron at 22:30 UTC Mon–Fri, and an ET-cash-close-anchored rolling daily
-  window. `LEADERBOARD_DAILY_AUTO_DEPLOY` is strict opt-in and must stay that way.
-- **The landing page already has the shape of the hook**: a `Race` section
-  (`landing/src/components/home/Race.tsx`) with a standings table and a
-  leaderboard equity chart — rendering hardcoded `SAMPLE_CURVES`/`SAMPLE_STANDINGS`
-  (`:17-32`) badged "Illustrative" (`:74,107`).
+  enforcement.
+- **Two pieces of dead scaffolding already exist for this feature.**
+  `app.html:1403-1410` renders a permanent empty state — *"Season hasn't started
+  yet. Participating teams will appear here when the contest season opens."* And
+  `#homeGetStartedBtn` (`app.html:411`) has zero JS wiring. Both get filled, not
+  deleted.
+- **Simulated forward execution is nearly assembled.**
+  `domain/trading/execution.py:1-6` is in-memory execution over explicit
+  cash/positions/trades, extracted from the backtester, and `paper_session.py`
+  tracks equity history.
+- **A generic transactional email sender exists.**
+  `infrastructure/email/sender.py:45` — `async send_email(to, subject,
+  text_body)` over Brevo, 84 lines total.
+- **Analytics partly exist.** `@vercel/analytics` ships via `App.tsx:2,30`
+  (`package.json:75`), same-origin on Vercel so no CSP change was needed. It
+  covers landing pageviews and traffic sources — **not** custom funnel events,
+  and **not** `/app`, which does not load the React bundle.
+- **A landing rebuild is close to mechanical.** `landing/README.md:56-63`:
+  `npm run build`, copy content-hashed assets, delete superseded ones, repoint
+  `<script>`/`<link>`, keep four hand-written auth markers. Content hashes are
+  the cache bust — no `?v=`. `test_frontend_bundle_integrity.py` guards the
+  mechanical half in CI.
 
-### Measured cost per entry, one month-window
+### Measured cost per entry
 
-From prod `GET /api/v1/leaderboard`, 160–161 LLM calls each:
+From prod `GET /api/v1/leaderboard`, 160–161 LLM calls over the month window:
 
-| Model | est. cost |
-|---|---|
-| Nemotron 3 Nano 30B | **$0.072** |
-| DeepSeek V4 Pro | $0.756 |
-| Qwen3.7 Plus | $1.593 |
-| Claude Haiku 4.5 | $1.726 |
-| Claude Sonnet 4.6 | $4.941 |
-| Gemini 3.1 Pro Preview | $11.263 |
-| GPT-5.5 | $13.888 |
+| Model | Replay (month, ~160 calls) | Forward (week, ~36 calls) |
+|---|---|---|
+| **Nemotron 3 Nano 30B** | **$0.072** | **~$0.016** |
+| DeepSeek V4 Pro | $0.756 | ~$0.17 |
+| Qwen3.7 Plus | $1.593 | — |
+| Claude Haiku 4.5 | $1.726 | — |
+| Claude Sonnet 4.6 | $4.941 | — |
+| Gemini 3.1 Pro Preview | $11.263 | — |
+| GPT-5.5 | $13.888 | — |
 
-Full board rebuild: **$34.24**. At Nemotron, 100 entrants × 5 attempts is
-**$36/season**; 1000 entrants × 5 is $360.
+Full board rebuild: $34.24.
 
 ### What does not exist
 
 - **No path from a user agent to the board.** The roster is hand-edited
-  `dashboard/config/leaderboard.json`; entries resolve to one of six hardcoded
-  classes in `_STRATEGY_CLASSES` (`registry.py:19-26`); `domain/leaderboard/`
-  contains **zero** references to `external_agents`, `user_id`, `owner_id` or
-  `agent_id`. Publishing today means editing JSON, running a CLI locally, and
-  committing `backtest.db`.
+  `leaderboard.json`; entries resolve to six hardcoded classes in
+  `_STRATEGY_CLASSES` (`registry.py:19-26`); `domain/leaderboard/` contains
+  **zero** references to `external_agents`, `user_id`, `owner_id` or `agent_id`.
 - **No onboarding system of any kind.** No tour library, no `data-step`
-  attributes, no spotlight overlay, no step sequencer. "onboarding" appears only
-  in comments.
-- **No user publish path to Community.** 7 templates, all lab-authored, from
-  static `dashboard/config/marketplace.json`.
-- **`#homeGetStartedBtn`** (`app.html:411`) has zero JS wiring. It is a dead
-  button and has always been one.
+  attributes, no spotlight overlay, no step sequencer.
+- **No email verification at signup.** Every `verif` hit in `users.py` is
+  password checking. An account is free, unverified and instant.
+- **No order submission anywhere.** `submit_order|place_order|create_order`
+  across `domain/trading/` and `infrastructure/brokers/` returns zero hits;
+  `paper_backend.py:1-7` states the Alpaca client is read-only and that live
+  paper trading "needs its own design pass."
+- **No user publish path to the marketplace.** 7 templates, all lab-authored,
+  from static `marketplace.json`.
 
-### Why the two harnesses are not interchangeable
+## Architecture: two loops over one harness
 
-A 30-dimension reconciliation of the house path (`LLMAgentStrategy` via
-`deploy_model_run`) against the user path (`HourlyBacktester` via
-`POST /backtest/run`) found ~10 divergences. Four are individually fatal to
-"just reuse the engine":
-
-1. **No config key reaches the prompt on the house path.** `LLMAgentStrategy`
-   reads only `mode`, `model_id`, `integration`, `reasoning_effort`,
-   `temperature`, `symbols` (`llm_agent.py:47-53, 91-93`) and calls
-   `make_trading_decision_with_llm` with no `strategy_prompt` and no `pipeline`
-   (`llm_agent.py:176-182`), so `create_prompt`'s `custom_prompt` is always
-   `None` and `SAFE_TRADING_PROMPT` (`validator.py:545-664`) is unconditional.
-2. **The paths do not share a template**, so "only the instruction differs" is
-   not expressible. The house sends `SYSTEM_PROMPT` + `SAFE_TRADING_PROMPT`;
-   the pipeline sends `PIPELINE_SYSTEM_PROMPT` + `_build_step_prompt`.
-3. **Capital.** House 10,000 (`service.py:948`); user runs are 422'd above 3,000
-   (`backtests.py:1146-1149`) and clamped again in the worker.
-4. **H6 has no user-side evidence.** The engine computes `llm_decisions` and
-   never reads or persists it; `decision_steps` is never computed at all.
-
-Six further divergences, none previously known, matter for comparability:
-the house fetches bars from `reference_start_date` for indicator warm-up while
-the engine fetches only `[start, end]` (leaving SMA50 immature for the first
-~50 bars of a ≤31-day window); the house bumps the end date `+1 day`; the engine
-applies an 80%-symbol-coverage filter before market hours; the engine passes a
-`market` key into the snapshot the house omits; the engine plumbs no
-`temperature` at all; the house retries 4× with a reasoning-disabled rescue call
-while the pipeline falls back to rule-based on first unparseable response.
-
-## Architecture: two loops
-
-The design does **not** attempt to make one harness serve both purposes.
-
-| | **Loop A — Iterate** (exists, unchanged) | **Loop B — Attempt** (new) |
+| | **Loop A — Iterate** (exists, unchanged) | **Loop B — Compete** (new) |
 |---|---|---|
-| Path | `HourlyBacktester` | `LLMAgentStrategy` |
-| Model | user's choice | Nemotron, `temperature: 0` |
-| Window | ≤31 days, user-chosen | 2026-04-15 → 2026-05-15, warm-up from 2026-03-15 |
+| Driver | `HourlyBacktester` | `LLMAgentStrategy` |
+| Harness | `PortfolioManager` | **the same `PortfolioManager`** |
+| Model | user's choice | pinned per season |
+| Window | ≤31 days, user-chosen | season-defined |
 | Capital | ≤$3,000 | $10,000 |
 | Universe | user-chosen, ≤30 | DJIA-30 |
-| H6 | not enforced | enforced |
-| Cost | existing controls | $0.072, decrements the ledger |
+| H6 integrity | not enforced | enforced |
 | Meaning | rehearsal | **the official score** |
 
 **An attempt is the submission.** There is no separate publish step: spending an
-attempt produces a real contest curve, and the entry's best attempt is what the
-board shows. Entering a season is one explicit action; after that, best-of
-publishes automatically.
+attempt produces a real board curve, and the entry's best attempt is what shows.
 
-**Rationale for not routing the score through the engine** (recorded so it is
-not revisited): doing so requires changing the capital cap, the bar-fetch
-window, the coverage filter and the `market_context` pass, plus adding
-`decision_steps` and persisting `llm_decisions` — five behaviour changes to the
-shipping product path. Raising `MAX_BACKTEST_INITIAL_CAPITAL` from 3,000 to
-10,000 alone breaks `test_agents_api.py:485-494`,
-`test_agent_backtest_allocation.py`, `test_my_agents_capital_ui.py` and the
-frontend clamp at `agent-editor.js:628-660`, and reverses the paper-vs-backtest
-capital invariant established by the earlier My Agents UX round.
+**Rationale for not routing the score through Loop A** (recorded so it is not
+revisited): raising `MAX_BACKTEST_INITIAL_CAPITAL` from 3,000 to 10,000 alone
+breaks `test_agents_api.py:485-494`, `test_agent_backtest_allocation.py`,
+`test_my_agents_capital_ui.py` and the frontend clamp at
+`agent-editor.js:628-660`, and reverses the paper-vs-backtest capital invariant
+established by the My Agents UX round. Loop B also needs the warm-up window and
+the no-coverage-filter timestamp set, neither of which Loop A has.
 
-## The Open Track
+## The two boards
 
-### Two tracks, one Competition page
+### Replay — the qualifier
 
-- **Model Track** — the existing 7 LLM entries and 5 baselines. **Frozen.**
-  Their published curves must not change.
-- **Open Track** — a house reference entry plus all user entries, every one of
-  them produced by the same new function.
+Perpetual, over the existing fixed month. Never resets: a fixed replay's result
+never changes, so resetting would delete history and re-charge everyone to
+reproduce identical curves. One long-lived season id; 5 lifetime attempts per
+account; best attempt published.
 
-The Open Track carries its **own house reference**: one entry run through the
-identical submission path with the house instruction supplied as its
-`strategy_prompt`. This costs $0.072/season and sidesteps the riskiest change in
-the space — giving the existing seven entries an explicit `strategy_prompt`
-would alter what they produce on any re-deploy, break reproducibility of
-published curves, and flip tests across `test_prompts.py`, `test_validator.py`,
-`test_llm_validator.py` and `test_portfolio_manager_move.py`.
+Carries an **Open Track house reference**: one entry run through the identical
+submission path with the house instruction supplied as its `strategy_prompt`.
+This costs $0.072 and sidesteps the riskiest change in the space — giving the
+existing seven entries an explicit `strategy_prompt` would alter what they
+produce on any re-deploy, break reproducibility of published curves, and flip
+tests across `test_prompts.py`, `test_validator.py`, `test_llm_validator.py` and
+`test_portfolio_manager_move.py`.
 
-Comparability inside the Open Track is exact by construction, because every
-entry including the reference goes through one code path.
+### Forward Season — the competition
 
-### Season configuration
+Weekly, Monday open → Friday close, simulated forward execution on real bars.
+The instruction locks when the run begins. Entry requires **at least one
+completed Replay attempt** — Replay is the qualifier in fact, not just in copy.
 
-Seasons live in config, not a table, until there is a second one:
+A nightly job advances each entry's persisted portfolio one trading day, reusing
+`domain/trading/execution.py` and the shape of the existing daily-refresh cron.
+Note the daily leaderboard is **not** reusable as-is: `daily_window_dates()`
+(`service.py:79-91`) returns the last completed weekday as both start *and* end,
+re-running a fresh one-day backtest each night with no portfolio carried across
+days. The Forward Season needs persisted state the daily board deliberately does
+not keep.
+
+**This is simulated, not brokered.** It must not be called "paper trading" in
+the UI: `app.html:847` already has a **Paper Trading** subtab under My Agents,
+and "Paper Trading Allocated Capital (max $3,000)" appears in four places tied
+to reserving cash from My Portfolio. The two must stay distinguishable.
+
+## Season configuration
+
+**Replay lives in config. Forward seasons are derived, not configured.**
+
+A new Forward Season opens every Monday, so hand-editing config weekly would
+mean a deploy per season — unworkable. Forward seasons are computed from a
+template plus date arithmetic, exactly as `daily_window_dates()`
+(`service.py:79-91`) already derives the daily window: `season_id` is
+`fwd-<ISO year>-W<week>`, the window is that week's Monday→Friday, and
+everything else comes from the template. No table, no weekly deploy.
+
+The Replay config:
 
 ```json
 {
-  "season_id": "s1",
-  "label": "Season 1",
+  "season_id": "replay-s1",
+  "kind": "replay",
+  "label": "Replay Qualifier",
+  "perpetual": true,
   "pinned_model": {
     "model_id": "nvidia/nemotron-3-nano-30b-a3b",
     "integration": "openrouter",
@@ -233,18 +293,19 @@ Seasons live in config, not a table, until there is a second one:
               "reference_start_date": "2026-03-15" },
   "initial_capital": 10000,
   "attempts_granted": 5,
-  "house_reference_entry_id": "s1_house_reference"
+  "house_reference_entry_id": "replay_s1_house_reference"
 }
 ```
 
-`attempts_granted` is the single knob governing cost, iteration count and
-throughput. It is deliberately one number.
+The Forward template carries the same shape with `kind: "forward"`,
+`perpetual: false`, no `window` (derived) and no `attempts_granted` (a Forward
+entry is a slot, so the column defaults to 0).
 
-### Data model
+## Data model
 
-Two new tables beside `agent_runs` on the run-history database
-(`AGENT_RUNS_DATABASE_URL`). **No foreign keys to `owner_user_id` or
-`agent_id`**: accounts live behind `USERS_DATABASE_URL` and agents behind
+Three tables beside `agent_runs` on the run-history database
+(`AGENT_RUNS_DATABASE_URL`). **No foreign keys to `owner_user_id` or `agent_id`**:
+accounts live behind `USERS_DATABASE_URL` and agents behind
 `CONTENT_DATABASE_URL`, in different Neon projects. They are opaque strings by
 necessity, and no code path may join across them.
 
@@ -254,10 +315,12 @@ leaderboard_entries
   season_id          TEXT NOT NULL
   owner_user_id      TEXT NOT NULL  -- opaque; different database
   agent_id           TEXT NOT NULL  -- opaque; different database
-  display_name       TEXT NOT NULL
+  alias              TEXT NOT NULL  -- per-season display name; defaults to the
+                                    -- account display name, editable until the
+                                    -- entry's first attempt is submitted
   best_run_id        TEXT           -- FK-in-spirit to agent_runs.run_id
   best_return        REAL
-  attempts_granted   INTEGER NOT NULL
+  attempts_granted   INTEGER NOT NULL DEFAULT 0   -- replay seasons only
   attempts_used      INTEGER NOT NULL DEFAULT 0
   created_at, updated_at
 
@@ -266,172 +329,311 @@ leaderboard_attempts
   entry_id           TEXT NOT NULL
   run_id             TEXT NOT NULL
   attempt_no         INTEGER NOT NULL
+  instruction_text   TEXT NOT NULL      -- the submitted string, snapshotted
   instruction_sha256 TEXT NOT NULL
   total_return       REAL
   h6_passed          INTEGER NOT NULL   -- BOOLEAN on the Postgres twin
+  failure_kind       TEXT               -- NULL | 'h6_rejected' | 'infrastructure'
   created_at
+
+forward_positions                       -- forward seasons only
+  entry_id           TEXT NOT NULL
+  as_of_date         TEXT NOT NULL
+  cash               REAL NOT NULL
+  positions_json     TEXT NOT NULL
+  equity             REAL NOT NULL
+  PRIMARY KEY (entry_id, as_of_date)
 ```
 
-The `h6_passed` type divergence is called out explicitly because
-`test_store_twin_parity.py` compares column *names* only and will not catch it.
+Three notes:
+
+- **`instruction_text` is not optional.** A hash is one-way; without the text you
+  cannot re-run an entry, show a user what they submitted, or perform the
+  graduation hand-off. The previous draft stored only the hash.
+- **`failure_kind` must be set at the point of failure**, never inferred later
+  from a null return. Per the fail-closed lesson in `CLAUDE.md`, the dangerous
+  version is the one where "rejected on integrity" and "OpenRouter 502" look
+  identical.
+- **The `h6_passed` type divergence is called out explicitly** because
+  `test_store_twin_parity.py` compares column *names* only and will not catch it.
 
 One entry per user per season. `attempts_granted`/`attempts_used` **is** the
-credit ledger: a season grants, a submission decrements, and a future billing
+credit ledger v0: a season grants, a submission decrements, and a future billing
 path tops up — same table, no migration.
 
-`instruction_sha256` gives the integrity signal for free. Two attempts sharing a
-hash were re-runs, not iterations, so the entry detail can honestly show
-"5 attempts · 3 distinct instructions" without banning anything.
+## Submission path
 
-### Submission path
-
-Six changes, modelled on the reconciliation's recommended shape:
-
-- **C1 — `LLMAgentStrategy` accepts an instruction.** In
-  `llm_agent.py:47-81` add
-  `self.strategy_prompt = (self.config.get("strategy_prompt") or "").strip() or None`,
+- **C1 — `LLMAgentStrategy` accepts an instruction.** Add
+  `self.strategy_prompt = (self.config.get("strategy_prompt") or "").strip() or None`
   and pass `strategy_prompt=self.strategy_prompt` at `llm_agent.py:176-182`.
   `make_trading_decision_with_llm` already declares the parameter
-  (`portfolio_manager.py:243`) and already threads it (`:463`). No downstream
+  (`portfolio_manager.py:233`) and already threads it (`:453`). No downstream
   signature changes.
-- **C2 — deliberately void.** The reconciliation proposed giving both sides a
-  shared template so house and user entries differ only by instruction. This
-  design **rejects that** in favour of the Open Track house reference above:
-  the existing seven entries are not touched, and comparability is achieved
-  within the Open Track instead of across both tracks. The number is retained
-  so this spec maps 1:1 onto the source analysis.
+- **C2 — deliberately void.** The source reconciliation proposed giving both
+  sides a shared template so house and user entries differ only by instruction.
+  This design rejects that in favour of the Open Track house reference: the
+  existing seven entries are not touched, and comparability is achieved within
+  the Open Track. The number is retained so this spec maps onto the analysis.
 - **C3 — one submission entry point.** A new `deploy_user_entry(...)` in
   `domain/leaderboard/service.py`, modelled on `deploy_model_run`
-  (`service.py:926-1041`). It builds a config dict carrying the season's pinned
-  model plus `strategy_prompt`, calls the unchanged `get_strategy()`
-  (`registry.py:37-47`), and **reuses `service.py:979-989` and `:996-1013`
-  verbatim** for bar fetching, warm-up, the run, counters and the H6 guard.
-  Capital, window, warm-up, the `+1 day` bump, the no-coverage-filter timestamp
-  set and integrity all come for free because it is literally the same code.
+  (`service.py:926-1041`). It builds a config carrying the season's pinned model
+  plus `strategy_prompt`, calls the unchanged `get_strategy()`, and **reuses
+  `service.py:979-989` and `:996-1013` verbatim** for bar fetching, warm-up, the
+  run, counters and the H6 guard. Capital, window, warm-up, the `+1 day` bump,
+  the no-coverage-filter timestamp set and integrity all come for free because
+  it is literally the same code.
 - **C4 — pin what was submitted.** `_llm_run_metadata` (`service.py:894-921`)
-  gains `agent_id`, `season_id` and `strategy_prompt_sha256`. Without this a
-  published curve cannot be attributed to the string that produced it.
+  gains `agent_id`, `season_id` and `strategy_prompt_sha256`.
 - **C5 — an authenticated ingress.** A new owner-authenticated, rate-limited
   route in `api/routers/leaderboard.py`, returning 202 and queueing, following
-  the existing `/daily/refresh` shape (`:52-106`).
-- **C6 — leave the engine alone.** No changes to `HourlyBacktester`,
+  the existing `/daily/refresh` shape.
+- **C6 — leave Loop A alone.** No changes to `HourlyBacktester`,
   `MAX_BACKTEST_INITIAL_CAPITAL`, the fetch window or the coverage filter.
+- **C7 — collapse the one-step pipeline into `strategy_prompt`.** At submission,
+  read `pipeline[0]["prompt"]` and pass it as `strategy_prompt`; **reject any
+  entry with `len(pipeline) != 1`**. This is what makes "season entries are a
+  single instruction" an enforceable validation rather than a copy promise, and
+  it keeps user entries on the same `SAFE_TRADING_PROMPT` path as the house
+  reference. The step's `outputFormat` is **ignored** — the UI must say so,
+  because silently dropping a field the editor displays is exactly what produces
+  "the leaderboard is broken" reports.
+- **C8 — forward advance job.** A daily job that loads each active forward
+  entry's `forward_positions` row, fetches the day's bars, runs the pinned model
+  over that day's steps, executes via `domain/trading/execution.py`, and writes
+  the next row. Idempotent on `(entry_id, as_of_date)`.
 
-### Integrity
+## Integrity, abuse and spend
 
-H6 applies unchanged and for free, because C3 reuses the guard call site.
+### H6
+
+Applies unchanged and for free, because C3 reuses the guard call site.
 `_reject_if_llm_fallback` (`service.py:833-892`) rejects an entry whose model
 drove under `MIN_LLM_DECISION_COVERAGE = 0.95` of steps, keyed on
 `llm_decisions` (success-exit counter) rather than `llm_calls` (billing
-counter). A failed attempt still decrements the ledger and is recorded with
-`h6_passed = 0`; it simply cannot become `best_run_id`.
-
-Evidence this is survivable on a nano model: the house Nemotron entry is
-published on the live board, so it cleared H6 through this same harness.
+counter). Evidence this is survivable on a nano model: the house Nemotron entry
+is published on the live board, so it cleared H6 through this same harness.
 
 `allow_fallback` must remain absent from every HTTP surface, as it is today.
 
-### Cost and throughput
+### Refunds
 
-Cost is bounded by construction: `attempts_granted × entrants × $0.072`.
+- **H6 rejection does not refund.** An instruction that makes a nano model emit
+  unparseable output *is* a worse instruction, and refunding removes the only
+  pressure toward instructions the model can follow. Recorded with
+  `h6_passed = 0`, `failure_kind = 'h6_rejected'`; it can never become
+  `best_run_id`.
+- **Infrastructure failure refunds.** `failure_kind = 'infrastructure'`
+  increments nothing.
 
-Throughput is **not** solved by this design and is flagged for the plan.
-Attempts do not contend with the engine's process-wide `backtest_status["running"]`
-flag, but ~500 runs/season at 2–4 minutes each is roughly 25 hours serialized.
-These are I/O-bound LLM calls, so modest concurrency (3–4 workers) is the
-obvious answer, but issue **#202** reports blocking sync I/O on exactly the
-leaderboard routes and the agent-scale investigation measured throughput
-collapsing under load. The design is a FIFO queue with the position shown to the
-user; **the worker count must be settled against #202 during planning, not
-guessed here.**
+### Abuse
+
+Signup is free, instant and unverified today, while each attempt spends real
+money. Ten accounts is ten minutes of work; a script makes it a thousand.
+
+- **Email verification at account creation.** Reuses the Brevo code flow built
+  for the email-change feature. **Existing accounts are grandfathered as
+  verified** — forcing verification on next login would lock out real accounts
+  in the prod database. This makes `BREVO_API_KEY` a hard signup dependency
+  (see Deploy prerequisites).
+- **A hard global spend ceiling**, `LEADERBOARD_MONTHLY_BUDGET_USD`, default
+  **$50**, checked before dequeue and refusing with a clear user-facing message
+  rather than failing silently. Verification raises the cost of abuse; it does
+  not eliminate it. The precedent is on this repo — a public anonymous GET in
+  PR #325 triggered seven billable LLM deploys, inside pytest.
+- Additional per-run authorization checks may later be added at the
+  auth/authz layer ahead of every backtest and paper-trading run; this design
+  does not preclude them.
+
+### Cost model at scale
+
+Free tier: **5 lifetime Replay attempts + 1 Forward entry per week.**
+
+| Policy | At 100 users | At 500 users |
+|---|---|---|
+| Replay, 5 lifetime | $36 one-time | **$180 one-time** |
+| Forward, 1 entry/week | ~$7/month | **~$34/month** |
+| *(rejected)* Replay +1/day refill | ~$216/month | ~$1,080/month |
+
+A daily Replay refill was considered and rejected: it is 97% of total spend and
+buys a return-visit mechanic the Forward Season and weekly email already
+provide. Daily refills become the first thing credits buy once billing exists —
+which is the shape the ledger was designed for.
+
+**Contingency:** if the Phase 0 probe forces the pinned model to DeepSeek V4
+Pro, every figure multiplies ~10.5× and the free tier at 500 users becomes
+~$1,890. **The budget holds and the grant shrinks** (5 lifetime Replay attempts
+→ 1; Forward stays weekly).
 
 ## The board
 
 Default visible series, never more than 5–8 lines:
 
-1. Buy & Hold / DJIA baseline — the real question; 6 of 7 house models lost to it
-2. The Open Track house reference — the bar being challenged
-3. Top 3 Open Track entries
-4. **The signed-in user's own entry, pinned unconditionally**, at any rank
+1. DJIA / buy-and-hold baseline — the honest bar
+2. The seven house models as a **thin, grey, unlabelled cluster** — "the models
+   we tried"
+3. The Open Track house reference — the specific number being challenged
+4. Top 3 entries
+5. **The signed-in user's own entry, pinned unconditionally**, at any rank
 
-Everything else remains available but hidden. This is a **default-selection
+Everything else stays available but hidden. This is a **default-selection
 policy, not a charting feature**: it decides the initial contents of the
-existing `hiddenSeries` set, which the existing curve picker and custom legend
-already manage.
+existing `hiddenSeries` set, which the curve picker and custom legend already
+manage.
 
 Pinning the user's own curve is deliberate. Top-N-only means most entrants see a
 chart they are absent from, which is the moment they stop caring.
 
-**Rank against the baseline, not only against each other.** Because Season 1
-pins a model whose house result is `-0.22%`, the board will accumulate entries
-that beat the house and still lose to buy-and-hold. Show return *and* a
-"beat the market" marker so a win cannot quietly mean "lost money slower than a
-bad model did".
+**Rank against the pinned model's house curve as the headline; show
+beat-the-market as a separate, scarce badge.** Season 1 pins a model whose house
+result is `-0.22%`, so the board will accumulate entries that beat the house and
+still lose to buy-and-hold — and it is likely that most of the field loses to
+buy-and-hold, since six of seven house models already do. Headlining
+"+1.4% vs. the house instruction" stays truthful when the field underperforms;
+headlining a market-beating claim would not. **We are not in the business of
+implying the market is easy to beat.**
+
+Labels must distinguish *a different model* from *a different instruction*, or
+"beat them" is ambiguous once both tracks share a chart.
 
 **Not in v1:** a percentile band for the hidden field. Correct at 500 entries,
-speculative at 12; the curve picker already surfaces any individual line.
+speculative at 12.
+
+## Information architecture
+
+The Competition tab keeps its four subtabs (`app.html:1396-1401`), remapped:
+
+| Subtab | Today | After |
+|---|---|---|
+| Daily Leaderboard | rolling 1-day model board | unchanged |
+| Competition Leaderboard | frozen contest board | **season board** with a Replay / Forward switch |
+| Participating Teams | permanent empty state | **Participating Traders** — the entrant list, finally populated |
+| About | contest rules | + season rules |
+
+Two renames, no new navigation. **"Teams" becomes "Traders"** in user-visible
+copy — each entrant is one person. Note the styling layer keeps `kind: 'team'`
+and `TEAM_COLOR_PALETTE` internally; that is deliberate (renaming the series kind
+would churn `js/leaderboard.js` for no user-visible gain), but it means the word
+persists in code while the UI says "trader".
+
+The Replay/Forward switch reuses the interaction shape of the existing `%`/`$`
+toggle.
+
+## Isolation contract
+
+**Boards must not be able to break each other.** Binding requirements:
+
+1. **Separate endpoints per board**, not one combined payload.
+2. **Each landing section fetches its own data** and renders its own empty/error
+   state. One failed fetch must not blank the page.
+3. **A server-side kill switch per board** — two env-backed booleans making the
+   board's endpoint return a *disabled* payload the frontend renders as a
+   maintenance state. Designing the disabled state matters: an unhandled backend
+   exception escapes `CORSMiddleware` un-headered and presents in the browser as
+   a CORS error, so "we turned it off" and "it is broken" would otherwise look
+   identical at exactly the moment they must be told apart.
+4. **Separate queue paths**, so a Replay queue backup cannot stall the Forward
+   advance job.
+
+A consequence: swapping which chart leads the landing page is a **one-line move**
+in `landing-page.tsx:18-22` plus the standard bundle refresh. No swap mechanism
+is built — building one would be more complex than the swap.
 
 ## The funnel
 
 ### Landing
 
 Wire the existing `Race` section to `GET /api/v1/leaderboard`, following the
-fetch pattern `MarketTicker.tsx:13-19,77-117` already establishes. Two
-constraints: remove the "Illustrative" badge once the data is real, and fetch
+fetch pattern `MarketTicker.tsx:13-19,77-117` establishes. Remove the
+"Illustrative" badges (`Race.tsx:74,107`) once the data is real, and fetch
 same-origin through the Vercel rewrite rather than hardcoding
-`agentictrading.onrender.com` as `MarketTicker` does.
+`agentictrading.onrender.com`.
 
-CTA copy derives from the platform's own result: *"Our instruction lost 0.22%
-with this model. Write a better one."*
+**Layout:** move `Race` directly under the hero (it is currently section 5 of 5,
+immediately before `FooterCTA`). Above the chart, a **Forward Season status
+strip** — *"Season 12 · day 3 of 5 · 44 traders"* or *"Next season opens
+Monday"* — which doubles as the between-seasons CTA. Below the Replay chart, the
+Forward chart as its own clearly-labelled section. When Forward proves out, the
+two sections swap by reordering one line.
 
-Shipping note: `Race.tsx` is Vite/React source but the served page is
-hand-patched HTML carrying ~390 lines of auth code with no React counterpart.
-The refresh is `npm run build` → copy hashed assets → hand-edit the script/link
-hashes → preserve the four auth blocks verbatim, per
-`dashboard/landing/README.md:31-81`, guarded mechanically by
-`test_frontend_bundle_integrity.py`.
+`Race.tsx` draws with **recharts** (`:3-12`), not Chart.js. The landing board is
+therefore a second implementation; none of `js/leaderboard.js`'s custom legend,
+endpoint labels or tiering transfers. Accept the divergence for v1, but hold the
+visual grammar constant — dashed grey baseline, bold entry lines — so it reads
+as one product.
+
+Copy: *"Most models lost to buy-and-hold. Can you beat them with a better
+instruction?"* — "instruction" rather than "strategy", both because it is what
+the editor already calls it (`label: "Trading instruction"`) and because
+`domain/strategies/` is an existing product noun.
+
+Renumber `Talk`/`Test` to 01/02 and make the board an unnumbered frame above
+them. **This copy is Allan's** (`storyline.ts`, `WhyCare.tsx:5`,
+`FooterCTA.tsx:10`) and needs his sign-off.
 
 Post-signup redirect is unchanged: `/app?view=agents` with `nav-state`
-pre-seeded (`index.html:307-328`).
+pre-seeded — plus a verification interstitial (see Abuse).
 
 ### Onboarding
 
 **A guided tour is explicitly rejected.** Tours explain the UI, but the observed
-problem is that users do not know the goal; tours are stateless once dismissed,
-so they do nothing for the user who leaves and returns; and the repo has zero
-tour infrastructure, so it would mean building a spotlight/positioning framework
-from scratch.
+problem is that users do not know the goal; tours are stateless once dismissed;
+and the repo has zero tour infrastructure.
 
 Instead, a **persistent Season checklist card** pinned at the top of My Agents —
 a card in the existing shelf renderer, not an overlay framework:
 
 ```
-Season 1 · Nemotron 3 Nano                        5 attempts left
+Replay Qualifier · Nemotron 3 Nano                5 attempts left
 The house instruction lost 0.22%. Beat it.
 
   [x] Your starter agent is ready
   [ ] Write its trading instruction        [ Configure ]
-  [ ] Run an attempt on the season window  [ Run attempt ]
+  [ ] Run a qualifying attempt             [ Run attempt ]
 ```
 
-In Phase 1 the third step renders disabled with `Season 1 opens soon`; see
-Rollout.
-
 On first successful attempt it collapses into a permanent season HUD —
-`Season 1 · rank 34 of 112 · 3 attempts left` — so it never becomes dead weight.
+`Replay · rank 34 of 112 · 3 attempts left · Forward Season opens Monday` — so it
+never becomes dead weight.
 
-The checklist and the credit ledger are the **same state object**: the card
-renders `attempts_remaining`, the integrity rule enforces it, and future billing
-tops it up. Because it is server-side it survives the browser change that
-today's `localStorage` onboarding guard (`ensureDefaultFoundationAgent`,
+The checklist and the ledger are the **same state object**: the card renders
+`attempts_remaining`, the integrity rule enforces it, and future billing tops it
+up. Being server-side, it survives the browser change that today's
+`localStorage` onboarding guard (`ensureDefaultFoundationAgent`,
 `app.js:1703-1776`) does not.
 
-One additional surface: a single welcome screen shown once after signup, stating
-the goal in a sentence with a button that scrolls to the checklist. One screen,
-not a sequence. The auth-modal pattern in `index.html` is the model to copy.
+Attempts must show **used, remaining, and that a started run cannot be
+cancelled**, stated before submission rather than discovered after.
+
+One welcome screen shown once after signup, stating the goal in a sentence with
+a button that scrolls to the checklist. One screen, not a sequence.
 
 **Fix while here:** wire `#homeGetStartedBtn` (`app.html:411`) to the checklist,
-or remove it. It currently does nothing.
+or remove it.
+
+### Submission surface
+
+A **"Submit to Season"** action on the agent configuration page, enabled only
+when the agent has exactly one pipeline step and disabled with a stated reason
+otherwise — which is also how future multi-step agents will present. Submission
+**snapshots** the instruction into the attempt row; referencing the live agent
+would let a Wednesday edit silently change a curve that is mid-flight.
+
+While an attempt runs, the user sees **queue position and estimate**, not a
+blocking modal, reusing the progress presentation My Agents backtests already
+have.
+
+### Graduation
+
+On any completed attempt, the entry detail offers *"run this instruction on your
+own model and universe"* — one click from the frozen season into Loop A, which
+already exists. **Carry the instruction text only**, everything else at Loop A
+defaults, with copy stating the difference outright: *"Different engine and
+capital — this will not reproduce your season score."*
+
+Carrying window/universe/scaled-capital instead was considered and rejected: it
+looks more helpful and quietly implies a comparability that does not exist, so
+the first user who gets a different number reasonably concludes the leaderboard
+is broken.
 
 ### Community → Agent Marketplace
 
@@ -442,95 +644,181 @@ asserts they match, and passes if both move.
 
 **Do not rename** the `community` page key, `#communityView`, `NAV_VIEW_MAP`
 entries or the `nav-state` localStorage value: live bookmarks break for no
-user-visible gain. Note that `?view=marketplace` already exists as a legacy
-alias pointing at `community`, so the rename makes the legacy alias the accurate
-one.
+user-visible gain. `?view=marketplace` already exists as a legacy alias, so the
+rename makes the legacy alias the accurate one.
 
-A user publish path is **out of scope for v1**. The competition creates the
-natural demand for it ("publish my season entry as a template"), so it lands
-better as v1.1 with a real corpus than as empty scaffolding now.
+A user publish path is out of scope for v1. The competition creates the natural
+demand for it, so it lands better as v1.1 with a real corpus.
+
+## Measurement
+
+Two systems with separate jobs:
+
+- **Vercel Analytics** (already shipped) — acquisition: pageviews, traffic
+  sources, landing behaviour.
+- **A first-party event beacon** to the backend — the funnel, on both surfaces.
+  Permitted by both CSPs' `connect-src` without any change, $0, and unaffected
+  by the ad-blocking that a quant-adjacent academic audience does at high rates.
+
+Exactly six events: `landing_view`, `board_interact`, `cta_click`,
+`signup_complete`, `instruction_saved`, `attempt_submitted`. They answer every
+Phase 1 question and nothing more.
+
+**Acquisition channel:** the professor's and lab's academic network, plus the
+existing Discord. One channel, designed for deliberately.
+
+**Share artifacts:** a static site-wide `og:image` immediately (today
+`index.html:12` requests `summary_large_image` and supplies none — the worst of
+both), then a client-side canvas "download your result card" with Phase 3.
+Dynamically rendered per-entry OG images are **rejected**: Render's free tier
+spins down and link-preview crawlers abandon in seconds, so most first shares —
+exactly when the link matters — would render nothing.
+
+## Notifications
+
+One email at Friday close: *"Season 12 closed. You placed 8th of 44. Next season
+opens Monday."* Built on `send_email` (`sender.py:45`). Requires an opt-out from
+the start. `send_email` is `async` while ATL routes must stay sync `def`
+(#292), so it is called from the cron path, never from a request handler.
+
+Discord posting of weekly top entries is **deferred but designed for**: the
+notification layer takes a channel abstraction with email implemented and
+Discord stubbed, so adding it later is a new channel rather than a refactor.
 
 ## Non-goals
 
-- Live paper trading, real-time execution, or any broker order submission.
-  `execution/paper_backend.py` stays a stub.
+- Broker-backed live paper trading, real-time execution, or order submission.
+  `execution/paper_backend.py` stays a stub. The Forward Season is **simulated**
+  and does not depend on it.
 - Real capital. Ever, on this surface.
 - Changing the published Model Track curves.
 - Raising `MAX_BACKTEST_INITIAL_CAPITAL`.
-- A credit/billing system. The ledger shape anticipates it; pricing is out of
-  scope.
+- A credit/billing system. The ledger anticipates it; pricing is out of scope.
+- Multi-step pipelines as season entries.
 - A user publish path into the marketplace.
 - Percentile/field bands on the chart.
+- A runtime chart-swap mechanism.
 
 ## Verification
 
 - **H6 on the new insert path.** The guard's docstring states it is applied on
   *both* insert paths; `deploy_user_entry` makes a third. `test_deploy_guard.py`
-  needs the mirror coverage cases or an entry can bypass integrity.
-- **Postgres twins for both new tables.** They sit on the run-history database,
-  so both `BacktestDatabase` and `PostgresBacktestDatabase` need implementations,
-  enforced by `test_store_twin_parity.py`. That guard parses source text, so it
-  cannot see f-string DDL and compares column *names* only — `NOT NULL`
-  divergence is invisible and must be checked by hand.
+  needs mirror coverage or an entry can bypass integrity.
+- **Postgres twins for all three new tables**, enforced by
+  `test_store_twin_parity.py`. That guard parses source text, so it cannot see
+  f-string DDL and compares column *names* only — `NOT NULL` divergence is
+  invisible and must be checked by hand.
 - **Route-contract freeze golden sets updated in the same commit as C5**, or
   every open PR reddens. Per-router and full-app freezes drift independently.
-- **Frontend copy guards** for the checklist and CTA strings, following the
-  existing `tests/_frontend_source.py` pattern.
-- **Cache-buster bumps** for every touched frontend asset (`app.js?v=`,
-  `js/leaderboard.js?v=`, `styles.css?v=`), each versioned independently.
-- Cost assertion: a test pinning the season's pinned model to the config, so a
-  silent switch to a frontier model cannot multiply spend 190x unnoticed.
+- **`len(pipeline) != 1` rejection** tested at the API boundary, not only the UI.
+- **Spend-ceiling test**: the dequeue refuses past the ceiling and the refusal is
+  visible, not silent.
+- **A pinned-model assertion**, so a silent switch to a frontier model cannot
+  multiply spend 190× unnoticed.
+- **Isolation tests**: each board's endpoint disabled independently, and the
+  frontend renders the maintenance state rather than a blank page.
+- **Frontend copy guards** for the checklist and CTA strings, following
+  `tests/_frontend_source.py`.
+- **Cache-buster bumps** for every touched frontend asset, each versioned
+  independently. The landing bundle needs none — content hashes are the bust.
 
-### Deploy prerequisites
+## Deploy prerequisites
 
+- **`BREVO_API_KEY` + `ACCOUNT_EMAIL_FROM` become required for signup**, not
+  just for email changes. Unset, account creation fails. This is a change in
+  severity and must be set before the verification gate merges.
 - **`OPENROUTER_API_KEY` must be set in the Render dashboard.** Nemotron is the
   only board entry not on CommonStack, and OpenRouter is never auto-selected
   (`providers/__init__.py:11`). Unset, submissions silently fail.
-- `LEADERBOARD_DAILY_AUTO_DEPLOY` stays strict opt-in. Never restore any
-  default that enables it implicitly.
+- `LEADERBOARD_MONTHLY_BUDGET_USD` — default $50.
+- Two board kill-switch booleans.
+- `LEADERBOARD_DAILY_AUTO_DEPLOY` stays strict opt-in. Never restore any default
+  that enables it implicitly.
 - Render env writes are single-key PUT only; a bulk PUT wipes the list, and they
-  do not trigger a redeploy.
+  do **not** trigger a redeploy — so a ceiling change takes effect on next
+  deploy, not immediately.
 
 ## Rollout
 
-**Phase 1 — display only.** Ship the board changes, the landing wiring, the CTA,
-the welcome screen and the checklist, with **only the house reference entry**
-present. Total cost: **$0.072**.
+Each phase is a **separate PR**, and each must be independently shippable and
+independently disableable.
 
-The checklist ships in a **preseason state**: steps 1 and 2 (starter agent,
-write the instruction) are live and fully actionable; the attempt step renders
-disabled with `Season 1 opens soon` and a working email-notify or Discord link.
-This is the honest version — a checklist whose final step silently does nothing
-is exactly the dead-CTA failure this design is fixing (`#homeGetStartedBtn`).
+**Phase 0 — the probe. A gate, not a phase.** C1 plus six deliberately opposite
+instructions (aggressive momentum, defensive cash-heavy, equal-weight
+buy-and-hold, contrarian mean-reversion, verbose-analytical, and one nonsense
+control) run through `deploy_model_run` on **two models**: Nemotron and DeepSeek
+V4 Pro. Total **$4.97**. Needs `OPENROUTER_API_KEY` locally.
 
-What Phase 1 therefore proves: whether the board and CTA convert a visitor into
-a signup, and whether a signed-up user reaches a written instruction. What it
-cannot prove: attempt throughput, H6 pass rates on user instructions, or queue
-behaviour.
+The entire design rests on an unverified assumption — that better instructions
+produce better returns on a 30B nano model whose prompt is dominated by an
+unconditional `SAFE_TRADING_PROMPT`. If the spread across genuinely opposite
+instructions is under ~1pp on Nemotron but not DeepSeek, pin DeepSeek and apply
+the contingency above. **If both are flat, the instruction axis does not exist
+and Phase 2 must not be built.**
 
-**Phase 2 — open attempts.** Ship C1/C3/C4/C5, the two tables and the queue.
-The checklist's third step activates; nothing else about it changes.
+The five non-control instructions become the seed field, so this spend also
+solves the cold-start problem below.
 
-This ordering is deliberate: every expensive or corrupting failure mode
-(queue thrash, H6 rejections, unbounded spend) lives on the attempt path, while
-everything that reveals whether the hook converts lives on the display path.
+**Phase 1 — evidence and measurement.** **C1 only**, plus the six seed entries
+(house reference + the probe's five non-control instructions) added as
+`leaderboard.json` config entries carrying `strategy_prompt` — **no new tables,
+no ingress, no queue**. Hero chart on real data, `Race` promoted above the fold,
+seeds **visibly labelled house-authored**, the first-party beacon, static
+`og:image`, CTA copy, Community→Agent Marketplace rename, "Teams"→"Traders".
+No user entries yet.
 
-## Open items
+**Incremental cost: ~$0.** The six curves are the Nemotron half of the Phase 0
+probe; C1 is what makes a config entry able to carry an instruction at all, so a
+seed and a probe run are the same object. Regenerating them costs $0.43.
 
-1. **Attempt worker concurrency** — settle against #202 during planning.
-2. **`attempts_granted` value** — 5 assumed throughout; confirm before build.
-3. **Entry display names** — whether entries show account display name, a
-   chosen alias, or are anonymous by default. Affects moderation surface.
-4. **Season 1 dates** — whether to keep the current contest window or pick a
-   window outside the pinned model's training data.
+A board with one entry is not a board, which is why the seeds matter: the
+Open Track would otherwise ship containing only the house reference, in the
+phase whose entire purpose is testing whether the board converts. Seeds are
+config-driven house entries, not database rows — the committed `backtest.db` is
+the prod database, so seeding by committing rows is not an option.
+
+**Phase 2 — the Replay qualifier.** C3/C4/C5/C7 (C1 shipped in Phase 1),
+`leaderboard_entries` and `leaderboard_attempts` with their Postgres twins, the
+attempt ledger, email verification at signup, the checklist, the Submit action,
+the queue (**two workers**, one env var, redeploy to change), graduation.
+
+Two concurrent workers rather than the three or four originally floated: issue
+**#202** reports blocking sync I/O on exactly the leaderboard routes, and the
+agent-scale investigation measured throughput collapsing under load. Starting at
+two makes the first real measurement cheap to recover from.
+
+**Phase 3 — Forward Seasons.** C8, `forward_positions` and its twin, derived
+weekly seasons, the Friday result email with opt-out, the share-card download,
+the notification channel abstraction with Discord stubbed.
+
+Ordering is forced, not chosen: Forward entry is gated on a completed Replay
+attempt, so Phase 3 cannot precede Phase 2.
+
+**Watch item:** Phase 1 is the only phase shipping without users being able to
+act. If Phase 0 comes back strong, consider collapsing 1 and 2 — a hero chart
+with a CTA leading to a season nobody can enter is the `#homeGetStartedBtn`
+failure at the largest scale yet.
+
+## Recorded assumptions
+
+Stated rather than left implicit; correct any that are wrong before planning.
+
+1. **Existing prod accounts are grandfathered as verified.**
+2. **Forward seasons source bars from Alpaca**, same as Replay.
+3. **The Daily Leaderboard is untouched** by this work.
+4. **`attempts_granted = 5`** for the Replay qualifier, lifetime.
+5. **Replay keeps the current window** (`2026-04-15 → 2026-05-15`) — its
+   look-ahead exposure is acceptable because Forward is the competitive board.
+6. **The pinned model survives Phase 0.** If not, the contingency applies.
 
 ## References
 
 - Central DB: `knowledge/opt-employment-2026.md` § "The 2026-08-08 Pivot" —
   professor's goal, nof1 competitive research, verified-unbuilt scope.
 - Central DB: `decisions/2026-08.md`, entry 2026-08-08.
-- `docs/superpowers/specs/2026-08-05-asset-class-shelves-design.md` — shelf
-  rendering the checklist card sits inside.
+- `docs/superpowers/specs/2026-08-05-asset-class-shelves-design.md` — the shelf
+  renderer the checklist card sits inside.
 - PR #325 (`45ccbc0`) — daily refresh cron and status UI.
 - PR #326 — open at time of writing, touches `js/leaderboard.js`; rebase onto it.
-- Issues #145 (scheduler), #202 (event-loop blocking), #230 (`decide()` seam).
+- Issues #145 (scheduler), #202 (event-loop blocking), #230 (`decide()` seam),
+  #258 (run cancellation).

--- a/docs/superpowers/specs/2026-08-09-participatory-competition-design.md
+++ b/docs/superpowers/specs/2026-08-09-participatory-competition-design.md
@@ -43,6 +43,29 @@
 > files they point into have since moved (`js/leaderboard.js` alone went 1,037 →
 > 1,600 lines). Re-verify any reference before acting on it; the surrounding
 > claims were checked at reconciliation and hold.
+>
+> ### Where authority now lives
+>
+> This document is no longer the only design doc covering these boards, and on the
+> boards' own UI and payload contract it is **not** the authority:
+>
+> - **`docs/superpowers/specs/2026-08-15-live-trading-leaderboard-ui.md`** — the
+>   newer spec, written alongside #352. It owns the Live Trading UI, the proposed
+>   payload contract, the preview state and the settled data-feasibility question.
+>   Where the two documents disagree about *the boards*, that one wins. This
+>   document remains the authority on **user entry** — the attempt ledger, the
+>   submission path, integrity and spend — which that one explicitly places out of
+>   scope.
+> - **Issue #354** — build the Live Trading season engine. This is C8, already
+>   filed with the invariants and the `AGENT_RUNS_DATABASE_URL` placement. **Do not
+>   file a second issue for C8**; the §Rollout note below proposing it be split out
+>   ahead of Phase 2 is a scheduling argument to make *on #354*.
+> - **Issue #355** — the two frontier questions the 2026-08-15 grilling left open.
+>   It states outright that both **block this PR and Phase 2**: whether the
+>   qualifier gate survives now that the practice board is unranked, and whether
+>   `instruction_sha256` config-freeze means anything for user-owned, editable
+>   entries. Neither is resolved here, and neither should be resolved by inference
+>   from this document's older framing.
 
 ## Goal
 
@@ -374,8 +397,28 @@ constrain Phase 3, and three of them are guarded by tests that will fail loudly:
    `trading_days_total`. An advance engine emitting a different total will render
    a progress bar that disagrees with the chrome.
 
+#### Seasons reset — a decision made after this document and adopted here
+
+`2026-08-15-live-trading-leaderboard-ui.md`, decision 3: **every season resets.
+Entries do not carry across seasons; joining is a per-season decision.** That
+document records it as the cost control — perpetual entries would bill every
+signup ever, every night, forever.
+
+This is *compatible* with what this spec already said ("Live Trading is a slot,
+not a ledger") and makes it sharper: a slot is per-season by construction, so
+there is no carry-forward state to design and no lifetime grant to track on this
+board. Two consequences to carry into Phase 3 rather than rediscover:
+
+- The §Cost model figure of "1 entry per season" is now a *structural* property,
+  not a policy that could be relaxed. Relaxing it re-introduces the unbounded
+  nightly bill that decision 3 exists to prevent.
+- Re-entry each season is the return-visit mechanic. That partially answers the
+  watch item in §Cost model about the two-week gap — the user has to come back to
+  re-enter, which a perpetual entry would not require.
+
 **Consequence for sequencing:** C8 is currently the only thing standing between
-prod and Season 1 of a board users can already open. See §Rollout.
+prod and Season 1 of a board users can already open. Tracked as **issue #354**.
+See §Rollout.
 
 ## Season configuration
 
@@ -1047,6 +1090,9 @@ Competition attempt, so Phase 3 cannot precede Phase 2.
 > makes that shipped board real — and it needs no user entries, no attempt
 > ledger, and nothing from Phase 2 to run against the existing house roster.
 >
+> **Already filed as issue #354** — make the scheduling argument there rather
+> than opening anything new.
+>
 > **Consider splitting C8 out and landing it before Phase 2.** The gating
 > argument ("Live Trading entry requires a completed Competition attempt") is
 > about *user entry*, and C8 with a house-only roster has no users in it. Landing
@@ -1114,5 +1160,10 @@ Stated rather than left implicit; correct any that are wrong before planning.
   preview, Daily Leaderboard tab retired and its cron paused.
 - **PR #357 (`60fa01f`, merged 2026-08-15)** — leaderboard-first landing and
   `/app` home; added `BoardPreview.tsx` and the "Illustrative example" guard.
+- **`docs/superpowers/specs/2026-08-15-live-trading-leaderboard-ui.md`** — the
+  newer board-side spec; authoritative on the Live Trading UI and payload
+  contract. See "Where authority now lives" at the top of this document.
+- **Issues #354** (season engine = C8) and **#355** (qualifier gate and
+  `instruction_sha256` scope — both stated to block this PR and Phase 2).
 - Issues #145 (scheduler), #202 (event-loop blocking), #230 (`decide()` seam),
   #258 (run cancellation).

--- a/docs/superpowers/specs/2026-08-09-participatory-competition-design.md
+++ b/docs/superpowers/specs/2026-08-09-participatory-competition-design.md
@@ -1,0 +1,536 @@
+# Participatory competition: an Open Track users can enter
+
+**Date:** 2026-08-09
+**Status:** Design approved, pending implementation plan
+
+## Goal
+
+Give ATL a hook. Today a new visitor reads a tagline and lands on an empty
+My Agents page with no stated objective; users report not knowing what the
+platform wants from them. This design makes the **leaderboard the objective**:
+a visitor sees a live board of models trading, is told the house instruction
+lost money, and is invited to write a better one.
+
+The differentiator is participation. Researched 2026-08-08: nof1.ai's Alpha
+Arena is spectator-only (nof1 picks the models and writes the single shared
+prompt) and has been dormant since its Season 1.5 ended 2025-12-03, with no
+Season 2 as of 2026-08. TradeRank built a public Agent Builder and disabled it.
+StrategyArena takes external strategies but is explicitly educational
+simulation. **No public LLM-trading leaderboard currently accepts
+user-submitted, prompt-defined agents.**
+
+Alpha Arena varies the *model* across one shared prompt. This design does the
+inverse: one shared model, N user instructions. That axis is unoccupied, and it
+is also the cheap one.
+
+## Decisions taken
+
+| Decision | Choice | Why |
+|---|---|---|
+| Season window | Fixed historical month, re-runs capped by the attempt budget | Simplest to ship; no waiting for real time to pass |
+| Board display | Best attempt only; attempt count in entry detail | User's call — a losing attempt never has to be worn |
+| Competition axis | One pinned model, instructions compete | One variable; predictable cost; the unoccupied axis |
+| Season 1 model | Nemotron 3 Nano 30B | Cheapest by 10x, and the house lost with it — the prompt carries the signal |
+| Funding | Platform pays | No credit system exists yet |
+| Attempt budget | Per-entry consumable balance | Is the credit ledger v0; billing tops it up later with no migration |
+
+### The look-ahead trade-off, recorded deliberately
+
+A fixed historical window means entrants can iterate against a known outcome,
+and the current contest window (2026-04-15 → 2026-05-15) may fall inside the
+training data of competing models. This was raised and accepted: the board
+measures prompt engineering against a fixed replay, not alpha discovery, and
+should be described that way in user-facing copy.
+
+Two facts materially reduce the risk and are load-bearing:
+
+1. **Nemotron is pinned to `temperature: 0`** — uniquely among the seven house
+   entries, which otherwise run at provider default. Verified at
+   `dashboard/config/leaderboard.json` (`"temperature": 0`,
+   `"reasoning_effort": "none"`) and plumbed for real:
+   `llm_agent.py:53-81` validates the value (finite, 0–1, rejects bools,
+   rejects combining with extended thinking) and `llm_agent.py:181` passes it
+   into the call. Re-running an unchanged instruction therefore returns a
+   near-identical curve, so repeated attempts cannot mine sampling variance
+   the way they could on a default-temperature model.
+   This is *near*-deterministic, not bitwise: providers still vary through
+   batching and MoE routing. Do not document it as reproducible.
+2. **`instruction_sha256` is recorded per attempt** (see Data model), so two
+   attempts sharing a hash are visibly re-runs rather than iterations.
+
+The attempt cap therefore exists to bound cost and iteration count, not to stop
+variance mining.
+
+## Background: verified state of the code
+
+Verified 2026-08-08/09 against `origin/main` @ `45ccbc0`. The local checkout was
+seven commits behind at the time of writing; read leaderboard files at
+`origin/main`.
+
+### What already exists and is better than assumed
+
+- **The board is a one-month backtest already.** `leaderboard.json` fixes
+  `initial_capital: 10000`, `start_date: 2026-04-15`, `end_date: 2026-05-15`,
+  `reference_start_date: 2026-03-15` (indicator warm-up, no in-window
+  look-ahead). 12 entries live in prod: 5 baselines + 7 LLM models.
+- **The chart is the most developed frontend in the repo.**
+  `dashboard/frontend/js/leaderboard.js` (1,037 lines): three visual tiers by
+  `kind` (benchmark / strategy / model, differing in width, dash and alpha),
+  a hand-built custom legend (`buildCustomLegend`, `:810-847`) with Chart.js's
+  own legend disabled, a grouped curve picker with per-group checkboxes
+  (`renderCurvePicker`, `:185-230`) driving a shared `hiddenSeries` set,
+  endpoint labels with collision avoidance in a reserved 120px gutter
+  (`endpointLabelPlugin`, `:735-808`), a %/$ toggle, and tooltips carrying rank
+  and delta-vs-SPY.
+- **`buildEquityCurvesFromEntries` (`:477-512`) merges every entry onto one
+  shared hour-precision time axis**, not by array index — because SPY ticks at
+  `:30` and LLM agents at `:00`. Built for 12 entries, this is exactly what
+  makes an N-entry board tractable.
+- **The board is already fully public.** No auth dependency on
+  `GET /api/v1/leaderboard`; `middleware.py:47-49` exempts `/api/*` from session
+  enforcement; `applyInitialNavigation()` runs regardless of sign-in state.
+  A logged-out visitor already sees the whole Competition tab.
+- **Deep links exist**: `?view=contest|daily|competition|leaderboard|participants|about`
+  via `NAV_VIEW_MAP` (`app.html:28-44`).
+- **PR #325 is merged** (`45ccbc0`), shipping `POST /api/v1/leaderboard/daily/refresh`
+  (secret-gated, 202 + background thread, rate-limited 20/hr), a nightly GitHub
+  Actions cron at 22:30 UTC Mon–Fri, and an ET-cash-close-anchored rolling daily
+  window. `LEADERBOARD_DAILY_AUTO_DEPLOY` is strict opt-in and must stay that way.
+- **The landing page already has the shape of the hook**: a `Race` section
+  (`landing/src/components/home/Race.tsx`) with a standings table and a
+  leaderboard equity chart — rendering hardcoded `SAMPLE_CURVES`/`SAMPLE_STANDINGS`
+  (`:17-32`) badged "Illustrative" (`:74,107`).
+
+### Measured cost per entry, one month-window
+
+From prod `GET /api/v1/leaderboard`, 160–161 LLM calls each:
+
+| Model | est. cost |
+|---|---|
+| Nemotron 3 Nano 30B | **$0.072** |
+| DeepSeek V4 Pro | $0.756 |
+| Qwen3.7 Plus | $1.593 |
+| Claude Haiku 4.5 | $1.726 |
+| Claude Sonnet 4.6 | $4.941 |
+| Gemini 3.1 Pro Preview | $11.263 |
+| GPT-5.5 | $13.888 |
+
+Full board rebuild: **$34.24**. At Nemotron, 100 entrants × 5 attempts is
+**$36/season**; 1000 entrants × 5 is $360.
+
+### What does not exist
+
+- **No path from a user agent to the board.** The roster is hand-edited
+  `dashboard/config/leaderboard.json`; entries resolve to one of six hardcoded
+  classes in `_STRATEGY_CLASSES` (`registry.py:19-26`); `domain/leaderboard/`
+  contains **zero** references to `external_agents`, `user_id`, `owner_id` or
+  `agent_id`. Publishing today means editing JSON, running a CLI locally, and
+  committing `backtest.db`.
+- **No onboarding system of any kind.** No tour library, no `data-step`
+  attributes, no spotlight overlay, no step sequencer. "onboarding" appears only
+  in comments.
+- **No user publish path to Community.** 7 templates, all lab-authored, from
+  static `dashboard/config/marketplace.json`.
+- **`#homeGetStartedBtn`** (`app.html:411`) has zero JS wiring. It is a dead
+  button and has always been one.
+
+### Why the two harnesses are not interchangeable
+
+A 30-dimension reconciliation of the house path (`LLMAgentStrategy` via
+`deploy_model_run`) against the user path (`HourlyBacktester` via
+`POST /backtest/run`) found ~10 divergences. Four are individually fatal to
+"just reuse the engine":
+
+1. **No config key reaches the prompt on the house path.** `LLMAgentStrategy`
+   reads only `mode`, `model_id`, `integration`, `reasoning_effort`,
+   `temperature`, `symbols` (`llm_agent.py:47-53, 91-93`) and calls
+   `make_trading_decision_with_llm` with no `strategy_prompt` and no `pipeline`
+   (`llm_agent.py:176-182`), so `create_prompt`'s `custom_prompt` is always
+   `None` and `SAFE_TRADING_PROMPT` (`validator.py:545-664`) is unconditional.
+2. **The paths do not share a template**, so "only the instruction differs" is
+   not expressible. The house sends `SYSTEM_PROMPT` + `SAFE_TRADING_PROMPT`;
+   the pipeline sends `PIPELINE_SYSTEM_PROMPT` + `_build_step_prompt`.
+3. **Capital.** House 10,000 (`service.py:948`); user runs are 422'd above 3,000
+   (`backtests.py:1146-1149`) and clamped again in the worker.
+4. **H6 has no user-side evidence.** The engine computes `llm_decisions` and
+   never reads or persists it; `decision_steps` is never computed at all.
+
+Six further divergences, none previously known, matter for comparability:
+the house fetches bars from `reference_start_date` for indicator warm-up while
+the engine fetches only `[start, end]` (leaving SMA50 immature for the first
+~50 bars of a ≤31-day window); the house bumps the end date `+1 day`; the engine
+applies an 80%-symbol-coverage filter before market hours; the engine passes a
+`market` key into the snapshot the house omits; the engine plumbs no
+`temperature` at all; the house retries 4× with a reasoning-disabled rescue call
+while the pipeline falls back to rule-based on first unparseable response.
+
+## Architecture: two loops
+
+The design does **not** attempt to make one harness serve both purposes.
+
+| | **Loop A — Iterate** (exists, unchanged) | **Loop B — Attempt** (new) |
+|---|---|---|
+| Path | `HourlyBacktester` | `LLMAgentStrategy` |
+| Model | user's choice | Nemotron, `temperature: 0` |
+| Window | ≤31 days, user-chosen | 2026-04-15 → 2026-05-15, warm-up from 2026-03-15 |
+| Capital | ≤$3,000 | $10,000 |
+| Universe | user-chosen, ≤30 | DJIA-30 |
+| H6 | not enforced | enforced |
+| Cost | existing controls | $0.072, decrements the ledger |
+| Meaning | rehearsal | **the official score** |
+
+**An attempt is the submission.** There is no separate publish step: spending an
+attempt produces a real contest curve, and the entry's best attempt is what the
+board shows. Entering a season is one explicit action; after that, best-of
+publishes automatically.
+
+**Rationale for not routing the score through the engine** (recorded so it is
+not revisited): doing so requires changing the capital cap, the bar-fetch
+window, the coverage filter and the `market_context` pass, plus adding
+`decision_steps` and persisting `llm_decisions` — five behaviour changes to the
+shipping product path. Raising `MAX_BACKTEST_INITIAL_CAPITAL` from 3,000 to
+10,000 alone breaks `test_agents_api.py:485-494`,
+`test_agent_backtest_allocation.py`, `test_my_agents_capital_ui.py` and the
+frontend clamp at `agent-editor.js:628-660`, and reverses the paper-vs-backtest
+capital invariant established by the earlier My Agents UX round.
+
+## The Open Track
+
+### Two tracks, one Competition page
+
+- **Model Track** — the existing 7 LLM entries and 5 baselines. **Frozen.**
+  Their published curves must not change.
+- **Open Track** — a house reference entry plus all user entries, every one of
+  them produced by the same new function.
+
+The Open Track carries its **own house reference**: one entry run through the
+identical submission path with the house instruction supplied as its
+`strategy_prompt`. This costs $0.072/season and sidesteps the riskiest change in
+the space — giving the existing seven entries an explicit `strategy_prompt`
+would alter what they produce on any re-deploy, break reproducibility of
+published curves, and flip tests across `test_prompts.py`, `test_validator.py`,
+`test_llm_validator.py` and `test_portfolio_manager_move.py`.
+
+Comparability inside the Open Track is exact by construction, because every
+entry including the reference goes through one code path.
+
+### Season configuration
+
+Seasons live in config, not a table, until there is a second one:
+
+```json
+{
+  "season_id": "s1",
+  "label": "Season 1",
+  "pinned_model": {
+    "model_id": "nvidia/nemotron-3-nano-30b-a3b",
+    "integration": "openrouter",
+    "temperature": 0,
+    "reasoning_effort": "none",
+    "mode": "safe_trading"
+  },
+  "window": { "start_date": "2026-04-15", "end_date": "2026-05-15",
+              "reference_start_date": "2026-03-15" },
+  "initial_capital": 10000,
+  "attempts_granted": 5,
+  "house_reference_entry_id": "s1_house_reference"
+}
+```
+
+`attempts_granted` is the single knob governing cost, iteration count and
+throughput. It is deliberately one number.
+
+### Data model
+
+Two new tables beside `agent_runs` on the run-history database
+(`AGENT_RUNS_DATABASE_URL`). **No foreign keys to `owner_user_id` or
+`agent_id`**: accounts live behind `USERS_DATABASE_URL` and agents behind
+`CONTENT_DATABASE_URL`, in different Neon projects. They are opaque strings by
+necessity, and no code path may join across them.
+
+```
+leaderboard_entries
+  entry_id           TEXT PK        -- namespaced, must not collide with lb_*
+  season_id          TEXT NOT NULL
+  owner_user_id      TEXT NOT NULL  -- opaque; different database
+  agent_id           TEXT NOT NULL  -- opaque; different database
+  display_name       TEXT NOT NULL
+  best_run_id        TEXT           -- FK-in-spirit to agent_runs.run_id
+  best_return        REAL
+  attempts_granted   INTEGER NOT NULL
+  attempts_used      INTEGER NOT NULL DEFAULT 0
+  created_at, updated_at
+
+leaderboard_attempts
+  id                 INTEGER PK
+  entry_id           TEXT NOT NULL
+  run_id             TEXT NOT NULL
+  attempt_no         INTEGER NOT NULL
+  instruction_sha256 TEXT NOT NULL
+  total_return       REAL
+  h6_passed          INTEGER NOT NULL   -- BOOLEAN on the Postgres twin
+  created_at
+```
+
+The `h6_passed` type divergence is called out explicitly because
+`test_store_twin_parity.py` compares column *names* only and will not catch it.
+
+One entry per user per season. `attempts_granted`/`attempts_used` **is** the
+credit ledger: a season grants, a submission decrements, and a future billing
+path tops up — same table, no migration.
+
+`instruction_sha256` gives the integrity signal for free. Two attempts sharing a
+hash were re-runs, not iterations, so the entry detail can honestly show
+"5 attempts · 3 distinct instructions" without banning anything.
+
+### Submission path
+
+Six changes, modelled on the reconciliation's recommended shape:
+
+- **C1 — `LLMAgentStrategy` accepts an instruction.** In
+  `llm_agent.py:47-81` add
+  `self.strategy_prompt = (self.config.get("strategy_prompt") or "").strip() or None`,
+  and pass `strategy_prompt=self.strategy_prompt` at `llm_agent.py:176-182`.
+  `make_trading_decision_with_llm` already declares the parameter
+  (`portfolio_manager.py:243`) and already threads it (`:463`). No downstream
+  signature changes.
+- **C2 — deliberately void.** The reconciliation proposed giving both sides a
+  shared template so house and user entries differ only by instruction. This
+  design **rejects that** in favour of the Open Track house reference above:
+  the existing seven entries are not touched, and comparability is achieved
+  within the Open Track instead of across both tracks. The number is retained
+  so this spec maps 1:1 onto the source analysis.
+- **C3 — one submission entry point.** A new `deploy_user_entry(...)` in
+  `domain/leaderboard/service.py`, modelled on `deploy_model_run`
+  (`service.py:926-1041`). It builds a config dict carrying the season's pinned
+  model plus `strategy_prompt`, calls the unchanged `get_strategy()`
+  (`registry.py:37-47`), and **reuses `service.py:979-989` and `:996-1013`
+  verbatim** for bar fetching, warm-up, the run, counters and the H6 guard.
+  Capital, window, warm-up, the `+1 day` bump, the no-coverage-filter timestamp
+  set and integrity all come for free because it is literally the same code.
+- **C4 — pin what was submitted.** `_llm_run_metadata` (`service.py:894-921`)
+  gains `agent_id`, `season_id` and `strategy_prompt_sha256`. Without this a
+  published curve cannot be attributed to the string that produced it.
+- **C5 — an authenticated ingress.** A new owner-authenticated, rate-limited
+  route in `api/routers/leaderboard.py`, returning 202 and queueing, following
+  the existing `/daily/refresh` shape (`:52-106`).
+- **C6 — leave the engine alone.** No changes to `HourlyBacktester`,
+  `MAX_BACKTEST_INITIAL_CAPITAL`, the fetch window or the coverage filter.
+
+### Integrity
+
+H6 applies unchanged and for free, because C3 reuses the guard call site.
+`_reject_if_llm_fallback` (`service.py:833-892`) rejects an entry whose model
+drove under `MIN_LLM_DECISION_COVERAGE = 0.95` of steps, keyed on
+`llm_decisions` (success-exit counter) rather than `llm_calls` (billing
+counter). A failed attempt still decrements the ledger and is recorded with
+`h6_passed = 0`; it simply cannot become `best_run_id`.
+
+Evidence this is survivable on a nano model: the house Nemotron entry is
+published on the live board, so it cleared H6 through this same harness.
+
+`allow_fallback` must remain absent from every HTTP surface, as it is today.
+
+### Cost and throughput
+
+Cost is bounded by construction: `attempts_granted × entrants × $0.072`.
+
+Throughput is **not** solved by this design and is flagged for the plan.
+Attempts do not contend with the engine's process-wide `backtest_status["running"]`
+flag, but ~500 runs/season at 2–4 minutes each is roughly 25 hours serialized.
+These are I/O-bound LLM calls, so modest concurrency (3–4 workers) is the
+obvious answer, but issue **#202** reports blocking sync I/O on exactly the
+leaderboard routes and the agent-scale investigation measured throughput
+collapsing under load. The design is a FIFO queue with the position shown to the
+user; **the worker count must be settled against #202 during planning, not
+guessed here.**
+
+## The board
+
+Default visible series, never more than 5–8 lines:
+
+1. Buy & Hold / DJIA baseline — the real question; 6 of 7 house models lost to it
+2. The Open Track house reference — the bar being challenged
+3. Top 3 Open Track entries
+4. **The signed-in user's own entry, pinned unconditionally**, at any rank
+
+Everything else remains available but hidden. This is a **default-selection
+policy, not a charting feature**: it decides the initial contents of the
+existing `hiddenSeries` set, which the existing curve picker and custom legend
+already manage.
+
+Pinning the user's own curve is deliberate. Top-N-only means most entrants see a
+chart they are absent from, which is the moment they stop caring.
+
+**Rank against the baseline, not only against each other.** Because Season 1
+pins a model whose house result is `-0.22%`, the board will accumulate entries
+that beat the house and still lose to buy-and-hold. Show return *and* a
+"beat the market" marker so a win cannot quietly mean "lost money slower than a
+bad model did".
+
+**Not in v1:** a percentile band for the hidden field. Correct at 500 entries,
+speculative at 12; the curve picker already surfaces any individual line.
+
+## The funnel
+
+### Landing
+
+Wire the existing `Race` section to `GET /api/v1/leaderboard`, following the
+fetch pattern `MarketTicker.tsx:13-19,77-117` already establishes. Two
+constraints: remove the "Illustrative" badge once the data is real, and fetch
+same-origin through the Vercel rewrite rather than hardcoding
+`agentictrading.onrender.com` as `MarketTicker` does.
+
+CTA copy derives from the platform's own result: *"Our instruction lost 0.22%
+with this model. Write a better one."*
+
+Shipping note: `Race.tsx` is Vite/React source but the served page is
+hand-patched HTML carrying ~390 lines of auth code with no React counterpart.
+The refresh is `npm run build` → copy hashed assets → hand-edit the script/link
+hashes → preserve the four auth blocks verbatim, per
+`dashboard/landing/README.md:31-81`, guarded mechanically by
+`test_frontend_bundle_integrity.py`.
+
+Post-signup redirect is unchanged: `/app?view=agents` with `nav-state`
+pre-seeded (`index.html:307-328`).
+
+### Onboarding
+
+**A guided tour is explicitly rejected.** Tours explain the UI, but the observed
+problem is that users do not know the goal; tours are stateless once dismissed,
+so they do nothing for the user who leaves and returns; and the repo has zero
+tour infrastructure, so it would mean building a spotlight/positioning framework
+from scratch.
+
+Instead, a **persistent Season checklist card** pinned at the top of My Agents —
+a card in the existing shelf renderer, not an overlay framework:
+
+```
+Season 1 · Nemotron 3 Nano                        5 attempts left
+The house instruction lost 0.22%. Beat it.
+
+  [x] Your starter agent is ready
+  [ ] Write its trading instruction        [ Configure ]
+  [ ] Run an attempt on the season window  [ Run attempt ]
+```
+
+In Phase 1 the third step renders disabled with `Season 1 opens soon`; see
+Rollout.
+
+On first successful attempt it collapses into a permanent season HUD —
+`Season 1 · rank 34 of 112 · 3 attempts left` — so it never becomes dead weight.
+
+The checklist and the credit ledger are the **same state object**: the card
+renders `attempts_remaining`, the integrity rule enforces it, and future billing
+tops it up. Because it is server-side it survives the browser change that
+today's `localStorage` onboarding guard (`ensureDefaultFoundationAgent`,
+`app.js:1703-1776`) does not.
+
+One additional surface: a single welcome screen shown once after signup, stating
+the goal in a sentence with a button that scrolls to the checklist. One screen,
+not a sequence. The auth-modal pattern in `index.html` is the model to copy.
+
+**Fix while here:** wire `#homeGetStartedBtn` (`app.html:411`) to the checklist,
+or remove it. It currently does nothing.
+
+### Community → Agent Marketplace
+
+Change exactly two user-visible strings: the nav label (`app.html:195`) and the
+page title (`app.html:1600`). They must change together —
+`test_frontend_marketplace_placement.py::test_community_page_header_matches_the_nav_button`
+asserts they match, and passes if both move.
+
+**Do not rename** the `community` page key, `#communityView`, `NAV_VIEW_MAP`
+entries or the `nav-state` localStorage value: live bookmarks break for no
+user-visible gain. Note that `?view=marketplace` already exists as a legacy
+alias pointing at `community`, so the rename makes the legacy alias the accurate
+one.
+
+A user publish path is **out of scope for v1**. The competition creates the
+natural demand for it ("publish my season entry as a template"), so it lands
+better as v1.1 with a real corpus than as empty scaffolding now.
+
+## Non-goals
+
+- Live paper trading, real-time execution, or any broker order submission.
+  `execution/paper_backend.py` stays a stub.
+- Real capital. Ever, on this surface.
+- Changing the published Model Track curves.
+- Raising `MAX_BACKTEST_INITIAL_CAPITAL`.
+- A credit/billing system. The ledger shape anticipates it; pricing is out of
+  scope.
+- A user publish path into the marketplace.
+- Percentile/field bands on the chart.
+
+## Verification
+
+- **H6 on the new insert path.** The guard's docstring states it is applied on
+  *both* insert paths; `deploy_user_entry` makes a third. `test_deploy_guard.py`
+  needs the mirror coverage cases or an entry can bypass integrity.
+- **Postgres twins for both new tables.** They sit on the run-history database,
+  so both `BacktestDatabase` and `PostgresBacktestDatabase` need implementations,
+  enforced by `test_store_twin_parity.py`. That guard parses source text, so it
+  cannot see f-string DDL and compares column *names* only — `NOT NULL`
+  divergence is invisible and must be checked by hand.
+- **Route-contract freeze golden sets updated in the same commit as C5**, or
+  every open PR reddens. Per-router and full-app freezes drift independently.
+- **Frontend copy guards** for the checklist and CTA strings, following the
+  existing `tests/_frontend_source.py` pattern.
+- **Cache-buster bumps** for every touched frontend asset (`app.js?v=`,
+  `js/leaderboard.js?v=`, `styles.css?v=`), each versioned independently.
+- Cost assertion: a test pinning the season's pinned model to the config, so a
+  silent switch to a frontier model cannot multiply spend 190x unnoticed.
+
+### Deploy prerequisites
+
+- **`OPENROUTER_API_KEY` must be set in the Render dashboard.** Nemotron is the
+  only board entry not on CommonStack, and OpenRouter is never auto-selected
+  (`providers/__init__.py:11`). Unset, submissions silently fail.
+- `LEADERBOARD_DAILY_AUTO_DEPLOY` stays strict opt-in. Never restore any
+  default that enables it implicitly.
+- Render env writes are single-key PUT only; a bulk PUT wipes the list, and they
+  do not trigger a redeploy.
+
+## Rollout
+
+**Phase 1 — display only.** Ship the board changes, the landing wiring, the CTA,
+the welcome screen and the checklist, with **only the house reference entry**
+present. Total cost: **$0.072**.
+
+The checklist ships in a **preseason state**: steps 1 and 2 (starter agent,
+write the instruction) are live and fully actionable; the attempt step renders
+disabled with `Season 1 opens soon` and a working email-notify or Discord link.
+This is the honest version — a checklist whose final step silently does nothing
+is exactly the dead-CTA failure this design is fixing (`#homeGetStartedBtn`).
+
+What Phase 1 therefore proves: whether the board and CTA convert a visitor into
+a signup, and whether a signed-up user reaches a written instruction. What it
+cannot prove: attempt throughput, H6 pass rates on user instructions, or queue
+behaviour.
+
+**Phase 2 — open attempts.** Ship C1/C3/C4/C5, the two tables and the queue.
+The checklist's third step activates; nothing else about it changes.
+
+This ordering is deliberate: every expensive or corrupting failure mode
+(queue thrash, H6 rejections, unbounded spend) lives on the attempt path, while
+everything that reveals whether the hook converts lives on the display path.
+
+## Open items
+
+1. **Attempt worker concurrency** — settle against #202 during planning.
+2. **`attempts_granted` value** — 5 assumed throughout; confirm before build.
+3. **Entry display names** — whether entries show account display name, a
+   chosen alias, or are anonymous by default. Affects moderation surface.
+4. **Season 1 dates** — whether to keep the current contest window or pick a
+   window outside the pinned model's training data.
+
+## References
+
+- Central DB: `knowledge/opt-employment-2026.md` § "The 2026-08-08 Pivot" —
+  professor's goal, nof1 competitive research, verified-unbuilt scope.
+- Central DB: `decisions/2026-08.md`, entry 2026-08-08.
+- `docs/superpowers/specs/2026-08-05-asset-class-shelves-design.md` — shelf
+  rendering the checklist card sits inside.
+- PR #325 (`45ccbc0`) — daily refresh cron and status UI.
+- PR #326 — open at time of writing, touches `js/leaderboard.js`; rebase onto it.
+- Issues #145 (scheduler), #202 (event-loop blocking), #230 (`decide()` seam).

--- a/docs/superpowers/specs/2026-08-09-participatory-competition-design.md
+++ b/docs/superpowers/specs/2026-08-09-participatory-competition-design.md
@@ -1,7 +1,48 @@
 # Participatory competition: two boards users can enter
 
 **Date:** 2026-08-09 (rewritten same day after a design grilling)
-**Status:** Design approved, pending implementation plan
+**Reconciled:** 2026-08-15 against `origin/main` @ `88c7b8c`
+**Status:** Phase 0 pending (gated on spend). Phases 2–3 designed, unbuilt.
+
+> ## Reconciliation notice — read before acting on this document
+>
+> This spec was written on 2026-08-09 and describes **two boards that did not
+> exist yet**, named "Replay" and "Forward Season". Six days later, PR #352
+> shipped two boards to prod with different names and a different cadence, and
+> PR #357 rewrote the landing page around them. Neither PR was written against
+> this spec.
+>
+> **The shipped boards are the house-only halves of the two designed here.** They
+> carry the same windows and the same substrate; what they lack is the user entry
+> path this document exists to specify. So this design is no longer "add two
+> boards" — it is **"add user entry to the two boards that now exist"**, which is
+> strictly less work and removes the risk of shipping a parallel, competing pair.
+>
+> | This spec called it | Prod calls it | Same? |
+> |---|---|---|
+> | Replay — perpetual qualifier over a fixed month | **Competition Leaderboard** | Same window and substrate; prod has no entry path and no attempt ledger |
+> | Forward Season — forward execution on real bars | **Live Trading Leaderboard** | Same substrate and intent; **cadence changed weekly → two weeks**, and prod has no advance engine at all |
+>
+> The vocabulary throughout this document has been updated to the shipped names.
+> Three substantive consequences are recorded inline where they bite, and are
+> **not** cosmetic:
+>
+> 1. **The instruction lock is now two weeks, not one** (§Decisions taken). The
+>    original argument for the lock rested on the next season being days away.
+>    That argument is weaker at 10 trading days and is restated honestly rather
+>    than carried over.
+> 2. **C8 is no longer only a Phase 3 feature.** The Live Trading board is *in
+>    prod today* in a Season 0 preview with no nightly advance. C8 is what makes
+>    the already-shipped board real, independent of user entry (§Rollout).
+> 3. **Phase 1 is largely obsolete.** #352/#357 delivered its landing-page half
+>    by other means, and in one case in the opposite direction — the landing board
+>    ships *illustrative* data under a guard test that requires the label. See the
+>    plan document's task table.
+>
+> **Line numbers below are as of 2026-08-09 unless a note says otherwise.** The
+> files they point into have since moved (`js/leaderboard.js` alone went 1,037 →
+> 1,600 lines). Re-verify any reference before acting on it; the surrounding
+> claims were checked at reconciliation and hold.
 
 ## Goal
 
@@ -26,11 +67,11 @@ is also the cheap one.
 
 ### Come, and stay — the two mechanisms, named
 
-- **Come** is the Replay board: seven named frontier models, six of which lost
-  to buy-and-hold over a real month, on one chart above the fold, with a CTA
+- **Come** is the Competition board: seven named frontier models, six of which
+  lost to buy-and-hold over a real month, on one chart above the fold, with a CTA
   that points at a specific beatable number.
-- **Stay** is the weekly Forward Season cycle: submit Monday, watch the board
-  move daily, get a result email Friday, next season opens Monday.
+- **Stay** is the Live Trading season cycle: submit at season open, watch the
+  board move daily, get a result email at season close, next season opens after.
 
 A fixed replay alone cannot produce a return visit — the race ends the moment
 you submit. That is why there are two boards and not one.
@@ -39,15 +80,15 @@ you submit. That is why there are two boards and not one.
 
 | Decision | Choice | Why |
 |---|---|---|
-| Board count | Two: Replay (perpetual) + Forward Season (weekly) | Replay is the argument; Forward is the habit |
-| Replay window | The existing fixed month, never reset | A fixed replay's result never changes; resetting deletes history and re-charges for the same curve |
-| Forward substrate | **Simulated** forward execution on real bars | Decouples the season from broker paper trading, which does not exist |
-| Forward cadence | One week, Mon open → Fri close | Locked instructions cost little when the next season is days away |
-| Instruction lock | Locks when the run begins | User's call; the weekly cadence is what makes it survivable |
+| Board count | Two: Competition (perpetual) + Live Trading (seasonal) | Competition is the argument; Live Trading is the habit |
+| Competition window | The existing fixed month, never reset | A fixed replay's result never changes; resetting deletes history and re-charges for the same curve |
+| Live Trading substrate | **Simulated** forward execution on real bars | Decouples the season from broker paper trading, which does not exist |
+| Live Trading cadence | **Two weeks — 10 trading days** | *Changed 2026-08-15.* Was "one week, Mon→Fri". PR #352 shipped two-week seasons and `SEASON_TRADING_DAYS = 10` (`js/leaderboard.js:276`); the season strip, progress meter and Season 0 chrome are all built to it. Matching prod beats re-litigating a cadence that already has UI |
+| Instruction lock | Locks when the run begins | **Weakened by the cadence change.** The original argument was that a locked instruction costs little when the next season is days away; at 10 trading days the user waits twice as long to correct a bad instruction. Two mitigations, neither free: allow one instruction edit before the first advance, or grant a mid-season re-entry slot. **Resolve this in Phase 3 planning — do not treat the original "user's call" as still-decided** |
 | Competition axis | One pinned model, instructions compete | One variable; predictable cost; the unoccupied axis |
 | Season 1 model | Nemotron 3 Nano 30B, `temperature: 0` | Cheapest by 10×, and the house lost with it — the prompt carries the signal |
 | Entry shape | An agent with **exactly one** pipeline step | Matches how the product already stores instructions |
-| Attempts | 5 lifetime on Replay; Forward is a slot, not a ledger | Under a locked forward run there is nothing to spend a second attempt on |
+| Attempts | 5 lifetime on Competition; Live Trading is a slot, not a ledger | Under a locked forward run there is nothing to spend a second attempt on |
 | Abuse control | Email verification at **account creation** + a hard global monthly spend ceiling | Accounts are free and instant; attempts cost real money |
 | Funding | Platform pays, capped at $50/month | No credit system exists yet |
 | Graduation | Carry the instruction text only into Loop A | Loop A cannot reproduce season conditions; pretending otherwise invites bug reports |
@@ -56,16 +97,16 @@ you submit. That is why there are two boards and not one.
 
 The earlier draft accepted that a fixed historical window lets entrants iterate
 against a known outcome, and that the window may sit inside competing models'
-training data. **The Forward Season resolves this** rather than merely
-disclosing it: it runs on bars that do not exist when the instruction locks.
+training data. **Live Trading resolves this** rather than merely disclosing it:
+it runs on bars that do not exist when the instruction locks.
 
-Replay keeps the known-outcome property and is therefore explicitly positioned
-as a **qualifier**, not the competitive board. Its purpose is evidence (the
-hero chart) and practice (the cheap, repeatable loop). A Replay rank is a score
-against a fixed replay; a Forward rank is a forecast. User-facing copy must say
-so.
+Competition keeps the known-outcome property and is therefore explicitly
+positioned as a **qualifier**, not the competitive board. Its purpose is evidence
+(the hero chart) and practice (the cheap, repeatable loop). A Competition rank is
+a score against a fixed replay; a Live Trading rank is a forecast. User-facing
+copy must say so.
 
-Two facts still reduce Replay's gameability and are load-bearing:
+Two facts still reduce Competition's gameability and are load-bearing:
 
 1. **Nemotron is pinned to `temperature: 0`** — uniquely among the seven house
    entries, which otherwise run at provider default. Verified at
@@ -129,12 +170,15 @@ pipeline-less agents. This is why C7 (below) exists.
 
 ### What already exists and is better than assumed
 
-- **The Replay board is a one-month backtest already.** `leaderboard.json` fixes
-  `initial_capital: 10000`, `start_date: 2026-04-15`, `end_date: 2026-05-15`,
-  `reference_start_date: 2026-03-15`. 12 entries live in prod: 5 baselines +
-  7 LLM models.
+- **The Competition board is a one-month backtest already.** `leaderboard.json`
+  fixes `initial_capital: 10000`, `start_date: 2026-04-15`, `end_date:
+  2026-05-15`, `reference_start_date: 2026-03-15`. 12 entries live in prod: 5
+  baselines + 7 LLM models. *(Re-verified 2026-08-15: still exactly 12 entries,
+  5 + 7, and still no `strategy_prompt`, `label: "Open Track"` or `authored_by`
+  key anywhere in the config.)*
 - **The chart is the most developed frontend in the repo.**
-  `dashboard/frontend/js/leaderboard.js` (1,037 lines): three visual tiers by
+  `dashboard/frontend/js/leaderboard.js` (1,037 lines; **1,600 as of
+  2026-08-15** — #326, #352 and #357 all landed in it): three visual tiers by
   `kind` (benchmark / strategy / model / **team**), a hand-built custom legend
   (`buildCustomLegend`, `:810-847`) with Chart.js's own legend disabled, a
   grouped curve picker (`renderCurvePicker`, `:185-230`) driving a shared
@@ -148,11 +192,20 @@ pipeline-less agents. This is why C7 (below) exists.
 - **The board is already fully public.** No auth dependency on
   `GET /api/v1/leaderboard`; `middleware.py:47-49` exempts `/api/*` from session
   enforcement.
-- **Two pieces of dead scaffolding already exist for this feature.**
-  `app.html:1403-1410` renders a permanent empty state — *"Season hasn't started
-  yet. Participating teams will appear here when the contest season opens."* And
-  `#homeGetStartedBtn` (`app.html:411`) has zero JS wiring. Both get filled, not
-  deleted.
+- **One piece of dead scaffolding already exists for this feature.**
+  `app.html:1403-1410` (**`:1428-1439` as of 2026-08-15**) renders a permanent
+  empty state — *"Season hasn't started yet. Participating teams will appear here
+  when the contest season opens."* It gets filled, not deleted.
+
+  > **Correction (2026-08-15).** This bullet originally also claimed
+  > `#homeGetStartedBtn` (`app.html:411`, now `:468`) "has zero JS wiring". That
+  > was **already false when written**: `initHomeGetStarted()` was added to
+  > `home-page.js` in `08c85aa` on **2026-07-25**, two weeks earlier. The button
+  > opens the signup modal when signed out and navigates to the agents playground
+  > when signed in, and its label swaps between the two states. Nothing here needs
+  > wiring. The dead-CTA *lesson* stands and is still worth honouring — a CTA that
+  > leads nowhere is a bug — but it is a past failure to avoid repeating, not an
+  > open defect this design gets credit for fixing.
 - **Simulated forward execution is nearly assembled.**
   `domain/trading/execution.py:1-6` is in-memory execution over explicit
   cash/positions/trades, extracted from the backtester, and `paper_session.py`
@@ -174,10 +227,10 @@ pipeline-less agents. This is why C7 (below) exists.
 
 From prod `GET /api/v1/leaderboard`, 160–161 LLM calls over the month window:
 
-| Model | Replay (month, ~160 calls) | Forward (week, ~36 calls) |
+| Model | Competition (month, ~160 calls) | Live Trading (2 weeks, ~73 calls) |
 |---|---|---|
-| **Nemotron 3 Nano 30B** | **$0.072** | **~$0.016** |
-| DeepSeek V4 Pro | $0.756 | ~$0.17 |
+| **Nemotron 3 Nano 30B** | **$0.072** | **~$0.033** |
+| DeepSeek V4 Pro | $0.756 | ~$0.35 |
 | Qwen3.7 Plus | $1.593 | — |
 | Claude Haiku 4.5 | $1.726 | — |
 | Claude Sonnet 4.6 | $4.941 | — |
@@ -185,6 +238,13 @@ From prod `GET /api/v1/leaderboard`, 160–161 LLM calls over the month window:
 | GPT-5.5 | $13.888 | — |
 
 Full board rebuild: $34.24.
+
+> **Cadence change, 2026-08-15.** The right-hand column was "Forward (week, ~36
+> calls)". A two-week season is 10 trading days at the observed ~7.3 calls/day,
+> so per-entry cost roughly doubles — but seasons arrive half as often, so
+> **monthly spend per active user is unchanged** and every figure in §Cost model
+> at scale still holds. This is the one place the cadence change is free; the
+> instruction lock (§Decisions taken) is where it is not.
 
 ### What does not exist
 
@@ -229,7 +289,16 @@ the no-coverage-filter timestamp set, neither of which Loop A has.
 
 ## The two boards
 
-### Replay — the qualifier
+> **Both boards now exist in prod as house-only boards** (PR #352, merged
+> 2026-08-15 as `7db504d`). What follows describes the *participatory* versions.
+> Read every requirement below as an addition to a shipped board, not as a new
+> board to stand up. What prod is missing in both cases is identical: an entry
+> path, an attempt ledger, and a user-owned row.
+
+### Competition — the qualifier
+
+*(Designed here as "Replay". Shipped as the **Competition Leaderboard**;
+`period=contest`, `VALID_PERIODS[0]`.)*
 
 Perpetual, over the existing fixed month. Never resets: a fixed replay's result
 never changes, so resetting would delete history and re-charge everyone to
@@ -244,43 +313,106 @@ produce on any re-deploy, break reproducibility of published curves, and flip
 tests across `test_prompts.py`, `test_validator.py`, `test_llm_validator.py` and
 `test_portfolio_manager_move.py`.
 
-### Forward Season — the competition
+**Prod gap:** `get_leaderboard` builds every row from the curated `strategies`
+roster in `dashboard/config/leaderboard.json`, and `api/routers/leaderboard.py`
+exposes no submission route. The board is display-only by construction.
 
-Weekly, Monday open → Friday close, simulated forward execution on real bars.
-The instruction locks when the run begins. Entry requires **at least one
-completed Replay attempt** — Replay is the qualifier in fact, not just in copy.
+### Live Trading — the competition
+
+*(Designed here as "Forward Season". Shipped as the **Live Trading
+Leaderboard**.)*
+
+**Two weeks — 10 consecutive trading days** — of simulated forward execution on
+real bars. The instruction locks when the run begins. Entry requires **at least
+one completed Competition attempt** — Competition is the qualifier in fact, not
+just in copy.
 
 A nightly job advances each entry's persisted portfolio one trading day, reusing
 `domain/trading/execution.py` and the shape of the existing daily-refresh cron.
 Note the daily leaderboard is **not** reusable as-is: `daily_window_dates()`
 (`service.py:79-91`) returns the last completed weekday as both start *and* end,
 re-running a fresh one-day backtest each night with no portfolio carried across
-days. The Forward Season needs persisted state the daily board deliberately does
-not keep.
+days. Live Trading needs persisted state the daily board deliberately does not
+keep.
 
 **This is simulated, not brokered.** It must not be called "paper trading" in
 the UI: `app.html:847` already has a **Paper Trading** subtab under My Agents,
 and "Paper Trading Allocated Capital (max $3,000)" appears in four places tied
-to reserving cash from My Portfolio. The two must stay distinguishable.
+to reserving cash from My Portfolio. The two must stay distinguishable. *(Prod
+already honours this: the shipped tab is "Live Trading", and the landing copy
+states outright that "Live" names the direction the board runs, not brokered
+execution.)*
+
+#### What prod shipped, and the three invariants any advance engine must respect
+
+The shipped board is a **Season 0 preview**: real Competition curves rendered
+under season chrome, plus a banner saying nothing on it has advanced. Four facts
+constrain Phase 3, and three of them are guarded by tests that will fail loudly:
+
+1. **There is no season engine and no `live` period.** `VALID_PERIODS =
+   ("contest", "daily")` (`service.py:50`); `live` and `season` are *frontend*
+   vocabulary only (`normalizeBoardPeriod()`, `js/leaderboard.js:636`).
+   `_normalize_period` coerces anything unrecognised back to `contest` rather
+   than 4xx-ing, so `GET /api/v1/leaderboard?period=live` returns a perfectly
+   successful **200 carrying the Competition board**. Adding `"live"` to
+   `VALID_PERIODS` is the natural first commit and is safe — see (2).
+2. **The preview banner is anchored on evidence of an advance, not on the
+   period.** `isLivePreview()` is `isLiveBoard() && !seasonHasAdvanced(payload)`,
+   and `seasonHasAdvanced()` tests `season.last_advanced_date` /
+   `trading_days_elapsed > 0` — fields only a real advance can write. This is
+   deliberate and is pinned by a source-shape test: an earlier `payload.period
+   !== 'live'` form would have let the season engine's first commit silently
+   clear every banner while nothing had run. **Do not simplify it back to a
+   period check.** The happy consequence is that C8 needs no banner work at all —
+   the first successful advance clears it by writing the field.
+3. **Season 0 is falsy.** Every read of the season number goes through
+   `displayedSeasonNumber()` + `Number.isFinite`, because `season?.number ? … :
+   '—'` renders the shakedown season as no season at all. Any payload C8 emits
+   must keep season 0 distinguishable from a missing season.
+4. **Season length is `SEASON_TRADING_DAYS = 10`** (`js/leaderboard.js:276`),
+   used as the denominator of the season progress meter when the payload omits
+   `trading_days_total`. An advance engine emitting a different total will render
+   a progress bar that disagrees with the chrome.
+
+**Consequence for sequencing:** C8 is currently the only thing standing between
+prod and Season 1 of a board users can already open. See §Rollout.
 
 ## Season configuration
 
-**Replay lives in config. Forward seasons are derived, not configured.**
+**Competition lives in config. Live Trading seasons are derived, not
+configured.**
 
-A new Forward Season opens every Monday, so hand-editing config weekly would
-mean a deploy per season — unworkable. Forward seasons are computed from a
-template plus date arithmetic, exactly as `daily_window_dates()`
-(`service.py:79-91`) already derives the daily window: `season_id` is
-`fwd-<ISO year>-W<week>`, the window is that week's Monday→Friday, and
-everything else comes from the template. No table, no weekly deploy.
+A new season opens every two weeks, so hand-editing config per season would mean
+a deploy per season — unworkable. Seasons are computed from a template plus date
+arithmetic, in the spirit of `daily_window_dates()` (`service.py:79-91`), which
+already derives the daily window.
 
-The Replay config:
+**The derivation changed with the cadence (2026-08-15).** The original scheme was
+`season_id = fwd-<ISO year>-W<week>`, which works only for week-aligned seasons —
+a fortnight has no ISO name, and the ISO-week counter resets mid-season at every
+year boundary. Derive from an explicit anchor instead:
+
+```
+season_number = floor(trading_days_between(anchor, today) / 10) + 1
+season_id     = "live-s<season_number>"
+window        = the 10 consecutive trading days starting at
+                anchor + 14 calendar days × (season_number - 1)
+```
+
+Counting in **trading days, not calendar days**, is what keeps a holiday week
+from silently shortening a season to 9 sessions. Before the anchor date the
+derivation yields **season 0**, which is exactly the shakedown state prod renders
+today — so the preview is a natural value of this function rather than a special
+case bolted beside it. Keep it distinguishable from a *missing* season (see
+invariant 3 above). No table, no per-season deploy.
+
+The Competition config:
 
 ```json
 {
-  "season_id": "replay-s1",
-  "kind": "replay",
-  "label": "Replay Qualifier",
+  "season_id": "competition-s1",
+  "kind": "competition",
+  "label": "Competition Qualifier",
   "perpetual": true,
   "pinned_model": {
     "model_id": "nvidia/nemotron-3-nano-30b-a3b",
@@ -293,13 +425,19 @@ The Replay config:
               "reference_start_date": "2026-03-15" },
   "initial_capital": 10000,
   "attempts_granted": 5,
-  "house_reference_entry_id": "replay_s1_house_reference"
+  "house_reference_entry_id": "competition_s1_house_reference"
 }
 ```
 
-The Forward template carries the same shape with `kind: "forward"`,
-`perpetual: false`, no `window` (derived) and no `attempts_granted` (a Forward
-entry is a slot, so the column defaults to 0).
+The Live Trading template carries the same shape with `kind: "live"`,
+`perpetual: false`, an `anchor_date`, `trading_days: 10`, no `window` (derived)
+and no `attempts_granted` (a Live Trading entry is a slot, so the column defaults
+to 0).
+
+`kind: "live"` matches the period string the frontend already sends, so adding
+`"live"` to `VALID_PERIODS` (`service.py:50`) is the one-line backend change that
+makes the shipped tab stop silently serving the Competition board. It is safe to
+land on its own — the preview banner does not key on the period.
 
 ## Data model
 
@@ -320,7 +458,7 @@ leaderboard_entries
                                     -- entry's first attempt is submitted
   best_run_id        TEXT           -- FK-in-spirit to agent_runs.run_id
   best_return        REAL
-  attempts_granted   INTEGER NOT NULL DEFAULT 0   -- replay seasons only
+  attempts_granted   INTEGER NOT NULL DEFAULT 0   -- competition seasons only
   attempts_used      INTEGER NOT NULL DEFAULT 0
   created_at, updated_at
 
@@ -336,7 +474,7 @@ leaderboard_attempts
   failure_kind       TEXT               -- NULL | 'h6_rejected' | 'infrastructure'
   created_at
 
-forward_positions                       -- forward seasons only
+forward_positions                       -- Live Trading seasons only
   entry_id           TEXT NOT NULL
   as_of_date         TEXT NOT NULL
   cash               REAL NOT NULL
@@ -397,10 +535,20 @@ path tops up — same table, no migration.
   reference. The step's `outputFormat` is **ignored** — the UI must say so,
   because silently dropping a field the editor displays is exactly what produces
   "the leaderboard is broken" reports.
-- **C8 — forward advance job.** A daily job that loads each active forward
-  entry's `forward_positions` row, fetches the day's bars, runs the pinned model
-  over that day's steps, executes via `domain/trading/execution.py`, and writes
-  the next row. Idempotent on `(entry_id, as_of_date)`.
+- **C8 — the nightly advance job.** A daily job that loads each active Live
+  Trading entry's `forward_positions` row, fetches the day's bars, runs the
+  pinned model over that day's steps, executes via
+  `domain/trading/execution.py`, and writes the next row. Idempotent on
+  `(entry_id, as_of_date)`.
+
+  The table keeps the name `forward_positions` rather than `live_positions`
+  deliberately: the whole point of §Live Trading is that "live" names the
+  *direction* the board runs and never brokered execution, and a table called
+  `live_positions` sitting next to `infrastructure/brokers/` is the one name most
+  likely to be misread as real positions by someone skimming.
+
+  **C8 is not only a Phase 3 concern.** It is the sole missing piece between prod
+  and Season 1 of a board users can already open — see §Rollout.
 
 ## Integrity, abuse and spend
 
@@ -446,23 +594,36 @@ money. Ten accounts is ten minutes of work; a script makes it a thousand.
 
 ### Cost model at scale
 
-Free tier: **5 lifetime Replay attempts + 1 Forward entry per week.**
+Free tier: **5 lifetime Competition attempts + 1 Live Trading entry per season.**
 
 | Policy | At 100 users | At 500 users |
 |---|---|---|
-| Replay, 5 lifetime | $36 one-time | **$180 one-time** |
-| Forward, 1 entry/week | ~$7/month | **~$34/month** |
-| *(rejected)* Replay +1/day refill | ~$216/month | ~$1,080/month |
+| Competition, 5 lifetime | $36 one-time | **$180 one-time** |
+| Live Trading, 1 entry/season | ~$7/month | **~$34/month** |
+| *(rejected)* Competition +1/day refill | ~$216/month | ~$1,080/month |
 
-A daily Replay refill was considered and rejected: it is 97% of total spend and
-buys a return-visit mechanic the Forward Season and weekly email already
+The monthly figures are **unchanged by the two-week cadence**: a season costs
+twice as much and arrives half as often (§Measured cost per entry).
+
+A daily Competition refill was considered and rejected: it is 97% of total spend
+and buys a return-visit mechanic the season cycle and its result email already
 provide. Daily refills become the first thing credits buy once billing exists —
 which is the shape the ledger was designed for.
 
+> **Watch item added 2026-08-15.** The rejection assumed a *weekly* return-visit
+> mechanic. A two-week cycle is a materially weaker habit loop, and the daily
+> board that used to fill the gap between seasons is retired — PR #352 replaced
+> the Daily Leaderboard tab and commented out its nightly cron, so **nothing
+> refreshes automatically in prod today**. If retention is the goal, the gap
+> between season close and next season open now needs its own answer. Do not
+> close it by re-arming `LEADERBOARD_DAILY_AUTO_DEPLOY`: that flag lets an
+> anonymous GET trigger seven billable model deploys, which is the exact hazard
+> its strict opt-in exists to prevent.
+
 **Contingency:** if the Phase 0 probe forces the pinned model to DeepSeek V4
 Pro, every figure multiplies ~10.5× and the free tier at 500 users becomes
-~$1,890. **The budget holds and the grant shrinks** (5 lifetime Replay attempts
-→ 1; Forward stays weekly).
+~$1,890. **The budget holds and the grant shrinks** (5 lifetime Competition
+attempts → 1; Live Trading stays 1 per season).
 
 ## The board
 
@@ -500,14 +661,23 @@ speculative at 12.
 
 ## Information architecture
 
-The Competition tab keeps its four subtabs (`app.html:1396-1401`), remapped:
+The Competition tab keeps its four subtabs. **The roster changed under this
+section on 2026-08-15** (PR #352): the Daily Leaderboard subtab is gone and Live
+Trading took its slot, so the mapping below is rewritten against what prod
+actually renders (`app.html:1431-1434`).
 
-| Subtab | Today | After |
+| Subtab (`data-competition-tab`) | Today in prod | After |
 |---|---|---|
-| Daily Leaderboard | rolling 1-day model board | unchanged |
-| Competition Leaderboard | frozen contest board | **season board** with a Replay / Forward switch |
-| Participating Teams | permanent empty state | **Participating Traders** — the entrant list, finally populated |
-| About | contest rules | + season rules |
+| `leaderboard` — Competition Leaderboard | fixed-window house board | + user entries and the attempt ledger |
+| `live` — Live Trading Leaderboard | Season 0 preview, serving Competition curves under season chrome | the real season board, once C8 advances it |
+| `participants` — Participating Teams | permanent empty state | **Participating Traders** — the entrant list, finally populated |
+| `about` | contest rules | + season rules |
+
+> **This is strictly less work than designed.** The original plan was to turn one
+> subtab into a season board carrying a Replay/Forward switch modelled on the
+> `%`/`$` toggle. Prod already ships the two boards as **two separate subtabs**,
+> so the switch is unnecessary — delete that idea rather than building it. What
+> remains is populating boards that already have their own navigation.
 
 Two renames, no new navigation. **"Teams" becomes "Traders"** in user-visible
 copy — each entrant is one person. Note the styling layer keeps `kind: 'team'`
@@ -515,8 +685,8 @@ and `TEAM_COLOR_PALETTE` internally; that is deliberate (renaming the series kin
 would churn `js/leaderboard.js` for no user-visible gain), but it means the word
 persists in code while the UI says "trader".
 
-The Replay/Forward switch reuses the interaction shape of the existing `%`/`$`
-toggle.
+*(The Replay/Forward switch described here is withdrawn — prod ships the two
+boards as separate subtabs. See the note above.)*
 
 ## Isolation contract
 
@@ -531,8 +701,8 @@ toggle.
    exception escapes `CORSMiddleware` un-headered and presents in the browser as
    a CORS error, so "we turned it off" and "it is broken" would otherwise look
    identical at exactly the moment they must be told apart.
-4. **Separate queue paths**, so a Replay queue backup cannot stall the Forward
-   advance job.
+4. **Separate queue paths**, so a Competition queue backup cannot stall the Live
+   Trading advance job.
 
 A consequence: swapping which chart leads the landing page is a **one-line move**
 in `landing-page.tsx:18-22` plus the standard bundle refresh. No swap mechanism
@@ -542,6 +712,35 @@ is built — building one would be more complex than the swap.
 
 ### Landing
 
+> **Largely delivered by PR #357 (2026-08-15), by different means. Read the
+> status note before implementing anything in this subsection.**
+>
+> **Done:** the board is above the fold. #357 extracted the chart into a new
+> `BoardPreview` component and mounted it in `Hero.tsx:144`, rather than
+> reordering `landing-page.tsx`. `Race` never moved — it is still the last
+> section, and `FooterCTA` still reads `Talk → Test → Race`.
+>
+> **Done differently, on the other surface:** the *live* board landed on the
+> `/app` home screen, not the landing page. `home-page.js:1518` fetches
+> `GET /api/v1/leaderboard` and renders real standings with a labelled sample
+> fallback.
+>
+> **Reversed:** the Vercel landing page deliberately ships **illustrative**
+> data. `BoardPreview.tsx` hardcodes `SAMPLE_CURVES`/`SAMPLE_STANDINGS` under a
+> visible "Illustrative example" badge, and
+> `test_landing_copy_register.py::test_illustrative_example_label_appears_at_least_twice`
+> now **requires** that label to appear at least twice in the shipped bundle.
+> The requirement below to remove the badges is therefore not merely undone —
+> acting on it means deleting a guard a merged PR added on purpose.
+>
+> **If the live-data-on-landing idea is revived, argue it on the merits first.**
+> The landing page is served from Vercel while the API is on Render's free tier,
+> which spins down; an above-the-fold cross-origin fetch to a cold backend is the
+> weakest possible first impression, and that is a real reason to prefer a
+> labelled sample here even though `/app` gets live data. Whatever is decided,
+> the honesty rule is non-negotiable: **sample data must be visibly labelled as
+> sample.** Both current cards are.
+
 Wire the existing `Race` section to `GET /api/v1/leaderboard`, following the
 fetch pattern `MarketTicker.tsx:13-19,77-117` establishes. Remove the
 "Illustrative" badges (`Race.tsx:74,107`) once the data is real, and fetch
@@ -549,11 +748,16 @@ same-origin through the Vercel rewrite rather than hardcoding
 `agentictrading.onrender.com`.
 
 **Layout:** move `Race` directly under the hero (it is currently section 5 of 5,
-immediately before `FooterCTA`). Above the chart, a **Forward Season status
-strip** — *"Season 12 · day 3 of 5 · 44 traders"* or *"Next season opens
-Monday"* — which doubles as the between-seasons CTA. Below the Replay chart, the
-Forward chart as its own clearly-labelled section. When Forward proves out, the
-two sections swap by reordering one line.
+immediately before `FooterCTA`). Above the chart, a **season status strip** —
+*"Season 12 · day 3 of 10 · 44 traders"* or *"Next season opens soon"* — which
+doubles as the between-seasons CTA. Below the Competition chart, the Live Trading
+chart as its own clearly-labelled section. When Live Trading proves out, the two
+sections swap by reordering one line.
+
+*(A season strip already exists on `/app` — `renderSeasonStrip`, hidden on the
+Competition board. The landing equivalent should read from the same payload
+fields, `trading_days_elapsed` / `trading_days_total`, rather than inventing a
+second source of season truth.)*
 
 `Race.tsx` draws with **recharts** (`:3-12`), not Chart.js. The landing board is
 therefore a second implementation; none of `js/leaderboard.js`'s custom legend,
@@ -570,6 +774,13 @@ Renumber `Talk`/`Test` to 01/02 and make the board an unnumbered frame above
 them. **This copy is Allan's** (`storyline.ts`, `WhyCare.tsx:5`,
 `FooterCTA.tsx:10`) and needs his sign-off.
 
+> **Mostly done as a side effect of #357, and one loose end.** `Talk.tsx:13` and
+> `Test.tsx:143` carry `01 — Talk` / `02 — Test`, and the board's `03 — Race`
+> line is gone — which is exactly the end state described here, reached without
+> anyone asking for the sign-off. The loose end is `FooterCTA.tsx:10`, which
+> still restates the old sequence as `Talk → Test → Race`. It is now the only
+> place claiming an ordering the page no longer has.
+
 Post-signup redirect is unchanged: `/app?view=agents` with `nav-state`
 pre-seeded — plus a verification interstitial (see Abuse).
 
@@ -583,7 +794,7 @@ Instead, a **persistent Season checklist card** pinned at the top of My Agents �
 a card in the existing shelf renderer, not an overlay framework:
 
 ```
-Replay Qualifier · Nemotron 3 Nano                5 attempts left
+Competition Qualifier · Nemotron 3 Nano           5 attempts left
 The house instruction lost 0.22%. Beat it.
 
   [x] Your starter agent is ready
@@ -592,7 +803,7 @@ The house instruction lost 0.22%. Beat it.
 ```
 
 On first successful attempt it collapses into a permanent season HUD —
-`Replay · rank 34 of 112 · 3 attempts left · Forward Season opens Monday` — so it
+`Competition · rank 34 of 112 · 3 attempts left · next season opens soon` — so it
 never becomes dead weight.
 
 The checklist and the ledger are the **same state object**: the card renders
@@ -607,8 +818,11 @@ cancelled**, stated before submission rather than discovered after.
 One welcome screen shown once after signup, stating the goal in a sentence with
 a button that scrolls to the checklist. One screen, not a sequence.
 
-**Fix while here:** wire `#homeGetStartedBtn` (`app.html:411`) to the checklist,
-or remove it.
+~~**Fix while here:** wire `#homeGetStartedBtn` (`app.html:411`) to the
+checklist, or remove it.~~ **Withdrawn 2026-08-15** — the button was already
+wired on 2026-07-25 (`08c85aa`); see the correction in §Background. If the
+checklist ships, deciding whether this CTA should point at it instead of the
+agents playground is a live question, but it is a redirect, not a fix.
 
 ### Submission surface
 
@@ -676,20 +890,20 @@ exactly when the link matters — would render nothing.
 
 ## Notifications
 
-One email at Friday close: *"Season 12 closed. You placed 8th of 44. Next season
+One email at season close: *"Season 12 closed. You placed 8th of 44. Next season
 opens Monday."* Built on `send_email` (`sender.py:45`). Requires an opt-out from
 the start. `send_email` is `async` while ATL routes must stay sync `def`
 (#292), so it is called from the cron path, never from a request handler.
 
-Discord posting of weekly top entries is **deferred but designed for**: the
+Discord posting of each season's top entries is **deferred but designed for**: the
 notification layer takes a channel abstraction with email implemented and
 Discord stubbed, so adding it later is a new channel rather than a refactor.
 
 ## Non-goals
 
 - Broker-backed live paper trading, real-time execution, or order submission.
-  `execution/paper_backend.py` stays a stub. The Forward Season is **simulated**
-  and does not depend on it.
+  `execution/paper_backend.py` stays a stub. Live Trading is **simulated** and
+  does not depend on it.
 - Real capital. Ever, on this surface.
 - Changing the published Model Track curves.
 - Raising `MAX_BACKTEST_INITIAL_CAPITAL`.
@@ -750,11 +964,36 @@ control) run through `deploy_model_run` on **two models**: Nemotron and DeepSeek
 V4 Pro. Total **$4.97**. Needs `OPENROUTER_API_KEY` locally.
 
 The entire design rests on an unverified assumption — that better instructions
-produce better returns on a 30B nano model whose prompt is dominated by an
-unconditional `SAFE_TRADING_PROMPT`. If the spread across genuinely opposite
-instructions is under ~1pp on Nemotron but not DeepSeek, pin DeepSeek and apply
-the contingency above. **If both are flat, the instruction axis does not exist
-and Phase 2 must not be built.**
+produce better returns on a 30B nano model. If the spread across genuinely
+opposite instructions is under ~1pp on Nemotron but not DeepSeek, pin DeepSeek
+and apply the contingency above. **If both are flat, the instruction axis does
+not exist and Phase 2 must not be built.**
+
+> **Correction (2026-08-15) — the stated reason for expecting failure was
+> wrong, and the gate is more favourable than this document claimed.**
+>
+> The original sentence read "…a 30B nano model **whose prompt is dominated by an
+> unconditional `SAFE_TRADING_PROMPT`**". That is not what the code does. A
+> caller-supplied instruction **replaces** the `SAFE_TRADING_PROMPT` strategy body
+> outright; only a fixed execution-contract scaffold is concatenated after it —
+> `CUSTOM_STRATEGY_OUTPUT_CONTRACT` (`validator.py:667-711`), joined by
+> `create_custom_prompt` (`:730`). The instruction gets the entire strategy slot,
+> not a corner of one.
+>
+> This does not remove the need for the gate — a nano model may still fail to act
+> on instruction content, which is the real question — but it does remove the
+> specific mechanism this document predicted would suppress the signal, and it
+> raises the prior on a pass. Two knock-on effects worth holding in mind when
+> reading the probe results:
+>
+> - **A flat result is now more damning, not less.** With the instruction owning
+>   the whole strategy body, "the model ignores it" is the remaining explanation,
+>   and there is no prompt-dilution fix to try next.
+> - **The control instruction matters even more than stated.** Since instructions
+>   fully replace the strategy body, a nonsense control still produces a
+>   *syntactically valid* run. A control landing mid-pack means the model responds
+>   to having a strategy body at all rather than to its content — the outcome that
+>   passes a naive spread check while the board ranks noise.
 
 The five non-control instructions become the seed field, so this spend also
 solves the cold-start problem below.
@@ -767,6 +1006,14 @@ seeds **visibly labelled house-authored**, the first-party beacon, static
 `og:image`, CTA copy, Community→Agent Marketplace rename, "Teams"→"Traders".
 No user entries yet.
 
+> **Status 2026-08-15: mostly overtaken. Do not execute this phase as written.**
+> The landing-page half was delivered by #352/#357 through different components,
+> and the "hero chart on real data" item was resolved in the opposite direction
+> on the landing page (labelled sample data, now guarded). What genuinely remains
+> from Phase 1 is a short list — C1, the seed field, `og:image`, and the two
+> renames — enumerated task-by-task with current line numbers in the companion
+> plan document. Read that table before touching anything here.
+
 **Incremental cost: ~$0.** The six curves are the Nemotron half of the Phase 0
 probe; C1 is what makes a config entry able to carry an instruction at all, so a
 seed and a probe run are the same object. Regenerating them costs $0.43.
@@ -777,7 +1024,7 @@ phase whose entire purpose is testing whether the board converts. Seeds are
 config-driven house entries, not database rows — the committed `backtest.db` is
 the prod database, so seeding by committing rows is not an option.
 
-**Phase 2 — the Replay qualifier.** C3/C4/C5/C7 (C1 shipped in Phase 1),
+**Phase 2 — the Competition qualifier.** C3/C4/C5/C7 (C1 shipped in Phase 1),
 `leaderboard_entries` and `leaderboard_attempts` with their Postgres twins, the
 attempt ledger, email verification at signup, the checklist, the Submit action,
 the queue (**two workers**, one env var, redeploy to change), graduation.
@@ -787,29 +1034,70 @@ Two concurrent workers rather than the three or four originally floated: issue
 agent-scale investigation measured throughput collapsing under load. Starting at
 two makes the first real measurement cheap to recover from.
 
-**Phase 3 — Forward Seasons.** C8, `forward_positions` and its twin, derived
-weekly seasons, the Friday result email with opt-out, the share-card download,
-the notification channel abstraction with Discord stubbed.
+**Phase 3 — Live Trading seasons.** C8, `forward_positions` and its twin,
+derived two-week seasons, the season-close email with opt-out, the share-card
+download, the notification channel abstraction with Discord stubbed.
 
-Ordering is forced, not chosen: Forward entry is gated on a completed Replay
-attempt, so Phase 3 cannot precede Phase 2.
+Ordering is forced, not chosen: Live Trading entry is gated on a completed
+Competition attempt, so Phase 3 cannot precede Phase 2.
+
+> **C8's priority changed on 2026-08-15, and the forced ordering above does not
+> apply to it.** The Live Trading Leaderboard is *in prod now*, in a Season 0
+> preview that has never advanced, because no advance engine exists. C8 is what
+> makes that shipped board real — and it needs no user entries, no attempt
+> ledger, and nothing from Phase 2 to run against the existing house roster.
+>
+> **Consider splitting C8 out and landing it before Phase 2.** The gating
+> argument ("Live Trading entry requires a completed Competition attempt") is
+> about *user entry*, and C8 with a house-only roster has no users in it. Landing
+> it early converts a preview banner into a board that moves, which is the
+> `Stay` half of the goal, and it does so without waiting on the Phase 0 probe —
+> advancing seven existing house entries does not depend on whether *instructions*
+> move returns.
+>
+> Two things to carry into that decision: the four invariants in §Live Trading
+> (the banner clears itself when the advance writes `last_advanced_date`, so no
+> frontend work is implied), and the cost. Advancing the full house roster nightly
+> is the expensive shape — price it against the pinned-model-only alternative
+> before arming any schedule, and remember that PR #352 paused the nightly cron
+> precisely because it was deploying seven billable models for a board nobody
+> could open.
 
 **Watch item:** Phase 1 is the only phase shipping without users being able to
 act. If Phase 0 comes back strong, consider collapsing 1 and 2 — a hero chart
-with a CTA leading to a season nobody can enter is the `#homeGetStartedBtn`
-failure at the largest scale yet.
+with a CTA leading to a season nobody can enter is the dead-CTA failure at the
+largest scale yet.
+
+> **This watch item is now live, not hypothetical.** #352/#357 shipped the hero
+> chart without the entry path, so the state this warned about is the state prod
+> is in. It is handled honestly for the moment — the landing board is labelled
+> illustrative and the Season 0 banner says nothing has advanced — but the
+> mitigation is a disclaimer, not a destination. This strengthens the case for
+> collapsing what remains of Phase 1 into Phase 2 rather than shipping another
+> display-only increment.
 
 ## Recorded assumptions
 
 Stated rather than left implicit; correct any that are wrong before planning.
 
 1. **Existing prod accounts are grandfathered as verified.**
-2. **Forward seasons source bars from Alpaca**, same as Replay.
-3. **The Daily Leaderboard is untouched** by this work.
-4. **`attempts_granted = 5`** for the Replay qualifier, lifetime.
-5. **Replay keeps the current window** (`2026-04-15 → 2026-05-15`) — its
-   look-ahead exposure is acceptable because Forward is the competitive board.
+2. **Live Trading seasons source bars from Alpaca**, same as Competition.
+3. ~~**The Daily Leaderboard is untouched** by this work.~~ **Void 2026-08-15.**
+   PR #352 retired the Daily Leaderboard tab in favour of Live Trading and
+   commented out its nightly `schedule:`. The route, the secret and the cron line
+   all survive in `.github/workflows/daily-leaderboard.yml` because the season
+   engine's nightly advance is the same call — re-enable by uncommenting, do not
+   rewrite. Consequence: **nothing refreshes any board automatically in prod
+   today.**
+4. **`attempts_granted = 5`** for the Competition qualifier, lifetime.
+5. **Competition keeps the current window** (`2026-04-15 → 2026-05-15`) — its
+   look-ahead exposure is acceptable because Live Trading is the competitive
+   board.
 6. **The pinned model survives Phase 0.** If not, the contingency applies.
+7. **Added 2026-08-15: the two-week cadence is taken as fixed**, because prod
+   already renders it. If a future round wants weekly back, it is a UI change in
+   `js/leaderboard.js` as well as a config one — reopen §Decisions taken, where
+   the instruction-lock trade-off is recorded as unresolved.
 
 ## References
 
@@ -819,6 +1107,12 @@ Stated rather than left implicit; correct any that are wrong before planning.
 - `docs/superpowers/specs/2026-08-05-asset-class-shelves-design.md` — the shelf
   renderer the checklist card sits inside.
 - PR #325 (`45ccbc0`) — daily refresh cron and status UI.
-- PR #326 — open at time of writing, touches `js/leaderboard.js`; rebase onto it.
+- ~~PR #326 — open at time of writing, touches `js/leaderboard.js`; rebase onto
+  it.~~ **Merged 2026-08-09**; the rebase constraint is void.
+- **PR #352 (`7db504d`, merged 2026-08-15)** — the two-board redesign this spec
+  was reconciled against: Competition + Live Trading, two-week seasons, Season 0
+  preview, Daily Leaderboard tab retired and its cron paused.
+- **PR #357 (`60fa01f`, merged 2026-08-15)** — leaderboard-first landing and
+  `/app` home; added `BoardPreview.tsx` and the "Illustrative example" guard.
 - Issues #145 (scheduler), #202 (event-loop blocking), #230 (`decide()` seam),
   #258 (run cancellation).


### PR DESCRIPTION
Gate cleared by the repo owner on 2026-08-15 after the reconciliation below. (This line previously read "DO NOT MERGE until the team has signed off"; recording that it was lifted deliberately, not overlooked.)

Docs only. No code, no schema, no routes.

**What this is.** ATL's hook becomes a participatory leaderboard: users write one trading instruction, run it against the same harness the house entries use, and see where they land.

**Reconciled 2026-08-15 (`78368ad`).** This was written on 2026-08-09 and described two boards that did not exist. PR #352 then shipped two boards with different names and a different cadence, and PR #357 rewrote the landing page around them — neither against this spec. The docs now match prod:

| Was | Now | Note |
|---|---|---|
| Replay | **Competition Leaderboard** | same window; prod has no entry path |
| Forward Season | **Live Trading Leaderboard** | cadence **weekly → two weeks**; prod has no advance engine |

The design is no longer "add two boards" but **"add user entry to the two boards that now exist"** — strictly less work.

**Three things a reviewer should look at:**

1. *The Phase 0 gate got a better prior.* The plan justified the probe by claiming the prompt is dominated by an unconditional `SAFE_TRADING_PROMPT`. It isn't — a custom instruction **replaces** that body outright (`validator.py:667-711`, joined by `create_custom_prompt` at `:730`). The gate still matters, but a flat result would now be more damning, and the nonsense control is the load-bearing measurement, not the spread.
2. *C8 changed priority.* The Live Trading board is in prod as a Season 0 preview that has never advanced. C8 needs no user entries and doesn't depend on the probe, so it is proposed for splitting out ahead of Phase 2.
3. *One task is now actively wrong.* Task 7 would delete `test_illustrative_example_label_appears_at_least_twice`, a guard #357 added deliberately. Marked superseded rather than silently dropped.

**Also corrected:** `#homeGetStartedBtn` was described as unwired; it was wired on 2026-07-25 (`08c85aa`). The two-week cadence doubles the instruction lock, so that decision is explicitly reopened rather than inherited.

**Status of the plan's 12 tasks:** 1–4 valid as written · 5 blocked (premise withdrawn) · 6, 9, 10 valid, line numbers refreshed · 7 superseded · 8 done by other means, one loose end (`FooterCTA.tsx:10`) · 11 conditional · 12 rewrite.

**Merging does not start any work.** Phase 0 remains blocked on the ~$4.97 probe spend, which still needs an explicit go-ahead. Allan's sign-off on the `01/02/03` storyline is still outstanding — note #357 already renumbered it without asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
