### PR TITLE
test(backtests): stop test_plot_png_cached_per_run reaching live Yahoo

### DIFF
--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -69,6 +69,25 @@ def test_plot_png_cached_per_run(monkeypatch):
         return [{"timestamp": "2026-05-01T10:00:00", "equity": 100000},
                 {"timestamp": "2026-05-01T11:00:00", "equity": 101000}]
 
+    # fake_run carries no `metadata`, so _market_profile_for_run falls back to
+    # the Alpaca/US profile with index_baseline_enabled true, which makes
+    # _render_run_plot_png call market_index_baselines_for_run ->
+    # fetch_index_hourly for ^DJI/^NDX. Without this patch that is a real
+    # HTTPS call to query1.finance.yahoo.com on every run (issue #320: flakes
+    # when Yahoo is slow/rate-limited). Stub it here, same pattern as
+    # test_equity_plot.py; the network fetch is incidental to what this test
+    # covers (lru_cache behaviour).
+    from datetime import datetime, timezone
+    _ts = lambda s: datetime.fromisoformat(s).replace(
+        tzinfo=timezone.utc
+    )
+    monkeypatch.setattr(
+        "dashboard.backend.equity_plot.fetch_index_hourly",
+        lambda _sym, _start, _end: [
+            (_ts("2026-05-01T10:00:00"), 40_000.0),
+            (_ts("2026-05-01T11:00:00"), 41_000.0),
+        ],
+    )
     monkeypatch.setattr(bt.db, "get_run", fake_get_run)
     monkeypatch.setattr(bt.db, "get_equity_curve", fake_equity)
     monkeypatch.setattr(bt, "filter_market_hours", lambda pts: pts)  # isolate caching

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -11,8 +11,10 @@ import inspect
 import json
 import time
 import uuid
+from datetime import datetime
 
 import pytest
+import pytz
 from fastapi.testclient import TestClient
 
 from dashboard.backend.app import app
@@ -41,7 +43,7 @@ def test_plot_png_matplotlib_hoisted_to_module():
 
 def test_plot_png_cached_per_run(monkeypatch):
     bt._render_run_plot_png.cache_clear()
-    calls = {"get_run": 0, "equity": 0}
+    calls = {"get_run": 0, "equity": 0, "yahoo": 0}
     fake_run = {
         "session_id": None, "created_at": "2026-05-01T10:00:00", "agent_name": "Agent",
         "start_date": "2026-05-01", "end_date": "2026-05-07", "mode": "safe_trading",
@@ -58,6 +60,16 @@ def test_plot_png_cached_per_run(monkeypatch):
     # the assertions either way.
     run_id = f"run_x_{uuid.uuid4().hex}"
 
+    # 10:30/11:30 ET (== 14:30/15:30 UTC). compute_index_baseline_values first
+    # drops every index level failing is_market_hour, then aligns the survivors
+    # onto the agent's own timeline with a 30-minute nearest-match tolerance —
+    # so the equity curve *and* the stubbed index levels both have to sit inside
+    # the session. Stamps outside it (e.g. a naive 10:00 "UTC", which is 06:00
+    # ET) make the baselines come back empty with the test still passing.
+    et = pytz.timezone("US/Eastern")
+    t0 = et.localize(datetime(2026, 5, 1, 10, 30)).astimezone(pytz.UTC)
+    t1 = et.localize(datetime(2026, 5, 1, 11, 30)).astimezone(pytz.UTC)
+
     def fake_get_run(rid):
         if rid == run_id:
             calls["get_run"] += 1
@@ -66,8 +78,9 @@ def test_plot_png_cached_per_run(monkeypatch):
     def fake_equity(rid):
         if rid == run_id:
             calls["equity"] += 1
-        return [{"timestamp": "2026-05-01T10:00:00", "equity": 100000},
-                {"timestamp": "2026-05-01T11:00:00", "equity": 101000}]
+        # Naive-UTC ISO strings, the shape the DB stores.
+        return [{"timestamp": t0.replace(tzinfo=None).isoformat(), "equity": 100000},
+                {"timestamp": t1.replace(tzinfo=None).isoformat(), "equity": 101000}]
 
     # fake_run carries no `metadata`, so _market_profile_for_run falls back to
     # the Alpaca/US profile with index_baseline_enabled true, which makes
@@ -77,20 +90,29 @@ def test_plot_png_cached_per_run(monkeypatch):
     # when Yahoo is slow/rate-limited). Stub it here, same pattern as
     # test_equity_plot.py; the network fetch is incidental to what this test
     # covers (lru_cache behaviour).
-    from datetime import datetime, timezone
-    _ts = lambda s: datetime.fromisoformat(s).replace(
-        tzinfo=timezone.utc
-    )
+    def fake_fetch_index_hourly(_symbol, start, end):
+        if (start, end) == (fake_run["start_date"], fake_run["end_date"]):
+            calls["yahoo"] += 1  # same stray-thread gating as the counters above
+        return [(t0, 40_000.0), (t1, 41_000.0)]
+
     monkeypatch.setattr(
-        "dashboard.backend.equity_plot.fetch_index_hourly",
-        lambda _sym, _start, _end: [
-            (_ts("2026-05-01T10:00:00"), 40_000.0),
-            (_ts("2026-05-01T11:00:00"), 41_000.0),
-        ],
+        "dashboard.backend.equity_plot.fetch_index_hourly", fake_fetch_index_hourly
     )
     monkeypatch.setattr(bt.db, "get_run", fake_get_run)
     monkeypatch.setattr(bt.db, "get_equity_curve", fake_equity)
     monkeypatch.setattr(bt, "filter_market_hours", lambda pts: pts)  # isolate caching
+
+    # Record what the renderer is handed: an index baseline that got filtered
+    # away upstream arrives as [], which would leave this path uncovered while
+    # every other assertion still passed.
+    rendered = {}
+    real_render = bt.render_backtest_equity_png
+
+    def spy_render(**kwargs):
+        rendered.setdefault("baselines", kwargs["baselines"])
+        return real_render(**kwargs)
+
+    monkeypatch.setattr(bt, "render_backtest_equity_png", spy_render)
 
     first = bt._render_run_plot_png(run_id)
     second = bt._render_run_plot_png(run_id)
@@ -98,6 +120,11 @@ def test_plot_png_cached_per_run(monkeypatch):
     assert first == second
     assert first[:8] == b"\x89PNG\r\n\x1a\n"      # valid PNG
     assert calls["get_run"] == 1                  # 2nd call served from cache
+    assert calls["yahoo"] == 2                    # stub answered ^DJI + ^NDX, no network
+    assert [label for label, _key, _values in rendered["baselines"]] == [
+        "DJIA index",
+        "Nasdaq-100",
+    ]
     bt._render_run_plot_png.cache_clear()
 
 


### PR DESCRIPTION
## Summary

`test_plot_png_cached_per_run` made a real HTTPS request to
`query1.finance.yahoo.com` on every run (^DJI/^NDX), because its fake_run
carries no `metadata` — so `_market_profile_for_run` falls back to the
Alpaca/US profile with `index_baseline_enabled` true, and
`_render_run_plot_png` calls `market_index_baselines_for_run` ->
`fetch_index_hourly`. It flaked when Yahoo was slow or rate-limited (~1 in 9
local runs; failing runs ~25s vs ~5s for passes).

## Fix

Monkeypatch `dashboard.backend.equity_plot.fetch_index_hourly` to a stub in
the test, matching the existing sibling pattern in `test_equity_plot.py`. The
test's purpose is asserting `lru_cache` behaviour (`calls["get_run"] == 1`); the
network fetch was incidental to what it covers.

## Testing / verification

- **RED:** with outbound sockets blocked, the pre-fix test fails trying to reach
  `query1.finance.yahoo.com` (`NewConnectionError`). This reproduces the
  flake's network dependency.
- **GREEN:** with the patch and sockets still blocked, the test passes offline
  in ~1s (hermetic).
- Full backend suite: `pytest dashboard/backend/tests/` — **2644 passed,
  70 skipped**.

## Scope

This test only. Every sibling on the same path already guards the call
(`test_equity_plot.py`, `integration/test_ifind_ashare_backtest.py`).

## Review fixes (`b97c330`)

The stub in `d3c323b` was silently discarded before it reached the renderer:
its levels were stamped 10:00/11:00 naive-UTC = 06:00/07:00 ET, so
`compute_index_baseline_values` dropped them all on `is_market_hour` and
returned `None` for both indices. The test rendered a baseline-free chart, so
the index-baseline path it used to cover (whenever Yahoo answered) was no
longer covered at all.

- Both the equity curve and the stub now sit at 10:30/11:30 ET, built the same
  way as `test_equity_plot.py`. Moving only the stub is not enough — the
  survivors of the market-hours filter are reindexed onto the agent timeline
  with a 30-minute nearest tolerance, and the equity curve's 10:00/11:00 stamps
  were 4.5h away.
- Added a fetch counter (gated on this run's date range, like the sibling
  counters) and an assertion on the baselines the renderer is handed, so the
  patch is load-bearing: a later change that stops routing through
  `equity_plot.fetch_index_hourly` can no longer restore the live call silently.
- Verified by mutation — out-of-session stamps → `baselines []` (fails); patch
  removed → blocked socket (fails). Full backend suite with outbound sockets
  blocked: **2657 passed, 67 skipped**.

## Issue

Addresses the test half of Open-Finance-Lab/AgenticTrading#320. **Deliberately
not a closing keyword**: that issue's final section records a second, unfixed
concern — `market_index_baselines_for_run` at `backtests.py:1721` is unguarded
and `app.py` registers handlers only for `ApiError`/`RequestValidationError`,
so a Yahoo 429/5xx/timeout propagates as an unhandled 500 from the public
`GET /api/v1/backtest/runs/{run_id}/plot.png`. #320 stays open until that is
either fixed or split into its own issue.
