### PR TITLE
feat(ui): add tooltips to AI Hedge Fund analyst selector

### DIFF
--- a/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
+++ b/dashboard/backend/tests/test_ai_hedge_fund_frontend.py
@@ -21,6 +21,120 @@ def _slice(source: str, start: str, end: str) -> str:
     return source[start_index:end_index]
 
 
+def _analyst_metadata_records() -> list[tuple[str, str, str]]:
+    metadata = _slice(
+        _EDITOR_JS,
+        "const AI_HEDGE_FUND_ANALYSTS = [",
+        "];",
+    )
+    return re.findall(
+        r"\{\s*id: '([^']+)',\s*label: '([^']+)',\s*"
+        r"description: '([^']+)',\s*\}",
+        metadata,
+    )
+
+
+def test_every_selectable_analyst_has_a_concise_description():
+    records = _analyst_metadata_records()
+    expected_ids_and_labels = [
+        ("aswath_damodaran", "Aswath Damodaran"),
+        ("ben_graham", "Ben Graham"),
+        ("bill_ackman", "Bill Ackman"),
+        ("cathie_wood", "Cathie Wood"),
+        ("charlie_munger", "Charlie Munger"),
+        ("michael_burry", "Michael Burry"),
+        ("mohnish_pabrai", "Mohnish Pabrai"),
+        ("nassim_taleb", "Nassim Taleb"),
+        ("peter_lynch", "Peter Lynch"),
+        ("phil_fisher", "Phil Fisher"),
+        ("rakesh_jhunjhunwala", "Rakesh Jhunjhunwala"),
+        ("stanley_druckenmiller", "Stanley Druckenmiller"),
+        ("warren_buffett", "Warren Buffett"),
+        ("technical_analyst", "Technical"),
+        ("fundamentals_analyst", "Fundamentals"),
+        ("growth_analyst", "Growth"),
+        ("news_sentiment_analyst", "News Sentiment"),
+        ("sentiment_analyst", "Sentiment"),
+        ("valuation_analyst", "Valuation"),
+    ]
+
+    assert [(analyst_id, label) for analyst_id, label, _ in records] == (
+        expected_ids_and_labels
+    )
+    for _, _, description in records:
+        assert description == description.strip()
+        assert description
+        assert len(description.split()) <= 30
+        assert description[-1] in ".!?"
+
+
+def test_analyst_tooltips_support_pointer_and_keyboard_users():
+    renderer = _slice(
+        _EDITOR_JS,
+        "function renderAiHedgeFundAnalysts(agent)",
+        "function selectedAiHedgeFundAnalysts()",
+    )
+
+    assert 'value="${escapeHtml(id)}"' in renderer
+    assert 'aria-labelledby="${escapeHtml(labelId)}"' in renderer
+    assert 'aria-describedby="${escapeHtml(tooltipId)}"' in renderer
+    assert 'role="tooltip"' in renderer
+    assert "${escapeHtml(description)}" in renderer
+    assert "${selected.has(id) ? 'checked' : ''}" in renderer
+    assert "option.addEventListener('mouseenter'" in renderer
+    assert "option.addEventListener('mouseleave'" in renderer
+    assert "option.addEventListener('focusin'" in renderer
+    assert "option.addEventListener('focusout'" in renderer
+
+    positioner = _slice(
+        _EDITOR_JS,
+        "function positionAiHedgeFundTooltip(option)",
+        "function renderAiHedgeFundAnalysts(agent)",
+    )
+    assert "getBoundingClientRect()" in positioner
+    assert "window.visualViewport" in positioner
+    assert "--analyst-tooltip-left" in positioner
+    assert "--analyst-tooltip-top" in positioner
+    assert "'resize'" in _EDITOR_JS
+    assert "'scroll'" in _EDITOR_JS
+
+    assert ".agent-editor-analyst-option:has(input:focus-visible)" in _STYLES_CSS
+    assert ".agent-editor-analyst-option.is-tooltip-visible" in _STYLES_CSS
+    tooltip_styles = _slice(
+        _STYLES_CSS,
+        ".agent-editor-analyst-tooltip {",
+        ".agent-editor-analyst-option.is-tooltip-visible",
+    )
+    reveal_styles = _slice(
+        _STYLES_CSS,
+        ".agent-editor-analyst-option.is-tooltip-visible",
+        "@media (prefers-reduced-motion: reduce)",
+    )
+    assert "position: fixed" in tooltip_styles
+    assert "visibility: hidden" in tooltip_styles
+    assert "pointer-events: none" in tooltip_styles
+    assert "max-width:" in tooltip_styles
+    assert "overflow-wrap: anywhere" in tooltip_styles
+    assert "opacity: 1" in reveal_styles
+    assert "visibility: visible" in reveal_styles
+
+
+def test_analyst_tooltips_do_not_change_runtime_config_submission():
+    selected = _slice(
+        _EDITOR_JS,
+        "function selectedAiHedgeFundAnalysts()",
+        "function setFinancialDatasetsStatus",
+    )
+    editor_state = _slice(
+        _EDITOR_JS,
+        "function getEditorState()",
+        "function snapshotState()",
+    )
+
+    assert ').map((input) => input.value);' in selected
+    assert "? { analysts: selectedAiHedgeFundAnalysts() }" in editor_state
+
+
 def test_hosted_editor_replaces_model_picker_with_managed_metadata():
     assert 'id="agentEditorModelField"' in _APP_HTML
     assert 'id="agentEditorManagedModelField"' in _APP_HTML
@@ -154,5 +268,5 @@ def test_editor_asset_cache_bust_advances_with_its_source():
     editor_version = int(re.search(r"js/agent-editor\.js\?v=(\d+)", _APP_HTML).group(1))
     styles_version = int(re.search(r"styles\.css\?v=(\d+)", _APP_HTML).group(1))
 
-    assert editor_version >= 17
-    assert styles_version >= 71
+    assert editor_version >= 27
+    assert styles_version >= 87

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -180,4 +180,4 @@ def test_slow_boot_notice_is_wired():
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
     assert "app.js?v=77" in APP_HTML
-    assert "styles.css?v=86" in APP_HTML
+    assert "styles.css?v=87" in APP_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=86">
+    <link rel="stylesheet" href="styles.css?v=87">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -1759,7 +1759,7 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
-    <script src="js/agent-editor.js?v=26" defer></script>
+    <script src="js/agent-editor.js?v=27" defer></script>
     <script src="app.js?v=77" defer></script>
     <script src="js/leaderboard.js?v=19" defer></script>
     <script src="home-page.js?v=37" defer></script>

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -21,25 +21,101 @@
   const CASH_OVERRIDE_PREFIX = 'agent-cash-allocation:';
   const AI_HEDGE_FUND_RUNTIME = 'ai_hedge_fund';
   const AI_HEDGE_FUND_ANALYSTS = [
-    ['aswath_damodaran', 'Aswath Damodaran'],
-    ['ben_graham', 'Ben Graham'],
-    ['bill_ackman', 'Bill Ackman'],
-    ['cathie_wood', 'Cathie Wood'],
-    ['charlie_munger', 'Charlie Munger'],
-    ['michael_burry', 'Michael Burry'],
-    ['mohnish_pabrai', 'Mohnish Pabrai'],
-    ['nassim_taleb', 'Nassim Taleb'],
-    ['peter_lynch', 'Peter Lynch'],
-    ['phil_fisher', 'Phil Fisher'],
-    ['rakesh_jhunjhunwala', 'Rakesh Jhunjhunwala'],
-    ['stanley_druckenmiller', 'Stanley Druckenmiller'],
-    ['warren_buffett', 'Warren Buffett'],
-    ['technical_analyst', 'Technical'],
-    ['fundamentals_analyst', 'Fundamentals'],
-    ['growth_analyst', 'Growth'],
-    ['news_sentiment_analyst', 'News Sentiment'],
-    ['sentiment_analyst', 'Sentiment'],
-    ['valuation_analyst', 'Valuation'],
+    {
+      id: 'aswath_damodaran',
+      label: 'Aswath Damodaran',
+      description: 'Estimates intrinsic value by connecting company narratives with growth, reinvestment, risk, cash flow, and relative valuation.',
+    },
+    {
+      id: 'ben_graham',
+      label: 'Ben Graham',
+      description: 'Uses value-investing principles and a margin of safety to identify financially strong, potentially undervalued companies.',
+    },
+    {
+      id: 'bill_ackman',
+      label: 'Bill Ackman',
+      description: 'Seeks high-quality, cash-generative businesses where financial discipline, catalysts, or activism can unlock value.',
+    },
+    {
+      id: 'cathie_wood',
+      label: 'Cathie Wood',
+      description: 'Looks for disruptive, innovation-led companies with exponential growth potential, large markets, and long time horizons.',
+    },
+    {
+      id: 'charlie_munger',
+      label: 'Charlie Munger',
+      description: 'Favors predictable, high-quality businesses with durable moats and strong management at fair valuations.',
+    },
+    {
+      id: 'michael_burry',
+      label: 'Michael Burry',
+      description: 'Hunts for contrarian deep-value opportunities using free cash flow, EV/EBIT, balance-sheet risk, and hard catalysts.',
+    },
+    {
+      id: 'mohnish_pabrai',
+      label: 'Mohnish Pabrai',
+      description: 'Seeks simple, durable businesses with protected downside, high free-cash-flow yields, low leverage, and doubling potential.',
+    },
+    {
+      id: 'nassim_taleb',
+      label: 'Nassim Taleb',
+      description: 'Evaluates tail risk, antifragility, fragility, and convexity to find asymmetric opportunities with limited downside.',
+    },
+    {
+      id: 'peter_lynch',
+      label: 'Peter Lynch',
+      description: 'Looks for understandable businesses with steady growth and ten-bagger potential at reasonable PEG-based valuations.',
+    },
+    {
+      id: 'phil_fisher',
+      label: 'Phil Fisher',
+      description: 'Seeks long-term growers with strong management, R&D investment, durable margins, and thorough scuttlebutt-style research.',
+    },
+    {
+      id: 'rakesh_jhunjhunwala',
+      label: 'Rakesh Jhunjhunwala',
+      description: 'Seeks understandable, financially strong businesses with durable moats, quality management, consistent growth, and a margin of safety.',
+    },
+    {
+      id: 'stanley_druckenmiller',
+      label: 'Stanley Druckenmiller',
+      description: 'Targets asymmetric opportunities with strong growth, price momentum, and sentiment while controlling drawdown, leverage, and volatility risk.',
+    },
+    {
+      id: 'warren_buffett',
+      label: 'Warren Buffett',
+      description: 'Seeks businesses with durable moats, strong management, predictable fundamentals, and intrinsic value above market price.',
+    },
+    {
+      id: 'technical_analyst',
+      label: 'Technical',
+      description: 'Analyzes price trends and technical indicators to identify trading signals.',
+    },
+    {
+      id: 'fundamentals_analyst',
+      label: 'Fundamentals',
+      description: 'Evaluates company financial health using profitability, growth, leverage, and other fundamental metrics.',
+    },
+    {
+      id: 'growth_analyst',
+      label: 'Growth',
+      description: 'Identifies opportunities using revenue, earnings, and cash-flow growth, valuation, margins, insider activity, and financial health.',
+    },
+    {
+      id: 'news_sentiment_analyst',
+      label: 'News Sentiment',
+      description: 'Analyzes company-news sentiment, classifying recent headlines when needed, and aggregates it into a trading signal.',
+    },
+    {
+      id: 'sentiment_analyst',
+      label: 'Sentiment',
+      description: 'Combines company-news sentiment with insider trading activity to gauge market sentiment and generate a signal.',
+    },
+    {
+      id: 'valuation_analyst',
+      label: 'Valuation',
+      description: 'Estimates intrinsic value using DCF, owner earnings, EV/EBITDA, and residual-income models, then compares it with market value.',
+    },
   ];
   // Match app.js: same-origin locally, hosted backend everywhere else. In
   // Same-origin API base. Local uvicorn serves the backend; production Vercel
@@ -179,15 +255,135 @@
     }
   }
 
+  function positionAiHedgeFundTooltip(option) {
+    const tooltip = option?.querySelector('.agent-editor-analyst-tooltip');
+    if (!tooltip) return;
+
+    const optionRect = option.getBoundingClientRect();
+    const margin = 12;
+    const gap = 8;
+    const visualViewport = window.visualViewport;
+    const viewportLeft = visualViewport?.offsetLeft || 0;
+    const viewportTop = visualViewport?.offsetTop || 0;
+    const viewportWidth = Math.min(
+      visualViewport?.width || window.innerWidth,
+      document.documentElement.clientWidth || window.innerWidth,
+    );
+    const viewportHeight = Math.min(
+      visualViewport?.height || window.innerHeight,
+      document.documentElement.clientHeight || window.innerHeight,
+    );
+    const viewportRight = viewportLeft + viewportWidth;
+    const viewportBottom = viewportTop + viewportHeight;
+    const editorBodyRect = option.closest('.agent-editor-body')?.getBoundingClientRect();
+    const safeTop = Math.max(
+      viewportTop + margin,
+      (editorBodyRect?.top || viewportTop) + margin,
+    );
+    const safeBottom = Math.min(
+      viewportBottom - margin,
+      (editorBodyRect?.bottom || viewportBottom) - margin,
+    );
+
+    if (optionRect.bottom <= safeTop || optionRect.top >= safeBottom) {
+      tooltip.hidden = true;
+      return;
+    }
+
+    tooltip.hidden = false;
+    tooltip.style.setProperty(
+      '--analyst-tooltip-max-width',
+      `${Math.max(1, viewportWidth - margin * 2)}px`,
+    );
+    const tooltipRect = tooltip.getBoundingClientRect();
+
+    const preferredLeft = optionRect.left + (optionRect.width - tooltipRect.width) / 2;
+    const safeLeft = viewportLeft + margin;
+    const maxLeft = Math.max(safeLeft, viewportRight - tooltipRect.width - margin);
+    const left = Math.min(Math.max(preferredLeft, safeLeft), maxLeft);
+
+    const above = optionRect.top - tooltipRect.height - gap;
+    const below = optionRect.bottom + gap;
+    const preferredTop = above >= safeTop ? above : below;
+    const maxTop = Math.max(safeTop, safeBottom - tooltipRect.height);
+    const top = Math.min(Math.max(preferredTop, safeTop), maxTop);
+
+    tooltip.style.setProperty('--analyst-tooltip-left', `${Math.round(left)}px`);
+    tooltip.style.setProperty('--analyst-tooltip-top', `${Math.round(top)}px`);
+  }
+
+  let activeAiHedgeFundTooltipOption = null;
+  let analystTooltipPositionFrame = null;
+
+  function showAiHedgeFundTooltip(option) {
+    if (activeAiHedgeFundTooltipOption !== option) {
+      activeAiHedgeFundTooltipOption?.classList.remove('is-tooltip-visible');
+      activeAiHedgeFundTooltipOption = option;
+    }
+    positionAiHedgeFundTooltip(option);
+    option.classList.add('is-tooltip-visible');
+  }
+
+  function hideAiHedgeFundTooltip(option) {
+    option?.classList.remove('is-tooltip-visible');
+    if (activeAiHedgeFundTooltipOption === option) {
+      activeAiHedgeFundTooltipOption = null;
+    }
+  }
+
+  function restoreKeyboardFocusedAiHedgeFundTooltip() {
+    const focusedInput = document.querySelector(
+      'input[name="agentEditorAiHedgeFundAnalyst"]:focus-visible',
+    );
+    const focusedOption = focusedInput?.closest('.agent-editor-analyst-option');
+    if (focusedOption) showAiHedgeFundTooltip(focusedOption);
+  }
+
+  function scheduleActiveAiHedgeFundTooltipPosition() {
+    if (
+      analystTooltipPositionFrame !== null
+      || !activeAiHedgeFundTooltipOption?.isConnected
+    ) return;
+    analystTooltipPositionFrame = window.requestAnimationFrame(() => {
+      analystTooltipPositionFrame = null;
+      if (activeAiHedgeFundTooltipOption?.isConnected) {
+        positionAiHedgeFundTooltip(activeAiHedgeFundTooltipOption);
+      }
+    });
+  }
+
   function renderAiHedgeFundAnalysts(agent) {
     const grid = document.getElementById('agentEditorAiHedgeFundAnalysts');
     if (!grid) return;
+    hideAiHedgeFundTooltip(activeAiHedgeFundTooltipOption);
     const selected = new Set(agent?.runtime_config?.analysts || []);
-    grid.innerHTML = AI_HEDGE_FUND_ANALYSTS.map(([id, label]) => `
-      <label class="agent-editor-analyst-option">
-        <input type="checkbox" name="agentEditorAiHedgeFundAnalyst" value="${escapeHtml(id)}" ${selected.has(id) ? 'checked' : ''}>
-        <span>${escapeHtml(label)}</span>
-      </label>`).join('');
+    grid.innerHTML = AI_HEDGE_FUND_ANALYSTS.map(({ id, label, description }) => {
+      const labelId = `agentEditorAiHedgeFundAnalyst-${id}-label`;
+      const tooltipId = `agentEditorAiHedgeFundAnalyst-${id}-tooltip`;
+      return `
+        <label class="agent-editor-analyst-option">
+          <input type="checkbox" name="agentEditorAiHedgeFundAnalyst" value="${escapeHtml(id)}" aria-labelledby="${escapeHtml(labelId)}" aria-describedby="${escapeHtml(tooltipId)}" ${selected.has(id) ? 'checked' : ''}>
+          <span id="${escapeHtml(labelId)}">${escapeHtml(label)}</span>
+          <span id="${escapeHtml(tooltipId)}" class="agent-editor-analyst-tooltip" role="tooltip">${escapeHtml(description)}</span>
+        </label>`;
+    }).join('');
+    grid.querySelectorAll('.agent-editor-analyst-option').forEach((option) => {
+      option.addEventListener('mouseenter', () => showAiHedgeFundTooltip(option));
+      option.addEventListener('mouseleave', () => {
+        hideAiHedgeFundTooltip(option);
+        restoreKeyboardFocusedAiHedgeFundTooltip();
+      });
+      option.addEventListener('focusin', () => {
+        window.requestAnimationFrame(() => {
+          if (option.querySelector('input:focus-visible')) {
+            showAiHedgeFundTooltip(option);
+          }
+        });
+      });
+      option.addEventListener('focusout', (event) => {
+        if (!option.contains(event.relatedTarget)) hideAiHedgeFundTooltip(option);
+      });
+    });
   }
 
   function selectedAiHedgeFundAnalysts() {
@@ -1075,6 +1271,7 @@
       if (!window.confirm('Discard unsaved changes?')) return;
     }
 
+    hideAiHedgeFundTooltip(activeAiHedgeFundTooltipOption);
     const view = document.getElementById('agentEditorView');
     if (view) view.hidden = true;
     document.body.classList.remove('agent-editor-open');
@@ -1265,6 +1462,20 @@
     const body = document.getElementById('agentEditorView');
     body?.addEventListener('input', markDirtyFromInput);
     body?.addEventListener('change', markDirtyFromInput);
+    document.querySelector('.agent-editor-body')?.addEventListener(
+      'scroll',
+      scheduleActiveAiHedgeFundTooltipPosition,
+      { passive: true },
+    );
+    window.addEventListener('resize', scheduleActiveAiHedgeFundTooltipPosition);
+    window.visualViewport?.addEventListener(
+      'resize',
+      scheduleActiveAiHedgeFundTooltipPosition,
+    );
+    window.visualViewport?.addEventListener(
+      'scroll',
+      scheduleActiveAiHedgeFundTooltipPosition,
+    );
 
     document.addEventListener('keydown', (event) => {
       const view = document.getElementById('agentEditorView');

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9884,9 +9884,51 @@ body.agent-editor-open {
     cursor: pointer;
 }
 
+.agent-editor-analyst-option:has(input:focus-visible) {
+    outline: 2px solid rgba(34, 211, 238, 0.65);
+    outline-offset: 2px;
+}
+
 .agent-editor-analyst-option:has(input:checked) {
     border-color: var(--info-color);
     background: rgba(0, 191, 255, 0.08);
+}
+
+.agent-editor-analyst-tooltip {
+    position: fixed;
+    left: var(--analyst-tooltip-left, 16px);
+    top: var(--analyst-tooltip-top, 16px);
+    z-index: 1300;
+    box-sizing: border-box;
+    width: max-content;
+    max-width: min(280px, var(--analyst-tooltip-max-width, calc(100vw - 32px)));
+    padding: 8px 10px;
+    border: 1px solid rgba(148, 163, 184, 0.38);
+    border-radius: 8px;
+    background: rgba(10, 14, 28, 0.96);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+    color: #e2e8f0;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateY(4px);
+    transition: opacity 0.12s ease, transform 0.12s ease, visibility 0.12s;
+}
+
+.agent-editor-analyst-option.is-tooltip-visible .agent-editor-analyst-tooltip {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-editor-analyst-tooltip {
+        transition: none;
+    }
 }
 
 .agent-editor-credential-field {


### PR DESCRIPTION
## Summary

Adds concise descriptions to each selectable AI Hedge Fund analyst in the agent editor.

The descriptions appear as accessible tooltips on mouse hover and keyboard focus, helping users understand what each analyst does before selecting it.

## Implementation

- Adds descriptions for all selectable AI Hedge Fund analysts.
- Keeps descriptions metadata-driven.
- Supports mouse hover and keyboard focus.
- Preserves existing analyst IDs, default selections, and runtime configuration.
- Uses viewport-aware positioning and existing ATL dark-theme styling.

## Scope

This is a UI-only follow-up to the AI Hedge Fund hosted runtime integration.

No changes were made to:
- AI Hedge Fund runtime execution
- backtesting
- Risk Manager or Portfolio Manager
- Financial Datasets
- OpenRouter
- credentials
- capital or portfolio logic
- Paper Trading
- Robinhood
- deployment configuration

## Verification

- Focused tests: 25 passed
- Frontend/UI regression tests: 242 passed
- JavaScript syntax checks passed
- Python compilation passed
- `git diff --check` passed
- Secret/local-path/artifact scans clean
- Local visual verification completed for mouse hover and keyboard focus