### PR TITLE
fix(backtest): pass session_id to insert_run in CLI save path

### DIFF
--- a/dashboard/backend/tests/test_backtest_cli_save.py
+++ b/dashboard/backend/tests/test_backtest_cli_save.py
@@ -1,0 +1,69 @@
+"""Tests for the backtest CLI save path (dashboard/scripts/backtest.py).
+
+Regression for the "insert_run missing session_id" TypeError: the CLI's
+save_backtest_to_database() called db.insert_run() without the required
+session_id positional arg, so every `python dashboard/scripts/backtest.py`
+save raised. Each standalone CLI run has no session concept, so it now passes
+session_id=run_id — the same pattern the /paper/start-session fix uses.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load_backtest_script():
+    """Import dashboard/scripts/backtest.py (not a package) in isolation."""
+    path = _SCRIPTS_DIR / "backtest.py"
+    spec = importlib.util.spec_from_file_location("backtest_script", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    # The script imports sibling modules (backtest_engine, _bootstrap) by bare
+    # name, so the scripts dir must be on sys.path for those to resolve.
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(_SCRIPTS_DIR))
+    return module
+
+
+def test_save_backtest_to_database_passes_session_id(monkeypatch):
+    """insert_run must receive session_id (= run_id) so the CLI save succeeds."""
+    module = _load_backtest_script()
+
+    calls = {}
+
+    class FakeDb:
+        def insert_run(self, **kwargs):
+            calls["insert_run"] = kwargs
+
+        def insert_equity_points(self, run_id, curve):
+            calls["insert_equity_points"] = (run_id, curve)
+
+    monkeypatch.setattr(module, "db", FakeDb())
+
+    results = {
+        "agent_a": {
+            "metrics": {
+                "total_return": 0.05,
+                "sharpe_ratio": 1.2,
+                "max_drawdown": -0.03,
+                "num_trades": 5,
+            },
+            "equity_curve": [{"timestamp": "t", "equity": 100000}],
+        },
+    }
+
+    module.save_backtest_to_database(results, "2026-01-01", "2026-02-01")
+
+    kwargs = calls["insert_run"]
+    assert "session_id" in kwargs, "insert_run missing session_id"
+    assert kwargs["session_id"] == kwargs["run_id"]
+    assert kwargs["agent_name"] == "agent_a"
+    assert calls["insert_equity_points"][0] == kwargs["run_id"]

--- a/dashboard/backend/tests/test_backtest_cli_save.py
+++ b/dashboard/backend/tests/test_backtest_cli_save.py
@@ -3,17 +3,27 @@
 Regression for the "insert_run missing session_id" TypeError: the CLI's
 save_backtest_to_database() called db.insert_run() without the required
 session_id positional arg, so every `python dashboard/scripts/backtest.py`
-save raised. Each standalone CLI run has no session concept, so it now passes
-session_id=run_id — the same pattern the /paper/start-session fix uses.
+save raised.
+
+The stub deliberately binds each call against the *real*
+``BacktestDatabase.insert_run`` signature instead of swallowing ``**kwargs``.
+A permissive stub cannot fail the way production fails: it would keep passing
+if ``insert_run`` grew another required parameter, which is precisely the
+defect class this file exists to catch.
 """
 
 import importlib.util
+import inspect
 import sys
 from pathlib import Path
 
 import pytest
 
+from dashboard.backend.database import BacktestDatabase
+
 _SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+_INSERT_RUN_SIGNATURE = inspect.signature(BacktestDatabase.insert_run)
 
 
 def _load_backtest_script():
@@ -33,37 +43,146 @@ def _load_backtest_script():
     return module
 
 
-def test_save_backtest_to_database_passes_session_id(monkeypatch):
-    """insert_run must receive session_id (= run_id) so the CLI save succeeds."""
+class _ContractCheckingDb:
+    """Records insert_run calls, rejecting any that the real DB would reject."""
+
+    def __init__(self):
+        self.calls = {}
+
+    def insert_run(self, *args, **kwargs):
+        # Raises TypeError for a missing/unknown parameter, exactly as the real
+        # BacktestDatabase.insert_run would. `self` stands in for the bound
+        # instance the real (unbound) signature still expects.
+        bound = _INSERT_RUN_SIGNATURE.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        self.calls["insert_run"] = dict(bound.arguments)
+
+    def insert_equity_points(self, run_id, curve):
+        self.calls["insert_equity_points"] = (run_id, curve)
+
+
+def test_save_backtest_to_database_satisfies_insert_run_contract(monkeypatch):
+    """The CLI's insert_run call must satisfy the real DB signature."""
     module = _load_backtest_script()
+    db = _ContractCheckingDb()
+    monkeypatch.setattr(module, "db", db)
 
-    calls = {}
-
-    class FakeDb:
-        def insert_run(self, **kwargs):
-            calls["insert_run"] = kwargs
-
-        def insert_equity_points(self, run_id, curve):
-            calls["insert_equity_points"] = (run_id, curve)
-
-    monkeypatch.setattr(module, "db", FakeDb())
-
-    results = {
-        "agent_a": {
-            "metrics": {
-                "total_return": 0.05,
-                "sharpe_ratio": 1.2,
-                "max_drawdown": -0.03,
-                "num_trades": 5,
+    module.save_backtest_to_database(
+        {
+            "agent_a": {
+                # BacktestMetrics reports percent (see the scale test below).
+                "metrics": {
+                    "total_return": 10.0,
+                    "sharpe_ratio": 1.2,
+                    "max_drawdown": -3.0,
+                    "num_trades": 5,
+                },
+                "equity_curve": [{"timestamp": "t", "equity": 110000}],
             },
-            "equity_curve": [{"timestamp": "t", "equity": 100000}],
         },
-    }
+        "2026-01-01",
+        "2026-02-01",
+    )
 
-    module.save_backtest_to_database(results, "2026-01-01", "2026-02-01")
-
-    kwargs = calls["insert_run"]
-    assert "session_id" in kwargs, "insert_run missing session_id"
-    assert kwargs["session_id"] == kwargs["run_id"]
+    kwargs = db.calls["insert_run"]
+    assert kwargs["session_id"], "insert_run missing session_id"
     assert kwargs["agent_name"] == "agent_a"
-    assert calls["insert_equity_points"][0] == kwargs["run_id"]
+    assert kwargs["mode"] == "backtest"
+    assert db.calls["insert_equity_points"][0] == kwargs["run_id"]
+
+
+def test_save_backtest_to_database_uses_the_shared_sessionless_key(monkeypatch):
+    """Sessionless writers share one grouping key; a per-run id orphans the row.
+
+    ``agent_runs.session_id`` is an ownership/grouping key — every
+    session-scoped query (``get_runs_by_session``, ``get_runs_by_sessions``,
+    ``get_run_with_session``) and every stale-run sweep reaches rows *through*
+    it. Minting a fresh session id per CLI invocation makes each run its own
+    unreachable island. ``legacy-demo-session`` is what BacktestEngine defaults
+    to, what backtest_hourly_agent's --session-id defaults to, and what
+    database.py backfills onto pre-session rows.
+    """
+    module = _load_backtest_script()
+    db = _ContractCheckingDb()
+    monkeypatch.setattr(module, "db", db)
+
+    module.save_backtest_to_database(
+        {
+            "agent_a": {
+                "metrics": {
+                    "total_return": 10.0,
+                    "sharpe_ratio": 1.2,
+                    "max_drawdown": -3.0,
+                    "num_trades": 5,
+                },
+                "equity_curve": [{"timestamp": "t", "equity": 110000}],
+            },
+        },
+        "2026-01-01",
+        "2026-02-01",
+    )
+
+    kwargs = db.calls["insert_run"]
+    assert kwargs["session_id"] == "legacy-demo-session"
+    assert kwargs["session_id"] != kwargs["run_id"]
+
+
+def test_backtest_metrics_are_reported_in_percent():
+    """Pins the producer side of the scale contract.
+
+    ``BacktestMetrics.total_return`` / ``max_drawdown`` are percentages
+    (backtest_engine multiplies by 100). If that ever changes to fractions, the
+    CLI's /100 conversion becomes a double-divide — this test reds first so the
+    two halves can't drift apart silently.
+    """
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+    try:
+        from backtest_engine import BacktestEngine
+    finally:
+        sys.path.remove(str(_SCRIPTS_DIR))
+
+    engine = BacktestEngine(initial_capital=100000)
+    engine.register_agent("agent_a")
+    portfolio = engine.portfolios["agent_a"]
+    portfolio.record_daily_equity("2026-01-01", {})
+    portfolio.cash = 110000  # all-cash +10%
+    portfolio.record_daily_equity("2026-01-02", {})
+
+    metrics = engine.calculate_metrics("agent_a")
+    assert metrics.total_return == pytest.approx(10.0)  # percent, not 0.10
+
+
+def test_save_backtest_to_database_stores_fractions_not_percent(monkeypatch):
+    """agent_runs stores fractions; the CLI must convert down from percent.
+
+    Every other insert_run writer stores ``(final - initial) / initial``, and
+    the frontend disambiguates by magnitude (``Math.abs(x) <= 1 ? x * 100 : x``
+    in app.js). Storing percent would make a genuine +0.4% run render as
+    "+40.00%" on the public, unfiltered /runs list.
+    """
+    module = _load_backtest_script()
+    db = _ContractCheckingDb()
+    monkeypatch.setattr(module, "db", db)
+
+    module.save_backtest_to_database(
+        {
+            "agent_a": {
+                "metrics": {
+                    "total_return": 0.4,  # +0.4 percent
+                    "sharpe_ratio": 1.2,
+                    "max_drawdown": -12.5,  # -12.5 percent
+                    "num_trades": 5,
+                },
+                "equity_curve": [{"timestamp": "t", "equity": 100400}],
+            },
+        },
+        "2026-01-01",
+        "2026-02-01",
+    )
+
+    kwargs = db.calls["insert_run"]
+    assert kwargs["total_return"] == pytest.approx(0.004)
+    assert kwargs["max_drawdown"] == pytest.approx(-0.125)
+    # The magnitude heuristic must read these as fractions, not as percentages.
+    assert abs(kwargs["total_return"]) <= 1
+    assert abs(kwargs["max_drawdown"]) <= 1

--- a/dashboard/scripts/backtest.py
+++ b/dashboard/scripts/backtest.py
@@ -393,9 +393,11 @@ def save_backtest_to_database(results: Dict, start_date: str, end_date: str):
         metrics = data["metrics"]
         equity_curve = data["equity_curve"]
         
-        # Insert run metadata
+        # Insert run metadata. The CLI has no session concept, so each run is
+        # its own session — same pattern as the /paper/start-session fix.
         db.insert_run(
             run_id=run_id,
+            session_id=run_id,
             agent_name=agent,
             mode="backtest",
             start_date=start_date,

--- a/dashboard/scripts/backtest.py
+++ b/dashboard/scripts/backtest.py
@@ -393,20 +393,30 @@ def save_backtest_to_database(results: Dict, start_date: str, end_date: str):
         metrics = data["metrics"]
         equity_curve = data["equity_curve"]
         
-        # Insert run metadata. The CLI has no session concept, so each run is
-        # its own session — same pattern as the /paper/start-session fix.
+        # Insert run metadata. This standalone CLI has no session of its own,
+        # so it uses the same grouping key every other sessionless writer uses
+        # (engine.BacktestEngine's default and backtest_hourly_agent's
+        # --session-id default), which is also what database.py backfills onto
+        # pre-session rows. A per-run session id would instead mint one orphan
+        # session per invocation, unreachable by every session-scoped query.
+        #
+        # BacktestMetrics reports return/drawdown in PERCENT (backtest_engine
+        # multiplies by 100), but agent_runs stores FRACTIONS — every other
+        # insert_run caller writes (final - initial) / initial. The frontend
+        # disambiguates by magnitude (`Math.abs(x) <= 1 ? x * 100 : x`), so
+        # storing percent here would render a +0.4% run as "+40.00%".
         db.insert_run(
             run_id=run_id,
-            session_id=run_id,
+            session_id="legacy-demo-session",
             agent_name=agent,
             mode="backtest",
             start_date=start_date,
             end_date=end_date,
             initial_equity=100000,
             final_equity=equity_curve[-1]["equity"] if equity_curve else 100000,
-            total_return=metrics["total_return"],
+            total_return=metrics["total_return"] / 100.0,
             sharpe_ratio=metrics["sharpe_ratio"],
-            max_drawdown=metrics["max_drawdown"],
+            max_drawdown=metrics["max_drawdown"] / 100.0,
             num_trades=metrics["num_trades"]
         )
         


### PR DESCRIPTION
## Why

`dashboard/scripts/backtest.py` calls `db.insert_run(...)` without the required `session_id` positional arg, so `python dashboard/scripts/backtest.py` fails at the save step on every run with `TypeError: insert_run() missing 1 required positional argument: 'session_id'`.

Unblocking that save is necessary but not sufficient: the call also had the wrong **scale** and the wrong **grouping key**, so a working save would have written silently-bad rows instead of crashing.

## Summary

- `save_backtest_to_database()` now passes `session_id="legacy-demo-session"` — the shared key every other sessionless writer uses (`BacktestEngine`'s default, `backtest_hourly_agent`'s `--session-id` default, and what `database.py` backfills onto pre-session rows). A per-run session id would mint one orphan session per invocation, unreachable by every session-scoped query (`get_runs_by_session`, `get_runs_by_sessions`, `get_run_with_session`) and by stale-run sweeps.
- `total_return` / `max_drawdown` are divided by 100. `BacktestMetrics` reports **percent** (`backtest_engine` multiplies by 100), but `agent_runs` stores **fractions** — every other `insert_run` caller writes `(final - initial) / initial`. `GET /runs` is public and unfiltered, and the frontend disambiguates by magnitude (`Math.abs(x) <= 1 ? x * 100 : x`), so a genuine +0.4% run would have been stored as `0.4`, read back as a fraction, and rendered **"+40.00%"**.
- Regression tests bind each call against the **real** `BacktestDatabase.insert_run` signature via `inspect.signature(...).bind(...)`, plus a producer-side test pinning that `BacktestMetrics` really is percent-scaled.

## Issue Number

Fixes Open-Finance-Lab/AgenticTrading#264

## How to Test

1. `pytest dashboard/backend/tests/test_backtest_cli_save.py` — 4 passed
2. Full suite: `pytest dashboard/backend/tests/` — 2655 passed, 67 skipped

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The tests import `dashboard/scripts/backtest.py` via `importlib` (it's not a package) and monkeypatch the module's `db` with a recording stub, so no real database is touched and the committed seed DB is unaffected.

The stub deliberately does **not** accept `**kwargs`. A permissive stub cannot fail the way production fails: add another required parameter to `insert_run` and the CLI would break with the identical `TypeError` while the test stayed green — precisely the defect class this file exists to catch. Binding against the real signature was verified to red against pre-PR `main` with that same `TypeError`.

An earlier revision of this PR used `session_id=run_id`, citing `/paper/start-session` as precedent. That precedent is `mode="paper"`, which surfaces through mode-scoped and global listings; backtest-mode rows surface session-scoped, so the analogy does not carry over.
