### PR TITLE
test(backtests): make plot-png cache test hermetic with unique key

### DIFF
--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -48,20 +48,24 @@ def test_plot_png_cached_per_run(monkeypatch):
         "baseline_buyhold_run_id": None, "baseline_djia_run_id": None,
     }
 
-    # Unique per-invocation key: the render cache is a module-level lru_cache
-    # shared across tests, and a leftover TestClient threadpool render (from an
-    # earlier test) that lands *after* cache_clear() would populate a fixed
-    # "run_x" entry with real data — making the 2nd call a cache hit and the
-    # get_run count 0 instead of 1 (intermittent flake). A unique key keeps
-    # this test hermetic against that race.
+    # #139's traceback was lost, so the real flake mechanism is unconfirmed.
+    # Defense in depth against cross-test interference: the render cache is a
+    # module-level lru_cache and bt.db is a process-wide singleton (patched
+    # for any thread while this test runs), so (a) a unique per-invocation
+    # key guarantees no other code path can collide with this test's cache
+    # entry, and (b) the counters only count calls for *this* key, so a stray
+    # db.get_run from another test's leftover threadpool thread cannot skew
+    # the assertions either way.
     run_id = f"run_x_{uuid.uuid4().hex}"
 
     def fake_get_run(rid):
-        calls["get_run"] += 1
+        if rid == run_id:
+            calls["get_run"] += 1
         return fake_run
 
     def fake_equity(rid):
-        calls["equity"] += 1
+        if rid == run_id:
+            calls["equity"] += 1
         return [{"timestamp": "2026-05-01T10:00:00", "equity": 100000},
                 {"timestamp": "2026-05-01T11:00:00", "equity": 101000}]
 
@@ -89,7 +93,8 @@ def test_plot_png_missing_run_not_cached(monkeypatch):
     hits = {"n": 0}
 
     def counting_get_run(rid):
-        hits["n"] += 1
+        if rid == "missing":  # same stray-thread gating as the cache test above
+            hits["n"] += 1
         return None
 
     monkeypatch.setattr(bt.db, "get_run", counting_get_run)

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -48,6 +48,14 @@ def test_plot_png_cached_per_run(monkeypatch):
         "baseline_buyhold_run_id": None, "baseline_djia_run_id": None,
     }
 
+    # Unique per-invocation key: the render cache is a module-level lru_cache
+    # shared across tests, and a leftover TestClient threadpool render (from an
+    # earlier test) that lands *after* cache_clear() would populate a fixed
+    # "run_x" entry with real data — making the 2nd call a cache hit and the
+    # get_run count 0 instead of 1 (intermittent flake). A unique key keeps
+    # this test hermetic against that race.
+    run_id = f"run_x_{uuid.uuid4().hex}"
+
     def fake_get_run(rid):
         calls["get_run"] += 1
         return fake_run
@@ -61,8 +69,8 @@ def test_plot_png_cached_per_run(monkeypatch):
     monkeypatch.setattr(bt.db, "get_equity_curve", fake_equity)
     monkeypatch.setattr(bt, "filter_market_hours", lambda pts: pts)  # isolate caching
 
-    first = bt._render_run_plot_png("run_x")
-    second = bt._render_run_plot_png("run_x")
+    first = bt._render_run_plot_png(run_id)
+    second = bt._render_run_plot_png(run_id)
 
     assert first == second
     assert first[:8] == b"\x89PNG\r\n\x1a\n"      # valid PNG


### PR DESCRIPTION
## Why

`test_plot_png_cached_per_run` failed once in a full-suite run (86s vs normal 43-45s) and never reproduced — but the traceback was lost, so nobody knows which assertion failed. The module-level `@lru_cache` on `_render_run_plot_png` and the process-wide `bt.db` singleton are real shared-state seams across the test process.

## Summary

- The test used the fixed cache key `"run_x"` on a cache shared across the whole test process. Review found no code path that can actually populate that key from outside the test (the production route is only reached via `/runs/{run_id}/plot.png` URLs no test requests), so the originally hypothesized cache-poisoning mechanism cannot be #139's cause — the real cause remains unconfirmed.
- Hardening, covering both failure directions (defense in depth, not a proven-root-cause fix):
  - unique per-invocation key (`f"run_x_{uuid.uuid4().hex}"`) so no other code path can ever collide with this test's cache entry (count 0 direction);
  - counters gated on `rid == run_id` — `bt.db` is a process-wide singleton, so while it is monkeypatched *any* thread's `db.get_run` call hits the fake; unconditional counting meant a stray call from a leftover threadpool thread could tick the count to 2 (the opposite failure direction). Same gating applied to `test_plot_png_missing_run_not_cached`.
- No production code touched.

## Issue Number

Mitigates hypothesized cross-test interference vectors of Open-Finance-Lab/AgenticTrading#139. Deliberately **not** "Fixes": the original traceback was lost and the root cause is unconfirmed, so #139 should stay open until the flake recurs (now with counters that can't be polluted) or is positively diagnosed.

## How to Test

1. `pytest dashboard/backend/tests/test_backtests_router.py -k plot_png` — passes repeatedly
2. Full router file: `pytest dashboard/backend/tests/test_backtests_router.py` — 66 passed (re-verified at `0129d78`)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This makes the test hermetic against cross-test cache collisions *and* counter pollution, but it does not claim to have reproduced or root-caused #139 — the comment in the test says so explicitly, so the next intermittent failure gets triaged against honest documentation.
