### PR TITLE
fix(ui): readable agent settings and hide AHF panel on builtins

### DIFF
--- a/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
+++ b/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
@@ -34,6 +34,12 @@ def test_hosted_editor_replaces_model_picker_with_managed_metadata():
     )
     assert "modelField.hidden = hostedAiHedgeFund" in configure
     assert "managedModelField.hidden = !hostedAiHedgeFund" in configure
+    assert "hedgeFundPanel.hidden = !hostedAiHedgeFund" in configure
+    assert "simplePanel.hidden = hostedAiHedgeFund" in configure
+    # .agent-cp-field { display:flex } beats the UA [hidden] rule — without an
+    # explicit override the AI Hedge Fund panel leaked onto every built-in.
+    assert ".agent-cp-field[hidden]" in _STYLES_CSS
+    assert "#agentEditorAiHedgeFundPanel[hidden]" in _STYLES_CSS
     assert ".agent-editor-model-field[hidden]" in _STYLES_CSS
     assert ".agent-editor-managed-model-field[hidden]" in _STYLES_CSS
 

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -180,4 +180,4 @@ def test_slow_boot_notice_is_wired():
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
     assert "app.js?v=77" in APP_HTML
-    assert "styles.css?v=86" in APP_HTML
+    assert "styles.css?v=89" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -180,4 +180,4 @@ def test_slow_boot_notice_is_wired():
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
     assert "app.js?v=77" in APP_HTML
-    assert "styles.css?v=89" in APP_HTML
+    assert "styles.css?v=90" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_model_facets.py
+++ b/dashboard/backend/tests/test_frontend_model_facets.py
@@ -167,7 +167,7 @@ def test_three_empty_states_stay_distinguishable():
 def test_empty_state_precedence():
     script = f"""
 function escapeHtml(s) {{ return String(s); }}
-const MARKET_LABELS = {{ us_stocks: 'U.S.', cn_ashares: 'China A-Share' }};
+const MARKET_LABELS = {{ us_stocks: 'US Stocks', cn_ashares: 'China A-Share' }};
 {js_const("MODEL_VENDORS")}
 {fn_body("function marketplaceEmptyHtml")}
 const out = [
@@ -186,7 +186,7 @@ console.log(JSON.stringify(out));
     # A typed query wins: clearing the chips would not bring anything back.
     assert search_empty == "No templates match your search."
     assert "both filters" in both and "marketplace-clear-filters" in both
-    assert "U.S." in one_chip and "both filters" not in one_chip
+    assert "US Stocks" in one_chip and "both filters" not in one_chip
     assert none_at_all == "No templates match your search."
 
 
@@ -359,7 +359,7 @@ def test_shipped_grid_badges_only_open_weight_cards():
     script = f"""
 {fn_body("function escapeHtml")}
 {fn_body("function agentRobotIcon")}
-const MARKET_LABELS = {{ us_stocks: 'U.S.', cn_ashares: 'China A-Share' }};
+const MARKET_LABELS = {{ us_stocks: 'US Stocks', cn_ashares: 'China A-Share' }};
 {js_const("MODEL_VENDORS")}
 {fn_body("function modelVendorKey")}
 {fn_body("function modelVendorLicence")}
@@ -423,7 +423,7 @@ def test_closed_card_differs_from_open_card_by_exactly_the_badge():
     script = f"""
 {fn_body("function escapeHtml")}
 {fn_body("function agentRobotIcon")}
-const MARKET_LABELS = {{ us_stocks: 'U.S.', cn_ashares: 'China A-Share' }};
+const MARKET_LABELS = {{ us_stocks: 'US Stocks', cn_ashares: 'China A-Share' }};
 {js_const("MODEL_VENDORS")}
 {fn_body("function modelVendorKey")}
 {fn_body("function modelVendorLicence")}
@@ -544,7 +544,7 @@ def test_model_picker_gated_on_runtime_type_not_truthiness():
     script = f"""
 {fn_body("function escapeHtml")}
 {fn_body("function agentRobotIcon")}
-const MARKET_LABELS = {{ us_stocks: 'U.S.' }};
+const MARKET_LABELS = {{ us_stocks: 'US Stocks' }};
 {js_const("MODEL_VENDORS")}
 {js_const("SUPPORTED_MODELS")}
 {fn_body("function modelVendorKey")}

--- a/dashboard/backend/tests/test_frontend_shelves.py
+++ b/dashboard/backend/tests/test_frontend_shelves.py
@@ -199,7 +199,7 @@ def test_market_labels_is_the_only_declaration_of_the_market_names():
     not merely unused.
     """
     decl = js_const("MARKET_LABELS")
-    assert "us_stocks: 'U.S.'" in decl
+    assert "us_stocks: 'US Stocks'" in decl
     assert "cn_ashares: 'China A-Share'" in decl
     # The bare identifier only. `window.AGENT_SHELF_LABELS` -- the export name
     # agent-editor.js reads, deliberately unchanged so the editor needs no
@@ -230,7 +230,7 @@ def test_render_marketplace_category_chips_is_built_from_the_shared_label_map():
     body = _strip_js_comments(fn_body("function renderMarketplaceCategoryChips()"))
     assert "MARKET_LABELS" in body
     assert "'all'" in body
-    for label in ("U.S.", "China A-Share"):
+    for label in ("US Stocks", "China A-Share"):
         assert label not in body, f"{label!r} hardcoded instead of read from MARKET_LABELS"
 
 

--- a/dashboard/backend/tests/test_my_agents_capital_ui.py
+++ b/dashboard/backend/tests/test_my_agents_capital_ui.py
@@ -2,8 +2,9 @@
 
 Paper-trading capital used to sit in the agent editor's *header* as a 12.5px
 uppercase field while backtest capital was a separate input inside the Run
-Backtest modal, with nothing connecting them. They are now one card in the
-editor's main column, and the modal shows the saved backtest figure read-only.
+Backtest modal, with nothing connecting them. They are now peer fields in the
+Agent settings form (alongside model / market / trading prompt), and the modal
+shows the saved backtest figure read-only.
 
 These are contract guards, not style assertions: they pin *where the inputs
 live* and *that the modal no longer edits capital*, which is the behaviour the
@@ -24,15 +25,17 @@ def _slice(text: str, start_marker: str, end_marker: str) -> str:
 
 
 def test_configure_has_one_allocated_capital_card_with_both_inputs():
-    card = _slice(_APP_HTML, 'class="agent-capital-card', "</div>\n                    <div")
-    assert "Allocated Capital" in card
-    assert 'id="agentEditorCashAllocation"' in card
-    assert 'id="agentEditorBacktestAllocation"' in card
+    start = _APP_HTML.index('id="agentCpPanelSettings"')
+    end = _APP_HTML.index('id="agentEditorSimplePanel"', start)
+    settings = _APP_HTML[start:end]
+    assert 'id="agentEditorCashAllocation"' in settings
+    assert 'id="agentEditorBacktestAllocation"' in settings
+    assert "max $3,000" in settings
 
 
 def test_capital_inputs_are_no_longer_in_the_editor_header():
     """The header held a cramped uppercase field; the card replaces it."""
-    header = _slice(_APP_HTML, 'class="agent-editor-title-wrap"', "</header>")
+    header = _slice(_APP_HTML, 'class="agent-cp-hero"', 'class="agent-cp-shell"')
     assert 'id="agentEditorCashAllocation"' not in header
     assert 'id="agentEditorBacktestAllocation"' not in header
 

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=89">
+    <link rel="stylesheet" href="styles.css?v=90">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -1149,7 +1149,7 @@
                                 <label class="agent-cp-field" for="agentEditorBacktestAllocation">
                                     <span class="agent-cp-field-label">Backtest capital <span class="agent-cp-field-max">max $3,000</span></span>
                                     <input id="agentEditorBacktestAllocation" class="agent-cp-control agent-cp-control--mono" type="number" min="1" max="3000" step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
-                                    <span class="agent-cp-field-note">Simulated only — never spends real cash.</span>
+                                    <span class="agent-cp-field-note">Simulated only. Never spends real cash.</span>
                                 </label>
                             </div>
 

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1922,7 +1922,7 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
-    <script src="js/agent-editor.js?v=28" defer></script>
+    <script src="js/agent-editor.js?v=29" defer></script>
     <script src="app.js?v=77" defer></script>
     <script src="js/leaderboard.js?v=19" defer></script>
     <script src="home-page.js?v=37" defer></script>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=86">
+    <link rel="stylesheet" href="styles.css?v=89">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -987,108 +987,279 @@
 
     <!-- Fullscreen Agent Editor -->
     <div id="agentEditorView" class="agent-editor-view" hidden>
-        <header class="agent-editor-header">
-            <button id="agentEditorBackBtn" class="agent-editor-back-btn" type="button" aria-label="Back to My Agents">
+        <div class="agent-cp">
+            <button id="agentEditorBackBtn" class="agent-cp-back" type="button" aria-label="Back to My Agents">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-                Back to My Agents
+                My Agents
             </button>
-            <div class="agent-editor-title-wrap">
-                <input id="agentEditorNameInput" class="agent-editor-name-input" type="text" maxlength="100" placeholder="Agent name" aria-label="Agent name" autocomplete="off">
-                <p id="agentEditorMeta" class="agent-editor-meta"></p>
-                <label id="agentEditorModelField" class="agent-editor-model-field" for="agentEditorModelSelect">
-                    <span class="agent-editor-model-label">Model</span>
-                    <select id="agentEditorModelSelect" class="agent-editor-model-select" aria-label="Agent model"></select>
-                </label>
-                <div id="agentEditorManagedModelField" class="agent-editor-managed-model-field" aria-label="Hosted AI model" hidden>
-                    <span class="agent-editor-model-label">Hosted AI model</span>
-                    <strong id="agentEditorManagedModelValue" class="agent-editor-managed-model-value">OpenRouter · nvidia/nemotron-3-nano-30b-a3b</strong>
-                    <span class="agent-editor-managed-model-note">Managed for you by Agentic Trading Lab</span>
-                </div>
-                <label id="agentEditorCategoryField" class="agent-editor-model-field" for="agentEditorCategorySelect">
-                    <span class="agent-editor-model-label">Market</span>
-                    <select id="agentEditorCategorySelect" class="agent-editor-model-select" aria-label="Which market this agent trades"></select>
-                </label>
-                <textarea id="agentEditorDescription" class="agent-editor-description" rows="2" maxlength="280" placeholder="Optional description for this agent…" aria-label="Agent description"></textarea>
-                <div id="agentEditorBrokerPanel" class="agent-editor-broker section-card compact">
-                    <div class="agent-editor-broker-head">
-                        <h3 class="agent-editor-intro-title">Robinhood live trading</h3>
-                        <span id="agentEditorRobinhoodStatus" class="agent-editor-broker-status">Checking…</span>
+
+            <header class="agent-cp-hero">
+                <div class="agent-cp-identity">
+                    <div class="agent-cp-avatar" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="8" width="14" height="11" rx="3"/><circle cx="9.5" cy="13" r="1.1" fill="currentColor" stroke="none"/><circle cx="14.5" cy="13" r="1.1" fill="currentColor" stroke="none"/><path d="M9 17h6"/><path d="M9 8V6.5a3 3 0 0 1 6 0V8"/></svg>
                     </div>
-                    <p class="agent-editor-intro-text">Connect your Robinhood Agentic account to run this agent with real money. Orders only execute when live trading is enabled and the server execute switch is on.</p>
-                    <div id="agentEditorRobinhoodMeta" class="agent-editor-broker-meta" hidden></div>
-                    <label class="agent-editor-live-toggle">
-                        <input id="agentEditorLiveTradingEnabled" type="checkbox">
-                        <span>Enable live trading for this agent</span>
-                    </label>
-                    <div class="agent-editor-broker-actions">
-                        <button id="agentEditorConnectRobinhoodBtn" class="home-btn home-btn-secondary" type="button">Connect Robinhood</button>
-                        <button id="agentEditorDisconnectRobinhoodBtn" class="home-btn home-btn-secondary" type="button" hidden>Disconnect</button>
-                        <button id="agentEditorRunLiveBtn" class="home-btn home-btn-primary" type="button">Run Live</button>
-                    </div>
-                    <p id="agentEditorLiveRunResult" class="agent-editor-live-result" hidden></p>
-                </div>
-            </div>
-            <div class="agent-editor-header-actions">
-                <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>
-                <button id="agentEditorRunBacktestBtn" class="home-btn home-btn-secondary" type="button">Run Backtest</button>
-                <button id="agentEditorSaveBtn" class="home-btn home-btn-primary" type="button">Save</button>
-            </div>
-        </header>
-        <div class="agent-editor-body">
-            <div class="agent-editor-layout">
-                <div class="agent-editor-main">
-                    <div class="agent-capital-card section-card compact">
-                        <h3 class="agent-capital-title">Allocated Capital</h3>
-                        <div class="agent-capital-grid">
-                            <label class="agent-capital-field" for="agentEditorCashAllocation">
-                                <span class="agent-capital-label">Paper Trading <span class="agent-capital-max">max $3,000</span></span>
-                                <input id="agentEditorCashAllocation" class="agent-capital-input" type="number" min="0" max="3000" step="100" placeholder="1000" aria-label="Paper Trading Allocated Capital">
-                                <span class="agent-capital-note">Reserved from your My Portfolio balance while this agent paper-trades. Backtests use a separate simulated amount and never touch it.</span>
-                            </label>
-                            <label class="agent-capital-field" for="agentEditorBacktestAllocation">
-                                <span class="agent-capital-label">Backtesting <span class="agent-capital-max">max $3,000</span></span>
-                                <input id="agentEditorBacktestAllocation" class="agent-capital-input" type="number" min="1" max="3000" step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
-                                <span class="agent-capital-note">Simulated only. Never spends real cash.</span>
-                            </label>
+                    <div class="agent-cp-identity-text">
+                        <div class="agent-cp-title-row">
+                            <input id="agentEditorNameInput" class="agent-editor-name-input agent-cp-name-input" type="text" maxlength="100" placeholder="Agent name" aria-label="Agent name" autocomplete="off">
+                            <span id="agentEditorStatusBadge" class="agent-cp-status-badge">Draft</span>
                         </div>
-                        <p id="agentCapitalRealMoneyNote" class="control-helper">Every test here uses simulated money. Real money is involved only if you explicitly connect a brokerage account and turn on live trading.</p>
+                        <p id="agentEditorMeta" class="agent-editor-meta agent-cp-meta" hidden></p>
+                        <p id="agentEditorHeroDescription" class="agent-cp-hero-desc">Researches market data and identifies trading opportunities using a configurable LLM strategy.</p>
                     </div>
-                    <div id="agentEditorSimplePanel" class="agent-editor-simple section-card compact">
-                        <h3 class="agent-editor-intro-title">Trading instruction</h3>
-                        <p class="agent-editor-intro-text">Tell the agent how to trade in plain language. Each market hour it sees prices and its portfolio, follows your instruction, and decides what to buy or sell.</p>
-                        <textarea id="agentEditorSimpleInstruction" rows="6" maxlength="8000" placeholder="e.g. Spread the money across a few of the strongest available stocks. Buy on meaningful dips and take profits after strong run-ups." aria-label="Trading instruction"></textarea>
-                        <p class="agent-editor-simple-note">Leave this empty and the agent uses the platform's default trading strategy.</p>
-                        <details class="agent-editor-default-details">
-                            <summary>See the default instruction</summary>
-                            <p id="agentEditorDefaultInstructionText" class="agent-editor-default-text"></p>
-                        </details>
-                        <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note" hidden>This agent currently uses a custom multi-step strategy. Saving this instruction replaces it.</p>
-                    </div>
-                    <div id="agentEditorAiHedgeFundPanel" class="agent-editor-simple section-card compact" hidden>
-                        <h3 class="agent-editor-intro-title">AI Hedge Fund analyst panel</h3>
-                        <p class="agent-editor-intro-text">Choose the analysts that shape this agent's strategy. The AI model and its settings are hosted and managed by Agentic Trading Lab.</p>
-                        <div id="agentEditorAiHedgeFundAnalysts" class="agent-editor-analyst-grid" role="group" aria-label="AI Hedge Fund analysts"></div>
-                        <label class="auth-field agent-editor-credential-field" for="agentEditorFinancialDatasetsKey">
-                            <span>Financial Datasets access key (from financialdatasets.ai)</span>
-                            <input id="agentEditorFinancialDatasetsKey" type="password" autocomplete="new-password" placeholder="Leave blank to keep the stored key" aria-describedby="agentEditorFinancialDatasetsStatus">
-                        </label>
-                        <p id="agentEditorFinancialDatasetsStatus" class="agent-editor-simple-note">Checking credential…</p>
-                        <button id="agentEditorFinancialDatasetsRemove" class="agent-editor-credential-remove" type="button" hidden>Remove stored key</button>
-                        <p class="agent-editor-simple-note">Encrypted and stored securely. For your protection, it is never shown again after you save.</p>
-                    </div>
-                    <p id="agentEditorSaveStatus" class="agent-editor-save-status" hidden></p>
-                    <p class="agent-editor-hint">Tip: press <kbd>Ctrl</kbd>+<kbd>S</kbd> to save.</p>
                 </div>
-                <aside class="agent-editor-history" aria-label="Backtest history">
-                    <div class="agent-editor-history-card section-card compact">
-                        <div class="agent-editor-history-head">
-                            <h3 class="agent-editor-history-title">Backtest history</h3>
-                            <span id="agentEditorRunCount" class="agent-editor-run-count">0 runs</span>
-                        </div>
-                        <p class="agent-editor-history-hint">All backtest runs for this agent. Click a run to open it in Playground.</p>
-                        <div id="agentEditorRunHistory" class="agent-editor-run-history" role="list"></div>
+                <div class="agent-editor-header-actions agent-cp-hero-actions">
+                    <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>
+                    <button id="agentEditorTalkBtn" class="home-btn home-btn-secondary agent-cp-btn-talk" type="button">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                        Talk to agent
+                    </button>
+                    <button id="agentEditorRunBacktestBtn" class="home-btn home-btn-primary agent-cp-btn-run" type="button">
+                        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
+                        Run backtest
+                    </button>
+                </div>
+            </header>
+
+            <div class="agent-cp-shell">
+                <nav class="agent-cp-nav" aria-label="Control plane">
+                    <p class="agent-cp-nav-label">Control Plane</p>
+                    <div class="agent-cp-nav-list" role="tablist" aria-orientation="vertical">
+                        <button type="button" class="agent-cp-nav-item is-active" data-agent-cp-tab="overview" role="tab" aria-selected="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                            <span>Overview</span>
+                        </button>
+                        <button type="button" class="agent-cp-nav-item" data-agent-cp-tab="settings" role="tab" aria-selected="false">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 21v-7"/><path d="M4 10V3"/><path d="M12 21v-9"/><path d="M12 8V3"/><path d="M20 21v-5"/><path d="M20 12V3"/><path d="M1 14h6"/><path d="M9 8h6"/><path d="M17 16h6"/></svg>
+                            <span>Agent settings</span>
+                        </button>
+                        <button type="button" class="agent-cp-nav-item" data-agent-cp-tab="backtest" role="tab" aria-selected="false">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M9 3h6"/><path d="M10 3v6.5L6 18a2 2 0 0 0 1.8 3h8.4A2 2 0 0 0 18 18l-4-8.5V3"/><path d="M8.5 14h7"/></svg>
+                            <span>Backtest</span>
+                            <span id="agentEditorNavRunCount" class="agent-cp-nav-count">0</span>
+                        </button>
+                        <button type="button" class="agent-cp-nav-item" data-agent-cp-tab="paper" role="tab" aria-selected="false">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h8"/><path d="M8 17h5"/></svg>
+                            <span>Paper trading</span>
+                            <span class="agent-cp-nav-soon">Soon</span>
+                        </button>
+                        <button type="button" class="agent-cp-nav-item" data-agent-cp-tab="live" role="tab" aria-selected="false">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 12h3"/><path d="M19 12h3"/><path d="M12 2v3"/><path d="M12 19v3"/><circle cx="12" cy="12" r="4"/><path d="M4.9 4.9l2.1 2.1"/><path d="M17 17l2.1 2.1"/><path d="M17 7l2.1-2.1"/><path d="M4.9 19.1 7 17"/></svg>
+                            <span>Live trading</span>
+                        </button>
                     </div>
-                </aside>
+                    <div class="agent-cp-nav-footer">
+                        <div>Current version: <strong id="agentEditorVersionLabel">v1</strong></div>
+                        <div id="agentEditorUpdatedLabel">Updated —</div>
+                    </div>
+                </nav>
+
+                <div class="agent-cp-main">
+                    <!-- Overview -->
+                    <section id="agentCpPanelOverview" class="agent-cp-panel is-active" data-agent-cp-panel="overview" role="tabpanel">
+                        <div class="agent-cp-panel-head">
+                            <div>
+                                <h2 class="agent-cp-panel-title">Overview</h2>
+                                <p class="agent-cp-panel-sub">Monitor this agent and continue its workflow.</p>
+                            </div>
+                            <span id="agentEditorOverviewVersionBadge" class="agent-cp-chip">Agent v1</span>
+                        </div>
+                        <div class="agent-cp-status-grid">
+                            <button type="button" class="agent-cp-status-card" data-agent-cp-goto="settings">
+                                <div class="agent-cp-status-card-top">
+                                    <span class="agent-cp-status-icon" aria-hidden="true">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg>
+                                    </span>
+                                    <span class="agent-cp-status-arrow" aria-hidden="true">↗</span>
+                                </div>
+                                <h3 class="agent-cp-status-title">Agent configuration</h3>
+                                <p id="agentOverviewConfigPrimary" class="agent-cp-status-primary">—</p>
+                                <p id="agentOverviewConfigSecondary" class="agent-cp-status-secondary">—</p>
+                            </button>
+                            <button type="button" class="agent-cp-status-card" data-agent-cp-goto="backtest">
+                                <div class="agent-cp-status-card-top">
+                                    <span class="agent-cp-status-icon" aria-hidden="true">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19V5"/><path d="M4 19h16"/><path d="M8 17V10"/><path d="M12 17V7"/><path d="M16 17v-4"/></svg>
+                                    </span>
+                                    <span class="agent-cp-status-arrow" aria-hidden="true">↗</span>
+                                </div>
+                                <h3 class="agent-cp-status-title">Latest backtest</h3>
+                                <p id="agentOverviewBacktestPrimary" class="agent-cp-status-primary">No runs yet</p>
+                                <p id="agentOverviewBacktestSecondary" class="agent-cp-status-secondary">Run a backtest to see results</p>
+                            </button>
+                            <button type="button" class="agent-cp-status-card is-muted" data-agent-cp-goto="paper">
+                                <div class="agent-cp-status-card-top">
+                                    <span class="agent-cp-status-icon" aria-hidden="true">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>
+                                    </span>
+                                </div>
+                                <h3 class="agent-cp-status-title">Paper trading</h3>
+                                <p class="agent-cp-status-primary">Not deployed</p>
+                                <p class="agent-cp-status-secondary">Available soon</p>
+                            </button>
+                            <button type="button" class="agent-cp-status-card is-muted" data-agent-cp-goto="live">
+                                <div class="agent-cp-status-card-top">
+                                    <span class="agent-cp-status-icon" aria-hidden="true">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12h3"/><path d="M19 12h3"/><circle cx="12" cy="12" r="4"/></svg>
+                                    </span>
+                                </div>
+                                <h3 class="agent-cp-status-title">Live trading</h3>
+                                <p id="agentOverviewLivePrimary" class="agent-cp-status-primary">Not connected</p>
+                                <p class="agent-cp-status-secondary">Broker connection available here</p>
+                            </button>
+                        </div>
+                        <div class="agent-cp-activity">
+                            <div class="agent-cp-activity-head">
+                                <h3 class="agent-cp-activity-title">Agent activity</h3>
+                                <button type="button" class="agent-cp-link-btn" data-agent-cp-goto="backtest">View all</button>
+                            </div>
+                            <div id="agentEditorActivityList" class="agent-cp-activity-list"></div>
+                        </div>
+                    </section>
+
+                    <!-- Agent settings -->
+                    <section id="agentCpPanelSettings" class="agent-cp-panel" data-agent-cp-panel="settings" role="tabpanel" hidden>
+                        <div class="agent-cp-panel-head">
+                            <div>
+                                <h2 class="agent-cp-panel-title">Agent settings</h2>
+                                <p class="agent-cp-panel-sub">Set the model, market, capital, and trading prompt for this agent.</p>
+                            </div>
+                            <button id="agentEditorSaveBtn" class="home-btn home-btn-primary" type="button">Save changes</button>
+                        </div>
+
+                        <div class="agent-cp-settings-stack">
+                            <div class="agent-cp-form-grid">
+                                <label id="agentEditorModelField" class="agent-cp-field" for="agentEditorModelSelect">
+                                    <span class="agent-cp-field-label">Model</span>
+                                    <select id="agentEditorModelSelect" class="agent-cp-control agent-editor-model-select" aria-label="Agent model"></select>
+                                </label>
+                                <div id="agentEditorManagedModelField" class="agent-cp-field" aria-label="Hosted AI model" hidden>
+                                    <span class="agent-cp-field-label">Hosted AI model</span>
+                                    <strong id="agentEditorManagedModelValue" class="agent-editor-managed-model-value">OpenRouter · nvidia/nemotron-3-nano-30b-a3b</strong>
+                                    <span class="agent-cp-field-note">hosted and managed by Agentic Trading Lab</span>
+                                </div>
+                                <label id="agentEditorCategoryField" class="agent-cp-field" for="agentEditorCategorySelect">
+                                    <span class="agent-cp-field-label">Market</span>
+                                    <select id="agentEditorCategorySelect" class="agent-cp-control agent-editor-model-select" aria-label="Which market this agent trades"></select>
+                                </label>
+                                <label class="agent-cp-field" for="agentEditorCashAllocation">
+                                    <span class="agent-cp-field-label">Paper capital <span class="agent-cp-field-max">max $3,000</span></span>
+                                    <input id="agentEditorCashAllocation" class="agent-cp-control agent-cp-control--mono" type="number" min="0" max="3000" step="100" placeholder="1000" aria-label="Paper Trading Allocated Capital">
+                                    <span class="agent-cp-field-note">Reserved from My Portfolio while paper-trading.</span>
+                                </label>
+                                <label class="agent-cp-field" for="agentEditorBacktestAllocation">
+                                    <span class="agent-cp-field-label">Backtest capital <span class="agent-cp-field-max">max $3,000</span></span>
+                                    <input id="agentEditorBacktestAllocation" class="agent-cp-control agent-cp-control--mono" type="number" min="1" max="3000" step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
+                                    <span class="agent-cp-field-note">Simulated only — never spends real cash.</span>
+                                </label>
+                            </div>
+
+                            <div id="agentEditorSimplePanel" class="agent-cp-field agent-cp-field--wide agent-editor-simple">
+                                <span class="agent-cp-field-label" id="agentEditorInstructionLabel">Trading prompt</span>
+                                <textarea id="agentEditorSimpleInstruction" class="agent-cp-control agent-cp-control--area" rows="7" maxlength="8000" placeholder="e.g. Spread the money across a few of the strongest available stocks. Buy on meaningful dips and take profits after strong run-ups." aria-labelledby="agentEditorInstructionLabel"></textarea>
+                                <p class="agent-cp-field-note">Leave this empty and the agent uses the platform's default trading strategy.</p>
+                                <details class="agent-editor-default-details">
+                                    <summary>See the default instruction</summary>
+                                    <p id="agentEditorDefaultInstructionText" class="agent-editor-default-text"></p>
+                                </details>
+                                <p id="agentEditorSimpleReplaceNote" class="agent-editor-simple-note agent-editor-simple-note--warn" hidden>This agent currently uses a custom multi-step strategy. Saving this instruction replaces it.</p>
+                            </div>
+
+                            <div id="agentEditorAiHedgeFundPanel" class="agent-editor-simple agent-cp-field agent-cp-field--wide" hidden>
+                                <span class="agent-cp-field-label">AI Hedge Fund analysts</span>
+                                <p class="agent-cp-field-note">Hosted runtime — pick which analysts shape each trade.</p>
+                                <div id="agentEditorAiHedgeFundAnalysts" class="agent-editor-analyst-grid" role="group" aria-label="AI Hedge Fund analysts"></div>
+                                <label class="auth-field agent-editor-credential-field" for="agentEditorFinancialDatasetsKey">
+                                    <span>Financial Datasets access key</span>
+                                    <input id="agentEditorFinancialDatasetsKey" type="password" autocomplete="new-password" placeholder="Leave blank to keep the stored key" aria-describedby="agentEditorFinancialDatasetsStatus">
+                                </label>
+                                <p id="agentEditorFinancialDatasetsStatus" class="agent-editor-simple-note">Checking credential…</p>
+                                <button id="agentEditorFinancialDatasetsRemove" class="agent-editor-credential-remove" type="button" hidden>Remove stored key</button>
+                                <p class="agent-cp-field-note">Encrypted at rest. Never shown again after you save.</p>
+                            </div>
+                        </div>
+
+                        <p id="agentEditorSaveStatus" class="agent-editor-save-status" hidden></p>
+                    </section>
+
+                    <!-- Backtest -->
+                    <section id="agentCpPanelBacktest" class="agent-cp-panel" data-agent-cp-panel="backtest" role="tabpanel" hidden>
+                        <div class="agent-cp-panel-head">
+                            <div>
+                                <h2 class="agent-cp-panel-title">Backtest</h2>
+                                <p class="agent-cp-panel-sub">Test this agent on historical market data.</p>
+                            </div>
+                            <button id="agentEditorNewBacktestBtn" class="home-btn home-btn-primary" type="button">New backtest</button>
+                        </div>
+                        <div class="agent-cp-config-bar">
+                            <div class="agent-cp-config-metrics">
+                                <div>
+                                    <span class="agent-cp-config-label">Default initial capital</span>
+                                    <strong id="agentBacktestConfigCapital">—</strong>
+                                </div>
+                                <div>
+                                    <span class="agent-cp-config-label">Agent version</span>
+                                    <strong id="agentBacktestConfigVersion">v1</strong>
+                                </div>
+                                <div>
+                                    <span class="agent-cp-config-label">Market</span>
+                                    <strong id="agentBacktestConfigMarket">—</strong>
+                                </div>
+                            </div>
+                            <button type="button" class="home-btn home-btn-secondary" data-agent-cp-goto="settings">Configure</button>
+                        </div>
+                        <div class="agent-cp-history-block section-card compact">
+                            <div class="agent-editor-history-head">
+                                <h3 class="agent-editor-history-title">Backtest history</h3>
+                                <span id="agentEditorRunCount" class="agent-editor-run-count">0 runs</span>
+                            </div>
+                            <div id="agentEditorRunHistory" class="agent-editor-run-history agent-cp-run-table-wrap" role="list"></div>
+                        </div>
+                    </section>
+
+                    <!-- Paper (soon) -->
+                    <section id="agentCpPanelPaper" class="agent-cp-panel" data-agent-cp-panel="paper" role="tabpanel" hidden>
+                        <div class="agent-cp-panel-head">
+                            <div>
+                                <h2 class="agent-cp-panel-title">Paper trading</h2>
+                                <p class="agent-cp-panel-sub">Deploy this agent with simulated capital in live market hours.</p>
+                            </div>
+                            <span class="agent-cp-chip">Soon</span>
+                        </div>
+                        <div class="agent-cp-soon-card">
+                            <h3>Not deployed yet</h3>
+                            <p>Paper trading from the agent control plane is coming soon. You can still allocate paper capital under Agent settings.</p>
+                            <button type="button" class="home-btn home-btn-secondary" data-agent-cp-goto="settings">Open agent settings</button>
+                        </div>
+                    </section>
+
+                    <!-- Live -->
+                    <section id="agentCpPanelLive" class="agent-cp-panel" data-agent-cp-panel="live" role="tabpanel" hidden>
+                        <div class="agent-cp-panel-head">
+                            <div>
+                                <h2 class="agent-cp-panel-title">Live trading</h2>
+                                <p class="agent-cp-panel-sub">Connect a brokerage account and run this agent with real money when enabled.</p>
+                            </div>
+                        </div>
+                        <div id="agentEditorBrokerPanel" class="agent-editor-broker section-card compact agent-cp-card">
+                            <div class="agent-editor-broker-head">
+                                <h3 class="agent-editor-intro-title">Robinhood live trading</h3>
+                                <span id="agentEditorRobinhoodStatus" class="agent-editor-broker-status">Checking…</span>
+                            </div>
+                            <p class="agent-editor-intro-text">Connect your Robinhood Agentic account to run this agent with real money. Orders only execute when live trading is enabled and the server execute switch is on.</p>
+                            <div id="agentEditorRobinhoodMeta" class="agent-editor-broker-meta" hidden></div>
+                            <label class="agent-editor-live-toggle">
+                                <input id="agentEditorLiveTradingEnabled" type="checkbox">
+                                <span>Enable live trading for this agent</span>
+                            </label>
+                            <div class="agent-editor-broker-actions">
+                                <button id="agentEditorConnectRobinhoodBtn" class="home-btn home-btn-secondary" type="button">Connect Robinhood</button>
+                                <button id="agentEditorDisconnectRobinhoodBtn" class="home-btn home-btn-secondary" type="button" hidden>Disconnect</button>
+                                <button id="agentEditorRunLiveBtn" class="home-btn home-btn-primary" type="button">Run Live</button>
+                            </div>
+                            <p id="agentEditorLiveRunResult" class="agent-editor-live-result" hidden></p>
+                        </div>
+                    </section>
+                </div>
             </div>
         </div>
     </div>
@@ -1751,7 +1922,7 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
-    <script src="js/agent-editor.js?v=26" defer></script>
+    <script src="js/agent-editor.js?v=28" defer></script>
     <script src="app.js?v=77" defer></script>
     <script src="js/leaderboard.js?v=19" defer></script>
     <script src="home-page.js?v=37" defer></script>

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1135,7 +1135,7 @@
                                 <div id="agentEditorManagedModelField" class="agent-cp-field" aria-label="Hosted AI model" hidden>
                                     <span class="agent-cp-field-label">Hosted AI model</span>
                                     <strong id="agentEditorManagedModelValue" class="agent-editor-managed-model-value">OpenRouter · nvidia/nemotron-3-nano-30b-a3b</strong>
-                                    <span class="agent-cp-field-note">hosted and managed by Agentic Trading Lab</span>
+                                    <span class="agent-cp-field-note">Managed for you by Agentic Trading Lab</span>
                                 </div>
                                 <label id="agentEditorCategoryField" class="agent-cp-field" for="agentEditorCategorySelect">
                                     <span class="agent-cp-field-label">Market</span>
@@ -1144,7 +1144,7 @@
                                 <label class="agent-cp-field" for="agentEditorCashAllocation">
                                     <span class="agent-cp-field-label">Paper capital <span class="agent-cp-field-max">max $3,000</span></span>
                                     <input id="agentEditorCashAllocation" class="agent-cp-control agent-cp-control--mono" type="number" min="0" max="3000" step="100" placeholder="1000" aria-label="Paper Trading Allocated Capital">
-                                    <span class="agent-cp-field-note">Reserved from My Portfolio while paper-trading.</span>
+                                    <span class="agent-cp-field-note">Reserved from your My Portfolio balance while this agent paper-trades. Backtests use a separate simulated amount and never touch it.</span>
                                 </label>
                                 <label class="agent-cp-field" for="agentEditorBacktestAllocation">
                                     <span class="agent-cp-field-label">Backtest capital <span class="agent-cp-field-max">max $3,000</span></span>
@@ -1165,16 +1165,16 @@
                             </div>
 
                             <div id="agentEditorAiHedgeFundPanel" class="agent-editor-simple agent-cp-field agent-cp-field--wide" hidden>
-                                <span class="agent-cp-field-label">AI Hedge Fund analysts</span>
-                                <p class="agent-cp-field-note">Hosted runtime — pick which analysts shape each trade.</p>
+                                <span class="agent-cp-field-label">AI Hedge Fund analyst panel</span>
+                                <p class="agent-cp-field-note">Choose the analysts that shape this agent's strategy. The AI model and its settings are hosted and managed by Agentic Trading Lab.</p>
                                 <div id="agentEditorAiHedgeFundAnalysts" class="agent-editor-analyst-grid" role="group" aria-label="AI Hedge Fund analysts"></div>
                                 <label class="auth-field agent-editor-credential-field" for="agentEditorFinancialDatasetsKey">
-                                    <span>Financial Datasets access key</span>
+                                    <span>Financial Datasets access key (from financialdatasets.ai)</span>
                                     <input id="agentEditorFinancialDatasetsKey" type="password" autocomplete="new-password" placeholder="Leave blank to keep the stored key" aria-describedby="agentEditorFinancialDatasetsStatus">
                                 </label>
                                 <p id="agentEditorFinancialDatasetsStatus" class="agent-editor-simple-note">Checking credential…</p>
                                 <button id="agentEditorFinancialDatasetsRemove" class="agent-editor-credential-remove" type="button" hidden>Remove stored key</button>
-                                <p class="agent-cp-field-note">Encrypted at rest. Never shown again after you save.</p>
+                                <p class="agent-cp-field-note">Encrypted and stored securely. For your protection, it is never shown again after you save.</p>
                             </div>
                         </div>
 

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -487,7 +487,8 @@ const LEGACY_RUNTIME_MARKET = { ai_hedge_fund: 'us_stocks' };
  * Stocks is the only asset class the engine can backtest, so both entries here
  * live under it. */
 const MARKET_LABELS = {
-  us_stocks: 'U.S.',
+  // Retail-standard name (not bare "U.S." / "US Equities"). Slug stays us_stocks.
+  us_stocks: 'US Stocks',
   cn_ashares: 'China A-Share',
 };
 

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -84,6 +84,10 @@
   let financialDatasetsConfigured = false;
   let activeCpTab = 'overview';
   let cachedRuns = [];
+  // True when Market shows US Stocks only as a UI default for an uncategorized
+  // agent (DB category still null). Cleared when the user touches the select so
+  // Save of unrelated fields cannot silently shelf the agent.
+  let categoryUiDefaulted = false;
 
   function isAiHedgeFundAgent(agent = currentAgent) {
     return (agent?.runtime_type || 'pipeline') === AI_HEDGE_FUND_RUNTIME;
@@ -820,8 +824,9 @@
     if (!select) return;
     const labels = shelfLabels();
     // "" remains a saveable choice (backend folds it to NULL / un-shelves).
-    // Default the *visible* selection to US Stocks when nothing is stored yet
-    // -- bare "Not set (Prompting LLMs)" was stale copy and looked broken.
+    // Uncategorized agents show US Stocks as the suggested default, but
+    // categoryUiDefaulted keeps that from being PATCH'd until the user
+    // touches Market (see getEditorState).
     const options = [['', 'Not set']].concat(
       Object.keys(labels).map((slug) => [slug, labels[slug]]),
     );
@@ -833,7 +838,13 @@
       select.appendChild(option);
     });
     const current = String(agent?.category || '').trim().toLowerCase();
-    select.value = labels[current] ? current : 'us_stocks';
+    if (labels[current]) {
+      select.value = current;
+      categoryUiDefaulted = false;
+    } else {
+      select.value = labels.us_stocks ? 'us_stocks' : '';
+      categoryUiDefaulted = Boolean(labels.us_stocks);
+    }
   }
 
   function getEditorState() {
@@ -841,9 +852,11 @@
     const categorySelect = document.getElementById('agentEditorCategorySelect');
     // null means "omit the key", which the PATCH route reads as "leave alone".
     // "" means "clear the shelf" and must still be sent.
-    const category = categoryFieldApplies() && categorySelect
-      ? String(categorySelect.value || '')
-      : null;
+    // categoryUiDefaulted → null so a capital/name save does not invent a market.
+    let category = null;
+    if (categoryFieldApplies() && categorySelect) {
+      category = categoryUiDefaulted ? null : String(categorySelect.value || '');
+    }
     const nameInput = document.getElementById('agentEditorNameInput');
     const cashInput = document.getElementById('agentEditorCashAllocation');
     // Description was removed from Configure — it is not shown on agent cards
@@ -1540,6 +1553,9 @@
 
     const body = document.getElementById('agentEditorView');
     body?.addEventListener('input', (event) => {
+      if (event.target?.id === 'agentEditorCategorySelect') {
+        categoryUiDefaulted = false;
+      }
       markDirtyFromInput();
       if (
         event.target?.id === 'agentEditorModelSelect'
@@ -1551,6 +1567,9 @@
       }
     });
     body?.addEventListener('change', (event) => {
+      if (event.target?.id === 'agentEditorCategorySelect') {
+        categoryUiDefaulted = false;
+      }
       markDirtyFromInput();
       if (
         event.target?.id === 'agentEditorModelSelect'

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -82,6 +82,8 @@
   let isDirty = false;
   let savedSnapshot = '';
   let financialDatasetsConfigured = false;
+  let activeCpTab = 'overview';
+  let cachedRuns = [];
 
   function isAiHedgeFundAgent(agent = currentAgent) {
     return (agent?.runtime_type || 'pipeline') === AI_HEDGE_FUND_RUNTIME;
@@ -285,7 +287,225 @@
 
   function formatUsd(value) {
     if (value == null || Number.isNaN(Number(value))) return '—';
-    return `$${Number(value).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+    return `$${Number(value).toLocaleString(undefined, {
+      maximumFractionDigits: Number(value) % 1 === 0 ? 0 : 2,
+    })}`;
+  }
+
+  function formatReturnPct(run) {
+    if (typeof window.formatBacktestRunReturn === 'function') {
+      return window.formatBacktestRunReturn(run);
+    }
+    if (run?.total_return == null) return '—';
+    const pct = Math.abs(run.total_return) <= 1 ? run.total_return * 100 : run.total_return;
+    const sign = pct >= 0 ? '+' : '';
+    return `${sign}${pct.toFixed(1)}%`;
+  }
+
+  function returnToneClass(run) {
+    if (run?.total_return == null || Number.isNaN(Number(run.total_return))) return '';
+    return Number(run.total_return) >= 0 ? 'is-positive' : 'is-negative';
+  }
+
+  function formatRelativeTime(iso) {
+    if (typeof window.formatRelativeTime === 'function') return window.formatRelativeTime(iso);
+    if (!iso) return '';
+    const t = new Date(iso).getTime();
+    if (!Number.isFinite(t)) return '';
+    const mins = Math.round((Date.now() - t) / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins} min ago`;
+    const hours = Math.round(mins / 60);
+    if (hours < 48) return `${hours}h ago`;
+    return `${Math.round(hours / 24)}d ago`;
+  }
+
+  function formatShortDateRange(start, end) {
+    if (typeof window.formatShortDateRange === 'function') {
+      return window.formatShortDateRange(start, end);
+    }
+    const parts = [start, end].filter(Boolean);
+    return parts.length ? parts.join(' – ') : '—';
+  }
+
+  function marketLabelForAgent(agent) {
+    const labels = shelfLabels();
+    const slug = String(agent?.category || '').trim().toLowerCase();
+    if (labels[slug]) return labels[slug];
+    if (agent?.agent_type === 'builtin') return 'Not set';
+    return 'External';
+  }
+
+  function modelLabelForAgent(agent) {
+    if (isAiHedgeFundAgent(agent)) {
+      return document.getElementById('agentEditorManagedModelValue')?.textContent?.trim()
+        || 'Hosted Nemotron';
+    }
+    const select = document.getElementById('agentEditorModelSelect');
+    if (select?.selectedOptions?.[0]?.textContent) return select.selectedOptions[0].textContent.trim();
+    return agent?.model_name || '—';
+  }
+
+  function resolveStatusBadge(agent) {
+    if (typeof window.resolveAgentStatusBadge === 'function') {
+      return window.resolveAgentStatusBadge(agent);
+    }
+    const runCount = Number(agent?.run_count) || (Array.isArray(agent?.runs) ? agent.runs.length : 0);
+    if (runCount > 0 || agent?.latest_run?.run_id) {
+      return { key: 'backtested', label: 'Backtested', className: 'idle' };
+    }
+    return { key: 'draft', label: 'Draft', className: 'draft' };
+  }
+
+  function setActiveTab(tab) {
+    const allowed = new Set(['overview', 'settings', 'backtest', 'paper', 'live']);
+    activeCpTab = allowed.has(tab) ? tab : 'overview';
+
+    document.querySelectorAll('[data-agent-cp-tab]').forEach((btn) => {
+      const on = btn.getAttribute('data-agent-cp-tab') === activeCpTab;
+      btn.classList.toggle('is-active', on);
+      btn.setAttribute('aria-selected', on ? 'true' : 'false');
+    });
+
+    document.querySelectorAll('[data-agent-cp-panel]').forEach((panel) => {
+      const on = panel.getAttribute('data-agent-cp-panel') === activeCpTab;
+      panel.hidden = !on;
+      panel.classList.toggle('is-active', on);
+    });
+  }
+
+  function syncHeroDescription() {
+    const hero = document.getElementById('agentEditorHeroDescription');
+    if (!hero) return;
+    const text = String(currentAgent?.description || '').trim();
+    hero.textContent = text
+      || 'Researches market data and identifies trading opportunities using a configurable LLM strategy.';
+  }
+
+  function updateStatusChrome(agent = currentAgent) {
+    if (!agent) return;
+    const badge = document.getElementById('agentEditorStatusBadge');
+    const status = resolveStatusBadge(agent);
+    if (badge) {
+      const raw = status.label || (status.key === 'draft' ? 'Draft' : 'Draft');
+      badge.textContent = raw
+        .toLowerCase()
+        .replace(/\b\w/g, (ch) => ch.toUpperCase())
+        .replace('Paper Trading', 'Paper');
+      badge.className = 'agent-cp-status-badge';
+      if (status.className === 'idle') badge.classList.add('is-idle');
+      if (status.className === 'paper' || status.key === 'paper') badge.classList.add('is-paper');
+    }
+
+    const updated = agent.updated_at || agent.created_at;
+    const updatedLabel = document.getElementById('agentEditorUpdatedLabel');
+    if (updatedLabel) {
+      updatedLabel.textContent = updated
+        ? `Updated ${new Date(updated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+        : 'Updated —';
+    }
+
+    const version = agent.version || agent.current_version || 'v1';
+    const versionLabel = String(version).startsWith('v') ? String(version) : `v${version}`;
+    const versionEls = [
+      document.getElementById('agentEditorVersionLabel'),
+      document.getElementById('agentEditorOverviewVersionBadge'),
+      document.getElementById('agentBacktestConfigVersion'),
+    ];
+    versionEls.forEach((el) => {
+      if (!el) return;
+      el.textContent = el.id === 'agentEditorOverviewVersionBadge'
+        ? `Agent ${versionLabel}`
+        : versionLabel;
+    });
+  }
+
+  function renderOverview(runs = cachedRuns) {
+    const agent = currentAgent;
+    if (!agent) return;
+
+    const configPrimary = document.getElementById('agentOverviewConfigPrimary');
+    const configSecondary = document.getElementById('agentOverviewConfigSecondary');
+    if (configPrimary) configPrimary.textContent = modelLabelForAgent(agent);
+    if (configSecondary) {
+      configSecondary.textContent = `${marketLabelForAgent(agent)} · allocated ${formatUsd(
+        agent.backtest_allocation ?? agent.cash_allocation ?? 1000,
+      )}`;
+    }
+
+    const sorted = [...(runs || [])].sort(
+      (a, b) => (b.created_at || '').localeCompare(a.created_at || ''),
+    );
+    const latest = sorted[0] || agent.latest_run || null;
+    const btPrimary = document.getElementById('agentOverviewBacktestPrimary');
+    const btSecondary = document.getElementById('agentOverviewBacktestSecondary');
+    if (btPrimary && btSecondary) {
+      if (latest && latest.total_return != null) {
+        btPrimary.textContent = formatReturnPct(latest);
+        btPrimary.className = `agent-cp-status-primary ${returnToneClass(latest)}`;
+        const sharpe = latest.sharpe_ratio != null && Number.isFinite(Number(latest.sharpe_ratio))
+          ? ` · Sharpe ${Number(latest.sharpe_ratio).toFixed(2)}`
+          : '';
+        btSecondary.textContent = `${formatShortDateRange(latest.start_date, latest.end_date)}${sharpe}`;
+      } else {
+        btPrimary.textContent = sorted.length ? 'Completed' : 'No runs yet';
+        btPrimary.className = 'agent-cp-status-primary';
+        btSecondary.textContent = sorted.length
+          ? formatShortDateRange(latest?.start_date, latest?.end_date)
+          : 'Run a backtest to see results';
+      }
+    }
+
+    const capitalEl = document.getElementById('agentBacktestConfigCapital');
+    if (capitalEl) {
+      capitalEl.textContent = formatUsd(agent.backtest_allocation ?? agent.cash_allocation ?? 1000);
+    }
+    const marketEl = document.getElementById('agentBacktestConfigMarket');
+    if (marketEl) marketEl.textContent = marketLabelForAgent(agent);
+
+    const activity = document.getElementById('agentEditorActivityList');
+    if (!activity) return;
+    const items = [];
+    sorted.slice(0, 5).forEach((run) => {
+      items.push({
+        title: 'Backtest completed',
+        sub: `${formatShortDateRange(run.start_date, run.end_date)} · ${formatReturnPct(run)}`,
+        time: formatRelativeTime(run.created_at) || formatRunSecondary(run),
+        icon: 'check',
+      });
+    });
+    if (agent.updated_at && agent.updated_at !== agent.created_at) {
+      items.push({
+        title: 'Agent settings saved',
+        sub: 'Configuration updated',
+        time: formatRelativeTime(agent.updated_at),
+        icon: 'save',
+      });
+    }
+    items.push({
+      title: 'Agent created',
+      sub: `${agent.name || 'Agent'} ${agent.version || 'v1'}`,
+      time: formatRelativeTime(agent.created_at) || (agent.created_at
+        ? new Date(agent.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+        : '—'),
+      icon: 'plus',
+    });
+
+    const iconSvg = {
+      check: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg>',
+      save: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><path d="M17 21v-8H7v8"/><path d="M7 3v5h8"/></svg>',
+      plus: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14"/><path d="M5 12h14"/></svg>',
+    };
+
+    activity.innerHTML = items.slice(0, 6).map((item) => `
+      <div class="agent-cp-activity-item">
+        <span class="agent-cp-activity-icon" aria-hidden="true">${iconSvg[item.icon] || iconSvg.plus}</span>
+        <div>
+          <p class="agent-cp-activity-title-text">${escapeHtml(item.title)}</p>
+          <p class="agent-cp-activity-sub">${escapeHtml(item.sub)}</p>
+        </div>
+        <span class="agent-cp-activity-time">${escapeHtml(item.time || '')}</span>
+      </div>`).join('');
   }
 
   function setBrokerMessage(message, isError) {
@@ -385,6 +605,8 @@
           metaEl.hidden = true;
         }
       }
+      const livePrimary = document.getElementById('agentOverviewLivePrimary');
+      if (livePrimary) livePrimary.textContent = connected ? 'Connected' : 'Not connected';
       if (!connected) {
         setBrokerMessage('Not connected yet. Click Connect Robinhood to authorize.');
       } else {
@@ -574,7 +796,7 @@
   // floor for the case where app.js failed to load -- agent-editor.js is loaded
   // first, so this must never be read at module-init time.
   const SHELF_LABELS_FALLBACK = {
-    us_stocks: 'U.S.',
+    us_stocks: 'US Stocks',
     cn_ashares: 'China A-Share',
   };
 
@@ -597,10 +819,10 @@
     const select = document.getElementById('agentEditorCategorySelect');
     if (!select) return;
     const labels = shelfLabels();
-    // "" is a real, saveable choice, not a placeholder: the backend folds an
-    // empty string to NULL, which un-shelves the agent. It is listed first so
-    // an agent that has never been categorized shows its actual state.
-    const options = [['', 'Not set (shows under Prompting LLMs)']].concat(
+    // "" remains a saveable choice (backend folds it to NULL / un-shelves).
+    // Default the *visible* selection to US Stocks when nothing is stored yet
+    // -- bare "Not set (Prompting LLMs)" was stale copy and looked broken.
+    const options = [['', 'Not set']].concat(
       Object.keys(labels).map((slug) => [slug, labels[slug]]),
     );
     select.innerHTML = '';
@@ -611,7 +833,7 @@
       select.appendChild(option);
     });
     const current = String(agent?.category || '').trim().toLowerCase();
-    select.value = labels[current] ? current : '';
+    select.value = labels[current] ? current : 'us_stocks';
   }
 
   function getEditorState() {
@@ -623,8 +845,9 @@
       ? String(categorySelect.value || '')
       : null;
     const nameInput = document.getElementById('agentEditorNameInput');
-    const descInput = document.getElementById('agentEditorDescription');
     const cashInput = document.getElementById('agentEditorCashAllocation');
+    // Description was removed from Configure — it is not shown on agent cards
+    // and was only acting as a private note. Preserve whatever is already stored.
     let cash_allocation = null;
     if (cashInput && cashInput.value !== '') {
       const value = Number(cashInput.value);
@@ -695,7 +918,7 @@
     const credentialInput = document.getElementById('agentEditorFinancialDatasetsKey');
     return {
       name: nameInput ? nameInput.value.trim() : '',
-      description: descInput ? descInput.value.trim() : '',
+      description: String(currentAgent?.description || '').trim(),
       category,
       cash_allocation,
       backtest_allocation,
@@ -772,12 +995,10 @@
 
   function fillHeader(agent) {
     const nameInput = document.getElementById('agentEditorNameInput');
-    const descInput = document.getElementById('agentEditorDescription');
     const cashInput = document.getElementById('agentEditorCashAllocation');
     const meta = document.getElementById('agentEditorMeta');
 
     if (nameInput) nameInput.value = agent.name || '';
-    if (descInput) descInput.value = agent.description || '';
     if (cashInput) {
       cashInput.value = agent.cash_allocation != null ? String(agent.cash_allocation) : '';
     }
@@ -796,12 +1017,15 @@
     }
     if (meta) {
       meta.textContent = agent.agent_type === 'builtin' ? 'Built-in agent' : 'External agent';
+      meta.hidden = true;
     }
     const categoryField = document.getElementById('agentEditorCategoryField');
     if (categoryField) categoryField.hidden = !categoryFieldApplies(agent);
     fillCategorySelect(agent);
     const liveToggle = document.getElementById('agentEditorLiveTradingEnabled');
     if (liveToggle) liveToggle.checked = Boolean(agent.live_trading_enabled);
+    syncHeroDescription();
+    updateStatusChrome(agent);
   }
 
   function configureEditorMode(agent) {
@@ -961,35 +1185,68 @@
   function renderRunHistory(runs) {
     const container = document.getElementById('agentEditorRunHistory');
     const countEl = document.getElementById('agentEditorRunCount');
+    const navCountEl = document.getElementById('agentEditorNavRunCount');
     if (!container) return;
 
     const sorted = [...(runs || [])].sort(
       (a, b) => (b.created_at || '').localeCompare(a.created_at || ''),
     );
+    cachedRuns = sorted;
 
     if (countEl) {
       countEl.textContent = `${sorted.length} run${sorted.length === 1 ? '' : 's'}`;
     }
+    if (navCountEl) navCountEl.textContent = String(sorted.length);
 
     if (!sorted.length) {
       container.innerHTML = '<p class="agent-editor-run-empty">No backtest runs yet. Run a backtest from this agent to see history here.</p>';
+      renderOverview([]);
       return;
     }
 
-    container.innerHTML = sorted
-      .map(
-        (run) => `
-          <button type="button" class="agent-editor-run-item" data-run-id="${escapeHtml(run.run_id)}" role="listitem">
-            <span class="agent-editor-run-primary">${escapeHtml(formatRunPrimary(run))}</span>
-            <span class="agent-editor-run-secondary">${escapeHtml(formatRunSecondary(run))}</span>
-            ${formatRunMeta(run) ? `<span class="agent-editor-run-meta">${escapeHtml(formatRunMeta(run))}</span>` : ''}
-          </button>`,
-      )
-      .join('');
+    container.innerHTML = `
+      <table class="agent-cp-run-table">
+        <thead>
+          <tr>
+            <th>Run</th>
+            <th>Period</th>
+            <th>Initial capital</th>
+            <th>Return</th>
+            <th>Sharpe</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${sorted.map((run) => {
+            const ret = formatReturnPct(run);
+            const tone = returnToneClass(run);
+            const sharpe = run.sharpe_ratio != null && Number.isFinite(Number(run.sharpe_ratio))
+              ? Number(run.sharpe_ratio).toFixed(2)
+              : '—';
+            const capital = formatUsd(run.initial_equity ?? run.initial_capital ?? currentAgent?.backtest_allocation);
+            const created = run.created_at
+              ? new Date(run.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+              : '';
+            const runLabel = run.strategy_name || run.universe_label || run.agent_name || currentAgent?.name || 'Backtest';
+            return `
+              <tr data-run-id="${escapeHtml(run.run_id)}" role="listitem">
+                <td>
+                  <span class="agent-cp-run-name">${escapeHtml(runLabel)}</span>
+                  <span class="agent-cp-run-date">${escapeHtml(created)}</span>
+                </td>
+                <td>${escapeHtml(formatShortDateRange(run.start_date, run.end_date))}</td>
+                <td>${escapeHtml(capital)}</td>
+                <td class="agent-cp-run-return ${tone}">${escapeHtml(ret)}</td>
+                <td>${escapeHtml(sharpe)}</td>
+                <td><span class="agent-cp-run-status">Complete</span></td>
+              </tr>`;
+          }).join('')}
+        </tbody>
+      </table>`;
 
-    container.querySelectorAll('.agent-editor-run-item').forEach((btn) => {
-      btn.addEventListener('click', () => {
-        const runId = btn.dataset.runId;
+    container.querySelectorAll('tr[data-run-id]').forEach((row) => {
+      row.addEventListener('click', () => {
+        const runId = row.dataset.runId;
         if (!currentAgent || !runId) return;
         window.dispatchEvent(
           new CustomEvent('agent-editor-open-run', {
@@ -998,6 +1255,8 @@
         );
       });
     });
+
+    renderOverview(sorted);
   }
 
   async function refreshRunHistory(agent) {
@@ -1039,6 +1298,7 @@
     fillHeader(agent);
     populateModelSelect(agent);
     configureEditorMode(agent);
+    setActiveTab('overview');
 
     const instructionEl = document.getElementById('agentEditorSimpleInstruction');
     const defaultText = document.getElementById('agentEditorDefaultInstructionText');
@@ -1054,6 +1314,7 @@
     if (isAiHedgeFundAgent(agent)) {
       refreshFinancialDatasetsStatus(agent);
     }
+    renderOverview(currentAgent.runs || []);
 
     const view = document.getElementById('agentEditorView');
     if (view) {
@@ -1155,7 +1416,7 @@
       } finally {
         if (saveBtn) {
           saveBtn.disabled = false;
-          saveBtn.textContent = 'Save';
+          saveBtn.textContent = 'Save changes';
         }
       }
       return;
@@ -1197,6 +1458,7 @@
       }
 
       fillHeader(currentAgent);
+      renderOverview(cachedRuns);
       captureSavedSnapshot();
       showSaveStatus(
         clearingToDefault
@@ -1237,8 +1499,22 @@
     } finally {
       if (saveBtn) {
         saveBtn.disabled = false;
-        saveBtn.textContent = 'Save';
+        saveBtn.textContent = 'Save changes';
       }
+    }
+  }
+
+  function openRunBacktestFromEditor() {
+    if (!currentAgent) return;
+    // The modal reads the last-saved agent, so an unsaved edit would run the
+    // old instruction while the preview shows the new one. Same guard as Run Live.
+    if (isDirty) {
+      showSaveStatus('Save changes before Run Backtest', true);
+      setActiveTab('settings');
+      return;
+    }
+    if (typeof window.openRunBacktestModal === 'function') {
+      window.openRunBacktestModal(currentAgent);
     }
   }
 
@@ -1249,22 +1525,40 @@
     document.getElementById('agentEditorDisconnectRobinhoodBtn')?.addEventListener('click', disconnectRobinhood);
     document.getElementById('agentEditorFinancialDatasetsRemove')?.addEventListener('click', removeFinancialDatasetsCredential);
     document.getElementById('agentEditorRunLiveBtn')?.addEventListener('click', runLive);
-    document.getElementById('agentEditorRunBacktestBtn')?.addEventListener('click', () => {
-      if (!currentAgent) return;
-      // The modal reads the last-saved agent, so an unsaved edit would run the
-      // old instruction while the preview shows the new one. Same guard as Run Live.
-      if (isDirty) {
-        showSaveStatus('Save changes before Run Backtest', true);
-        return;
-      }
-      if (typeof window.openRunBacktestModal === 'function') {
-        window.openRunBacktestModal(currentAgent);
-      }
+    document.getElementById('agentEditorRunBacktestBtn')?.addEventListener('click', openRunBacktestFromEditor);
+    document.getElementById('agentEditorNewBacktestBtn')?.addEventListener('click', openRunBacktestFromEditor);
+    document.getElementById('agentEditorTalkBtn')?.addEventListener('click', () => {
+      showSaveStatus('Talk to agent is coming soon');
+    });
+
+    document.querySelectorAll('[data-agent-cp-tab]').forEach((btn) => {
+      btn.addEventListener('click', () => setActiveTab(btn.getAttribute('data-agent-cp-tab')));
+    });
+    document.querySelectorAll('[data-agent-cp-goto]').forEach((btn) => {
+      btn.addEventListener('click', () => setActiveTab(btn.getAttribute('data-agent-cp-goto')));
     });
 
     const body = document.getElementById('agentEditorView');
-    body?.addEventListener('input', markDirtyFromInput);
-    body?.addEventListener('change', markDirtyFromInput);
+    body?.addEventListener('input', (event) => {
+      markDirtyFromInput();
+      if (
+        event.target?.id === 'agentEditorModelSelect'
+        || event.target?.id === 'agentEditorCategorySelect'
+        || event.target?.id === 'agentEditorCashAllocation'
+        || event.target?.id === 'agentEditorBacktestAllocation'
+      ) {
+        renderOverview(cachedRuns);
+      }
+    });
+    body?.addEventListener('change', (event) => {
+      markDirtyFromInput();
+      if (
+        event.target?.id === 'agentEditorModelSelect'
+        || event.target?.id === 'agentEditorCategorySelect'
+      ) {
+        renderOverview(cachedRuns);
+      }
+    });
 
     document.addEventListener('keydown', (event) => {
       const view = document.getElementById('agentEditorView');

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -1047,7 +1047,8 @@ async function renderEquityCurvesChart() {
       scales: {
         x: {
           ticks: {
-            color: '#6b7280',
+            /* Match --text-muted / --text-secondary in styles.css */
+            color: '#94a3b8',
             maxRotation: 0,
             minRotation: 0,
             autoSkip: true,
@@ -1060,7 +1061,7 @@ async function renderEquityCurvesChart() {
         },
         y: {
           ticks: {
-            color: '#9ca3af',
+            color: '#cbd5e1',
             callback(value) {
               if (isMoney) return `$${formatLeaderboardNumber(value)}`;
               return `${(value * 100).toFixed(1)}%`;

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9268,14 +9268,15 @@ body.agent-editor-open {
 .agent-cp-form-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 14px 16px;
-    margin-bottom: 8px;
+    gap: 18px 20px;
+    margin-bottom: 0;
+    align-items: start;
 }
 
 .agent-cp-settings-stack {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 28px;
     margin-bottom: 16px;
 }
 
@@ -9290,6 +9291,7 @@ body.agent-editor-open {
     gap: 6px;
     margin: 0;
     text-align: left;
+    min-width: 0;
 }
 
 .agent-cp-field--wide {
@@ -9302,6 +9304,7 @@ body.agent-editor-open {
     font-size: 15px;
     font-weight: 650;
     text-align: left;
+    line-height: 1.3;
 }
 
 .agent-cp-field-max {
@@ -9314,7 +9317,8 @@ body.agent-editor-open {
 .agent-cp-field-note {
     color: var(--text-secondary);
     font-size: 13px;
-    line-height: 1.45;
+    line-height: 1.4;
+    margin: 0;
 }
 
 .agent-cp-control {
@@ -10625,8 +10629,22 @@ select.agent-cp-control option {
     margin-top: 6px;
 }
 .agent-editor-managed-model-value {
-    font-size: 15px;
+    display: block;
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 44px;
+    padding: 11px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--bg-input);
     color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 600;
+    font-family: var(--font-mono);
+    line-height: 1.4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 .agent-editor-managed-model-note {
     font-size: 13px;
@@ -10672,9 +10690,9 @@ select.agent-cp-control option {
     margin-top: 10px;
 }
 .agent-editor-simple-note {
-    margin: 10px 0 0;
+    margin: 6px 0 0;
     font-size: 13px;
-    line-height: 1.45;
+    line-height: 1.4;
     color: var(--text-secondary);
 }
 .agent-editor-simple-note--warn {
@@ -10702,28 +10720,84 @@ select.agent-cp-control option {
     line-height: 1.45;
 }
 
+/* Settings sections below the model/capital grid — clear visual break so the
+   denser AHF analyst block does not collide with the fields above. */
+#agentEditorSimplePanel,
+#agentEditorAiHedgeFundPanel {
+    padding-top: 22px;
+    border-top: 1px solid var(--border-color);
+    gap: 10px;
+}
+
 .agent-editor-analyst-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-    gap: 8px;
-    margin: 16px 0 20px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    margin: 4px 0 8px;
+}
+
+@media (max-width: 1100px) {
+    .agent-editor-analyst-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 640px) {
+    .agent-editor-analyst-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 .agent-editor-analyst-option {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 9px 10px;
+    min-width: 0;
+    min-height: 42px;
+    padding: 8px 10px;
     border: 1px solid var(--border-color);
     border-radius: 8px;
+    background: var(--bg-surface);
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.25;
     cursor: pointer;
+    transition: border-color 0.12s, background-color 0.12s;
+}
+
+.agent-editor-analyst-option > span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.agent-editor-analyst-option input {
+    flex-shrink: 0;
+    margin: 0;
 }
 
 .agent-editor-analyst-option:has(input:checked) {
-    border-color: var(--info-color);
-    background: rgba(0, 191, 255, 0.08);
+    border-color: rgba(0, 191, 255, 0.55);
+    background: rgba(0, 191, 255, 0.1);
+}
+
+/* Credential row inside settings must match .agent-cp-field, not auth-modal 12px. */
+.agent-cp .agent-editor-credential-field.auth-field {
+    margin-top: 8px;
+    font-size: 15px;
+    font-weight: 650;
+    color: var(--text-primary);
+    gap: 6px;
+}
+
+.agent-cp .agent-editor-credential-field.auth-field input {
+    padding: 11px 12px;
+    border-radius: 8px;
+    background: var(--bg-input);
+    font-size: 15px;
+    font-weight: 400;
 }
 
 .agent-editor-credential-field {
@@ -10733,12 +10807,12 @@ select.agent-cp-control option {
 .agent-editor-credential-remove {
     align-self: flex-start;
     margin-top: 4px;
-    padding: 4px 10px;
-    border: 1px solid var(--border, #d0d5dd);
+    padding: 6px 10px;
+    border: 1px solid var(--border-color);
     border-radius: 6px;
     background: transparent;
-    color: var(--text-secondary, #667085);
-    font-size: 12px;
+    color: var(--text-secondary);
+    font-size: 13px;
     cursor: pointer;
 }
 

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -35,10 +35,13 @@ textarea {
     --bg-input: #0a0e27;
     --bg-hover: #1a2047;
     
-    /* Text */
-    --text-primary: #e5e7eb;
-    --text-secondary: #9ca3af;
-    --text-muted: #6b7280;
+    /* Text — contrast vs --bg-primary #0a0e27 (WCAG AA normal text ≥4.5:1).
+       Keep the three roles distinct: primary = body, secondary = supporting,
+       muted = meta only. Do not darken muted back under ~#94a3b8; the old
+       #6b7280 measured ~3.9:1 and failed AA on this background. */
+    --text-primary: #e5e7eb;   /* ~15.4:1 */
+    --text-secondary: #cbd5e1; /* slate-300, ~11:1 — was #9ca3af */
+    --text-muted: #94a3b8;     /* slate-400, ~7.4:1 — was #6b7280 */
     
     /* Borders */
     --border-color: #1f2937;
@@ -60,6 +63,7 @@ textarea {
     /* Typography */
     --font-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
     --font-mono: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', monospace;
+    --font-size-base: 15px; /* was 14px; rem-based rules still track html, not this */
 
     /* Shared accent (used outside .home-view, e.g. My Agents) */
     --home-accent-cyan: #22d3ee;
@@ -82,7 +86,7 @@ body {
     background-color: var(--bg-primary);
     color: var(--text-primary);
     line-height: 1.6;
-    font-size: 14px;
+    font-size: var(--font-size-base);
     font-weight: 400;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -4644,7 +4648,7 @@ a.header-brand:hover .title-section h1 {
 }
 
 .run-backtest-modal-panel {
-    width: min(560px, calc(100vw - 32px));
+    width: min(760px, calc(100vw - 32px));
     max-height: calc(100vh - 48px);
     overflow: auto;
     /* Column layout so the submit button can be pinned to the bottom below. */
@@ -8746,6 +8750,839 @@ body.agent-editor-open {
     display: none !important;
 }
 
+/* ── Agent Control Plane (Configure redesign) ─────────────────────────── */
+.agent-cp {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    padding: 16px 20px 20px;
+    gap: 14px;
+    overflow: hidden;
+    background:
+        radial-gradient(ellipse 80% 50% at 10% -10%, rgba(92, 124, 250, 0.14), transparent 55%),
+        radial-gradient(ellipse 60% 40% at 90% 0%, rgba(34, 211, 238, 0.08), transparent 50%),
+        var(--bg-primary);
+}
+
+.agent-cp-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    padding: 6px 10px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+}
+
+.agent-cp-back svg {
+    width: 16px;
+    height: 16px;
+}
+
+.agent-cp-back:hover {
+    color: var(--home-accent-cyan, #22d3ee);
+    background: rgba(34, 211, 238, 0.08);
+}
+
+.agent-cp-hero {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    flex-shrink: 0;
+}
+
+.agent-cp-identity {
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
+    min-width: 0;
+    flex: 1;
+}
+
+.agent-cp-avatar {
+    width: 52px;
+    height: 52px;
+    border-radius: 14px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    color: var(--text-on-accent);
+    background: linear-gradient(145deg, var(--neutral-color), #3b82f6);
+    box-shadow: 0 8px 20px rgba(92, 124, 250, 0.28);
+}
+
+.agent-cp-avatar svg {
+    width: 28px;
+    height: 28px;
+}
+
+.agent-cp-identity-text {
+    min-width: 0;
+    flex: 1;
+}
+
+.agent-cp-title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.agent-cp-name-input.agent-editor-name-input {
+    width: auto;
+    max-width: min(420px, 100%);
+    padding: 4px 8px;
+    border-color: transparent;
+    background: transparent;
+    font-size: 28px;
+    font-weight: 750;
+    letter-spacing: -0.02em;
+}
+
+.agent-cp-name-input.agent-editor-name-input:hover,
+.agent-cp-name-input.agent-editor-name-input:focus {
+    border-color: var(--border-color);
+    background: var(--bg-input);
+}
+
+.agent-cp-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(0, 200, 81, 0.35);
+    background: rgba(0, 200, 81, 0.12);
+    color: var(--success-color);
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.agent-cp-status-badge::before {
+    content: '';
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 0 3px rgba(0, 200, 81, 0.18);
+}
+
+.agent-cp-status-badge.is-idle {
+    border-color: rgba(92, 124, 250, 0.4);
+    background: rgba(92, 124, 250, 0.14);
+    color: #93a8ff;
+}
+
+.agent-cp-status-badge.is-idle::before {
+    box-shadow: 0 0 0 3px rgba(92, 124, 250, 0.18);
+}
+
+.agent-cp-status-badge.is-paper {
+    border-color: rgba(34, 211, 238, 0.4);
+    background: rgba(34, 211, 238, 0.12);
+    color: var(--home-accent-cyan);
+}
+
+.agent-cp-status-badge.is-paper::before {
+    box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.18);
+}
+
+.agent-cp-hero-desc {
+    margin: 6px 0 0;
+    max-width: 560px;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.45;
+}
+
+.agent-cp-meta {
+    margin: 2px 0 0;
+}
+
+.agent-cp-hero-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.agent-cp-btn-talk,
+.agent-cp-btn-run {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.agent-cp-btn-talk svg,
+.agent-cp-btn-run svg {
+    width: 15px;
+    height: 15px;
+}
+
+.agent-cp-shell {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: 0;
+    min-height: 0;
+    flex: 1;
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    background: var(--bg-surface);
+    overflow: hidden;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
+}
+
+.agent-cp-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px 12px;
+    border-right: 1px solid var(--border-color);
+    background: rgba(10, 14, 39, 0.55);
+    min-height: 0;
+}
+
+.agent-cp-nav-label {
+    margin: 0 8px 6px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.agent-cp-nav-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    min-height: 0;
+}
+
+.agent-cp-nav-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 14px;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.agent-cp-nav-item svg {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+}
+
+.agent-cp-nav-item span:first-of-type {
+    flex: 1;
+    min-width: 0;
+}
+
+.agent-cp-nav-item:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+.agent-cp-nav-item.is-active {
+    background: var(--neutral-color);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 8px 18px rgba(92, 124, 250, 0.28);
+}
+
+.agent-cp-nav-count {
+    margin-left: auto;
+    min-width: 20px;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    text-align: center;
+}
+
+.agent-cp-nav-item:not(.is-active) .agent-cp-nav-count {
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+}
+
+.agent-cp-nav-soon {
+    margin-left: auto;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.agent-cp-nav-item.is-active .agent-cp-nav-soon {
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.agent-cp-nav-footer {
+    margin-top: auto;
+    padding: 12px 10px 4px;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+.agent-cp-nav-footer strong {
+    color: var(--text-primary);
+    font-weight: 700;
+}
+
+.agent-cp-main {
+    min-width: 0;
+    min-height: 0;
+    overflow: auto;
+    padding: 22px 24px 28px;
+    background: var(--bg-card);
+}
+
+.agent-cp-panel[hidden] {
+    display: none !important;
+}
+
+.agent-cp-panel-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.agent-cp-panel-title {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 22px;
+    font-weight: 750;
+    letter-spacing: -0.02em;
+}
+
+.agent-cp-panel-sub {
+    margin: 4px 0 0;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.45;
+}
+
+.agent-cp-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 10px;
+    border-radius: 999px;
+    border: 1px solid var(--border-color);
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 650;
+    white-space: nowrap;
+}
+
+.agent-cp-status-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    margin-bottom: 22px;
+}
+
+.agent-cp-status-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    padding: 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 14px;
+    background: linear-gradient(180deg, rgba(92, 124, 250, 0.08), rgba(10, 14, 39, 0.35));
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.15s, transform 0.15s, background 0.15s;
+}
+
+.agent-cp-status-card:hover {
+    border-color: rgba(92, 124, 250, 0.55);
+    transform: translateY(-1px);
+}
+
+.agent-cp-status-card.is-muted {
+    opacity: 0.78;
+    background: var(--bg-surface);
+}
+
+.agent-cp-status-card-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    margin-bottom: 8px;
+}
+
+.agent-cp-status-icon {
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    display: grid;
+    place-items: center;
+    background: rgba(92, 124, 250, 0.16);
+    color: #93a8ff;
+}
+
+.agent-cp-status-icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.agent-cp-status-arrow {
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.agent-cp-status-title {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 650;
+}
+
+.agent-cp-status-primary {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 18px;
+    font-weight: 750;
+    letter-spacing: -0.01em;
+}
+
+.agent-cp-status-primary.is-positive {
+    color: var(--success-color);
+}
+
+.agent-cp-status-primary.is-negative {
+    color: var(--danger-color);
+}
+
+.agent-cp-status-secondary {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 13px;
+}
+
+.agent-cp-activity-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
+
+.agent-cp-activity-title {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 15px;
+    font-weight: 700;
+}
+
+.agent-cp-link-btn {
+    border: none;
+    background: transparent;
+    color: var(--home-accent-cyan, #22d3ee);
+    font-size: 13px;
+    font-weight: 650;
+    cursor: pointer;
+}
+
+.agent-cp-link-btn:hover {
+    text-decoration: underline;
+}
+
+.agent-cp-activity-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.agent-cp-activity-item {
+    display: grid;
+    grid-template-columns: 36px minmax(0, 1fr) auto;
+    gap: 12px;
+    align-items: center;
+    padding: 12px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    background: var(--bg-surface);
+}
+
+.agent-cp-activity-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: rgba(92, 124, 250, 0.16);
+    color: #93a8ff;
+}
+
+.agent-cp-activity-icon svg {
+    width: 16px;
+    height: 16px;
+}
+
+.agent-cp-activity-title-text {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.agent-cp-activity-sub {
+    margin: 2px 0 0;
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.agent-cp-activity-time {
+    color: var(--text-muted);
+    font-size: 12px;
+    white-space: nowrap;
+}
+
+.agent-cp-form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px 16px;
+    margin-bottom: 8px;
+}
+
+.agent-cp-settings-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    margin-bottom: 16px;
+}
+
+.agent-cp-settings-footnote {
+    margin: -6px 0 0;
+}
+
+.agent-cp-field {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+    margin: 0;
+    text-align: left;
+}
+
+.agent-cp-field--wide {
+    grid-column: 1 / -1;
+}
+
+.agent-cp-field-label {
+    display: block;
+    color: var(--text-primary);
+    font-size: 15px;
+    font-weight: 650;
+    text-align: left;
+}
+
+.agent-cp-field-max {
+    margin-left: 6px;
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.agent-cp-field-note {
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+.agent-cp-control {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 11px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--bg-input);
+    color: var(--text-primary);
+    font-size: 15px;
+    font-family: inherit;
+    line-height: 1.4;
+}
+
+.agent-cp-control:focus {
+    outline: none;
+    border-color: rgba(92, 124, 250, 0.55);
+    box-shadow: 0 0 0 2px rgba(92, 124, 250, 0.14);
+}
+
+.agent-cp-control--mono {
+    font-family: var(--font-mono);
+}
+
+.agent-cp-control--area {
+    min-height: 140px;
+    resize: vertical;
+    line-height: 1.45;
+}
+
+select.agent-cp-control {
+    cursor: pointer;
+}
+
+select.agent-cp-control option {
+    background: var(--bg-card);
+    color: var(--text-primary);
+}
+
+.agent-cp-card {
+    margin-bottom: 14px;
+}
+
+.agent-cp-info-banner {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    margin: 8px 0 12px;
+    padding: 12px 14px;
+    border: 1px solid rgba(92, 124, 250, 0.35);
+    border-left: 3px solid var(--neutral-color);
+    border-radius: 10px;
+    background: rgba(92, 124, 250, 0.1);
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+.agent-cp-info-banner p {
+    margin: 0;
+}
+
+.agent-cp-info-icon {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    background: var(--neutral-color);
+    color: #fff;
+    font-size: 12px;
+    font-weight: 800;
+    font-style: italic;
+}
+
+.agent-cp-config-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 18px;
+    padding: 14px 16px;
+    border: 1px solid rgba(92, 124, 250, 0.3);
+    border-radius: 12px;
+    background: rgba(92, 124, 250, 0.08);
+}
+
+.agent-cp-config-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 22px;
+}
+
+.agent-cp-config-label {
+    display: block;
+    margin-bottom: 2px;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 650;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.agent-cp-config-metrics strong {
+    color: var(--text-primary);
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.agent-cp-history-block {
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    background: var(--bg-surface);
+    padding: 14px 16px 8px;
+}
+
+.agent-cp-run-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.agent-cp-run-table th {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border-color);
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 700;
+    text-align: left;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.agent-cp-run-table td {
+    padding: 12px 10px;
+    border-bottom: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    vertical-align: middle;
+}
+
+.agent-cp-run-table tr[data-run-id] {
+    cursor: pointer;
+    transition: background 0.12s;
+}
+
+.agent-cp-run-table tr[data-run-id]:hover {
+    background: var(--bg-hover);
+}
+
+.agent-cp-run-name {
+    display: block;
+    color: var(--text-primary);
+    font-weight: 650;
+}
+
+.agent-cp-run-date {
+    display: block;
+    margin-top: 2px;
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.agent-cp-run-return.is-positive {
+    color: var(--success-color);
+    font-weight: 700;
+}
+
+.agent-cp-run-return.is-negative {
+    color: var(--danger-color);
+    font-weight: 700;
+}
+
+.agent-cp-run-status {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: rgba(0, 200, 81, 0.12);
+    color: var(--success-color);
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.agent-cp-soon-card {
+    padding: 28px 24px;
+    border: 1px dashed var(--border-color);
+    border-radius: 14px;
+    background: var(--bg-surface);
+    text-align: left;
+}
+
+.agent-cp-soon-card h3 {
+    margin: 0 0 8px;
+    color: var(--text-primary);
+    font-size: 16px;
+}
+
+.agent-cp-soon-card p {
+    margin: 0 0 16px;
+    max-width: 480px;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+@media (max-width: 960px) {
+    .agent-cp-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .agent-cp-nav {
+        border-right: none;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .agent-cp-nav-list {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .agent-cp-nav-item {
+        width: auto;
+    }
+
+    .agent-cp-nav-footer {
+        display: none;
+    }
+
+    .agent-cp-status-grid,
+    .agent-cp-form-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 640px) {
+    .agent-cp {
+        padding: 10px 12px 14px;
+    }
+
+    .agent-cp-hero {
+        flex-direction: column;
+    }
+
+    .agent-cp-hero-actions {
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    .agent-cp-hero-actions .home-btn {
+        flex: 1;
+    }
+
+    .agent-cp-name-input.agent-editor-name-input {
+        font-size: 22px;
+    }
+
+    .agent-cp-main {
+        padding: 16px 14px 20px;
+    }
+
+    .agent-cp-config-bar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
 .agent-editor-header {
     display: flex;
     align-items: flex-start;
@@ -9138,7 +9975,7 @@ body.agent-editor-open {
 .agent-editor-hint {
     margin: 16px 0 0;
     font-size: 13px;
-    color: var(--text-muted);
+    color: var(--text-secondary);
 }
 
 .agent-editor-hint kbd {
@@ -9759,16 +10596,26 @@ body.agent-editor-open {
     border-color: var(--info-color);
 }
 
-/* Agent editor — model picker (Demo 1) */
+/* Agent editor — model picker (Demo 1). Legacy header layout was horizontal +
+   center-aligned; settings now uses .agent-cp-field. Keep these hide rules. */
 .agent-editor-model-field {
     display: flex;
     align-items: center;
     gap: 8px;
     margin-top: 6px;
 }
+/* .agent-cp-field sets display:flex, which beats the UA [hidden] rule and used
+   to leak the AI Hedge Fund panel onto every built-in agent's settings screen.
+   Any field that toggles with .hidden must opt into this override. */
+.agent-cp-field[hidden],
 .agent-editor-model-field[hidden],
-.agent-editor-managed-model-field[hidden] {
-    display: none;
+.agent-editor-managed-model-field[hidden],
+#agentEditorModelField[hidden],
+#agentEditorManagedModelField[hidden],
+#agentEditorCategoryField[hidden],
+#agentEditorSimplePanel[hidden],
+#agentEditorAiHedgeFundPanel[hidden] {
+    display: none !important;
 }
 .agent-editor-managed-model-field {
     display: flex;
@@ -9778,31 +10625,34 @@ body.agent-editor-open {
     margin-top: 6px;
 }
 .agent-editor-managed-model-value {
-    font-size: 13px;
+    font-size: 15px;
     color: var(--text-primary);
 }
 .agent-editor-managed-model-note {
-    font-size: 12px;
-    color: var(--text-secondary);
-}
-.agent-editor-model-label {
     font-size: 13px;
     color: var(--text-secondary);
 }
+.agent-editor-model-label {
+    font-size: 15px;
+    color: var(--text-secondary);
+}
+/* Size/padding live on .agent-cp-control (same elements). This class only
+   keeps native <select> menus readable on dark UI — do not re-shrink here. */
 .agent-editor-model-select {
-    background: var(--bg-input);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    color: var(--text-primary);
-    font-size: 0.85rem;
-    padding: 4px 8px;
-    /* Native <select> menus often paint a light OS panel; without this the
-       inherited light text becomes unreadable on white. */
     color-scheme: dark;
 }
 .agent-editor-model-select option {
     background-color: var(--bg-card);
     color: var(--text-primary);
+}
+.agent-cp .agent-editor-simple textarea.agent-cp-control {
+    /* Beat the legacy .agent-editor-simple textarea rule below so settings
+       controls share one size/padding/background with Model/Market inputs. */
+    margin-top: 0;
+    background: var(--bg-input);
+    font-size: 15px;
+    line-height: 1.45;
+    padding: 11px 12px;
 }
 .agent-editor-simple textarea {
     width: 100%;
@@ -9813,9 +10663,8 @@ body.agent-editor-open {
     color: var(--text-primary);
     /*
      * 14px, not `0.95rem`: `rem` resolves against the 16px html root while the
-     * whole app is sized off the 14px body, so 0.95rem painted this field at
-     * 15.2px -- a fractional size (blurry sub-pixel text) on a different scale
-     * from every other control.
+     * whole app is sized off the body base, so rem painted this field on a
+     * different scale from every other control.
      */
     font-size: 14px;
     line-height: 1.5;
@@ -9825,6 +10674,10 @@ body.agent-editor-open {
 .agent-editor-simple-note {
     margin: 10px 0 0;
     font-size: 13px;
+    line-height: 1.45;
+    color: var(--text-secondary);
+}
+.agent-editor-simple-note--warn {
     color: #fbbf24;
 }
 
@@ -9837,7 +10690,7 @@ body.agent-editor-open {
 .agent-editor-default-details summary {
     cursor: pointer;
     font-weight: 600;
-    color: var(--text-secondary);
+    color: var(--text-primary);
 }
 
 .agent-editor-default-text {
@@ -9845,6 +10698,8 @@ body.agent-editor-open {
     padding: 10px 12px;
     border-left: 2px solid var(--border-color);
     color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.45;
 }
 
 .agent-editor-analyst-grid {
@@ -9862,7 +10717,7 @@ body.agent-editor-open {
     border: 1px solid var(--border-color);
     border-radius: 8px;
     color: var(--text-primary);
-    font-size: 13px;
+    font-size: 14px;
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
Agent **Control Plane** redesign for the Configure screen (Overview / Settings / Backtest / Paper / Live), plus readability and a hosted-runtime visibility bugfix.

- **Layout:** fullscreen control-plane shell replaces the old single-column editor (nav + panels, status cards, run history table).
- **Typography:** raise `--text-muted` / `--text-secondary` and body base size; unify settings field/control sizes (stop `.agent-editor-model-select` from shrinking Model/Market).
- **Market:** label `U.S.` → **US Stocks**; uncategorized agents *show* US Stocks as a UI default, but category is not PATCH'd until the user touches Market.
- **Bugfix:** `.agent-cp-field { display:flex }` beat UA `[hidden]`, leaking the AI Hedge Fund panel onto every built-in agent — now forced hidden.
- **Copy declutter:** shorter helper notes in settings (register-string updates still pending — see review).

## Test plan
- [ ] Built-in agent → Agent settings: Trading prompt only, **no** AI Hedge Fund block
- [ ] AI Hedge Fund agent → analysts + credential fields; model picker hidden
- [ ] Uncategorized agent: Market shows US Stocks; saving only capital/name does **not** persist category; changing Market then Save does
- [ ] Hard refresh picks up `styles.css?v=89` / `agent-editor.js?v=29`
- [ ] `pytest dashboard/backend/tests/test_frontend_fast_boot.py dashboard/backend/tests/test_ai_hedge_fund_frontend.py -q`

## Known follow-up
`test_app_copy_register` still fails until settings/AHF **copy strings** are reconciled with the audience-language register (listed in review).