### PR TITLE
fix(leaderboard): stop leaking raw exception text on public GET

### DIFF
--- a/dashboard/backend/api/routers/leaderboard.py
+++ b/dashboard/backend/api/routers/leaderboard.py
@@ -7,6 +7,8 @@ status codes, exception messages, and service calls are unchanged; only the
 module location moved.
 """
 
+import traceback
+
 from fastapi import APIRouter, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
@@ -43,9 +45,17 @@ def api_get_leaderboard(
     try:
         return get_leaderboard(force_refresh=refresh, period=period)
     except RuntimeError as exc:
+        # Deliberate domain failure (e.g. "leaderboard not ready yet") — the
+        # message is safe to show.
         raise HTTPException(status_code=503, detail=str(exc)) from exc
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception:
+        # Public, unauthenticated endpoint: a raw exception string can embed
+        # internal infrastructure details (e.g. the Neon endpoint id from a
+        # psycopg connection failure). Log the traceback server-side and
+        # answer with a static message, mirroring the POST /daily/refresh
+        # sibling fix (PR #325).
+        print(f"⚠️ Leaderboard request failed: {traceback.format_exc()}")
+        raise HTTPException(status_code=500, detail="Failed to load leaderboard") from None
 
 
 @router.post("/daily/refresh")

--- a/dashboard/backend/api/routers/leaderboard.py
+++ b/dashboard/backend/api/routers/leaderboard.py
@@ -42,18 +42,27 @@ def api_get_leaderboard(
     Pass ?refresh=true to recompute (e.g. after config change).
     Pass ?period=daily for the rolling one-day board (weekends show Friday).
     """
+    # Public, unauthenticated endpoint: no exception text reaches the caller.
+    # A raw exception string can embed internal infrastructure details — the
+    # Neon endpoint id from a psycopg failure, or the server-side credentials
+    # path from AlpacaCredentialsError. Both branches log the traceback
+    # server-side and answer with a static message, mirroring the
+    # POST /daily/refresh sibling fix (PR #325).
+    #
+    # RuntimeError is NOT an allowlist of safe domain errors: it is the base
+    # class of this repo's market-data family (MarketDataUnavailableError ->
+    # AlpacaCredentialsError, MarketDataDependencyError,
+    # MarketDataCredentialsError, IFindClientError), all of which reach here
+    # through ensure_leaderboard_runs -> fetch_hourly_bars. It only selects the
+    # 503 status code, never the message.
     try:
         return get_leaderboard(force_refresh=refresh, period=period)
-    except RuntimeError as exc:
-        # Deliberate domain failure (e.g. "leaderboard not ready yet") — the
-        # message is safe to show.
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except RuntimeError:
+        print(f"⚠️ Leaderboard unavailable: {traceback.format_exc()}")
+        raise HTTPException(
+            status_code=503, detail="Leaderboard is temporarily unavailable"
+        ) from None
     except Exception:
-        # Public, unauthenticated endpoint: a raw exception string can embed
-        # internal infrastructure details (e.g. the Neon endpoint id from a
-        # psycopg connection failure). Log the traceback server-side and
-        # answer with a static message, mirroring the POST /daily/refresh
-        # sibling fix (PR #325).
         print(f"⚠️ Leaderboard request failed: {traceback.format_exc()}")
         raise HTTPException(status_code=500, detail="Failed to load leaderboard") from None
 

--- a/dashboard/backend/tests/test_leaderboard_api.py
+++ b/dashboard/backend/tests/test_leaderboard_api.py
@@ -104,6 +104,34 @@ def test_leaderboard_api_returns_baselines(client, monkeypatch):
     assert body["entries"][0]["entry_type"] == "baseline"
 
 
+def test_leaderboard_api_does_not_leak_exception_text(client, monkeypatch):
+    """Public GET must answer 500 with a static message, never raw exception text.
+
+    Regression for the Neon-host leak: a psycopg connection failure message
+    embeds the database endpoint id, and this endpoint is public +
+    unauthenticated, so `detail=str(exc)` would hand that to any visitor.
+    The traceback still goes to the server log via print().
+    """
+    monkeypatch.setattr(
+        "dashboard.backend.api.routers.leaderboard.get_leaderboard",
+        lambda **kwargs: (_ for _ in ()).throw(
+            # A psycopg connection failure is a plain Exception (OperationalError),
+            # NOT a RuntimeError — the RuntimeError branch is reserved for
+            # deliberate domain failures whose messages are safe to show.
+            Exception("stale connection: could not connect to "
+                      "ep-abc123.us-east-2.aws.neon.tech:5432"),
+        ),
+    )
+
+    resp = client.get("/api/v1/leaderboard")
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["detail"] == "Failed to load leaderboard"
+    # The internal endpoint id must never appear in the public response.
+    assert "neon.tech" not in resp.text
+    assert "ep-abc123" not in resp.text
+
+
 def test_daily_leaderboard_api_uses_daily_window(client, monkeypatch):
     day = "2026-07-14"  # Tuesday
     monkeypatch.setattr(lb_service, "daily_window_dates", lambda as_of=None: (day, day))

--- a/dashboard/backend/tests/test_leaderboard_api.py
+++ b/dashboard/backend/tests/test_leaderboard_api.py
@@ -10,6 +10,7 @@ from dashboard.backend.app import app
 import dashboard.backend.api.routers.leaderboard as leaderboard_router
 import dashboard.backend.database as db_module
 import dashboard.backend.domain.leaderboard.service as lb_service
+import dashboard.backend.infrastructure.market_data.alpaca_bars as alpaca_bars
 
 
 @pytest.fixture
@@ -116,8 +117,8 @@ def test_leaderboard_api_does_not_leak_exception_text(client, monkeypatch):
         "dashboard.backend.api.routers.leaderboard.get_leaderboard",
         lambda **kwargs: (_ for _ in ()).throw(
             # A psycopg connection failure is a plain Exception (OperationalError),
-            # NOT a RuntimeError — the RuntimeError branch is reserved for
-            # deliberate domain failures whose messages are safe to show.
+            # so it lands in the generic branch. The RuntimeError branch is
+            # covered separately below — it is equally unsafe to echo.
             Exception("stale connection: could not connect to "
                       "ep-abc123.us-east-2.aws.neon.tech:5432"),
         ),
@@ -130,6 +131,47 @@ def test_leaderboard_api_does_not_leak_exception_text(client, monkeypatch):
     # The internal endpoint id must never appear in the public response.
     assert "neon.tech" not in resp.text
     assert "ep-abc123" not in resp.text
+
+
+def test_leaderboard_api_does_not_leak_runtime_error_text(client, monkeypatch, tmp_path):
+    """The 503 branch must be static too — RuntimeError is not a safe allowlist.
+
+    ``MarketDataUnavailableError`` -> ``AlpacaCredentialsError`` subclass
+    ``RuntimeError`` (they were made RuntimeErrors to escape SystemExit, not as
+    a safety marker), and reach this handler through ``get_leaderboard`` ->
+    ``ensure_leaderboard_runs`` -> ``fetch_hourly_bars``. Their message embeds
+    the server-side credentials path, so ``detail=str(exc)`` on the 503 handed
+    that path to anonymous callers exactly like the 500 branch did — the daily
+    board hits it on any window with no cached runs yet.
+
+    The exception is raised by the *real* loader rather than hand-written, so a
+    reworded upstream message cannot drift away from this assertion.
+    """
+    creds_dir = tmp_path / "server-only" / "credentials"
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+    monkeypatch.setattr(alpaca_bars, "CREDENTIALS_DIR", creds_dir)
+
+    def _raise_from_real_loader(**kwargs):
+        alpaca_bars.AlpacaDataLoader()  # raises AlpacaCredentialsError
+
+    monkeypatch.setattr(
+        "dashboard.backend.api.routers.leaderboard.get_leaderboard",
+        _raise_from_real_loader,
+    )
+
+    # Sanity: the error really is a RuntimeError, so it really does take the
+    # 503 branch rather than the already-covered generic one.
+    with pytest.raises(RuntimeError) as raised:
+        alpaca_bars.AlpacaDataLoader()
+    assert str(creds_dir) in str(raised.value)
+
+    resp = client.get("/api/v1/leaderboard")
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Leaderboard is temporarily unavailable"
+    # The server-side credentials path must never reach a public caller.
+    assert str(creds_dir) not in resp.text
+    assert "alpaca.json" not in resp.text
 
 
 def test_daily_leaderboard_api_uses_daily_window(client, monkeypatch):


### PR DESCRIPTION
## Why

`GET /api/v1/leaderboard` is public and unauthenticated, but its exception handlers returned `detail=str(exc)`. Two different leaks came out of that:

- A psycopg connection failure message embeds the database server host — in prod that's the Neon endpoint id — reachable through the generic `500` branch.
- `AlpacaCredentialsError` embeds the **server-side credentials path** (`.../credentials/alpaca.json`), reachable through the `503` branch, because `MarketDataUnavailableError` subclasses `RuntimeError`.

This is the same `py/stack-trace-exposure` shape CodeQL flagged in PR #325 (fixed there for the POST sibling); the GET was pre-existing and outside that PR's diff.

## Summary

- Neither branch echoes exception text any more. Both log the traceback server-side (`print(f"...{traceback.format_exc()}")`, per repo convention) and return a static message: `"Failed to load leaderboard"` (500) / `"Leaderboard is temporarily unavailable"` (503).
- `RuntimeError` now selects only the **status code**, never the message. It is not an allowlist of safe domain errors: it is the base class of this repo's market-data family — `MarketDataUnavailableError` → `AlpacaCredentialsError`, `MarketDataDependencyError`, `MarketDataCredentialsError`, `IFindClientError` — all of which reach this handler via `get_leaderboard` → `ensure_leaderboard_runs` → `fetch_hourly_bars` → `AlpacaDataLoader()`. Those classes subclass `RuntimeError` to escape `SystemExit` (see the `alpaca_bars` module docstring), not as a safety marker.
- Two regression tests: one for each branch. The 503 test raises through the *real* `AlpacaDataLoader` rather than a hand-written message, so a reworded upstream string cannot drift away from the assertion.

## Issue Number

Fixes Open-Finance-Lab/AgenticTrading#327

## How to Test

1. `pytest dashboard/backend/tests/test_leaderboard_api.py` — 23 passed (incl. both leak regressions)
2. Full suite: `pytest dashboard/backend/tests/` — 2653 passed, 67 skipped

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The traceback still reaches operators via stdout (uvicorn logs), so the fix only hides the leak from anonymous callers, not from the server logs.

The 503 message was previously described here as carrying deliberate domain failures ("leaderboard not ready yet") that were safe to show. That message does not exist anywhere in the codebase, and no test or frontend code reads the 503 `detail`. The `RuntimeError`s that *can* actually reach this handler are the market-data family above and `LeaderboardFallbackError` (operator-facing text about `--allow-fallback`, raised unwrapped from `ensure_leaderboard_runs`) — none of which is useful to an anonymous visitor.

Other `detail=str(exc)` sites exist in authenticated routers (backtests, agents, etc.); those are not the same exposure class since they require auth, so they're out of scope here.
