### PR TITLE
perf(auth): move auth.py handlers off the event loop

### DIFF
--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -478,7 +478,12 @@ async def change_password(
     current_user: dict = Depends(get_current_user),
     authorization: Optional[str] = Header(default=None),
 ):
-    if not verify_password(payload.current_password, current_user["password_hash"]):
+    # bcrypt verify off the event loop: it is deliberately slow (~190 ms),
+    # and on a shared event loop it would stall every concurrent request
+    # (same reason login()/signup() already offload via asyncio.to_thread).
+    if not await asyncio.to_thread(
+        verify_password, payload.current_password, current_user["password_hash"]
+    ):
         raise HTTPException(status_code=400, detail="Current password is incorrect.")
     violations = validate_new_password(payload.new_password, current_user["email"])
     if violations:
@@ -608,7 +613,11 @@ async def request_email_change(
     current_user: dict = Depends(get_current_user),
 ):
     store = users_module.user_store
-    if not verify_password(payload.current_password, current_user["password_hash"]):
+    # bcrypt verify off the event loop (same as change_password): it is
+    # deliberately slow and would stall concurrent requests when inline.
+    if not await asyncio.to_thread(
+        verify_password, payload.current_password, current_user["password_hash"]
+    ):
         raise HTTPException(status_code=400, detail="Current password is incorrect.")
     if payload.new_email == str(current_user["email"]).strip().lower():
         raise HTTPException(status_code=400, detail="That is already your email address.")

--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -427,7 +427,7 @@ async def login(payload: LoginRequest, request: Request):
 
 
 @router.get("/me")
-async def me(
+def me(
     request: Request,
     authorization: Optional[str] = Header(default=None),
     current_user: dict = Depends(get_current_user),
@@ -461,7 +461,7 @@ def logout(
 
 
 @router.post("/logout-all")
-async def logout_all(request: Request, current_user: dict = Depends(get_current_user)):
+def logout_all(request: Request, current_user: dict = Depends(get_current_user)):
     users_module.user_store.delete_other_sessions(current_user["id"], keep_token=None)
     response = JSONResponse({"status": "ok"})
     clear_session_cookie(response)
@@ -472,22 +472,33 @@ async def logout_all(request: Request, current_user: dict = Depends(get_current_
 
 
 @router.post("/change-password")
-async def change_password(
+def change_password(
     payload: ChangePasswordRequest,
     request: Request,
     current_user: dict = Depends(get_current_user),
     authorization: Optional[str] = Header(default=None),
 ):
-    # bcrypt verify off the event loop: it is deliberately slow (~190 ms),
-    # and on a shared event loop it would stall every concurrent request
-    # (same reason login()/signup() already offload via asyncio.to_thread).
-    if not await asyncio.to_thread(
-        verify_password, payload.current_password, current_user["password_hash"]
-    ):
-        raise HTTPException(status_code=400, detail="Current password is incorrect.")
+    # Plain def, not async: nothing in this handler awaits, and *everything* in
+    # it blocks -- one bcrypt verify (~190 ms), a second bcrypt hash of the same
+    # cost inside update_password(), and three store round trips (network calls
+    # against Postgres in prod). Starlette runs a sync handler in the threadpool,
+    # so the whole lot costs one worker thread instead of freezing the event
+    # loop for every concurrent request. This is #292's fix applied to the
+    # handler #297 singled out for it; offloading only the verify would have
+    # left an identically slow hash on the loop. Pinned by BLOCKING_IO_HANDLERS
+    # in tests/test_event_loop_threadpool.py -- adding an await here silently
+    # takes it back out of that guard.
+    #
+    # Policy first, bcrypt second, for the same reason signup() checks in that
+    # order: a rejected new password changes nothing, so it should not cost a
+    # hash. The trade is that a request wrong on both counts now reports the
+    # policy violation instead of "Current password is incorrect"; neither is a
+    # secret, since signup enforces the same policy unauthenticated.
     violations = validate_new_password(payload.new_password, current_user["email"])
     if violations:
         raise HTTPException(status_code=400, detail=" ".join(violations))
+    if not verify_password(payload.current_password, current_user["password_hash"]):
+        raise HTTPException(status_code=400, detail="Current password is incorrect.")
     users_module.user_store.update_password(current_user["id"], payload.new_password)
     # Best-effort: revoke every other session so a stolen token dies with the old
     # password. Deliberately NOT atomic with the update above -- the two are separate
@@ -521,7 +532,7 @@ async def change_password(
 
 
 @router.put("/display-name")
-async def update_display_name(
+def update_display_name(
     payload: DisplayNameRequest,
     current_user: dict = Depends(get_current_user),
 ):
@@ -607,17 +618,20 @@ def _email_change_new_body(code: str) -> str:
     )
 
 
-@router.post("/email-change")
-async def request_email_change(
-    payload: EmailChangeRequest,
-    current_user: dict = Depends(get_current_user),
-):
-    store = users_module.user_store
-    # bcrypt verify off the event loop (same as change_password): it is
-    # deliberately slow and would stall concurrent requests when inline.
-    if not await asyncio.to_thread(
-        verify_password, payload.current_password, current_user["password_hash"]
-    ):
+def _authorize_email_change(store, current_user: dict, payload: EmailChangeRequest) -> None:
+    """Password check + policy + the three rate limits, or raise.
+
+    Extracted so request_email_change -- which must stay ``async def`` for the
+    awaited send below -- can run this whole blocking half in one worker-thread
+    hop. Every step here blocks: one bcrypt verify (~190 ms) plus four store
+    round trips, which are network calls against Postgres in prod. Offloading
+    only the bcrypt would leave the four round trips stalling the event loop,
+    which on a cold pooled connection costs more than the hash does.
+
+    Raises HTTPException directly; those propagate out of asyncio.to_thread
+    unchanged, so FastAPI turns them into the same responses as before.
+    """
+    if not verify_password(payload.current_password, current_user["password_hash"]):
         raise HTTPException(status_code=400, detail="Current password is incorrect.")
     if payload.new_email == str(current_user["email"]).strip().lower():
         raise HTTPException(status_code=400, detail="That is already your email address.")
@@ -682,6 +696,18 @@ async def request_email_change(
                 "Please wait a minute before requesting another code.", remaining
             )
 
+
+@router.post("/email-change")
+async def request_email_change(
+    payload: EmailChangeRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    # Stays async: send_email() is a real coroutine. Everything either side of
+    # it blocks, so each half goes to a worker thread rather than running on the
+    # event loop (#297). Two hops, not five inline store calls plus a bcrypt.
+    store = users_module.user_store
+    await asyncio.to_thread(_authorize_email_change, store, current_user, payload)
+
     code = generate_code()
     # Send BEFORE persisting. Persisting first and then failing to send would
     # burn the cooldown on a code that does not exist.
@@ -695,14 +721,17 @@ async def request_email_change(
             status_code=503,
             detail="Could not send the confirmation email. Please try again later.",
         )
-    store.create_email_change_request(
-        current_user["id"], payload.new_email, hash_code(code)
+    await asyncio.to_thread(
+        store.create_email_change_request,
+        current_user["id"],
+        payload.new_email,
+        hash_code(code),
     )
     return {"stage": "old", "new_email": payload.new_email}
 
 
 @router.get("/email-change")
-async def get_email_change(current_user: dict = Depends(get_current_user)):
+def get_email_change(current_user: dict = Depends(get_current_user)):
     """Let a reloaded page pick the flow back up instead of stranding the user."""
     row = users_module.user_store.get_active_email_change(current_user["id"])
     if not row:
@@ -716,7 +745,7 @@ async def get_email_change(current_user: dict = Depends(get_current_user)):
 
 
 @router.delete("/email-change")
-async def cancel_email_change(current_user: dict = Depends(get_current_user)):
+def cancel_email_change(current_user: dict = Depends(get_current_user)):
     """Cancel a pending change. Also the resend path: cancel, then start again,
     which re-verifies the password.
 
@@ -827,7 +856,7 @@ def _store_avatar(user_id: int, value: Optional[str]) -> dict:
 
 
 @router.put("/avatar")
-async def set_avatar(payload: AvatarRequest, current_user: dict = Depends(get_current_user)):
+def set_avatar(payload: AvatarRequest, current_user: dict = Depends(get_current_user)):
     try:
         value = _validate_avatar_data_uri(payload.avatar)
     except ValueError as exc:
@@ -836,7 +865,7 @@ async def set_avatar(payload: AvatarRequest, current_user: dict = Depends(get_cu
 
 
 @router.delete("/avatar")
-async def delete_avatar(current_user: dict = Depends(get_current_user)):
+def delete_avatar(current_user: dict = Depends(get_current_user)):
     return {"user": _store_avatar(current_user["id"], None)}
 
 
@@ -1005,7 +1034,7 @@ async def robinhood_oauth_complete(
 
 
 @router.post("/discord/start")
-async def discord_oauth_start(current_user: dict = Depends(get_current_user)):
+def discord_oauth_start(current_user: dict = Depends(get_current_user)):
     """Begin Discord OAuth linking for the logged-in website user."""
     if not discord_oauth.oauth_configured():
         raise HTTPException(

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -289,6 +289,43 @@ def test_change_password_invalidates_other_sessions_keeps_current(client):
     assert me_b.status_code == 401
 
 
+def test_password_verify_runs_off_event_loop(client, monkeypatch):
+    """bcrypt password checks must run in a worker thread, not the loop.
+
+    Regression for the perf issue where change-password and the email-change
+    request verified the current password inline: bcrypt is deliberately slow
+    (~190 ms), so a shared event loop stalled every concurrent request
+    (signup/login already offload via asyncio.to_thread).
+    """
+    import dashboard.backend.api.auth as auth
+
+    # Record which callables the handlers dispatch through asyncio.to_thread.
+    # The fix routes verify_password through it; without the fix it is called
+    # inline on the loop and never appears here.
+    offloaded = []
+
+    real_to_thread = auth.asyncio.to_thread
+
+    def recording_to_thread(func, *args, **kwargs):
+        offloaded.append(func)
+        return real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(auth.asyncio, "to_thread", recording_to_thread)
+
+    token = _signup_and_token(client, email="helen@example.com")
+
+    response = client.post(
+        "/api/auth/change-password",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"current_password": "orig-sturdy-pw-1", "new_password": "new-sturdy-pw-2"},
+    )
+    assert response.status_code == 200
+    assert auth.verify_password in offloaded, (
+        "password verify ran on the event loop; should be offloaded via to_thread"
+    )
+
+
+
 def test_change_password_revocation_failure_still_succeeds(client, monkeypatch, capsys):
     # The password write and the other-session revocation are two separate
     # transactions. If revocation raises, the (already-durable) password change

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -318,10 +318,15 @@ def test_password_verify_never_runs_on_the_event_loop(client, monkeypatch, sent_
     reversed: it breaks on a correct refactor, and passes while the handler
     still blocks on everything the offload did not cover.
     """
-    import dashboard.backend.api.auth as auth
+    # `from ... import auth as auth_api`, matching this file's other five sites:
+    # the plain `import dashboard.backend.api.auth` form collides with the
+    # `from dashboard.backend.api.auth import _humanize_wait` further down and
+    # trips py/import-and-import-from. Either form yields the module object the
+    # setattr seam below needs.
+    from dashboard.backend.api import auth as auth_api
 
     ran_on_loop = []
-    real_verify = auth.verify_password
+    real_verify = auth_api.verify_password
 
     def recording_verify(password, password_hash):
         ran_on_loop.append(_running_on_the_event_loop())
@@ -331,7 +336,7 @@ def test_password_verify_never_runs_on_the_event_loop(client, monkeypatch, sent_
     # rather than on asyncio or users. Patching `asyncio.to_thread` would rebind
     # it for the whole interpreter, so unrelated callers would land in the
     # recorder and the assertion would be over global traffic, not these routes.
-    monkeypatch.setattr(auth, "verify_password", recording_verify)
+    monkeypatch.setattr(auth_api, "verify_password", recording_verify)
 
     token = _signup_and_token(client, email="helen@example.com")
     headers = {"Authorization": f"Bearer {token}"}

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -289,41 +289,78 @@ def test_change_password_invalidates_other_sessions_keeps_current(client):
     assert me_b.status_code == 401
 
 
-def test_password_verify_runs_off_event_loop(client, monkeypatch):
-    """bcrypt password checks must run in a worker thread, not the loop.
+def _running_on_the_event_loop() -> bool:
+    """True when the calling thread is the one running the event loop.
 
-    Regression for the perf issue where change-password and the email-change
-    request verified the current password inline: bcrypt is deliberately slow
-    (~190 ms), so a shared event loop stalled every concurrent request
-    (signup/login already offload via asyncio.to_thread).
+    A worker thread has no running loop, so ``get_running_loop`` raises there.
+    """
+    import asyncio
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+def test_password_verify_never_runs_on_the_event_loop(client, monkeypatch, sent_emails):
+    """bcrypt must execute in a worker thread on every route that verifies one.
+
+    bcrypt is deliberately slow (~190 ms of CPU). Run on the event loop it
+    stalls every concurrent request for that long, which is what #292 fixed
+    across 58 handlers and #297 tracked for the two auth.py routes below.
+
+    This asserts the *property* -- no running loop on the thread doing the hash
+    -- rather than the mechanism, so it stays green for whichever offload a
+    handler uses (a plain ``def`` dispatched to the threadpool, asyncio.to_thread
+    or run_in_threadpool) and goes red only when the hash is back on the loop.
+    An assertion that a specific dispatcher was called has the failure modes
+    reversed: it breaks on a correct refactor, and passes while the handler
+    still blocks on everything the offload did not cover.
     """
     import dashboard.backend.api.auth as auth
 
-    # Record which callables the handlers dispatch through asyncio.to_thread.
-    # The fix routes verify_password through it; without the fix it is called
-    # inline on the loop and never appears here.
-    offloaded = []
+    ran_on_loop = []
+    real_verify = auth.verify_password
 
-    real_to_thread = auth.asyncio.to_thread
+    def recording_verify(password, password_hash):
+        ran_on_loop.append(_running_on_the_event_loop())
+        return real_verify(password, password_hash)
 
-    def recording_to_thread(func, *args, **kwargs):
-        offloaded.append(func)
-        return real_to_thread(func, *args, **kwargs)
-
-    monkeypatch.setattr(auth.asyncio, "to_thread", recording_to_thread)
+    # Patched on the auth module -- the name both handlers actually call --
+    # rather than on asyncio or users. Patching `asyncio.to_thread` would rebind
+    # it for the whole interpreter, so unrelated callers would land in the
+    # recorder and the assertion would be over global traffic, not these routes.
+    monkeypatch.setattr(auth, "verify_password", recording_verify)
 
     token = _signup_and_token(client, email="helen@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
 
-    response = client.post(
+    changed = client.post(
         "/api/auth/change-password",
-        headers={"Authorization": f"Bearer {token}"},
+        headers=headers,
         json={"current_password": "orig-sturdy-pw-1", "new_password": "new-sturdy-pw-2"},
     )
-    assert response.status_code == 200
-    assert auth.verify_password in offloaded, (
-        "password verify ran on the event loop; should be offloaded via to_thread"
-    )
+    assert changed.status_code == 200
 
+    requested = client.post(
+        "/api/auth/email-change",
+        headers=headers,
+        json={
+            "current_password": "new-sturdy-pw-2",
+            "new_email": "helen-next@example.com",
+        },
+    )
+    assert requested.status_code == 200, requested.text
+
+    assert len(ran_on_loop) == 2, (
+        f"expected one bcrypt verify per route, saw {len(ran_on_loop)} -- the "
+        "test no longer exercises what it claims to"
+    )
+    assert ran_on_loop == [False, False], (
+        "a bcrypt verify ran on the event loop thread, stalling every "
+        f"concurrent request for its duration (per-call on-loop: {ran_on_loop})"
+    )
 
 
 def test_change_password_revocation_failure_still_succeeds(client, monkeypatch, capsys):

--- a/dashboard/backend/tests/test_event_loop_threadpool.py
+++ b/dashboard/backend/tests/test_event_loop_threadpool.py
@@ -45,10 +45,27 @@ BLOCKING_IO_ROUTER_MODULES = {
 }
 
 # Handlers in modules that legitimately mix awaited and blocking work, so the
-# whole module cannot be pinned. auth.py's OAuth callbacks genuinely await, but
-# these do sync store I/O with no await in sight.
+# whole module cannot be pinned. auth.py's OAuth callbacks and the two mail
+# routes genuinely await; everything below does sync store I/O -- a network
+# round trip against Postgres in prod, and for change_password two bcrypt
+# rounds -- with no await in sight, so `def` is both safe and required.
+#
+# This set is also what stops the fix from being undone by accident: a handler
+# only stays covered while it has no ``await``, so adding one (e.g. wrapping a
+# single blocking call in ``asyncio.to_thread`` and leaving the rest inline)
+# silently drops it out of the guard. That is exactly what #332 first did to
+# change_password before #297's plain-``def`` fix was applied instead.
 BLOCKING_IO_HANDLERS = {
+    ("dashboard.backend.api.auth", "me"),
     ("dashboard.backend.api.auth", "logout"),
+    ("dashboard.backend.api.auth", "logout_all"),
+    ("dashboard.backend.api.auth", "change_password"),
+    ("dashboard.backend.api.auth", "update_display_name"),
+    ("dashboard.backend.api.auth", "get_email_change"),
+    ("dashboard.backend.api.auth", "cancel_email_change"),
+    ("dashboard.backend.api.auth", "set_avatar"),
+    ("dashboard.backend.api.auth", "delete_avatar"),
+    ("dashboard.backend.api.auth", "discord_oauth_start"),
 }
 
 


### PR DESCRIPTION
Closes #297. Follow-up to #292, which moved 58 blocking handlers to the threadpool but left `auth.py`.

**What was wrong:** `auth.py`'s handlers were `async def` while doing synchronous work on the event loop, so each request stalled every concurrent one — bcrypt for ~190 ms, plus store round trips that are network calls against Neon in prod.

**Changes**

- `change_password` → plain `def`. It contains no `await`, so per #297 the signature change is the fix: it moves the verify, the bcrypt **hash** inside `update_password()`, and three store round trips to the threadpool. Wrapping only the verify in `asyncio.to_thread` would have left an identically slow hash on the loop. Password-policy check hoisted above the bcrypt, matching `signup()` — a rejected new password now costs no hash, at the price of reporting the policy error first when a request is wrong on both counts.
- `request_email_change` stays `async def` (it awaits `send_email`), so its blocking half — the verify plus four store round trips — moves in one `to_thread` hop, and the insert in another.
- The other eight no-`await` `async def` handlers in `auth.py` (`me`, `logout_all`, `update_display_name`, `get_email_change`, `cancel_email_change`, `set_avatar`, `delete_avatar`, `discord_oauth_start`) flipped to `def` as well. Every route handler in the file is now either `async` with real awaits or plain `def` with none.

**Guard:** all ten pinned in `BLOCKING_IO_HANDLERS` (`tests/test_event_loop_threadpool.py`), as #297 asks. A pinned handler is only covered while it has no `await`, so adding one to offload a single call now fails the guard rather than silently exempting the handler.

**Tests:** `test_password_verify_never_runs_on_the_event_loop` asserts the property — `asyncio.get_running_loop()` raises on the thread doing the hash — rather than which dispatcher was used, so it survives a refactor to `run_in_threadpool` or a `def` flip and goes red only when the hash is back on the loop. Covers both routes. Mutation-checked: putting either handler back on the loop yields `[True, True]`. Suite 2652 passed, 67 skipped.

`signup`/`login` already offload via `asyncio.to_thread` (added in #281, not #292) — #297's table rows for those two are stale. Pool sizing across the two threadpools is #298's scope, not this PR's.
