### PR TITLE
feat(backtest): enforce A-share daily market rules

### DIFF
--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -260,6 +260,8 @@ class RunMetadata(BaseModel):
     # curve places no orders, so it carries the profile with the flag false.
     transaction_costs_applied: Optional[bool] = None
     transaction_cost_totals: Optional[Dict[str, Any]] = None
+    market_rule_profile: Optional[Dict[str, Any]] = None
+    market_rule_rejections: Optional[Dict[str, int]] = None
     # How much of the buy & hold sleeve filled. A lot-constrained benchmark on
     # a small account can place fewer symbols than requested, and a partly
     # placed benchmark must be legible rather than read as a real flat curve.
@@ -341,6 +343,8 @@ def _run_metadata_response(run: Dict[str, Any]) -> RunMetadata:
             "transaction_cost_profile",
             "transaction_costs_applied",
             "transaction_cost_totals",
+            "market_rule_profile",
+            "market_rule_rejections",
             "baseline_allocation",
             "rejected_orders_count",
             "rejected_orders_truncated",

--- a/dashboard/backend/baseline_generator.py
+++ b/dashboard/backend/baseline_generator.py
@@ -21,6 +21,7 @@ from datetime import datetime, time
 from dashboard.backend.paths import CREDENTIALS_DIR
 from dashboard.backend.domain.backtesting.constants import INITIAL_CAPITAL
 from dashboard.backend.domain.backtesting.currency import CurrencyContext
+from dashboard.backend.domain.backtesting.market_rules import MarketRuleCalendar
 from dashboard.backend.domain.trading.execution import calculate_transaction_costs
 from dashboard.backend.infrastructure.market_data.alpaca_bars import (
     MarketDataUnavailableError,
@@ -331,6 +332,7 @@ class BaselineGenerator:
         transaction_cost_totals: Optional[Dict[str, float]] = None,
         lot_size: int = 1,
         allocation_summary: Optional[Dict[str, Any]] = None,
+        market_rule_calendar: MarketRuleCalendar | None = None,
     ) -> List[Dict]:
         """
         Generate Buy & Hold baseline curve.
@@ -413,14 +415,51 @@ class BaselineGenerator:
             for symbol, df in bars_subset.items()
             if first_ts in df.index
         }
+        rule_aware = market_rule_calendar is not None
+
+        def _buy_allowed(symbol: str, timestamp, price: float) -> bool:
+            if market_rule_calendar is None:
+                return True
+            rule = market_rule_calendar.rule_for_timestamp(symbol, timestamp)
+            return not (
+                rule.suspended
+                or (
+                    rule.closing_limit_state.value == "upper"
+                    and rule.closing_gate_effective(
+                        timestamp=timestamp,
+                        reference_price=price,
+                        price_tick=(
+                            transaction_cost_profile.price_tick
+                            if transaction_cost_profile is not None
+                            else 0.01
+                        ),
+                    )
+                )
+            )
+
+        eligible_open_prices = {
+            symbol: price
+            for symbol, price in open_prices.items()
+            if _buy_allowed(symbol, first_ts, price)
+        }
+        market_blocked_symbols = set()
+        if market_rule_calendar is not None:
+            for symbol in bars_subset:
+                rule = market_rule_calendar.rule_for_timestamp(symbol, first_ts)
+                if rule.suspended or (
+                    symbol in open_prices
+                    and not _buy_allowed(symbol, first_ts, open_prices[symbol])
+                ):
+                    market_blocked_symbols.add(symbol)
         positions = _plan_buyhold_allocation(
-            open_prices,
+            eligible_open_prices,
             native_initial_capital,
             num_symbols,
             lot_size,
             transaction_cost_profile,
         )
 
+        pending_symbols = set(market_blocked_symbols)
         # Cost the plan once per symbol. The order-level pass matters for the
         # A-share ¥5 minimum commission: it is charged per submitted order, so
         # a symbol's whole sleeve must be priced as one order.
@@ -479,27 +518,66 @@ class BaselineGenerator:
         print(f"      Total invested: {native_symbol}{native_initial_capital - cash:,.0f}")
         print(f"      Cash remaining: {native_symbol}{cash:,.0f}")
         
-        # Build forward-filled price cache for smooth equity curve
+        # Build forward-filled price cache for smooth equity valuation. A cached
+        # price never makes a pending order eligible; retries still require a
+        # real symbol bar and a rule check at that exact timestamp.
         price_cache = {}
         for symbol, df in bars_subset.items():
-            if symbol not in positions:
+            if symbol not in positions and symbol not in pending_symbols:
                 continue
             
             price_cache[symbol] = {}
             last_price = df.loc[first_ts, "close"] if first_ts in df.index else None
-            
-            if last_price is None:
-                continue
-            
             for timestamp in all_timestamps:
                 if timestamp in df.index:
                     last_price = df.loc[timestamp, "close"]
                 # Forward-fill missing data
-                price_cache[symbol][timestamp] = last_price
+                if last_price is not None:
+                    price_cache[symbol][timestamp] = last_price
         
         # Calculate equity at each timestamp
         equity_curve = []
+        delayed_symbols = set(pending_symbols)
         for timestamp in all_timestamps:
+            if rule_aware and pending_symbols:
+                for symbol in sorted(tuple(pending_symbols)):
+                    frame = bars_subset[symbol]
+                    if timestamp not in frame.index:
+                        continue
+                    price = float(frame.loc[timestamp, "close"])
+                    if not _buy_allowed(symbol, timestamp, price):
+                        continue
+                    allocation = native_initial_capital / num_symbols
+                    lot = max(1, int(lot_size or 1))
+                    shares = int(allocation / price) // lot * lot
+                    while shares > 0 and _buy_order_cash_out(
+                        price, shares, transaction_cost_profile
+                    ) > cash:
+                        shares -= lot
+                    if shares <= 0:
+                        continue
+                    costs = calculate_transaction_costs(
+                        side="buy",
+                        reference_price=price,
+                        shares=shares,
+                        transaction_cost_profile=transaction_cost_profile,
+                    )
+                    cash += costs["net_cash_impact"]
+                    positions[symbol] = shares
+                    pending_symbols.remove(symbol)
+                    if transaction_cost_totals is not None:
+                        for field in (
+                            "gross_value",
+                            "slippage_amount",
+                            "commission",
+                            "stamp_duty",
+                            "transfer_fee",
+                            "total_fees",
+                        ):
+                            transaction_cost_totals[field] = (
+                                transaction_cost_totals.get(field, 0.0) + costs[field]
+                            )
+
             positions_value = 0
             
             for symbol, shares in positions.items():
@@ -518,6 +596,18 @@ class BaselineGenerator:
                 )
             )
         
+        if allocation_summary is not None and rule_aware:
+            allocation_summary.update({
+                "symbols_bought": len(positions),
+                "symbols_skipped": num_symbols - len(positions),
+                "invested_ratio": (
+                    (native_initial_capital - cash) / native_initial_capital
+                    if native_initial_capital
+                    else 0.0
+                ),
+                "symbols_delayed": len(delayed_symbols),
+                "symbols_unfilled": len(pending_symbols),
+            })
         return equity_curve
     
     def generate_index_baseline(
@@ -662,6 +752,7 @@ def generate_baselines(
     transaction_cost_totals: Optional[Dict[str, float]] = None,
     lot_size: int = 1,
     allocation_summary: Optional[Dict[str, Any]] = None,
+    market_rule_calendar: MarketRuleCalendar | None = None,
 ) -> Tuple[List[Dict], List[Dict]]:
     """
     Generate both baselines (Buy & Hold, Index).
@@ -683,17 +774,18 @@ def generate_baselines(
     generator = BaselineGenerator()
 
     buyhold_curve = generator.generate_buyhold_baseline(
-        bars_by_symbol,
-        start_date,
-        end_date,
-        initial_capital,
-        symbols_list,
-        market_timezone,
-        currency_context,
-        transaction_cost_profile,
-        transaction_cost_totals,
-        lot_size,
-        allocation_summary,
+        bars_by_symbol=bars_by_symbol,
+        start_date=start_date,
+        end_date=end_date,
+        initial_capital=initial_capital,
+        symbols_to_buy=symbols_list,
+        market_timezone=market_timezone,
+        currency_context=currency_context,
+        transaction_cost_profile=transaction_cost_profile,
+        transaction_cost_totals=transaction_cost_totals,
+        lot_size=lot_size,
+        allocation_summary=allocation_summary,
+        market_rule_calendar=market_rule_calendar,
     )
     
     index_curve = generator.generate_index_baseline(

--- a/dashboard/backend/baseline_generator.py
+++ b/dashboard/backend/baseline_generator.py
@@ -144,6 +144,7 @@ def _plan_buyhold_allocation(
     num_symbols: int,
     lot_size: int,
     transaction_cost_profile,
+    reserved_capital: float = 0.0,
 ) -> Dict[str, int]:
     """Share counts for an equal-weight buy & hold sleeve.
 
@@ -158,11 +159,19 @@ def _plan_buyhold_allocation(
     2. Top-up: whatever pass 1 could not place is swept into further lots,
        poorest symbol first, so the sleeve stays invested and stays as close to
        equal weight as whole lots allow.
+
+    ``reserved_capital`` is withheld from the top-up sweep. ``prices`` carries
+    only the symbols that may trade right now, so the sweep cannot see a symbol
+    the market has blocked and would happily spend its slice on the neighbours
+    that are open — leaving nothing for the retry when the block lifts, and
+    turning an equal-weight benchmark into a concentrated one. Callers that
+    intend to place a symbol later must reserve its slice here.
     """
     if not prices or capital <= 0 or num_symbols <= 0:
         return {}
 
     lot_size = max(1, int(lot_size or 1))
+    reserved = max(0.0, float(reserved_capital or 0.0))
     # Denominator is the full sleeve, not the priced subset: a symbol with no
     # bar at the open forfeits its slice rather than redistributing it, which
     # is what the equal-weight baseline has always done.
@@ -179,7 +188,7 @@ def _plan_buyhold_allocation(
         shares -= shares % lot_size
         # Fees push a naively-affordable order over its slice; shrink a lot at a
         # time until it fits both the slice and the cash on hand.
-        budget = min(allocation, capital - spent)
+        budget = min(allocation, capital - spent - reserved)
         while shares > 0 and _buy_order_cash_out(
             price, shares, transaction_cost_profile
         ) > budget:
@@ -194,7 +203,7 @@ def _plan_buyhold_allocation(
         return planned
 
     for _ in range(_MAX_TOPUP_LOTS):
-        remaining = capital - spent
+        remaining = capital - spent - reserved
         # Poorest-first keeps the sleeve balanced and gets an unrepresented
         # symbol its first lot before any symbol gets a second one.
         candidates = sorted(
@@ -451,15 +460,20 @@ class BaselineGenerator:
                     and not _buy_allowed(symbol, first_ts, open_prices[symbol])
                 ):
                     market_blocked_symbols.add(symbol)
+        pending_symbols = set(market_blocked_symbols)
         positions = _plan_buyhold_allocation(
             eligible_open_prices,
             native_initial_capital,
             num_symbols,
             lot_size,
             transaction_cost_profile,
+            # Hold back the blocked names' slices so the retry below has
+            # something to spend when the market reopens them.
+            reserved_capital=(
+                native_initial_capital / num_symbols * len(pending_symbols)
+            ),
         )
 
-        pending_symbols = set(market_blocked_symbols)
         # Cost the plan once per symbol. The order-level pass matters for the
         # A-share ¥5 minimum commission: it is charged per submitted order, so
         # a symbol's whole sleeve must be priced as one order.
@@ -505,13 +519,23 @@ class BaselineGenerator:
             )
         # Only an affordability shortfall is worth shouting about; a symbol with
         # no bar at the open is an ordinary data gap the loop above already
-        # skipped, and the counts above still record it.
-        if len(positions) < len(open_prices):
+        # skipped, and the counts above still record it. A symbol the market
+        # blocked is not a shortfall either — it is waiting on the retry below,
+        # and counting it here reports the wrong cause for the wrong symbol.
+        tradable_priced = len(open_prices) - len(
+            market_blocked_symbols & set(open_prices)
+        )
+        if len(positions) < tradable_priced:
             print(
-                f"      ⚠️  {len(open_prices) - len(positions)} of "
-                f"{len(open_prices)} priced symbols bought nothing — an equal "
-                f"slice is worth less than one {effective_lot}-share lot at "
-                f"this capital"
+                f"      ⚠️  {tradable_priced - len(positions)} of "
+                f"{tradable_priced} tradable priced symbols bought nothing — an "
+                f"equal slice is worth less than one {effective_lot}-share lot "
+                f"at this capital"
+            )
+        if pending_symbols:
+            print(
+                f"      ⏸️  {len(pending_symbols)} symbol(s) blocked by market "
+                f"rules at the open; their allocation is held for a later bar"
             )
 
         print(f"      Stocks bought: {len(positions)} ({', '.join(sorted(positions.keys())[:10])}{'...' if len(positions) > 10 else ''})")
@@ -550,9 +574,13 @@ class BaselineGenerator:
                     allocation = native_initial_capital / num_symbols
                     lot = max(1, int(lot_size or 1))
                     shares = int(allocation / price) // lot * lot
+                    # Cap at this symbol's own slice, exactly as pass 1 does:
+                    # with several symbols pending, the first one to reopen
+                    # must not spend the slices still reserved for the others.
+                    budget = min(allocation, cash)
                     while shares > 0 and _buy_order_cash_out(
                         price, shares, transaction_cost_profile
-                    ) > cash:
+                    ) > budget:
                         shares -= lot
                     if shares <= 0:
                         continue

--- a/dashboard/backend/database.py
+++ b/dashboard/backend/database.py
@@ -38,6 +38,11 @@ TRADE_OPTIONAL_AUDIT_FIELDS = (
     "native_total_fees",
     "native_net_cash_impact",
     "fx_rate",
+    "market_rule_date",
+    "market_rule_suspended",
+    "market_rule_closing_limit_state",
+    "market_rule_official_close",
+    "market_rule_closing_gate_effective",
 )
 
 
@@ -216,6 +221,11 @@ class BacktestDatabase:
                 native_total_fees REAL,
                 native_net_cash_impact REAL,
                 fx_rate REAL,
+                market_rule_date TEXT,
+                market_rule_suspended INTEGER,
+                market_rule_closing_limit_state TEXT,
+                market_rule_official_close REAL,
+                market_rule_closing_gate_effective INTEGER,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (run_id) REFERENCES agent_runs(run_id)
             )
@@ -571,6 +581,11 @@ class BacktestDatabase:
                 ("native_total_fees", "ALTER TABLE trades ADD COLUMN native_total_fees REAL"),
                 ("native_net_cash_impact", "ALTER TABLE trades ADD COLUMN native_net_cash_impact REAL"),
                 ("fx_rate", "ALTER TABLE trades ADD COLUMN fx_rate REAL"),
+                ("market_rule_date", "ALTER TABLE trades ADD COLUMN market_rule_date TEXT"),
+                ("market_rule_suspended", "ALTER TABLE trades ADD COLUMN market_rule_suspended INTEGER"),
+                ("market_rule_closing_limit_state", "ALTER TABLE trades ADD COLUMN market_rule_closing_limit_state TEXT"),
+                ("market_rule_official_close", "ALTER TABLE trades ADD COLUMN market_rule_official_close REAL"),
+                ("market_rule_closing_gate_effective", "ALTER TABLE trades ADD COLUMN market_rule_closing_gate_effective INTEGER"),
             ),
         }
         for table, fields in additions.items():

--- a/dashboard/backend/database_postgres.py
+++ b/dashboard/backend/database_postgres.py
@@ -186,6 +186,11 @@ class PostgresBacktestDatabase:
                         native_total_fees DOUBLE PRECISION,
                         native_net_cash_impact DOUBLE PRECISION,
                         fx_rate DOUBLE PRECISION,
+                        market_rule_date TEXT,
+                        market_rule_suspended BOOLEAN,
+                        market_rule_closing_limit_state TEXT,
+                        market_rule_official_close DOUBLE PRECISION,
+                        market_rule_closing_gate_effective BOOLEAN,
                         created_at TEXT NOT NULL {created_at_default}
                     )
                     """
@@ -399,6 +404,26 @@ class PostgresBacktestDatabase:
                 cur.execute(
                     "ALTER TABLE trades ADD COLUMN IF NOT EXISTS "
                     "fx_rate DOUBLE PRECISION"
+                )
+                cur.execute(
+                    "ALTER TABLE trades ADD COLUMN IF NOT EXISTS "
+                    "market_rule_date TEXT"
+                )
+                cur.execute(
+                    "ALTER TABLE trades ADD COLUMN IF NOT EXISTS "
+                    "market_rule_suspended BOOLEAN"
+                )
+                cur.execute(
+                    "ALTER TABLE trades ADD COLUMN IF NOT EXISTS "
+                    "market_rule_closing_limit_state TEXT"
+                )
+                cur.execute(
+                    "ALTER TABLE trades ADD COLUMN IF NOT EXISTS "
+                    "market_rule_official_close DOUBLE PRECISION"
+                )
+                cur.execute(
+                    "ALTER TABLE trades ADD COLUMN IF NOT EXISTS "
+                    "market_rule_closing_gate_effective BOOLEAN"
                 )
 
                 # Postgres counterpart of SQLite's
@@ -683,10 +708,15 @@ class PostgresBacktestDatabase:
                          native_reference_price, native_gross_value,
                          native_slippage_amount, native_commission,
                          native_stamp_duty, native_transfer_fee,
-                         native_total_fees, native_net_cash_impact, fx_rate)
+                         native_total_fees, native_net_cash_impact, fx_rate,
+                         market_rule_date, market_rule_suspended,
+                         market_rule_closing_limit_state,
+                         market_rule_official_close,
+                         market_rule_closing_gate_effective)
                         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s,
                                 %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                                %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                                %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                                %s, %s, %s, %s, %s)
                         """,
                         (
                             run_id,
@@ -716,6 +746,11 @@ class PostgresBacktestDatabase:
                             trade.get("native_total_fees"),
                             trade.get("native_net_cash_impact"),
                             trade.get("fx_rate"),
+                            trade.get("market_rule_date"),
+                            trade.get("market_rule_suspended"),
+                            trade.get("market_rule_closing_limit_state"),
+                            trade.get("market_rule_official_close"),
+                            trade.get("market_rule_closing_gate_effective"),
                         ),
                     )
 
@@ -980,7 +1015,11 @@ class PostgresBacktestDatabase:
                            native_reference_price, native_gross_value,
                            native_slippage_amount, native_commission,
                            native_stamp_duty, native_transfer_fee,
-                           native_total_fees, native_net_cash_impact, fx_rate
+                           native_total_fees, native_net_cash_impact, fx_rate,
+                           market_rule_date, market_rule_suspended,
+                           market_rule_closing_limit_state,
+                           market_rule_official_close,
+                           market_rule_closing_gate_effective
                     FROM trades WHERE run_id = %s
                     ORDER BY timestamp ASC, id ASC
                     """,

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -811,6 +811,7 @@ class HourlyBacktester:
                         "suspended",
                         "limit_up_buy_blocked",
                         "limit_down_sell_blocked",
+                        "market_rule_unavailable",
                     )
                 }
                 market_rule_rejections = {

--- a/dashboard/backend/domain/backtesting/engine.py
+++ b/dashboard/backend/domain/backtesting/engine.py
@@ -52,6 +52,7 @@ from dashboard.backend.infrastructure.market_data.ifind_fx import (
     IFindFxError,
     MAX_RELATIVE_DEVIATION,
 )
+from dashboard.backend.domain.backtesting.market_rules import MarketRuleDataError
 from dashboard.backend.infrastructure.market_data.provider import (
     ALPACA,
     create_market_data_provider,
@@ -190,6 +191,7 @@ class HourlyBacktester:
         self.prompt_adaptations: List[Dict] = []
         self.rejected_orders: List[Dict] = []
         self.order_events: List[Dict] = []
+        self.market_rule_calendar = None
         self.t1_deferrals: List[Dict] = []
         # Model id; defaults to the gateway-appropriate slug (CommonStack vs native).
         self.model = model or default_model_name()
@@ -336,6 +338,18 @@ class HourlyBacktester:
                 if field in trade:
                     record[field] = float(trade[field])
             for field in (
+                "market_rule_date",
+                "market_rule_suspended",
+                "market_rule_closing_limit_state",
+                "market_rule_closing_gate_effective",
+            ):
+                if field in trade:
+                    record[field] = trade[field]
+            if trade.get("market_rule_official_close") is not None:
+                record["market_rule_official_close"] = float(
+                    trade["market_rule_official_close"]
+                )
+            for field in (
                 # No native_executed_value here: executed_value belongs to an
                 # order event, never to a trade row, and the column list the
                 # trades table persists does not carry it either.
@@ -426,6 +440,10 @@ class HourlyBacktester:
             ):
                 if field in record:
                     record[field] = float(record[field])
+            if record.get("market_rule_official_close") is not None:
+                record["market_rule_official_close"] = float(
+                    record["market_rule_official_close"]
+                )
             serialized.append(record)
         return serialized
 
@@ -537,7 +555,26 @@ class HourlyBacktester:
             )
         if self.data_source == IFIND_ASHARE:
             self._ifind_common_start = self._validate_ifind_loaded_data()
+            self._initialize_ifind_market_rules()
             self._initialize_ifind_currency_context()
+
+    def _initialize_ifind_market_rules(self) -> None:
+        """Load and validate official rules before any order can execute."""
+        if not hasattr(self.data_loader, "fetch_market_rules"):
+            raise MarketDataUnavailableError(
+                "Market rule data unavailable: iFinD provider has no rule capability"
+            )
+        try:
+            self.market_rule_calendar = self.data_loader.fetch_market_rules(
+                self.symbols,
+                self.start_date,
+                self.end_date,
+                bars_by_symbol=self.all_data,
+            )
+        except (IFindClientError, MarketRuleDataError, ValueError) as exc:
+            raise MarketDataUnavailableError(
+                f"Market rule data unavailable: {exc}"
+            ) from exc
 
     def _initialize_ifind_currency_context(self) -> None:
         """Load the iFinD historical conversion series for this A-share run."""
@@ -705,6 +742,9 @@ class HourlyBacktester:
                     "t_plus_one_enabled": profile.t_plus_one_enabled,
                 }
             )
+            calendar = getattr(self, "market_rule_calendar", None)
+            if calendar is not None:
+                metadata["market_rule_profile"] = calendar.to_metadata()
             context = self._require_currency_context()
             # Frames arrive sorted (the adapter rejects non-increasing
             # timestamps), so read the ends instead of materializing every
@@ -765,6 +805,21 @@ class HourlyBacktester:
                 truncated = len(rejected) - REJECTED_ORDER_SAMPLE_LIMIT
                 if truncated > 0:
                     meta["rejected_orders_truncated"] = truncated
+                market_rule_rejections = {
+                    reason: sum(1 for item in rejected if item.get("reason") == reason)
+                    for reason in (
+                        "suspended",
+                        "limit_up_buy_blocked",
+                        "limit_down_sell_blocked",
+                    )
+                }
+                market_rule_rejections = {
+                    reason: count
+                    for reason, count in market_rule_rejections.items()
+                    if count
+                }
+                if market_rule_rejections:
+                    meta["market_rule_rejections"] = market_rule_rejections
             deferrals = list(getattr(self, "t1_deferrals", []) or [])
             if deferrals:
                 # "How often did T+1 stop this agent exiting?" — the question a
@@ -940,6 +995,7 @@ class HourlyBacktester:
             t_plus_one_enabled=self.profile.t_plus_one_enabled,
             lot_size=self.profile.lot_size,
             transaction_cost_profile=self.profile.transaction_cost_profile,
+            market_rule_calendar=self.market_rule_calendar,
         )
         _decision_steps, post_trade_steps = split_pipeline(self.pipeline)
         if post_trade_steps:
@@ -1121,7 +1177,17 @@ class HourlyBacktester:
             
             # Execute trades (only if real data available)
             trades_before_execution = len(manager.trades)
-            manager.execute_actions(decision["actions"], market_data, timestamp)
+            fallback_prices = {
+                symbol: values[timestamp]
+                for symbol, values in price_cache.items()
+                if timestamp in values
+            }
+            manager.execute_actions(
+                decision["actions"],
+                market_data,
+                timestamp,
+                fallback_prices=fallback_prices,
+            )
             if runtime_invoked:
                 self.runtime_dispatcher.record_latest_execution(
                     len(manager.trades) - trades_before_execution
@@ -1282,6 +1348,7 @@ class HourlyBacktester:
             # fees but trades in single shares.
             lot_size=profile.lot_size,
             allocation_summary=baseline_allocation,
+            market_rule_calendar=self.market_rule_calendar,
         )
         
         if not equity_history:

--- a/dashboard/backend/domain/backtesting/market_rules.py
+++ b/dashboard/backend/domain/backtesting/market_rules.py
@@ -106,6 +106,15 @@ class DailyMarketRule:
         close = _as_decimal(self.official_close_price, field="official_close_price")
         if close <= 0:
             raise ValueError("official_close_price must be positive")
+        if self.final_bar_timestamp is None:
+            # The official feed says this security traded, but this run holds no
+            # intraday series for the day — a symbol whose hourly history starts
+            # late, or has a gap, inside a universe that traded through it. The
+            # observation is still worth carrying for the audit, but it can never
+            # gate: ``closing_gate_effective`` needs a bar to compare against,
+            # and no order can execute on a bar that does not exist either.
+            object.__setattr__(self, "official_close_price", close)
+            return
         timestamp = _as_datetime(
             self.final_bar_timestamp, field="final_bar_timestamp"
         )
@@ -123,6 +132,10 @@ class DailyMarketRule:
     ) -> bool:
         """Return whether this order is at the verified end-of-day limit close."""
         if self.suspended or self.closing_limit_state is ClosingLimitState.NONE:
+            return False
+        if self.final_bar_timestamp is None:
+            # Unverifiable rather than false: without the day's final bar there
+            # is no observation proving this order sits at the limit close.
             return False
         current = _as_datetime(timestamp, field="timestamp")
         if current != self.final_bar_timestamp:

--- a/dashboard/backend/domain/backtesting/market_rules.py
+++ b/dashboard/backend/domain/backtesting/market_rules.py
@@ -1,0 +1,195 @@
+"""Immutable market-rule contracts used by historical backtests.
+
+The domain deliberately knows nothing about iFinD indicator names or response shapes.
+Infrastructure adapters translate vendor observations into this contract before an
+execution loop starts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping
+
+
+MARKET_RULE_PROFILE_VERSION = "ifind-ashare-closing-rules-v1"
+MARKET_RULE_SOURCE = "ifind_http"
+
+
+class MarketRuleDataError(RuntimeError):
+    """Raised when required market-rule observations are unavailable or invalid."""
+
+
+class ClosingLimitState(str, Enum):
+    """Official security state at the daily close."""
+
+    NONE = "none"
+    UPPER = "upper"
+    LOWER = "lower"
+
+
+def _as_decimal(value: Any, *, field: str) -> Decimal:
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be numeric") from exc
+    if not result.is_finite():
+        raise ValueError(f"{field} must be finite")
+    return result
+
+
+def _as_datetime(value: Any, *, field: str) -> datetime:
+    converter = getattr(value, "to_pydatetime", None)
+    if callable(converter):
+        value = converter()
+    if not isinstance(value, datetime):
+        raise ValueError(f"{field} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+    return value
+
+
+def _tick_units(value: Any, price_tick: Any) -> Decimal:
+    price = _as_decimal(value, field="price")
+    tick = _as_decimal(price_tick, field="price_tick")
+    if tick <= 0:
+        raise ValueError("price_tick must be positive")
+    return (price / tick).to_integral_value(rounding=ROUND_HALF_UP)
+
+
+@dataclass(frozen=True)
+class DailyMarketRule:
+    """One validated A-share rule observation for one Shanghai market date."""
+
+    symbol: str
+    trading_date: date
+    suspended: bool
+    closing_limit_state: ClosingLimitState = ClosingLimitState.NONE
+    official_close_price: Decimal | None = None
+    final_bar_timestamp: datetime | None = None
+    source: str = MARKET_RULE_SOURCE
+    version: str = MARKET_RULE_PROFILE_VERSION
+
+    def __post_init__(self) -> None:
+        normalized_symbol = str(self.symbol or "").strip().upper()
+        if not normalized_symbol:
+            raise ValueError("symbol must be non-empty")
+        object.__setattr__(self, "symbol", normalized_symbol)
+
+        if not isinstance(self.trading_date, date) or isinstance(
+            self.trading_date, datetime
+        ):
+            raise ValueError("trading_date must be a date")
+        if not isinstance(self.suspended, bool):
+            raise ValueError("suspended must be a boolean")
+        try:
+            limit_state = ClosingLimitState(self.closing_limit_state)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("closing_limit_state is invalid") from exc
+        object.__setattr__(self, "closing_limit_state", limit_state)
+
+        if not str(self.source or "").strip() or not str(self.version or "").strip():
+            raise ValueError("market-rule source and version must be non-empty")
+
+        if self.suspended:
+            if limit_state is not ClosingLimitState.NONE:
+                raise ValueError("a suspended rule cannot carry a closing limit state")
+            if self.official_close_price is not None:
+                raise ValueError("a suspended rule cannot carry an official close")
+            if self.final_bar_timestamp is not None:
+                raise ValueError("a suspended rule cannot carry a final bar timestamp")
+            return
+
+        close = _as_decimal(self.official_close_price, field="official_close_price")
+        if close <= 0:
+            raise ValueError("official_close_price must be positive")
+        timestamp = _as_datetime(
+            self.final_bar_timestamp, field="final_bar_timestamp"
+        )
+        if timestamp.date() != self.trading_date:
+            raise ValueError("final_bar_timestamp must fall on trading_date")
+        object.__setattr__(self, "official_close_price", close)
+        object.__setattr__(self, "final_bar_timestamp", timestamp)
+
+    def closing_gate_effective(
+        self,
+        *,
+        timestamp: Any,
+        reference_price: Any,
+        price_tick: Any,
+    ) -> bool:
+        """Return whether this order is at the verified end-of-day limit close."""
+        if self.suspended or self.closing_limit_state is ClosingLimitState.NONE:
+            return False
+        current = _as_datetime(timestamp, field="timestamp")
+        if current != self.final_bar_timestamp:
+            return False
+        return _tick_units(reference_price, price_tick) == _tick_units(
+            self.official_close_price, price_tick
+        )
+
+    def to_audit(self, *, closing_gate_effective: bool = False) -> dict[str, object]:
+        """Return stable JSON-safe fields for an order-event audit record."""
+        return {
+            "market_rule_date": self.trading_date.isoformat(),
+            "market_rule_suspended": self.suspended,
+            "market_rule_closing_limit_state": self.closing_limit_state.value,
+            "market_rule_official_close": (
+                float(self.official_close_price)
+                if self.official_close_price is not None
+                else None
+            ),
+            "market_rule_closing_gate_effective": bool(closing_gate_effective),
+            "market_rule_source": self.source,
+            "market_rule_version": self.version,
+        }
+
+
+class MarketRuleCalendar:
+    """Read-only lookup of validated rules keyed by symbol and market date."""
+
+    def __init__(self, rules: Iterable[DailyMarketRule]) -> None:
+        normalized: dict[tuple[str, date], DailyMarketRule] = {}
+        for rule in rules:
+            if not isinstance(rule, DailyMarketRule):
+                raise TypeError("market-rule calendar accepts DailyMarketRule values")
+            key = (rule.symbol, rule.trading_date)
+            if key in normalized:
+                raise MarketRuleDataError(
+                    "Market rule data unavailable: duplicate symbol-date observation"
+                )
+            normalized[key] = rule
+        if not normalized:
+            raise MarketRuleDataError("Market rule data unavailable: calendar is empty")
+        self._rules: Mapping[tuple[str, date], DailyMarketRule] = MappingProxyType(
+            normalized
+        )
+
+    def rule_for(self, symbol: str, trading_date: date) -> DailyMarketRule:
+        key = (str(symbol or "").strip().upper(), trading_date)
+        try:
+            return self._rules[key]
+        except KeyError:
+            raise MarketRuleDataError(
+                "Market rule data unavailable: missing symbol-date observation"
+            ) from None
+
+    def rule_for_timestamp(self, symbol: str, timestamp: Any) -> DailyMarketRule:
+        current = _as_datetime(timestamp, field="timestamp")
+        return self.rule_for(symbol, current.date())
+
+    def __len__(self) -> int:
+        return len(self._rules)
+
+    def to_metadata(self) -> dict[str, object]:
+        sample = next(iter(self._rules.values()))
+        return {
+            "enabled": True,
+            "source": sample.source,
+            "version": sample.version,
+            "observations": len(self._rules),
+            "scope": "full_day_suspension_and_closing_limits",
+        }

--- a/dashboard/backend/domain/backtesting/portfolio_manager.py
+++ b/dashboard/backend/domain/backtesting/portfolio_manager.py
@@ -83,6 +83,7 @@ class PortfolioManager:
         t_plus_one_enabled: bool = False,
         lot_size: int = 1,
         transaction_cost_profile=None,
+        market_rule_calendar=None,
     ):
         self.initial_capital = initial_capital
         self.cash = initial_capital
@@ -98,6 +99,7 @@ class PortfolioManager:
         self.t_plus_one_enabled = t_plus_one_enabled
         self.lot_size = lot_size
         self.transaction_cost_profile = transaction_cost_profile
+        self.market_rule_calendar = market_rule_calendar
         self.transaction_cost_totals = {
             "gross_value": 0.0,
             "slippage_amount": 0.0,
@@ -763,9 +765,25 @@ class PortfolioManager:
         )
         return self.make_trading_decision(portfolio_state)
     
-    def execute_actions(self, actions: List[Dict], market_data: Dict, timestamp: datetime):
+    def execute_actions(
+        self,
+        actions: List[Dict],
+        market_data: Dict,
+        timestamp: datetime,
+        fallback_prices: Optional[Dict] = None,
+    ):
         """Execute trading decisions."""
         trades_before = len(self.trades)
+        market_rules = None
+        if self.market_rule_calendar is not None:
+            market_rules = {
+                action.get("symbol"): self.market_rule_calendar.rule_for_timestamp(
+                    action.get("symbol"), timestamp
+                )
+                for action in actions
+                if action.get("action") in {"buy", "sell"}
+                and action.get("symbol") in self._allowed_set
+            }
         self.cash = _execute_actions(
             actions=actions,
             market_data=market_data,
@@ -782,6 +800,8 @@ class PortfolioManager:
             order_events=self.order_events,
             order_event_repeats=self._order_event_repeats,
             transaction_cost_profile=self.transaction_cost_profile,
+            market_rules=market_rules,
+            fallback_prices=fallback_prices,
         )
         for trade in self.trades[trades_before:]:
             for field in self.transaction_cost_totals:

--- a/dashboard/backend/domain/trading/execution.py
+++ b/dashboard/backend/domain/trading/execution.py
@@ -448,8 +448,6 @@ def execute_actions(
         market_rule = None
         if market_rules is not None and action_type in {"buy", "sell"}:
             market_rule = market_rules.get(symbol)
-            if market_rule is None:
-                raise ValueError(f"market rule is missing for symbol={symbol}")
 
             reference_price = None
             if symbol in market_data:
@@ -457,6 +455,41 @@ def execute_actions(
             elif fallback_prices is not None:
                 reference_price = fallback_prices.get(symbol)
             display_price = 0.0 if reference_price is None else reference_price
+
+            if market_rule is None:
+                # Fail closed, but do not take the run down with it. Every
+                # producer filters to the allowed universe before reaching here,
+                # so this is unreachable today — and if one ever stops, letting
+                # a symbol trade ungated would defeat the calendar, while
+                # raising would discard every bar already simulated for a single
+                # stray action. Reject it and leave a record instead.
+                _record_rejection(
+                    timestamp=timestamp,
+                    symbol=symbol,
+                    action=action_type,
+                    requested_shares=shares,
+                    executed_shares=0,
+                    unfilled_shares=shares,
+                    reason="market_rule_unavailable",
+                )
+                _record_order_event(
+                    timestamp=timestamp,
+                    symbol=symbol,
+                    side=action_type.upper(),
+                    requested_shares=shares,
+                    executed_shares=0,
+                    price=display_price,
+                    status="rejected",
+                    reason="market_rule_unavailable",
+                    strategy_reason=reason,
+                    costs=(
+                        _zero_transaction_costs(display_price)
+                        if costs_enabled
+                        else None
+                    ),
+                )
+                continue
+
             current_market_rule_audit = market_rule.to_audit()
 
             if market_rule.suspended:

--- a/dashboard/backend/domain/trading/execution.py
+++ b/dashboard/backend/domain/trading/execution.py
@@ -115,8 +115,9 @@ def _append_rejection(
     executed_shares: float,
     unfilled_shares: float,
     reason: str,
+    audit: Optional[Dict[str, Any]] = None,
 ) -> None:
-    rejected_orders.append({
+    record = {
         "timestamp": timestamp,
         "symbol": symbol,
         "action": action,
@@ -125,7 +126,10 @@ def _append_rejection(
         "unfilled_shares": unfilled_shares,
         "status": "partial" if executed_shares > 0 else "rejected",
         "reason": reason,
-    })
+    }
+    if audit is not None:
+        record.update(audit)
+    rejected_orders.append(record)
 
 
 def _is_valid_lot_quantity(shares: Any, lot_size: int) -> bool:
@@ -183,6 +187,7 @@ def _append_order_event(
     strategy_reason: str,
     costs: Optional[Dict[str, float]] = None,
     repeat_index: Optional[Dict] = None,
+    audit: Optional[Dict[str, Any]] = None,
 ) -> None:
     if order_events is None:
         return
@@ -228,6 +233,8 @@ def _append_order_event(
     }
     if costs is not None:
         event.update(costs)
+    if audit is not None:
+        event.update(audit)
     order_events.append(event)
     if repeat_key is not None:
         repeat_index[repeat_key] = order_events[-1]
@@ -378,6 +385,8 @@ def execute_actions(
     order_events: Optional[List[Dict]] = None,
     order_event_repeats: Optional[Dict] = None,
     transaction_cost_profile: Any = None,
+    market_rules: Optional[Dict[str, Any]] = None,
+    fallback_prices: Optional[Dict[str, Any]] = None,
 ) -> float:
     """Apply ``actions`` to the given portfolio state in place.
 
@@ -393,10 +402,23 @@ def execute_actions(
     """
     costs_enabled = transaction_cost_profile is not None
 
+    current_market_rule_audit = None
+
     def _record_order_event(**fields) -> None:
         _append_order_event(
-            order_events, repeat_index=order_event_repeats, **fields
+            order_events,
+            repeat_index=order_event_repeats,
+            audit=current_market_rule_audit,
+            **fields,
         )
+
+    def _record_rejection(**fields) -> None:
+        if rejected_orders is not None:
+            _append_rejection(
+                rejected_orders,
+                audit=current_market_rule_audit,
+                **fields,
+            )
 
     current_date = None
     if t_plus_one_enabled:
@@ -422,10 +444,99 @@ def execute_actions(
         shares = action.get("shares", 0)
         reason = action.get("reason", "")
 
+        current_market_rule_audit = None
+        market_rule = None
+        if market_rules is not None and action_type in {"buy", "sell"}:
+            market_rule = market_rules.get(symbol)
+            if market_rule is None:
+                raise ValueError(f"market rule is missing for symbol={symbol}")
+
+            reference_price = None
+            if symbol in market_data:
+                reference_price = market_data[symbol]["close"]
+            elif fallback_prices is not None:
+                reference_price = fallback_prices.get(symbol)
+            display_price = 0.0 if reference_price is None else reference_price
+            current_market_rule_audit = market_rule.to_audit()
+
+            if market_rule.suspended:
+                _record_rejection(
+                    timestamp=timestamp,
+                    symbol=symbol,
+                    action=action_type,
+                    requested_shares=shares,
+                    executed_shares=0,
+                    unfilled_shares=shares,
+                    reason="suspended",
+                )
+                _record_order_event(
+                    timestamp=timestamp,
+                    symbol=symbol,
+                    side=action_type.upper(),
+                    requested_shares=shares,
+                    executed_shares=0,
+                    price=display_price,
+                    status="rejected",
+                    reason="suspended",
+                    strategy_reason=reason,
+                    costs=(
+                        _zero_transaction_costs(display_price)
+                        if costs_enabled
+                        else None
+                    ),
+                )
+                continue
+
         if symbol not in market_data:
             continue
 
         price = market_data[symbol]["close"]
+
+        if market_rule is not None:
+            price_tick = getattr(transaction_cost_profile, "price_tick", 0.01)
+            closing_gate_effective = market_rule.closing_gate_effective(
+                timestamp=timestamp,
+                reference_price=price,
+                price_tick=price_tick,
+            )
+            current_market_rule_audit = market_rule.to_audit(
+                closing_gate_effective=closing_gate_effective
+            )
+            limit_state = market_rule.closing_limit_state.value
+            market_rejection_reason = None
+            if closing_gate_effective and action_type == "buy" and limit_state == "upper":
+                market_rejection_reason = "limit_up_buy_blocked"
+            elif (
+                closing_gate_effective
+                and action_type == "sell"
+                and limit_state == "lower"
+            ):
+                market_rejection_reason = "limit_down_sell_blocked"
+            if market_rejection_reason is not None:
+                _record_rejection(
+                    timestamp=timestamp,
+                    symbol=symbol,
+                    action=action_type,
+                    requested_shares=shares,
+                    executed_shares=0,
+                    unfilled_shares=shares,
+                    reason=market_rejection_reason,
+                )
+                _record_order_event(
+                    timestamp=timestamp,
+                    symbol=symbol,
+                    side=action_type.upper(),
+                    requested_shares=shares,
+                    executed_shares=0,
+                    price=price,
+                    status="rejected",
+                    reason=market_rejection_reason,
+                    strategy_reason=reason,
+                    costs=(
+                        _zero_transaction_costs(price) if costs_enabled else None
+                    ),
+                )
+                continue
 
         if (
             lot_size > 1
@@ -433,8 +544,7 @@ def execute_actions(
             and not _is_valid_lot_quantity(shares, lot_size)
         ):
             if rejected_orders is not None:
-                _append_rejection(
-                    rejected_orders,
+                _record_rejection(
                     timestamp=timestamp,
                     symbol=symbol,
                     action=action_type,
@@ -495,6 +605,8 @@ def execute_actions(
                 })
                 if costs_enabled:
                     trades[-1].update(calculated_costs)
+                if current_market_rule_audit is not None:
+                    trades[-1].update(current_market_rule_audit)
                 _record_order_event(
                     timestamp=timestamp,
                     symbol=symbol,
@@ -517,8 +629,7 @@ def execute_actions(
                 # legacy single-share branch's semantics are frozen.
                 if lot_size > 1:
                     if rejected_orders is not None:
-                        _append_rejection(
-                            rejected_orders,
+                        _record_rejection(
                             timestamp=timestamp,
                             symbol=symbol,
                             action="buy",
@@ -583,6 +694,8 @@ def execute_actions(
                 })
                 if costs_enabled:
                     trades[-1].update(calculated_costs)
+                if current_market_rule_audit is not None:
+                    trades[-1].update(current_market_rule_audit)
 
             unfilled_shares = shares - sell_shares
             if unfilled_shares <= _SHARE_EPSILON:
@@ -610,8 +723,7 @@ def execute_actions(
             frozen_shares = max(held_shares - sellable_shares, 0)
             t1_unfilled = min(unfilled_shares, frozen_shares)
             if t1_unfilled > _SHARE_EPSILON:
-                _append_rejection(
-                    rejected_orders,
+                _record_rejection(
                     timestamp=timestamp,
                     symbol=symbol,
                     action="sell",
@@ -622,8 +734,7 @@ def execute_actions(
                 )
             insufficient_shares = unfilled_shares - t1_unfilled
             if insufficient_shares > _SHARE_EPSILON:
-                _append_rejection(
-                    rejected_orders,
+                _record_rejection(
                     timestamp=timestamp,
                     symbol=symbol,
                     action="sell",
@@ -685,6 +796,8 @@ def execute_actions(
                 })
                 if costs_enabled:
                     trades[-1].update(calculated_costs)
+                if current_market_rule_audit is not None:
+                    trades[-1].update(current_market_rule_audit)
                 unfilled_shares = shares - sell_shares
                 _record_order_event(
                     timestamp=timestamp,
@@ -712,8 +825,7 @@ def execute_actions(
                 # branch still skips silently, it just no longer skips
                 # *invisibly*.
                 if lot_size > 1 and rejected_orders is not None:
-                    _append_rejection(
-                        rejected_orders,
+                    _record_rejection(
                         timestamp=timestamp,
                         symbol=symbol,
                         action="sell",

--- a/dashboard/backend/infrastructure/market_data/ifind_ashare.py
+++ b/dashboard/backend/infrastructure/market_data/ifind_ashare.py
@@ -11,11 +11,13 @@ import pandas as pd
 from .ifind_adapter import response_to_frames
 from .ifind_client import IFindHttpClient
 from .ifind_fx import IFindHistoricalFxProvider
+from .ifind_market_rules import response_to_market_rules
 from .profiles import IFIND_ASHARE, MarketProfile, get_market_profile
 
 
 DateInput = str | date | datetime
 Adapter = Callable[..., dict[str, pd.DataFrame]]
+MarketRuleAdapter = Callable[..., object]
 _MARKET_TIMEZONE = ZoneInfo("Asia/Shanghai")
 _MINIMUM_BARS = 50
 
@@ -38,12 +40,14 @@ class IFindAshareProvider:
         client: IFindHttpClient | None = None,
         adapter: Adapter = response_to_frames,
         fx_provider: IFindHistoricalFxProvider | None = None,
+        market_rule_adapter: MarketRuleAdapter = response_to_market_rules,
     ) -> None:
         self.profile = profile or get_market_profile(IFIND_ASHARE)
         if self.profile.data_source != IFIND_ASHARE:
             raise ValueError("iFinD provider requires an iFinD market profile")
         self._client = client if client is not None else IFindHttpClient()
         self._adapter = adapter
+        self._market_rule_adapter = market_rule_adapter
         self._fx_provider = (
             fx_provider
             if fx_provider is not None
@@ -92,6 +96,45 @@ class IFindAshareProvider:
             canonical_symbols,
             start_date,
             end_date,
+        )
+
+    def fetch_market_rules(
+        self,
+        symbols: Sequence[str],
+        start: DateInput,
+        end: DateInput,
+        *,
+        bars_by_symbol: dict[str, pd.DataFrame],
+    ):
+        """Return the official validated rule calendar for loaded A-share bars."""
+        canonical_symbols = self._validate_universe(symbols)
+        start_date = self._as_market_date(start)
+        end_date = self._as_market_date(end)
+        if end_date <= start_date:
+            raise IFindDateInputError("iFinD end date must be after start date")
+
+        required_dates = sorted({
+            timestamp.date()
+            for frame in bars_by_symbol.values()
+            for timestamp in frame.index
+        })
+        payload = self._client.fetch_daily_market_rules(
+            canonical_symbols,
+            start_date,
+            end_date,
+        )
+        price_tick = (
+            self.profile.transaction_cost_profile.price_tick
+            if self.profile.transaction_cost_profile is not None
+            else 0.01
+        )
+        return self._market_rule_adapter(
+            payload,
+            expected_symbols=canonical_symbols,
+            required_dates=required_dates,
+            bars_by_symbol=bars_by_symbol,
+            fetch_basic_status=self._client.fetch_basic_market_status,
+            price_tick=price_tick,
         )
 
     def _validate_universe(self, symbols: Sequence[str]) -> tuple[str, ...]:

--- a/dashboard/backend/infrastructure/market_data/ifind_client.py
+++ b/dashboard/backend/infrastructure/market_data/ifind_client.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_BASE_URL = "https://quantapi.51ifind.com"
 HIGH_FREQUENCY_ENDPOINT = "/api/v1/high_frequency"
 HISTORY_QUOTATION_ENDPOINT = "/api/v1/cmd_history_quotation"
+BASIC_DATA_ENDPOINT = "/api/v1/basic_data_service"
 DEFAULT_TIMEOUT = (3.0, 20.0)
 _RETRY_DELAYS = (0.5, 1.0)
 # Honour a server-supplied Retry-After, but never park a backtest thread on an
@@ -155,6 +156,51 @@ class IFindHttpClient:
             normalized_symbols,
             start,
             end,
+            payload,
+        )
+
+    def fetch_daily_market_rules(
+        self,
+        symbols: Sequence[str],
+        start: date,
+        end: date,
+    ) -> Mapping[str, object]:
+        """Fetch official daily status, closing limit state, and close in CNY."""
+        normalized_symbols = self._validate_request(symbols, start, end)
+        payload = self._build_daily_market_rules_payload(
+            normalized_symbols, start, end
+        )
+        return self._request_json(
+            HISTORY_QUOTATION_ENDPOINT,
+            normalized_symbols,
+            start,
+            end,
+            payload,
+        )
+
+    def fetch_basic_market_status(
+        self,
+        symbols: Sequence[str],
+        trading_date: date,
+    ) -> Mapping[str, object]:
+        """Fetch official same-date status supplements for blank history rows."""
+        if isinstance(symbols, (str, bytes)):
+            raise IFindRequestError("symbols must be a non-empty sequence")
+        if any(not isinstance(symbol, str) for symbol in symbols):
+            raise IFindRequestError("symbols must contain only strings")
+        normalized_symbols = tuple(symbol.strip() for symbol in symbols)
+        if not normalized_symbols or any(not symbol for symbol in normalized_symbols):
+            raise IFindRequestError("symbols must be a non-empty sequence")
+        if not isinstance(trading_date, date):
+            raise IFindRequestError("trading_date must be a date value")
+        payload = self._build_basic_market_status_payload(
+            normalized_symbols, trading_date
+        )
+        return self._request_json(
+            BASIC_DATA_ENDPOINT,
+            normalized_symbols,
+            trading_date,
+            trading_date + timedelta(days=1),
             payload,
         )
 
@@ -319,7 +365,7 @@ class IFindHttpClient:
             "endtime": f"{effective_last_day.isoformat()} 15:00:00",
             "functionpara": {
                 "Interval": "60",
-                "CPS": "forward1",
+                "CPS": "no",
                 "Timeformat": "LocalTime",
                 "Limitstart": "09:30:00",
                 "Limitend": "15:00:00",
@@ -345,6 +391,49 @@ class IFindHttpClient:
                 "Currency": currency,
                 "Fill": "Blank",
             },
+        }
+
+    @staticmethod
+    def _build_daily_market_rules_payload(
+        symbols: Sequence[str],
+        start: date,
+        end: date,
+    ) -> dict[str, object]:
+        effective_last_day = end - timedelta(days=1)
+        return {
+            "codes": ",".join(symbols),
+            "indicators": (
+                "close,ths_trading_status_stock,"
+                "ths_up_and_down_status_stock"
+            ),
+            "startdate": start.isoformat(),
+            "enddate": effective_last_day.isoformat(),
+            "functionpara": {
+                "Interval": "D",
+                "CPS": "1",
+                "Currency": "RMB",
+                "Fill": "Blank",
+            },
+        }
+
+    @staticmethod
+    def _build_basic_market_status_payload(
+        symbols: Sequence[str],
+        trading_date: date,
+    ) -> dict[str, object]:
+        date_value = trading_date.isoformat()
+        return {
+            "codes": ",".join(symbols),
+            "indipara": [
+                {
+                    "indicator": "ths_trading_status_stock",
+                    "indiparams": [date_value],
+                },
+                {
+                    "indicator": "ths_up_and_down_status_stock",
+                    "indiparams": [date_value],
+                },
+            ],
         }
 
     @staticmethod

--- a/dashboard/backend/infrastructure/market_data/ifind_market_rules.py
+++ b/dashboard/backend/infrastructure/market_data/ifind_market_rules.py
@@ -1,0 +1,311 @@
+"""Translate verified iFinD status responses into ATL market-rule objects."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any
+
+import pandas as pd
+
+from dashboard.backend.domain.backtesting.market_rules import (
+    ClosingLimitState,
+    DailyMarketRule,
+    MarketRuleCalendar,
+    MarketRuleDataError,
+)
+
+
+TRADING_STATUS_FIELD = "ths_trading_status_stock"
+LIMIT_STATUS_FIELD = "ths_up_and_down_status_stock"
+
+
+def _fail(detail: str) -> MarketRuleDataError:
+    return MarketRuleDataError(f"Market rule data unavailable: {detail}")
+
+
+def _as_date(value: Any) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = str(value or "")[:10]
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        raise _fail("invalid rule date") from None
+
+
+def _values(table: Mapping[str, object], field: str, symbol: str) -> list[object]:
+    raw = table.get(field)
+    if not isinstance(raw, list):
+        raise _fail(f"missing field={field} for symbol={symbol}")
+    return raw
+
+
+def _status_is_suspended(trading_status: object, limit_status: object) -> bool:
+    values = (str(trading_status or ""), str(limit_status or ""))
+    return any("停牌" in value for value in values)
+
+
+def _limit_state(value: object) -> ClosingLimitState:
+    text = str(value or "").strip()
+    if text == "涨停":
+        return ClosingLimitState.UPPER
+    if text == "跌停":
+        return ClosingLimitState.LOWER
+    if text in {"非涨跌停", "停牌"}:
+        return ClosingLimitState.NONE
+    raise _fail("unknown closing limit status")
+
+
+def _numeric_close(value: object, symbol: str, trading_date: date) -> Decimal | None:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    try:
+        close = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        raise _fail(f"invalid official close for {symbol} {trading_date}") from None
+    if not close.is_finite() or close <= 0:
+        raise _fail(f"invalid official close for {symbol} {trading_date}")
+    return close
+
+
+def _table_by_symbol(payload: Mapping[str, object], expected: Sequence[str]) -> dict[str, Mapping[str, object]]:
+    tables = payload.get("tables")
+    if not isinstance(tables, list):
+        raise _fail("response tables are malformed")
+    result: dict[str, Mapping[str, object]] = {}
+    expected_set = set(expected)
+    for item in tables:
+        if not isinstance(item, Mapping):
+            raise _fail("response table is malformed")
+        symbol = str(item.get("thscode") or "").strip().upper()
+        table = item.get("table")
+        if symbol not in expected_set or not isinstance(table, Mapping):
+            raise _fail("response contains an unexpected or malformed symbol table")
+        if symbol in result:
+            raise _fail("duplicate symbol rule response")
+        result[symbol] = table
+    return result
+
+
+def _history_rows(
+    payload: Mapping[str, object], expected: Sequence[str]
+) -> dict[tuple[str, date], dict[str, object]]:
+    tables = payload.get("tables")
+    if not isinstance(tables, list):
+        raise _fail("history response tables are malformed")
+    expected_set = set(expected)
+    rows: dict[tuple[str, date], dict[str, object]] = {}
+    seen_symbols: set[str] = set()
+    for item in tables:
+        if not isinstance(item, Mapping):
+            raise _fail("history response table is malformed")
+        symbol = str(item.get("thscode") or "").strip().upper()
+        if symbol not in expected_set:
+            raise _fail("history response contains an unexpected symbol")
+        if symbol in seen_symbols:
+            raise _fail("duplicate history symbol response")
+        seen_symbols.add(symbol)
+        times = item.get("time")
+        table = item.get("table")
+        if not isinstance(times, list) or not isinstance(table, Mapping):
+            raise _fail(f"history response is malformed for symbol={symbol}")
+        fields = {
+            field: _values(table, field, symbol)
+            for field in ("close", TRADING_STATUS_FIELD, LIMIT_STATUS_FIELD)
+        }
+        lengths = {len(times), *(len(values) for values in fields.values())}
+        if len(lengths) != 1:
+            raise _fail(f"history field lengths differ for symbol={symbol}")
+        for index, raw_date in enumerate(times):
+            trading_date = _as_date(raw_date)
+            key = (symbol, trading_date)
+            if key in rows:
+                raise _fail("duplicate symbol-date history response")
+            rows[key] = {
+                "close": fields["close"][index],
+                "trading_status": fields[TRADING_STATUS_FIELD][index],
+                "limit_status": fields[LIMIT_STATUS_FIELD][index],
+            }
+    missing_symbols = expected_set - seen_symbols
+    if missing_symbols:
+        raise _fail(f"history response is missing symbols={sorted(missing_symbols)!r}")
+    return rows
+
+
+def _basic_rows(
+    payload: Mapping[str, object], expected: Sequence[str], trading_date: date
+) -> dict[str, dict[str, object]]:
+    tables = _table_by_symbol(payload, expected)
+    result: dict[str, dict[str, object]] = {}
+    for symbol in expected:
+        table = tables.get(symbol)
+        if table is None:
+            raise _fail(f"basic status response is missing symbol={symbol}")
+        trading_values = _values(table, TRADING_STATUS_FIELD, symbol)
+        limit_values = _values(table, LIMIT_STATUS_FIELD, symbol)
+        if len(trading_values) != 1 or len(limit_values) != 1:
+            raise _fail(f"basic status response has invalid row count for {symbol}")
+        result[symbol] = {
+            "close": None,
+            "trading_status": trading_values[0],
+            "limit_status": limit_values[0],
+            "date": trading_date,
+        }
+    return result
+
+
+def _final_bar_for_date(frame: pd.DataFrame, trading_date: date) -> datetime | None:
+    timestamps = []
+    for timestamp in frame.index:
+        if hasattr(timestamp, "to_pydatetime"):
+            timestamp = timestamp.to_pydatetime()
+        if not isinstance(timestamp, datetime):
+            continue
+        if timestamp.date() == trading_date:
+            timestamps.append(timestamp)
+    if not timestamps:
+        return None
+    return max(timestamps)
+
+
+def _bar_close(frame: pd.DataFrame, timestamp: datetime) -> object:
+    try:
+        value = frame.loc[pd.Timestamp(timestamp), "close"]
+    except (KeyError, IndexError, TypeError):
+        raise _fail("final hourly bar close is unavailable") from None
+    if isinstance(value, pd.Series):
+        raise _fail("duplicate final hourly bar")
+    return value
+
+
+def _same_price_tick(left: Decimal, right: Decimal, price_tick: Decimal) -> bool:
+    if price_tick <= 0:
+        raise _fail("price tick is invalid")
+    return (
+        (left / price_tick).to_integral_value(rounding=ROUND_HALF_UP)
+        == (right / price_tick).to_integral_value(rounding=ROUND_HALF_UP)
+    )
+
+
+def _require_price_tick(
+    value: Decimal, price_tick: Decimal, symbol: str, trading_date: date
+) -> None:
+    if value % price_tick != 0:
+        raise _fail(f"price tick mismatch for {symbol} {trading_date}")
+
+
+def response_to_market_rules(
+    payload: Mapping[str, object],
+    *,
+    expected_symbols: Sequence[str],
+    required_dates: Sequence[date],
+    bars_by_symbol: Mapping[str, pd.DataFrame],
+    fetch_basic_status: Callable[[Sequence[str], date], Mapping[str, object]],
+    price_tick: Decimal | float = Decimal("0.01"),
+) -> MarketRuleCalendar:
+    """Normalize daily history plus official blank-row supplements."""
+    expected = tuple(str(symbol).strip().upper() for symbol in expected_symbols)
+    dates = tuple(sorted(set(required_dates)))
+    if not expected or not dates:
+        raise _fail("rule calendar scope is empty")
+    history = _history_rows(payload, expected)
+    tick = Decimal(str(price_tick))
+    if tick <= 0:
+        raise _fail("price tick is invalid")
+
+    supplements: dict[tuple[str, date], dict[str, object]] = {}
+    for trading_date in dates:
+        missing = []
+        for symbol in expected:
+            row = history.get((symbol, trading_date))
+            if row is None or any(
+                row.get(field) in (None, "")
+                for field in ("trading_status", "limit_status")
+            ):
+                missing.append(symbol)
+        if missing:
+            supplement_payload = fetch_basic_status(tuple(missing), trading_date)
+            supplements_for_date = _basic_rows(
+                supplement_payload, missing, trading_date
+            )
+            supplements.update({
+                (symbol, trading_date): row
+                for symbol, row in supplements_for_date.items()
+            })
+
+    rules: list[DailyMarketRule] = []
+    for symbol in expected:
+        frame = bars_by_symbol.get(symbol)
+        if frame is None:
+            raise _fail(f"hourly bars are missing symbol={symbol}")
+        for trading_date in dates:
+            row = history.get((symbol, trading_date))
+            supplement = supplements.get((symbol, trading_date))
+            if row is None:
+                row = supplement
+            elif any(
+                row.get(field) in (None, "")
+                for field in ("trading_status", "limit_status")
+            ):
+                row = {
+                    "close": row.get("close"),
+                    "trading_status": (
+                        row.get("trading_status")
+                        if row.get("trading_status") not in (None, "")
+                        else (
+                            supplement.get("trading_status") if supplement else None
+                        )
+                    ),
+                    "limit_status": (
+                        row.get("limit_status")
+                        if row.get("limit_status") not in (None, "")
+                        else (
+                            supplement.get("limit_status") if supplement else None
+                        )
+                    ),
+                }
+            if row is None:
+                raise _fail(f"missing symbol-date rule for {symbol} {trading_date}")
+
+            trading_status = row.get("trading_status")
+            limit_status = row.get("limit_status")
+            suspended = _status_is_suspended(trading_status, limit_status)
+            if suspended:
+                rules.append(
+                    DailyMarketRule(
+                        symbol=symbol,
+                        trading_date=trading_date,
+                        suspended=True,
+                    )
+                )
+                continue
+
+            state = _limit_state(limit_status)
+
+            official_close = _numeric_close(row.get("close"), symbol, trading_date)
+            if official_close is None or str(trading_status or "").strip() != "交易":
+                raise _fail(f"active rule is incomplete for {symbol} {trading_date}")
+            _require_price_tick(official_close, tick, symbol, trading_date)
+            final_bar = _final_bar_for_date(frame, trading_date)
+            if final_bar is None:
+                raise _fail(f"active rule has no hourly bars for {symbol} {trading_date}")
+            bar_close = _numeric_close(_bar_close(frame, final_bar), symbol, trading_date)
+            if bar_close is not None:
+                _require_price_tick(bar_close, tick, symbol, trading_date)
+            if bar_close is None or not _same_price_tick(bar_close, official_close, tick):
+                raise _fail(f"daily close does not match final hourly bar for {symbol} {trading_date}")
+            rules.append(
+                DailyMarketRule(
+                    symbol=symbol,
+                    trading_date=trading_date,
+                    suspended=False,
+                    closing_limit_state=state,
+                    official_close_price=official_close,
+                    final_bar_timestamp=final_bar,
+                )
+            )
+    return MarketRuleCalendar(rules)

--- a/dashboard/backend/infrastructure/market_data/ifind_market_rules.py
+++ b/dashboard/backend/infrastructure/market_data/ifind_market_rules.py
@@ -20,6 +20,15 @@ from dashboard.backend.domain.backtesting.market_rules import (
 TRADING_STATUS_FIELD = "ths_trading_status_stock"
 LIMIT_STATUS_FIELD = "ths_up_and_down_status_stock"
 
+# Wider than any A-share daily band (10% main boards, 20% STAR/ChiNext), so an
+# overnight move past it cannot have come from trading. Both the hourly bars and
+# these daily closes are requested unadjusted — deliberately, because the audit
+# has to show the official close a limit was set against, not a back-adjusted
+# one — and nothing in the backend applies dividends or splits. A 除权除息 date
+# therefore lands in the equity curve as a real overnight loss that never
+# happened. Detecting it does not fix it; it stops it being silent.
+_CORPORATE_ACTION_GAP = Decimal("0.21")
+
 
 def _fail(detail: str) -> MarketRuleDataError:
     return MarketRuleDataError(f"Market rule data unavailable: {detail}")
@@ -49,7 +58,7 @@ def _status_is_suspended(trading_status: object, limit_status: object) -> bool:
     return any("停牌" in value for value in values)
 
 
-def _limit_state(value: object) -> ClosingLimitState:
+def _limit_state(value: object, symbol: str, trading_date: date) -> ClosingLimitState:
     text = str(value or "").strip()
     if text == "涨停":
         return ClosingLimitState.UPPER
@@ -57,7 +66,14 @@ def _limit_state(value: object) -> ClosingLimitState:
         return ClosingLimitState.LOWER
     if text in {"非涨跌停", "停牌"}:
         return ClosingLimitState.NONE
-    raise _fail("unknown closing limit status")
+    # Naming the value is the whole diagnosis. The gate is deliberately keyed on
+    # exact vendor strings and stays that way — guessing at an unrecognised
+    # status is how a limit-locked day gets traded — but an operator has to be
+    # able to tell "iFinD added a status" from "this account answers in English"
+    # from "the field arrived blank", and a bare message tells them none of it.
+    raise _fail(
+        f"unknown closing limit status={text[:40]!r} for {symbol} {trading_date}"
+    )
 
 
 def _numeric_close(value: object, symbol: str, trading_date: date) -> Decimal | None:
@@ -226,6 +242,16 @@ def response_to_market_rules(
                 row.get(field) in (None, "")
                 for field in ("trading_status", "limit_status")
             ):
+                if row is not None and _status_is_suspended(
+                    row.get("trading_status"), row.get("limit_status")
+                ):
+                    # A suspended security is exactly what leaves these fields
+                    # blank, and one field already settles it — the supplement
+                    # cannot change the outcome. Skipping it matters because
+                    # this fetch is one blocking round trip per date: a universe
+                    # with something suspended most days would otherwise open
+                    # the run with dozens of sequential vendor calls.
+                    continue
                 missing.append(symbol)
         if missing:
             supplement_payload = fetch_basic_status(tuple(missing), trading_date)
@@ -238,10 +264,13 @@ def response_to_market_rules(
             })
 
     rules: list[DailyMarketRule] = []
+    unaligned: list[tuple[str, date]] = []
+    price_gaps: list[tuple[str, date, Decimal]] = []
     for symbol in expected:
         frame = bars_by_symbol.get(symbol)
         if frame is None:
             raise _fail(f"hourly bars are missing symbol={symbol}")
+        previous_close: Decimal | None = None
         for trading_date in dates:
             row = history.get((symbol, trading_date))
             supplement = supplements.get((symbol, trading_date))
@@ -282,17 +311,55 @@ def response_to_market_rules(
                         suspended=True,
                     )
                 )
+                # A halt legitimately lets the price gap on resumption, so it
+                # breaks the chain rather than producing a false positive.
+                previous_close = None
                 continue
 
-            state = _limit_state(limit_status)
+            state = _limit_state(limit_status, symbol, trading_date)
 
             official_close = _numeric_close(row.get("close"), symbol, trading_date)
-            if official_close is None or str(trading_status or "").strip() != "交易":
-                raise _fail(f"active rule is incomplete for {symbol} {trading_date}")
+            observed_status = str(trading_status or "").strip()
+            if observed_status != "交易":
+                # Split from the missing-close case on purpose: these two fail
+                # for opposite reasons and want opposite responses, and one
+                # message covering both sent operators looking at the data feed
+                # when the actual cause was a status string nobody had seen.
+                raise _fail(
+                    f"unexpected trading status={observed_status[:40]!r} for "
+                    f"{symbol} {trading_date}"
+                )
+            if official_close is None:
+                raise _fail(
+                    f"active rule has no official close for {symbol} {trading_date}"
+                )
             _require_price_tick(official_close, tick, symbol, trading_date)
+            if previous_close is not None and previous_close > 0:
+                move = abs(official_close - previous_close) / previous_close
+                if move > _CORPORATE_ACTION_GAP:
+                    price_gaps.append((symbol, trading_date, move))
+            previous_close = official_close
             final_bar = _final_bar_for_date(frame, trading_date)
             if final_bar is None:
-                raise _fail(f"active rule has no hourly bars for {symbol} {trading_date}")
+                # ``required_dates`` is the union across the universe, so this
+                # is one symbol's gap on a date its neighbours traded — which
+                # the engine already tolerates (50-bar minimum, common-index
+                # start, 80%-coverage bar filter). Failing the load here would
+                # reject universes that run today. Carry the observation
+                # ungated; the symbol's own bar dates below still get the full
+                # alignment check, so a wholesale contract break still trips.
+                unaligned.append((symbol, trading_date))
+                rules.append(
+                    DailyMarketRule(
+                        symbol=symbol,
+                        trading_date=trading_date,
+                        suspended=False,
+                        closing_limit_state=state,
+                        official_close_price=official_close,
+                        final_bar_timestamp=None,
+                    )
+                )
+                continue
             bar_close = _numeric_close(_bar_close(frame, final_bar), symbol, trading_date)
             if bar_close is not None:
                 _require_price_tick(bar_close, tick, symbol, trading_date)
@@ -308,4 +375,28 @@ def response_to_market_rules(
                     final_bar_timestamp=final_bar,
                 )
             )
+    if price_gaps:
+        sample = ", ".join(
+            f"{symbol} {trading_date} {move:.0%}"
+            for symbol, trading_date, move in price_gaps[:5]
+        )
+        print(
+            f"   ⚠️  {len(price_gaps)} overnight move(s) exceed every A-share "
+            f"daily limit band, which trading cannot produce — these prices are "
+            f"unadjusted, so a 除权除息 (ex-rights/ex-dividend) date will show in "
+            f"the equity curve and in the buy-and-hold baseline as a loss that "
+            f"did not happen: {sample}"
+            f"{' …' if len(price_gaps) > 5 else ''}"
+        )
+    if unaligned:
+        # Absent is not the same as broken: say so, or a run whose rules never
+        # gated anything looks exactly like one whose rules all held.
+        sample = ", ".join(
+            f"{symbol} {trading_date}" for symbol, trading_date in unaligned[:5]
+        )
+        print(
+            f"   ⚠️  {len(unaligned)} active symbol-date(s) have no hourly bars "
+            f"and cannot be closing-gated: {sample}"
+            f"{' …' if len(unaligned) > 5 else ''}"
+        )
     return MarketRuleCalendar(rules)

--- a/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
+++ b/dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py
@@ -16,6 +16,10 @@ import pytest
 from dashboard.backend.domain.backtesting import engine as engine_module
 from dashboard.backend.domain.backtesting.engine import HourlyBacktester
 from dashboard.backend.domain.backtesting.currency import CurrencyContext
+from dashboard.backend.domain.backtesting.market_rules import (
+    DailyMarketRule,
+    MarketRuleCalendar,
+)
 from dashboard.backend.infrastructure.llm import backtest_harness as llm_harness
 from dashboard.backend.infrastructure.market_data.profiles import (
     ALPACA,
@@ -44,6 +48,7 @@ class RecordingProvider:
         self.bars = bars
         self.calls = []
         self.fx_calls = []
+        self.rule_calls = []
 
     def fetch_bars(self, symbols, start, end):
         self.calls.append((symbols, start, end))
@@ -55,6 +60,35 @@ class RecordingProvider:
             datetime(2026, 3, 31).date(): 7.0,
             datetime(2026, 4, 15).date(): 7.1,
         }
+
+    def fetch_market_rules(self, symbols, start, end, *, bars_by_symbol):
+        self.rule_calls.append((symbols, start, end, bars_by_symbol))
+        rules = []
+        required_dates = sorted({
+            timestamp.date()
+            for frame in bars_by_symbol.values()
+            for timestamp in frame.index
+        })
+        for symbol in symbols:
+            frame = bars_by_symbol[symbol]
+            for trading_date in required_dates:
+                daily = frame[frame.index.date == trading_date]
+                if daily.empty:
+                    rules.append(DailyMarketRule(
+                        symbol=symbol,
+                        trading_date=trading_date,
+                        suspended=True,
+                    ))
+                    continue
+                final_bar = daily.index[-1].to_pydatetime()
+                rules.append(DailyMarketRule(
+                    symbol=symbol,
+                    trading_date=trading_date,
+                    suspended=False,
+                    official_close_price=daily.iloc[-1]["close"],
+                    final_bar_timestamp=final_bar,
+                ))
+        return MarketRuleCalendar(rules)
 
 
 class RecordingDB:
@@ -161,6 +195,56 @@ def test_order_event_serializer_converts_currency_and_preserves_fractional_reque
         "fx_rate": 7.0,
     }]
     json.dumps(serialized)
+
+
+def test_serializers_preserve_market_rule_audit_in_native_cny():
+    backtester = object.__new__(HourlyBacktester)
+    backtester.currency_context = CurrencyContext(
+        native_currency="CNY",
+        reporting_currency="USD",
+        timezone="Asia/Shanghai",
+        rates={datetime(2026, 4, 1).date(): 7.0},
+    )
+    timestamp = pd.Timestamp("2026-04-01T15:00:00", tz=CN)
+    audit = {
+        "market_rule_date": "2026-04-01",
+        "market_rule_suspended": False,
+        "market_rule_closing_limit_state": "upper",
+        "market_rule_official_close": 1_400.0,
+        "market_rule_closing_gate_effective": True,
+    }
+
+    trade = backtester._serialize_trades([{
+        "timestamp": timestamp,
+        "symbol": "600519.SH",
+        "side": "SELL",
+        "shares": 100,
+        "price": 1_400.0,
+        "proceeds": 140_000.0,
+        **audit,
+    }])[0]
+    event = backtester._serialize_order_events([{
+        "timestamp": timestamp,
+        "symbol": "600519.SH",
+        "side": "BUY",
+        "requested_shares": 100,
+        "executed_shares": 0,
+        "unfilled_shares": 100,
+        "price": 1_400.0,
+        "executed_value": 0,
+        "status": "rejected",
+        "reason": "limit_up_buy_blocked",
+        **audit,
+    }])[0]
+
+    for record in (trade, event):
+        assert record["market_rule_date"] == "2026-04-01"
+        assert record["market_rule_closing_limit_state"] == "upper"
+        assert record["market_rule_official_close"] == 1_400.0
+        assert record["market_rule_closing_gate_effective"] is True
+    assert trade["price"] == 200.0
+    assert event["price"] == 200.0
+    json.dumps([trade, event])
 
 
 def test_live_progress_keeps_bounded_order_event_tail(tmp_path):
@@ -369,7 +453,14 @@ def test_ifind_engine_uses_profile_symbols_in_explicit_rule_mode(monkeypatch):
         # An agent run executes through the cost path, so it did pay. The flag
         # separates the market's rule from this run's ledger — see the index
         # baseline, which carries the same profile with this set False.
-        "transaction_costs_applied": True,
+            "transaction_costs_applied": True,
+            "market_rule_profile": {
+                "enabled": True,
+                "source": "ifind_http",
+                "version": "ifind-ashare-closing-rules-v1",
+                "observations": 90,
+                "scope": "full_day_suspension_and_closing_limits",
+            },
         # No rejected_orders* keys at all: a clean run writes nothing rather
         # than an empty array on every A-share row.
     }
@@ -439,6 +530,13 @@ def test_ifind_engine_resolves_csi300_sample20_and_records_provenance(
         # Bare _run_metadata() is the provenance-only call the index baseline
         # makes; it advertises the market's cost rules without charging them.
         "transaction_costs_applied": False,
+        "market_rule_profile": {
+            "enabled": True,
+            "source": "ifind_http",
+            "version": "ifind-ashare-closing-rules-v1",
+            "observations": 300,
+            "scope": "full_day_suspension_and_closing_limits",
+        },
     }
 
 
@@ -753,9 +851,19 @@ def test_provider_without_fx_capability_is_named_not_blamed_on_credentials(monke
 
         def __init__(self, bars):
             self.bars = bars
+            self.rule_calls = []
 
         def fetch_bars(self, symbols, start, end):
             return {symbol: self.bars[symbol] for symbol in symbols}
+
+        def fetch_market_rules(self, symbols, start, end, *, bars_by_symbol):
+            return RecordingProvider.fetch_market_rules(
+                self,
+                symbols,
+                start,
+                end,
+                bars_by_symbol=bars_by_symbol,
+            )
 
     backtester = _ifind_backtester(monkeypatch, NoFxProvider(make_cn_bars()))
 
@@ -846,6 +954,24 @@ def test_agent_metadata_keeps_a_small_rejection_list_whole(monkeypatch):
     assert meta["rejected_orders"] == records
     assert meta["rejected_orders_count"] == 3
     assert "rejected_orders_truncated" not in meta
+
+
+def test_agent_metadata_counts_market_rule_rejections(monkeypatch):
+    records = [
+        {"reason": "suspended"},
+        {"reason": "suspended"},
+        {"reason": "limit_up_buy_blocked"},
+        {"reason": "limit_down_sell_blocked"},
+        {"reason": "t1_frozen"},
+    ]
+
+    meta = _metadata_stub(records, monkeypatch)
+
+    assert meta["market_rule_rejections"] == {
+        "suspended": 2,
+        "limit_up_buy_blocked": 1,
+        "limit_down_sell_blocked": 1,
+    }
 
 
 def test_agent_metadata_caps_the_sample_and_reports_the_true_total(monkeypatch):

--- a/dashboard/backend/tests/domain/backtesting/test_market_rules.py
+++ b/dashboard/backend/tests/domain/backtesting/test_market_rules.py
@@ -1,0 +1,129 @@
+"""Domain tests for immutable A-share market-rule observations."""
+
+from dataclasses import FrozenInstanceError
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from dashboard.backend.domain.backtesting.market_rules import (
+    ClosingLimitState,
+    DailyMarketRule,
+    MarketRuleCalendar,
+    MarketRuleDataError,
+)
+
+
+CN = ZoneInfo("Asia/Shanghai")
+DAY = date(2026, 7, 13)
+FINAL_BAR = datetime(2026, 7, 13, 15, 0, tzinfo=CN)
+
+
+def active_rule(state=ClosingLimitState.NONE):
+    return DailyMarketRule(
+        symbol="000725.sz",
+        trading_date=DAY,
+        suspended=False,
+        closing_limit_state=state,
+        official_close_price=Decimal("6.83"),
+        final_bar_timestamp=FINAL_BAR,
+    )
+
+
+def test_active_rule_is_normalized_immutable_and_auditable():
+    rule = active_rule(ClosingLimitState.LOWER)
+
+    assert rule.symbol == "000725.SZ"
+    assert rule.official_close_price == Decimal("6.83")
+    assert rule.to_audit(closing_gate_effective=True) == {
+        "market_rule_date": "2026-07-13",
+        "market_rule_suspended": False,
+        "market_rule_closing_limit_state": "lower",
+        "market_rule_official_close": 6.83,
+        "market_rule_closing_gate_effective": True,
+        "market_rule_source": "ifind_http",
+        "market_rule_version": "ifind-ashare-closing-rules-v1",
+    }
+    with pytest.raises(FrozenInstanceError):
+        rule.suspended = True
+
+
+def test_suspended_rule_carries_no_fake_price_or_bar():
+    rule = DailyMarketRule(
+        symbol="688981.SH",
+        trading_date=date(2025, 9, 1),
+        suspended=True,
+    )
+
+    assert rule.official_close_price is None
+    assert rule.final_bar_timestamp is None
+    assert rule.closing_limit_state is ClosingLimitState.NONE
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"official_close_price": 0}, "positive"),
+        ({"final_bar_timestamp": datetime(2026, 7, 13, 15)}, "timezone-aware"),
+        (
+            {"final_bar_timestamp": datetime(2026, 7, 14, 15, tzinfo=CN)},
+            "trading_date",
+        ),
+    ],
+)
+def test_active_rule_rejects_invalid_price_or_final_bar(kwargs, match):
+    values = {
+        "symbol": "000725.SZ",
+        "trading_date": DAY,
+        "suspended": False,
+        "official_close_price": Decimal("6.83"),
+        "final_bar_timestamp": FINAL_BAR,
+    }
+    values.update(kwargs)
+
+    with pytest.raises(ValueError, match=match):
+        DailyMarketRule(**values)
+
+
+def test_closing_gate_is_tick_safe_and_never_applies_to_earlier_bar():
+    rule = active_rule(ClosingLimitState.LOWER)
+
+    assert rule.closing_gate_effective(
+        timestamp=FINAL_BAR,
+        reference_price=6.8300000001,
+        price_tick=0.01,
+    )
+    assert not rule.closing_gate_effective(
+        timestamp=datetime(2026, 7, 13, 14, 0, tzinfo=CN),
+        reference_price=6.83,
+        price_tick=0.01,
+    )
+    assert not rule.closing_gate_effective(
+        timestamp=FINAL_BAR,
+        reference_price=6.84,
+        price_tick=0.01,
+    )
+
+
+def test_calendar_is_read_only_and_requires_exact_symbol_date():
+    rule = active_rule()
+    calendar = MarketRuleCalendar([rule])
+
+    assert calendar.rule_for("000725.sz", DAY) is rule
+    assert calendar.rule_for_timestamp("000725.SZ", FINAL_BAR) is rule
+    assert calendar.to_metadata() == {
+        "enabled": True,
+        "source": "ifind_http",
+        "version": "ifind-ashare-closing-rules-v1",
+        "observations": 1,
+        "scope": "full_day_suspension_and_closing_limits",
+    }
+    with pytest.raises(MarketRuleDataError, match="missing"):
+        calendar.rule_for("600519.SH", DAY)
+
+
+def test_calendar_rejects_duplicate_observation():
+    rule = active_rule()
+    with pytest.raises(MarketRuleDataError, match="duplicate"):
+        MarketRuleCalendar([rule, rule])

--- a/dashboard/backend/tests/domain/trading/test_execution.py
+++ b/dashboard/backend/tests/domain/trading/test_execution.py
@@ -6,7 +6,9 @@ Locks in the exact behavior of
 canonical package path; no external services are touched.
 """
 
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 import pytest
@@ -15,6 +17,10 @@ from dashboard.backend.domain.trading import execution as execution_module
 from dashboard.backend.domain.trading.execution import (
     calculate_transaction_costs,
     execute_actions,
+)
+from dashboard.backend.domain.backtesting.market_rules import (
+    ClosingLimitState,
+    DailyMarketRule,
 )
 from dashboard.backend.infrastructure.market_data.profiles import (
     ASHARE_TRANSACTION_COST_PROFILE,
@@ -52,7 +58,8 @@ def _run(actions, market_data, timestamp="t0", **state):
 
 
 def _run_ashare(actions, *, cash=100000, positions=None, available_positions=None,
-                frozen_lots=None, timestamp=None):
+                frozen_lots=None, timestamp=None, market_data=None,
+                market_rule=None, fallback_prices=None):
     timestamp = timestamp or datetime(2026, 4, 1, 10)
     positions = dict(positions or {})
     entry_prices = {
@@ -63,7 +70,9 @@ def _run_ashare(actions, *, cash=100000, positions=None, available_positions=Non
     rejected_orders = []
     new_cash = execute_actions(
         actions=actions,
-        market_data={"600519.SH": _row(100.0)},
+        market_data=(
+            {"600519.SH": _row(100.0)} if market_data is None else market_data
+        ),
         timestamp=timestamp,
         cash=cash,
         positions=positions,
@@ -76,6 +85,10 @@ def _run_ashare(actions, *, cash=100000, positions=None, available_positions=Non
         lot_size=100,
         order_events=order_events,
         transaction_cost_profile=ASHARE_TRANSACTION_COST_PROFILE,
+        market_rules=(
+            {"600519.SH": market_rule} if market_rule is not None else None
+        ),
+        fallback_prices=fallback_prices,
     )
     return {
         "cash": new_cash,
@@ -84,6 +97,108 @@ def _run_ashare(actions, *, cash=100000, positions=None, available_positions=Non
         "order_events": order_events,
         "rejected_orders": rejected_orders,
     }
+
+
+CN = ZoneInfo("Asia/Shanghai")
+
+
+def _market_rule(*, suspended=False, state=ClosingLimitState.NONE):
+    if suspended:
+        return DailyMarketRule(
+            symbol="600519.SH",
+            trading_date=date(2026, 4, 1),
+            suspended=True,
+        )
+    return DailyMarketRule(
+        symbol="600519.SH",
+        trading_date=date(2026, 4, 1),
+        suspended=False,
+        closing_limit_state=state,
+        official_close_price=Decimal("100.00"),
+        final_bar_timestamp=datetime(2026, 4, 1, 15, tzinfo=CN),
+    )
+
+
+@pytest.mark.parametrize("side", ["buy", "sell"])
+def test_suspension_rejects_both_sides_before_price_lot_or_t1_checks(side):
+    result = _run_ashare(
+        [{"symbol": "600519.SH", "action": side, "shares": 50}],
+        cash=100000,
+        positions={"600519.SH": 100},
+        available_positions={"600519.SH": 100},
+        timestamp=datetime(2026, 4, 1, 10, 30, tzinfo=CN),
+        market_data={},
+        market_rule=_market_rule(suspended=True),
+        fallback_prices={"600519.SH": 99.5},
+    )
+
+    assert result["cash"] == 100000
+    assert result["positions"] == {"600519.SH": 100}
+    assert result["trades"] == []
+    assert result["rejected_orders"][0]["reason"] == "suspended"
+    event = result["order_events"][0]
+    assert event["reason"] == "suspended"
+    assert event["price"] == 99.5
+    assert event["total_fees"] == 0
+    assert event["net_cash_impact"] == 0
+    assert event["market_rule_suspended"] is True
+
+
+def test_closing_upper_limit_blocks_buy_only_on_final_bar():
+    rule = _market_rule(state=ClosingLimitState.UPPER)
+    earlier = _run_ashare(
+        [{"symbol": "600519.SH", "action": "buy", "shares": 100}],
+        timestamp=datetime(2026, 4, 1, 14, tzinfo=CN),
+        market_rule=rule,
+    )
+    closing = _run_ashare(
+        [{"symbol": "600519.SH", "action": "buy", "shares": 100}],
+        timestamp=datetime(2026, 4, 1, 15, tzinfo=CN),
+        market_rule=rule,
+    )
+
+    assert earlier["positions"] == {"600519.SH": 100}
+    assert len(earlier["trades"]) == 1
+    assert closing["positions"] == {}
+    assert closing["cash"] == 100000
+    assert closing["trades"] == []
+    assert closing["order_events"][0]["reason"] == "limit_up_buy_blocked"
+    assert closing["order_events"][0]["market_rule_closing_gate_effective"] is True
+
+
+def test_closing_upper_limit_still_allows_sell():
+    result = _run_ashare(
+        [{"symbol": "600519.SH", "action": "sell", "shares": 100}],
+        positions={"600519.SH": 100},
+        available_positions={"600519.SH": 100},
+        timestamp=datetime(2026, 4, 1, 15, tzinfo=CN),
+        market_rule=_market_rule(state=ClosingLimitState.UPPER),
+    )
+
+    assert result["positions"] == {}
+    assert result["trades"][0]["side"] == "SELL"
+
+
+def test_closing_lower_limit_blocks_sell_but_allows_buy():
+    rule = _market_rule(state=ClosingLimitState.LOWER)
+    sell = _run_ashare(
+        [{"symbol": "600519.SH", "action": "sell", "shares": 100}],
+        positions={"600519.SH": 100},
+        available_positions={"600519.SH": 100},
+        timestamp=datetime(2026, 4, 1, 15, tzinfo=CN),
+        market_rule=rule,
+    )
+    buy = _run_ashare(
+        [{"symbol": "600519.SH", "action": "buy", "shares": 100}],
+        timestamp=datetime(2026, 4, 1, 15, tzinfo=CN),
+        market_rule=rule,
+    )
+
+    assert sell["positions"] == {"600519.SH": 100}
+    assert sell["cash"] == 100000
+    assert sell["order_events"][0]["reason"] == "limit_down_sell_blocked"
+    assert buy["positions"] == {"600519.SH": 100}
+    assert buy["trades"][0]["side"] == "BUY"
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/domain/trading/test_execution.py
+++ b/dashboard/backend/tests/domain/trading/test_execution.py
@@ -1298,3 +1298,31 @@ def test_sellable_positions_is_none_without_t_plus_one():
     pm = bha.PortfolioManager(100000)
     pm.available_positions = {"AAPL": 0}
     assert pm.sellable_positions is None
+
+
+def test_symbol_outside_the_rule_calendar_is_rejected_not_raised():
+    """A stray symbol must not trade ungated, and must not kill the run either.
+
+    Every producer filters to the allowed universe before it gets here, so this
+    is unreachable today. If one ever stops, raising would discard every bar
+    already simulated for a single action — and the rejection record is what
+    makes the gap visible instead of silent.
+    """
+    result = _run_ashare(
+        [{"symbol": "600520.SH", "action": "buy", "shares": 100}],
+        cash=100000,
+        timestamp=datetime(2026, 4, 1, 10, 30, tzinfo=CN),
+        market_data={"600519.SH": _row(100.0), "600520.SH": _row(50.0)},
+        market_rule=_market_rule(),
+    )
+
+    assert result["cash"] == 100000
+    assert result["positions"] == {}
+    assert result["trades"] == []
+    assert result["rejected_orders"][0]["reason"] == "market_rule_unavailable"
+    assert result["rejected_orders"][0]["symbol"] == "600520.SH"
+    event = result["order_events"][0]
+    assert event["status"] == "rejected"
+    assert event["reason"] == "market_rule_unavailable"
+    # No rule means no audit to attach; the row must not claim one.
+    assert "market_rule_date" not in event

--- a/dashboard/backend/tests/infrastructure/market_data/test_ifind_ashare.py
+++ b/dashboard/backend/tests/infrastructure/market_data/test_ifind_ashare.py
@@ -27,12 +27,24 @@ class SpyClient:
         self.payload = {"errorcode": 0, "tables": []} if payload is None else payload
         self.error = error
         self.calls = []
+        self.market_rule_calls = []
 
     def fetch_hourly_bars(self, symbols, start, end):
         self.calls.append((symbols, start, end))
         if self.error is not None:
             raise self.error
         return self.payload
+
+    def fetch_daily_market_rules(self, symbols, start, end):
+        self.market_rule_calls.append((symbols, start, end))
+        if self.error is not None:
+            raise self.error
+        return self.payload
+
+    def fetch_basic_market_status(self, symbols, trading_date):
+        raise AssertionError(
+            f"unexpected basic status call for {symbols!r} on {trading_date}"
+        )
 
 
 class SpyAdapter:
@@ -146,6 +158,48 @@ def test_fetches_historical_fx_for_the_same_registered_universe():
     assert result == {date(2026, 3, 31): 7.0}
     assert fx_provider.calls == [(A_SHARE_DEMO_6_SYMBOLS, START, END)]
     assert client.calls == []
+
+
+def test_fetches_daily_rules_once_and_passes_combined_clock_to_adapter():
+    from dashboard.backend.infrastructure.market_data.ifind_ashare import (
+        IFindAshareProvider,
+    )
+
+    payload = {"errorcode": 0, "tables": []}
+    client = SpyClient(payload)
+    expected = object()
+    adapter = SpyAdapter(expected)
+    provider = IFindAshareProvider(client=client, market_rule_adapter=adapter)
+    bars = {
+        A_SHARE_DEMO_6_SYMBOLS[0]: pd.DataFrame(
+            index=pd.DatetimeIndex(
+                [
+                    datetime(2026, 4, 1, 15, tzinfo=CN),
+                    datetime(2026, 4, 2, 15, tzinfo=CN),
+                ]
+            )
+        ),
+        A_SHARE_DEMO_6_SYMBOLS[1]: pd.DataFrame(
+            index=pd.DatetimeIndex([datetime(2026, 4, 2, 15, tzinfo=CN)])
+        ),
+    }
+
+    result = provider.fetch_market_rules(
+        A_SHARE_DEMO_6_SYMBOLS,
+        START,
+        END,
+        bars_by_symbol=bars,
+    )
+
+    assert result is expected
+    assert client.market_rule_calls == [(A_SHARE_DEMO_6_SYMBOLS, START, END)]
+    adapted_payload, kwargs = adapter.calls[0]
+    assert adapted_payload is payload
+    assert kwargs["expected_symbols"] == A_SHARE_DEMO_6_SYMBOLS
+    assert kwargs["required_dates"] == [date(2026, 4, 1), date(2026, 4, 2)]
+    assert kwargs["bars_by_symbol"] is bars
+    assert kwargs["fetch_basic_status"].__self__ is client
+    assert kwargs["price_tick"] == 0.01
 
 
 def test_fetches_selected_csi300_sample20_in_registered_order():

--- a/dashboard/backend/tests/infrastructure/market_data/test_ifind_client.py
+++ b/dashboard/backend/tests/infrastructure/market_data/test_ifind_client.py
@@ -84,7 +84,7 @@ def test_builds_official_hourly_request_with_exclusive_end():
         "endtime": "2026-04-22 15:00:00",
         "functionpara": {
             "Interval": "60",
-            "CPS": "forward1",
+            "CPS": "no",
             "Timeformat": "LocalTime",
             "Limitstart": "09:30:00",
             "Limitend": "15:00:00",
@@ -124,6 +124,57 @@ def test_builds_official_daily_close_request_with_exclusive_end(currency):
             "Currency": currency,
             "Fill": "Blank",
         },
+    }
+
+
+def test_builds_official_daily_market_rule_request_with_verified_indicators():
+    session = FakeSession([FakeResponse()])
+
+    result = make_client(session).fetch_daily_market_rules(
+        ["600519.SH", "601318.SH"], START, END
+    )
+
+    assert result == {"errorcode": 0, "tables": []}
+    url, kwargs = session.calls[0]
+    assert url == "https://ifind.test/api/v1/cmd_history_quotation"
+    assert kwargs["json"] == {
+        "codes": "600519.SH,601318.SH",
+        "indicators": (
+            "close,ths_trading_status_stock,ths_up_and_down_status_stock"
+        ),
+        "startdate": "2026-04-01",
+        "enddate": "2026-04-22",
+        "functionpara": {
+            "Interval": "D",
+            "CPS": "1",
+            "Currency": "RMB",
+            "Fill": "Blank",
+        },
+    }
+
+
+def test_builds_basic_status_supplement_request():
+    session = FakeSession([FakeResponse()])
+
+    result = make_client(session).fetch_basic_market_status(
+        ["688981.SH"], date(2025, 9, 1)
+    )
+
+    assert result == {"errorcode": 0, "tables": []}
+    url, kwargs = session.calls[0]
+    assert url == "https://ifind.test/api/v1/basic_data_service"
+    assert kwargs["json"] == {
+        "codes": "688981.SH",
+        "indipara": [
+            {
+                "indicator": "ths_trading_status_stock",
+                "indiparams": ["2025-09-01"],
+            },
+            {
+                "indicator": "ths_up_and_down_status_stock",
+                "indiparams": ["2025-09-01"],
+            },
+        ],
     }
 
 

--- a/dashboard/backend/tests/infrastructure/market_data/test_ifind_market_rules.py
+++ b/dashboard/backend/tests/infrastructure/market_data/test_ifind_market_rules.py
@@ -1,0 +1,279 @@
+"""Sanitized adapter tests for official iFinD A-share market rules."""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from dashboard.backend.domain.backtesting.market_rules import (
+    ClosingLimitState,
+    MarketRuleDataError,
+)
+from dashboard.backend.infrastructure.market_data.ifind_market_rules import (
+    response_to_market_rules,
+)
+
+
+CN = ZoneInfo("Asia/Shanghai")
+DAY_1 = date(2025, 8, 29)
+DAY_2 = date(2025, 9, 1)
+SYMBOLS = ("688981.SH", "600519.SH")
+
+
+def frame(rows):
+    return pd.DataFrame(
+        {"close": [price for _timestamp, price in rows]},
+        index=pd.DatetimeIndex(
+            [timestamp for timestamp, _price in rows],
+            name="timestamp",
+        ),
+    )
+
+
+def bars():
+    return {
+        "688981.SH": frame([
+            (datetime(2025, 8, 29, 14, tzinfo=CN), 102.0),
+            (datetime(2025, 8, 29, 15, tzinfo=CN), 101.5),
+        ]),
+        "600519.SH": frame([
+            (datetime(2025, 8, 29, 15, tzinfo=CN), 1480.0),
+            (datetime(2025, 9, 1, 14, tzinfo=CN), 1488.0),
+            (datetime(2025, 9, 1, 15, tzinfo=CN), 1490.0),
+        ]),
+    }
+
+
+def history_payload():
+    return {
+        "errorcode": 0,
+        "tables": [
+            {
+                "thscode": "688981.SH",
+                "time": ["2025-08-29", "2025-09-01"],
+                "table": {
+                    "close": [101.5, None],
+                    "ths_trading_status_stock": ["交易", None],
+                    "ths_up_and_down_status_stock": ["非涨跌停", None],
+                },
+            },
+            {
+                "thscode": "600519.SH",
+                "time": ["2025-08-29", "2025-09-01"],
+                "table": {
+                    "close": [1480.0, 1490.0],
+                    "ths_trading_status_stock": ["交易", "交易"],
+                    "ths_up_and_down_status_stock": ["非涨跌停", "涨停"],
+                },
+            },
+        ],
+    }
+
+
+def suspended_supplement(symbols, trading_date):
+    assert symbols == ("688981.SH",)
+    assert trading_date == DAY_2
+    return {
+        "errorcode": 0,
+        "tables": [
+            {
+                "thscode": "688981.SH",
+                "table": {
+                    "ths_trading_status_stock": [
+                        "Important announcement, suspended from 2025-09-01"
+                    ],
+                    "ths_up_and_down_status_stock": ["停牌"],
+                },
+            }
+        ],
+    }
+
+
+def adapt(payload=None, **kwargs):
+    return response_to_market_rules(
+        history_payload() if payload is None else payload,
+        expected_symbols=SYMBOLS,
+        required_dates=(DAY_1, DAY_2),
+        bars_by_symbol=bars(),
+        fetch_basic_status=suspended_supplement,
+        price_tick=0.01,
+        **kwargs,
+    )
+
+
+def test_normalizes_active_suspended_and_closing_limit_observations():
+    calendar = adapt()
+
+    normal = calendar.rule_for("688981.SH", DAY_1)
+    suspended = calendar.rule_for("688981.SH", DAY_2)
+    upper = calendar.rule_for("600519.SH", DAY_2)
+    assert not normal.suspended
+    assert normal.closing_limit_state is ClosingLimitState.NONE
+    assert suspended.suspended
+    assert suspended.official_close_price is None
+    assert upper.closing_limit_state is ClosingLimitState.UPPER
+    assert upper.official_close_price == 1490
+    assert upper.final_bar_timestamp == datetime(2025, 9, 1, 15, tzinfo=CN)
+
+
+def test_does_not_call_basic_supplement_when_history_is_complete():
+    payload = history_payload()
+    payload["tables"][0]["table"]["close"][1] = 103.0
+    payload["tables"][0]["table"]["ths_trading_status_stock"][1] = "交易"
+    payload["tables"][0]["table"]["ths_up_and_down_status_stock"][1] = "非涨跌停"
+    local_bars = bars()
+    local_bars["688981.SH"] = pd.concat([
+        local_bars["688981.SH"],
+        frame([(datetime(2025, 9, 1, 15, tzinfo=CN), 103.0)]),
+    ])
+
+    calendar = response_to_market_rules(
+        payload,
+        expected_symbols=SYMBOLS,
+        required_dates=(DAY_1, DAY_2),
+        bars_by_symbol=local_bars,
+        fetch_basic_status=lambda *_args: pytest.fail("unexpected supplement"),
+    )
+
+    assert len(calendar) == 4
+
+
+def test_supplements_blank_status_without_discarding_historical_close():
+    payload = history_payload()
+    payload["tables"][0]["table"]["close"][1] = 103.0
+    local_bars = bars()
+    local_bars["688981.SH"] = pd.concat([
+        local_bars["688981.SH"],
+        frame([(datetime(2025, 9, 1, 15, tzinfo=CN), 103.0)]),
+    ])
+
+    def active_supplement(symbols, trading_date):
+        assert symbols == ("688981.SH",)
+        assert trading_date == DAY_2
+        return {
+            "errorcode": 0,
+            "tables": [
+                {
+                    "thscode": "688981.SH",
+                    "table": {
+                        "ths_trading_status_stock": ["交易"],
+                        "ths_up_and_down_status_stock": ["非涨跌停"],
+                    },
+                }
+            ],
+        }
+
+    calendar = response_to_market_rules(
+        payload,
+        expected_symbols=SYMBOLS,
+        required_dates=(DAY_1, DAY_2),
+        bars_by_symbol=local_bars,
+        fetch_basic_status=active_supplement,
+    )
+
+    rule = calendar.rule_for("688981.SH", DAY_2)
+    assert not rule.suspended
+    assert rule.official_close_price == 103
+
+
+def test_supplements_only_the_blank_limit_status_field():
+    payload = history_payload()
+    payload["tables"][1]["table"]["ths_up_and_down_status_stock"][1] = None
+
+    def combined_supplement(symbols, trading_date):
+        assert symbols == ("688981.SH", "600519.SH")
+        assert trading_date == DAY_2
+        return {
+            "errorcode": 0,
+            "tables": [
+                {
+                    "thscode": "688981.SH",
+                    "table": {
+                        "ths_trading_status_stock": [
+                            "Important announcement, suspended from 2025-09-01"
+                        ],
+                        "ths_up_and_down_status_stock": ["停牌"],
+                    },
+                },
+                {
+                    "thscode": "600519.SH",
+                    "table": {
+                        "ths_trading_status_stock": ["交易"],
+                        "ths_up_and_down_status_stock": ["涨停"],
+                    },
+                }
+            ],
+        }
+
+    calendar = response_to_market_rules(
+        payload,
+        expected_symbols=SYMBOLS,
+        required_dates=(DAY_1, DAY_2),
+        bars_by_symbol=bars(),
+        fetch_basic_status=combined_supplement,
+    )
+
+    rule = calendar.rule_for("600519.SH", DAY_2)
+    assert rule.closing_limit_state is ClosingLimitState.UPPER
+    assert rule.official_close_price == 1490
+
+
+@pytest.mark.parametrize(
+    "mutate,match",
+    [
+        (
+            lambda payload: payload["tables"].pop(),
+            "missing symbols",
+        ),
+        (
+            lambda payload: payload["tables"][1]["table"].__setitem__(
+                "ths_up_and_down_status_stock", ["非涨跌停"]
+            ),
+            "lengths differ",
+        ),
+        (
+            lambda payload: payload["tables"][1]["table"][
+                "ths_up_and_down_status_stock"
+            ].__setitem__(1, "unknown"),
+            "unknown closing limit status",
+        ),
+        (
+            lambda payload: payload["tables"][1]["table"]["close"].__setitem__(
+                1, 1490.02
+            ),
+            "does not match",
+        ),
+        (
+            lambda payload: (
+                payload["tables"][1]["table"]["close"].__setitem__(1, 1490.004)
+            ),
+            "price tick",
+        ),
+    ],
+)
+def test_rejects_incomplete_or_misaligned_official_data(mutate, match):
+    payload = history_payload()
+    mutate(payload)
+
+    with pytest.raises(MarketRuleDataError, match=match):
+        adapt(payload)
+
+
+def test_rejects_supplement_that_does_not_explicitly_confirm_suspension():
+    def ambiguous_supplement(symbols, trading_date):
+        payload = suspended_supplement(symbols, trading_date)
+        payload["tables"][0]["table"] = {
+            "ths_trading_status_stock": [None],
+            "ths_up_and_down_status_stock": [None],
+        }
+        return payload
+
+    with pytest.raises(MarketRuleDataError, match="unknown closing limit status"):
+        response_to_market_rules(
+            history_payload(),
+            expected_symbols=SYMBOLS,
+            required_dates=(DAY_1, DAY_2),
+            bars_by_symbol=bars(),
+            fetch_basic_status=ambiguous_supplement,
+        )

--- a/dashboard/backend/tests/infrastructure/market_data/test_ifind_market_rules.py
+++ b/dashboard/backend/tests/infrastructure/market_data/test_ifind_market_rules.py
@@ -277,3 +277,158 @@ def test_rejects_supplement_that_does_not_explicitly_confirm_suspension():
             bars_by_symbol=bars(),
             fetch_basic_status=ambiguous_supplement,
         )
+
+
+def test_active_symbol_date_without_hourly_bars_is_kept_ungated():
+    """A symbol-date gap must not abort a run the loaders already tolerate.
+
+    ``required_dates`` is the union across the universe, so one symbol's short
+    or gappy hourly series drags in dates another symbol traded through. The
+    engine deliberately tolerates that — 50-bar minimum, common-index start,
+    80%-coverage bar filter — so failing the whole load here would reject
+    universes that run fine today. Without a bar there is nothing to align
+    against and nothing to execute, so the rule is recorded ungated.
+    """
+    payload = history_payload()
+    # 688981 traded on DAY_2 per the official feed, but its hourly series
+    # stops at DAY_1.
+    payload["tables"][0]["table"]["close"][1] = 103.0
+    payload["tables"][0]["table"]["ths_trading_status_stock"][1] = "交易"
+    payload["tables"][0]["table"]["ths_up_and_down_status_stock"][1] = "涨停"
+
+    calendar = response_to_market_rules(
+        payload,
+        expected_symbols=SYMBOLS,
+        required_dates=(DAY_1, DAY_2),
+        bars_by_symbol=bars(),
+        fetch_basic_status=lambda *_args: pytest.fail("unexpected supplement"),
+    )
+
+    unaligned = calendar.rule_for("688981.SH", DAY_2)
+    assert not unaligned.suspended
+    assert unaligned.official_close_price == 103
+    assert unaligned.final_bar_timestamp is None
+    # No bar means no closing gate can ever be proven, and no order can execute
+    # on a bar that does not exist.
+    assert not unaligned.closing_gate_effective(
+        timestamp=datetime(2025, 9, 1, 15, tzinfo=CN),
+        reference_price=103.0,
+        price_tick=0.01,
+    )
+    # The symbol's own bar dates keep the full alignment check.
+    assert calendar.rule_for("688981.SH", DAY_1).final_bar_timestamp == datetime(
+        2025, 8, 29, 15, tzinfo=CN
+    )
+
+
+def test_close_mismatch_still_fails_on_a_date_the_symbol_has_bars_for():
+    """The ungated escape hatch must not swallow a real contract break."""
+    payload = history_payload()
+    payload["tables"][1]["table"]["close"][1] = 1495.0
+
+    with pytest.raises(MarketRuleDataError, match="does not match final hourly bar"):
+        adapt(payload)
+
+
+def test_no_supplement_round_trip_when_the_row_already_proves_suspension():
+    """Suspension settles the row; the supplement cannot change the outcome.
+
+    The supplement is one blocking vendor call per date, and a suspended
+    security is exactly what leaves the other field blank — so the common case
+    was paying a sequential round trip for an answer already in hand.
+    """
+    payload = history_payload()
+    payload["tables"][0]["table"]["ths_trading_status_stock"][1] = "停牌"
+    payload["tables"][0]["table"]["ths_up_and_down_status_stock"][1] = None
+
+    calendar = response_to_market_rules(
+        payload,
+        expected_symbols=SYMBOLS,
+        required_dates=(DAY_1, DAY_2),
+        bars_by_symbol=bars(),
+        fetch_basic_status=lambda *_args: pytest.fail("unexpected supplement"),
+    )
+
+    assert calendar.rule_for("688981.SH", DAY_2).suspended
+
+
+def test_unrecognised_vendor_status_names_the_value_symbol_and_date():
+    """The gate stays keyed on exact strings, so the message has to diagnose.
+
+    'unknown closing limit status' alone cannot tell an operator whether iFinD
+    added a value, the account answered in English, or the field arrived blank.
+    """
+    payload = history_payload()
+    payload["tables"][1]["table"]["ths_up_and_down_status_stock"][1] = "未知状态"
+
+    with pytest.raises(MarketRuleDataError) as excinfo:
+        adapt(payload)
+
+    message = str(excinfo.value)
+    assert "unknown closing limit status" in message
+    assert "未知状态" in message
+    assert "600519.SH" in message
+    assert "2025-09-01" in message
+
+
+def test_unexpected_trading_status_is_reported_apart_from_a_missing_close():
+    payload = history_payload()
+    payload["tables"][1]["table"]["ths_trading_status_stock"][1] = "Trading"
+
+    with pytest.raises(MarketRuleDataError, match="unexpected trading status"):
+        adapt(payload)
+
+
+def test_unadjusted_ex_rights_gap_is_reported_not_swallowed(capsys):
+    """Unadjusted prices put corporate actions straight into the equity curve.
+
+    Both feeds are requested unadjusted so the audit can show the official close
+    a limit was set against, and nothing in the backend applies dividends or
+    splits. A 10-for-3 bonus issue therefore reads as a ~23% overnight loss in
+    the agent curve and the buy-and-hold baseline alike, with no offsetting cash
+    credit. This does not correct it — it stops it being invisible.
+    """
+    payload = history_payload()
+    payload["tables"][1]["table"]["close"][1] = 1140.00
+    local_bars = bars()
+    local_bars["600519.SH"] = frame([
+        (datetime(2025, 8, 29, 15, tzinfo=CN), 1480.0),
+        (datetime(2025, 9, 1, 14, tzinfo=CN), 1138.0),
+        (datetime(2025, 9, 1, 15, tzinfo=CN), 1140.0),
+    ])
+
+    response_to_market_rules(
+        payload,
+        expected_symbols=SYMBOLS,
+        required_dates=(DAY_1, DAY_2),
+        bars_by_symbol=local_bars,
+        fetch_basic_status=suspended_supplement,
+    )
+
+    warning = capsys.readouterr().out
+    assert "unadjusted" in warning
+    assert "600519.SH 2025-09-01" in warning
+
+
+def test_a_gap_across_a_suspension_is_not_reported_as_a_corporate_action():
+    """A halt legitimately lets the price gap when the security resumes."""
+    payload = history_payload()
+    payload["tables"][1]["table"]["ths_trading_status_stock"][0] = "停牌"
+    payload["tables"][1]["table"]["ths_up_and_down_status_stock"][0] = "停牌"
+    payload["tables"][1]["table"]["close"][0] = None
+    payload["tables"][1]["table"]["close"][1] = 1140.00
+    local_bars = bars()
+    local_bars["600519.SH"] = frame([
+        (datetime(2025, 9, 1, 14, tzinfo=CN), 1138.0),
+        (datetime(2025, 9, 1, 15, tzinfo=CN), 1140.0),
+    ])
+
+    calendar = response_to_market_rules(
+        payload,
+        expected_symbols=SYMBOLS,
+        required_dates=(DAY_1, DAY_2),
+        bars_by_symbol=local_bars,
+        fetch_basic_status=suspended_supplement,
+    )
+
+    assert calendar.rule_for("600519.SH", DAY_1).suspended

--- a/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
+++ b/dashboard/backend/tests/integration/test_ifind_ashare_backtest.py
@@ -57,16 +57,16 @@ def _official_payload(
 
     tables = []
     for offset, symbol in enumerate(symbols):
-        opens = [10.0 + offset + row * 0.1 for row in range(count)]
+        opens = [round(10.0 + offset + row * 0.1, 2) for row in range(count)]
         tables.append(
             {
                 "thscode": symbol,
                 "time": timestamps.copy(),
                 "table": {
                     "open": opens,
-                    "high": [value + 1.0 for value in opens],
-                    "low": [value - 1.0 for value in opens],
-                    "close": [value + 0.5 for value in opens],
+                    "high": [round(value + 1.0, 2) for value in opens],
+                    "low": [round(value - 1.0, 2) for value in opens],
+                    "close": [round(value + 0.5, 2) for value in opens],
                     "volume": [10_000 + row for row in range(count)],
                 },
             }
@@ -79,6 +79,7 @@ class _FakeIFindClient:
         self.payload = payload
         self.calls = []
         self.fx_calls = []
+        self.market_rule_calls = []
 
     def fetch_hourly_bars(self, symbols, start, end):
         self.calls.append((tuple(symbols), start, end))
@@ -98,6 +99,36 @@ class _FakeIFindClient:
                 }
             )
         return {"errorcode": 0, "errmsg": "", "tables": tables}
+
+    def fetch_daily_market_rules(self, symbols, start, end):
+        self.market_rule_calls.append((tuple(symbols), start, end))
+        hourly_by_symbol = {
+            item["thscode"]: item for item in self.payload["tables"]
+        }
+        tables = []
+        for symbol in symbols:
+            hourly = hourly_by_symbol[symbol]
+            closes_by_date = {}
+            for timestamp, close in zip(
+                hourly["time"], hourly["table"]["close"], strict=True
+            ):
+                closes_by_date[timestamp[:10]] = close
+            dates = list(closes_by_date)
+            tables.append(
+                {
+                    "thscode": symbol,
+                    "time": dates,
+                    "table": {
+                        "close": [closes_by_date[value] for value in dates],
+                        "ths_trading_status_stock": ["交易"] * len(dates),
+                        "ths_up_and_down_status_stock": ["非涨跌停"] * len(dates),
+                    },
+                }
+            )
+        return {"errorcode": 0, "errmsg": "", "tables": tables}
+
+    def fetch_basic_market_status(self, _symbols, _trading_date):
+        raise AssertionError("complete history must not require status supplements")
 
 
 class _CapturingThread:
@@ -490,6 +521,7 @@ def test_ifind_offline_response_reaches_engine_database_and_chart(
     backtest_hourly_agent.main()
 
     assert fake_client.calls == [(symbols, START, END)]
+    assert fake_client.market_rule_calls == [(symbols, START, END)]
     assert [call[3] for call in fake_client.fx_calls] == ["RMB", "MHB"]
     frames = observed["frames"]
     assert tuple(frames) == symbols
@@ -532,6 +564,13 @@ def test_ifind_offline_response_reaches_engine_database_and_chart(
         "native_initial_capital": 7_000.0,
         "transaction_cost_profile": ASHARE_TRANSACTION_COST_PROFILE.to_metadata(),
         "transaction_costs_applied": True,
+        "market_rule_profile": {
+            "enabled": True,
+            "source": "ifind_http",
+            "version": "ifind-ashare-closing-rules-v1",
+            "observations": len(symbols) * 15,
+            "scope": "full_day_suspension_and_closing_limits",
+        },
     }
     # A run with no fills writes no cost totals. The baseline may have initial
     # fills, so its totals are asserted separately below.

--- a/dashboard/backend/tests/test_backtests_router.py
+++ b/dashboard/backend/tests/test_backtests_router.py
@@ -391,6 +391,15 @@ def test_run_metadata_response_exposes_complete_ifind_profile():
                     "transfer_fee": 0.1,
                     "total_fees": 5.1,
                 },
+                "market_rule_profile": {
+                    "enabled": True,
+                    "source": "ifind_http",
+                    "version": "ifind-ashare-closing-rules-v1",
+                },
+                "market_rule_rejections": {
+                    "suspended": 2,
+                    "limit_up_buy_blocked": 1,
+                },
                 # The records themselves are deliberately NOT projected onto
                 # RunMetadata (it backs two list routes); only the scalars are.
                 "rejected_orders": [{
@@ -426,6 +435,8 @@ def test_run_metadata_response_exposes_complete_ifind_profile():
     assert response.lot_size == 100
     assert response.transaction_cost_profile["minimum_commission"] == 5.0
     assert response.transaction_cost_totals["total_fees"] == 5.1
+    assert response.market_rule_profile["enabled"] is True
+    assert response.market_rule_rejections["suspended"] == 2
     assert response.rejected_orders_count == 7200
     assert response.rejected_orders_truncated == 7000
     assert response.order_events_count == 7300
@@ -456,6 +467,8 @@ def test_run_metadata_response_keeps_new_fields_optional_for_legacy_runs():
     assert response.lot_size is None
     assert response.transaction_cost_profile is None
     assert response.transaction_cost_totals is None
+    assert response.market_rule_profile is None
+    assert response.market_rule_rejections is None
     # None, not 0: a legacy run predates the feature, it did not record zero
     # rejections. Same convention as t_plus_one_enabled above.
     assert response.rejected_orders_count is None

--- a/dashboard/backend/tests/test_baseline_generator_offline.py
+++ b/dashboard/backend/tests/test_baseline_generator_offline.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+from datetime import date
+from decimal import Decimal
 from zoneinfo import ZoneInfo
 
 from dashboard.backend import baseline_generator as baseline_module
 from dashboard.backend.baseline_generator import BaselineGenerator
+from dashboard.backend.domain.backtesting.market_rules import (
+    ClosingLimitState,
+    DailyMarketRule,
+    MarketRuleCalendar,
+)
 from dashboard.backend.infrastructure.market_data.alpaca_bars import (
     MarketDataUnavailableError,
 )
@@ -351,3 +358,61 @@ def test_us_baseline_is_untouched_by_the_lot_and_cost_plumbing():
     assert before == after
     # 100k over two names at 101/201 -> 495 and 248 whole shares, no top-up.
     assert before[0]["positions_value"] == pytest.approx(495 * 101 + 248 * 201)
+
+
+def test_a_share_baseline_retries_market_blocked_initial_buy_on_later_bar():
+    index = pd.DatetimeIndex(
+        [
+            "2026-04-01 15:00:00",
+            "2026-04-02 10:30:00",
+            "2026-04-02 15:00:00",
+        ],
+        tz=ZoneInfo("Asia/Shanghai"),
+        name="timestamp",
+    )
+    bars = {
+        "600519.SH": pd.DataFrame(
+            {"close": [10.0, 12.0, 13.0]},
+            index=index,
+        )
+    }
+    calendar = MarketRuleCalendar([
+        DailyMarketRule(
+            symbol="600519.SH",
+            trading_date=date(2026, 4, 1),
+            suspended=True,
+        ),
+        DailyMarketRule(
+            symbol="600519.SH",
+            trading_date=date(2026, 4, 2),
+            suspended=False,
+            closing_limit_state=ClosingLimitState.NONE,
+            official_close_price=Decimal("13.00"),
+            final_bar_timestamp=index[-1].to_pydatetime(),
+        ),
+    ])
+    summary = {}
+    totals = {}
+
+    curve = BaselineGenerator().generate_buyhold_baseline(
+        bars,
+        "2026-04-01",
+        "2026-04-02",
+        initial_capital=10_000,
+        symbols_to_buy=["600519.SH"],
+        market_timezone="Asia/Shanghai",
+        transaction_cost_profile=ASHARE_TRANSACTION_COST_PROFILE,
+        transaction_cost_totals=totals,
+        lot_size=100,
+        allocation_summary=summary,
+        market_rule_calendar=calendar,
+    )
+
+    assert curve[0]["cash"] == 10_000
+    assert curve[0]["positions_value"] == 0
+    assert curve[1]["cash"] < 10_000
+    assert curve[1]["positions_value"] > 0
+    assert summary["symbols_delayed"] == 1
+    assert summary["symbols_unfilled"] == 0
+    assert summary["symbols_bought"] == 1
+    assert totals["total_fees"] > 0

--- a/dashboard/backend/tests/test_baseline_generator_offline.py
+++ b/dashboard/backend/tests/test_baseline_generator_offline.py
@@ -416,3 +416,81 @@ def test_a_share_baseline_retries_market_blocked_initial_buy_on_later_bar():
     assert summary["symbols_unfilled"] == 0
     assert summary["symbols_bought"] == 1
     assert totals["total_fees"] > 0
+
+
+def test_a_share_baseline_holds_a_blocked_symbols_slice_for_its_retry():
+    """A blocked name's slice must survive the top-up sweep of its neighbours.
+
+    The sweep exists to place cash whole lots stranded, and it is blind to why
+    a symbol is absent from the price map. Left alone it spends the suspended
+    name's slice on the tradable one at the open, so the retry finds no cash,
+    and the equal-weight benchmark every agent is scored against silently
+    becomes a single-name position.
+    """
+    index = pd.DatetimeIndex(
+        [
+            "2026-04-01 15:00:00",
+            "2026-04-02 10:30:00",
+            "2026-04-02 15:00:00",
+        ],
+        tz=ZoneInfo("Asia/Shanghai"),
+        name="timestamp",
+    )
+    bars = {
+        "600519.SH": pd.DataFrame({"close": [10.0, 10.0, 10.0]}, index=index),
+        "600520.SH": pd.DataFrame({"close": [10.0, 10.0, 10.0]}, index=index),
+    }
+    rules = [
+        # 600519 is suspended for the whole opening day, so its slice can only
+        # be placed on a later bar.
+        DailyMarketRule(
+            symbol="600519.SH",
+            trading_date=date(2026, 4, 1),
+            suspended=True,
+        ),
+    ]
+    for symbol in ("600519.SH", "600520.SH"):
+        rules.append(
+            DailyMarketRule(
+                symbol=symbol,
+                trading_date=date(2026, 4, 2),
+                suspended=False,
+                closing_limit_state=ClosingLimitState.NONE,
+                official_close_price=Decimal("10.00"),
+                final_bar_timestamp=index[-1].to_pydatetime(),
+            )
+        )
+    rules.append(
+        DailyMarketRule(
+            symbol="600520.SH",
+            trading_date=date(2026, 4, 1),
+            suspended=False,
+            closing_limit_state=ClosingLimitState.NONE,
+            official_close_price=Decimal("10.00"),
+            final_bar_timestamp=index[0].to_pydatetime(),
+        )
+    )
+    summary = {}
+
+    curve = BaselineGenerator().generate_buyhold_baseline(
+        bars,
+        "2026-04-01",
+        "2026-04-02",
+        initial_capital=100_000,
+        symbols_to_buy=["600519.SH", "600520.SH"],
+        market_timezone="Asia/Shanghai",
+        transaction_cost_profile=ASHARE_TRANSACTION_COST_PROFILE,
+        lot_size=100,
+        allocation_summary=summary,
+        market_rule_calendar=MarketRuleCalendar(rules),
+    )
+
+    # The tradable name takes its own ¥50k slice and no more; the rest is held
+    # for the suspended name rather than swept into a second sleeve.
+    assert curve[0]["cash"] == pytest.approx(50_000, abs=1_500)
+    assert curve[0]["positions_value"] == pytest.approx(49_000, abs=1_500)
+    # Which is what lets the retry actually fill on the next day's bar.
+    assert summary["symbols_delayed"] == 1
+    assert summary["symbols_unfilled"] == 0
+    assert summary["symbols_bought"] == 2
+    assert curve[-1]["positions_value"] == pytest.approx(98_000, abs=3_000)

--- a/dashboard/backend/tests/test_currency_audit_database.py
+++ b/dashboard/backend/tests/test_currency_audit_database.py
@@ -77,6 +77,11 @@ def test_currency_audit_fields_round_trip_and_usd_rows_remain_nullable(tmp_path)
                 "native_total_fees": 0.77,
                 "native_net_cash_impact": -1_400.77,
                 "fx_rate": 7.0,
+                "market_rule_date": "2026-04-01",
+                "market_rule_suspended": False,
+                "market_rule_closing_limit_state": "upper",
+                "market_rule_official_close": 1_399.0,
+                "market_rule_closing_gate_effective": True,
             }
         ],
     )
@@ -98,6 +103,11 @@ def test_currency_audit_fields_round_trip_and_usd_rows_remain_nullable(tmp_path)
     assert trade["native_total_fees"] == 0.77
     assert trade["native_net_cash_impact"] == -1_400.77
     assert trade["fx_rate"] == 7.0
+    assert trade["market_rule_date"] == "2026-04-01"
+    assert trade["market_rule_suspended"] == 0
+    assert trade["market_rule_closing_limit_state"] == "upper"
+    assert trade["market_rule_official_close"] == 1_399.0
+    assert trade["market_rule_closing_gate_effective"] == 1
 
 
 def test_existing_schema_is_idempotently_migrated_with_nullable_audit_fields(tmp_path):
@@ -160,4 +170,9 @@ def test_existing_schema_is_idempotently_migrated_with_nullable_audit_fields(tmp
         "native_total_fees",
         "native_net_cash_impact",
         "fx_rate",
+        "market_rule_date",
+        "market_rule_suspended",
+        "market_rule_closing_limit_state",
+        "market_rule_official_close",
+        "market_rule_closing_gate_effective",
     } <= trade_columns

--- a/dashboard/backend/tests/test_database_lazy_migrations.py
+++ b/dashboard/backend/tests/test_database_lazy_migrations.py
@@ -77,6 +77,11 @@ _CURRENCY_TRADE_COLUMNS = {
     "native_total_fees": ("REAL", 0, None),
     "native_net_cash_impact": ("REAL", 0, None),
     "fx_rate": ("REAL", 0, None),
+    "market_rule_date": ("TEXT", 0, None),
+    "market_rule_suspended": ("INTEGER", 0, None),
+    "market_rule_closing_limit_state": ("TEXT", 0, None),
+    "market_rule_official_close": ("REAL", 0, None),
+    "market_rule_closing_gate_effective": ("INTEGER", 0, None),
 }
 
 # The one place the ALTER path cannot reproduce CREATE TABLE, and why.

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -179,5 +179,5 @@ def test_slow_boot_notice_is_wired():
 
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
-    assert "app.js?v=77" in APP_HTML
+    assert "app.js?v=78" in APP_HTML
     assert "styles.css?v=87" in APP_HTML

--- a/dashboard/backend/tests/test_ifind_ashare_frontend.py
+++ b/dashboard/backend/tests/test_ifind_ashare_frontend.py
@@ -279,6 +279,23 @@ def test_running_and_historical_results_show_ifind_provenance(js, css):
     assert re.search(r"run\.data_source\s*===\s*['\"]ifind_ashare['\"]", js)
 
 
+def test_historical_run_config_reads_delay_summary_from_linked_buyhold(js):
+    assert re.search(
+        r"function\s+renderBacktestRunConfig\([^)]*baselineRun\s*=\s*null",
+        js,
+        re.S,
+    )
+    assert re.search(
+        r"baselineAllocation\s*=\s*baselineMetadata\.baseline_allocation",
+        js,
+    )
+    assert re.search(
+        r"resolveBaselinesForRun\(selectedRun,\s*sessionRuns\)",
+        js,
+    )
+    assert re.search(r"baselineRun:\s*selectedBuyholdRun", js)
+
+
 def test_ifind_chart_does_not_render_us_index_series(js):
     assert re.search(r"filterIfindChartSeries\s*\(", js)
     assert "DJIA index" in js

--- a/dashboard/backend/tests/test_trading_log_order_events_ui.py
+++ b/dashboard/backend/tests/test_trading_log_order_events_ui.py
@@ -343,3 +343,29 @@ def test_repeated_rejection_reports_how_many_times_it_fired():
 
     assert "Insufficient cash for one lot" in result
     assert "×47 that day" in result
+
+
+def test_ordinary_a_share_fill_carries_no_market_rule_audit_line():
+    """The audit line is for rows a rule spoke to, not every A-share order.
+
+    Every order on a rule-aware run carries the same audit payload, so keying
+    the line on "an official close is present" prints a date-and-price row under
+    every fill and buries the handful that were actually suspended or gated.
+    """
+    source = _APP_JS.read_text(encoding="utf-8")
+    result = _run_node(_render_harness(source) + [
+        "renderTradingLog([{",
+        "  timestamp: '2026-04-01T15:00:00+08:00', symbol: '600519.SH', side: 'BUY',",
+        "  requested_shares: 100, executed_shares: 100, price: 13,",
+        "  status: 'filled', reason: '',",
+        "  market_rule_date: '2026-04-01', market_rule_suspended: false,",
+        "  market_rule_closing_limit_state: 'none',",
+        "  market_rule_official_close: 13,",
+        "  market_rule_closing_gate_effective: false,",
+        "}]);",
+        "console.log(JSON.stringify(tbody.innerHTML));",
+    ])
+
+    assert "¥13.00" not in result
+    assert "Official close" not in result
+    assert "Official status" not in result

--- a/dashboard/backend/tests/test_trading_log_order_events_ui.py
+++ b/dashboard/backend/tests/test_trading_log_order_events_ui.py
@@ -166,6 +166,7 @@ def _render_harness(source: str):
         _extract_function(source, "normalizeOrderRecord"),
         _extract_function(source, "formatTradingMoney"),
         _extract_function(source, "renderOrderCostAudit"),
+        _extract_function(source, "renderMarketRuleAudit"),
         _extract_function(source, "formatTradeTimestamp"),
         _extract_function(source, "paintTradingLog"),
         _extract_function(source, "renderTradingLog"),
@@ -196,6 +197,27 @@ def test_rendered_rejection_has_safe_reason_zero_fill_and_english_company():
     assert ">--<" in known
     assert "<img" not in result["unknown"]
     assert "Order not executed" in result["unknown"]
+
+
+def test_rendered_market_rule_rejection_has_english_reason_and_native_close():
+    source = _APP_JS.read_text(encoding="utf-8")
+    result = _run_node(_render_harness(source) + [
+        "renderTradingLog([{",
+        "  timestamp: '2026-04-01T15:00:00+08:00', symbol: '600519.SH', side: 'BUY',",
+        "  requested_shares: 100, executed_shares: 0, price: 200,",
+        "  status: 'rejected', reason: 'limit_up_buy_blocked',",
+        "  market_rule_date: '2026-04-01', market_rule_suspended: false,",
+        "  market_rule_closing_limit_state: 'upper',",
+        "  market_rule_official_close: 1400,",
+        "  market_rule_closing_gate_effective: true,",
+        "}]);",
+        "console.log(JSON.stringify(tbody.innerHTML));",
+    ])
+
+    assert "Buy blocked at upper limit" in result
+    assert "Official close: upper limit" in result
+    assert "¥1400.00" in result
+    assert "2026-04-01" in result
 
 
 def test_rendered_partial_uses_actual_value_and_side_filter():

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1772,7 +1772,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=27" defer></script>
-    <script src="app.js?v=77" defer></script>
+    <script src="app.js?v=78" defer></script>
     <script src="js/leaderboard.js?v=19" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1145,6 +1145,18 @@
                         <dt>Total costs</dt>
                         <dd id="backtestConfigTotalCosts">—</dd>
                     </div>
+                    <div class="backtest-config-row" id="backtestConfigMarketRulesRow" hidden>
+                        <dt>A-share market rules</dt>
+                        <dd id="backtestConfigMarketRules">—</dd>
+                    </div>
+                    <div class="backtest-config-row" id="backtestConfigRuleRejectionsRow" hidden>
+                        <dt>Rule rejections</dt>
+                        <dd id="backtestConfigRuleRejections">—</dd>
+                    </div>
+                    <div class="backtest-config-row" id="backtestConfigBaselineRulesRow" hidden>
+                        <dt>Baseline rule delays</dt>
+                        <dd id="backtestConfigBaselineRules">—</dd>
+                    </div>
                     <div class="backtest-config-row">
                         <dt>Market data</dt>
                         <dd id="backtestConfigMarketData">—</dd>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -6203,6 +6203,7 @@ function formatOrderExecutionReason(reason, strategyReason = '') {
         suspended: 'Suspended',
         limit_up_buy_blocked: 'Buy blocked at upper limit',
         limit_down_sell_blocked: 'Sell blocked at lower limit',
+        market_rule_unavailable: 'No market rule for this symbol',
     };
     const code = String(reason || '').trim();
     if (labels[code]) return labels[code];
@@ -6282,6 +6283,10 @@ function normalizeOrderRecord(record) {
     };
 }
 
+// Only rows a rule actually spoke to. An ordinary fill on an ordinary day
+// carries the same audit payload as a blocked one, so rendering whenever the
+// official close is present puts a date-and-price line under every single
+// A-share order and buries the handful that mean something.
 function renderMarketRuleAudit(order) {
     if (!order.marketRuleDate) return '';
     const details = [];
@@ -6292,10 +6297,10 @@ function renderMarketRuleAudit(order) {
         const side = order.marketRuleClosingLimitState === 'upper' ? 'upper' : 'lower';
         details.push(`Official close: ${side} limit`);
     }
+    if (!details.length) return '';
     if (Number.isFinite(order.marketRuleOfficialClose)) {
         details.push(`¥${order.marketRuleOfficialClose.toFixed(2)}`);
     }
-    if (!details.length) return '';
     return `<div class="trading-log-native">${escapeHtml(order.marketRuleDate)} · ${escapeHtml(details.join(' · '))}</div>`;
 }
 
@@ -6727,6 +6732,7 @@ function renderBacktestRunConfig(
         suspended: 'Suspended',
         limit_up_buy_blocked: 'Upper-limit buys',
         limit_down_sell_blocked: 'Lower-limit sells',
+        market_rule_unavailable: 'Missing rule',
     };
     const ruleRejectionParts = Object.entries(marketRuleRejections || {})
         .filter(([, count]) => Number(count) > 0)

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -6574,7 +6574,12 @@ function formatTransactionCostTotals(totals) {
 
 function renderBacktestRunConfig(
     run,
-    { running = false, launchConfig = null, statusLabel = null } = {},
+    {
+        running = false,
+        launchConfig = null,
+        statusLabel = null,
+        baselineRun = null,
+    } = {},
 ) {
     const empty = document.getElementById('backtestConfigEmpty');
     const list = document.getElementById('backtestConfigList');
@@ -6614,7 +6619,13 @@ function renderBacktestRunConfig(
         ?? run?.market_rule_profile;
     const marketRuleRejections = metadata.market_rule_rejections
         ?? run?.market_rule_rejections;
-    const baselineAllocation = metadata.baseline_allocation
+    const baselineMetadata = baselineRun?.metadata
+        && typeof baselineRun.metadata === 'object'
+        ? baselineRun.metadata
+        : {};
+    const baselineAllocation = baselineMetadata.baseline_allocation
+        ?? baselineRun?.baseline_allocation
+        ?? metadata.baseline_allocation
         ?? run?.baseline_allocation;
     // Absent (older runs) reads as applied; only an explicit false marks a
     // curve that carries the market's cost rules without ever paying them.
@@ -8105,9 +8116,14 @@ async function loadData() {
             }
 
             localStorage.setItem(SELECTED_BACKTEST_RUN_KEY, selectedRun.run_id);
+            const baselineIds = resolveBaselinesForRun(selectedRun, sessionRuns);
+            const selectedBuyholdRun = sessionRuns.find(
+                run => run.run_id === baselineIds.buyhold,
+            ) || null;
             renderBacktestRunConfig(selectedRun, {
                 running: false,
                 launchConfig: getBacktestLaunchConfig(selectedRun.run_id),
+                baselineRun: selectedBuyholdRun,
             });
 
             const chartUrl = `${API_BASE}/api/backtest/${encodeURIComponent(selectedRun.run_id)}/chart-data?t=${Date.now()}`;

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -6200,6 +6200,9 @@ function formatOrderExecutionReason(reason, strategyReason = '') {
         insufficient_cash: 'Insufficient cash',
         t1_frozen: 'T+1 frozen',
         insufficient_position: 'Insufficient position',
+        suspended: 'Suspended',
+        limit_up_buy_blocked: 'Buy blocked at upper limit',
+        limit_down_sell_blocked: 'Sell blocked at lower limit',
     };
     const code = String(reason || '').trim();
     if (labels[code]) return labels[code];
@@ -6268,7 +6271,32 @@ function normalizeOrderRecord(record) {
         nativeTransferFee: optionalNumber(record?.native_transfer_fee),
         nativeTotalFees: optionalNumber(record?.native_total_fees),
         nativeNetCashImpact: optionalNumber(record?.native_net_cash_impact),
+        marketRuleDate: record?.market_rule_date || null,
+        marketRuleSuspended: record?.market_rule_suspended === true
+            || record?.market_rule_suspended === 1,
+        marketRuleClosingLimitState: record?.market_rule_closing_limit_state || null,
+        marketRuleOfficialClose: optionalNumber(record?.market_rule_official_close),
+        marketRuleClosingGateEffective:
+            record?.market_rule_closing_gate_effective === true
+            || record?.market_rule_closing_gate_effective === 1,
     };
+}
+
+function renderMarketRuleAudit(order) {
+    if (!order.marketRuleDate) return '';
+    const details = [];
+    if (order.marketRuleSuspended) {
+        details.push('Official status: suspended');
+    } else if (order.marketRuleClosingLimitState
+        && order.marketRuleClosingLimitState !== 'none') {
+        const side = order.marketRuleClosingLimitState === 'upper' ? 'upper' : 'lower';
+        details.push(`Official close: ${side} limit`);
+    }
+    if (Number.isFinite(order.marketRuleOfficialClose)) {
+        details.push(`¥${order.marketRuleOfficialClose.toFixed(2)}`);
+    }
+    if (!details.length) return '';
+    return `<div class="trading-log-native">${escapeHtml(order.marketRuleDate)} · ${escapeHtml(details.join(' · '))}</div>`;
 }
 
 function formatTradingMoney(value, symbol) {
@@ -6373,6 +6401,7 @@ function paintTradingLog(normalizedRecords, options) {
         const assetName = resolveTradingAssetName(order.symbol);
         const quantity = `${order.executedShares.toLocaleString('en-US')} / ${order.requestedShares.toLocaleString('en-US')} shares`;
         const reason = formatOrderExecutionReason(order.reason, order.strategyReason);
+        const marketRuleAudit = renderMarketRuleAudit(order);
         // A rejection the agent re-issued on every bar of a day is stored once,
         // with its tally. Showing the tally is the difference between "this
         // blocked one order" and "this blocked the strategy all day".
@@ -6387,7 +6416,7 @@ function paintTradingLog(normalizedRecords, options) {
             <td>$${order.price.toFixed(2)}${priceAudit}</td>
             <td class="trading-log-value">${order.executedShares > 0 ? `${formatTradingMoney(order.value, '$')}${valueAudit}${costAudit}` : '--'}</td>
             <td><span class="order-status order-status-${order.status}" title="Order status: ${statusLabel}" aria-label="Order status: ${statusLabel}">${statusLabel}</span></td>
-            <td class="trading-log-reason">${escapeHtml(reason)}${repeatNote}</td>
+            <td class="trading-log-reason">${escapeHtml(reason)}${marketRuleAudit}${repeatNote}</td>
         </tr>`;
     }).join('');
 
@@ -6581,6 +6610,12 @@ function renderBacktestRunConfig(
         ?? run?.transaction_cost_profile;
     const transactionCostTotals = metadata.transaction_cost_totals
         ?? run?.transaction_cost_totals;
+    const marketRuleProfile = metadata.market_rule_profile
+        ?? run?.market_rule_profile;
+    const marketRuleRejections = metadata.market_rule_rejections
+        ?? run?.market_rule_rejections;
+    const baselineAllocation = metadata.baseline_allocation
+        ?? run?.baseline_allocation;
     // Absent (older runs) reads as applied; only an explicit false marks a
     // curve that carries the market's cost rules without ever paying them.
     const transactionCostsApplied = (metadata.transaction_costs_applied
@@ -6669,6 +6704,36 @@ function renderBacktestRunConfig(
             transactionCostsApplied
                 ? formatTransactionCostTotals(transactionCostTotals)
                 : 'Not applicable — reference price curve',
+        );
+    }
+    const showMarketRules = marketRuleProfile?.enabled === true;
+    const marketRulesRow = document.getElementById('backtestConfigMarketRulesRow');
+    if (marketRulesRow) marketRulesRow.hidden = !showMarketRules;
+    if (showMarketRules) {
+        setBacktestConfigText('backtestConfigMarketRules', 'Enabled');
+    }
+    const rejectionLabels = {
+        suspended: 'Suspended',
+        limit_up_buy_blocked: 'Upper-limit buys',
+        limit_down_sell_blocked: 'Lower-limit sells',
+    };
+    const ruleRejectionParts = Object.entries(marketRuleRejections || {})
+        .filter(([, count]) => Number(count) > 0)
+        .map(([reason, count]) => `${rejectionLabels[reason] || reason} ${Number(count)}`);
+    const ruleRejectionsRow = document.getElementById('backtestConfigRuleRejectionsRow');
+    if (ruleRejectionsRow) ruleRejectionsRow.hidden = ruleRejectionParts.length === 0;
+    if (ruleRejectionParts.length) {
+        setBacktestConfigText('backtestConfigRuleRejections', ruleRejectionParts.join(' · '));
+    }
+    const delayed = Number(baselineAllocation?.symbols_delayed || 0);
+    const unfilled = Number(baselineAllocation?.symbols_unfilled || 0);
+    const showBaselineRules = delayed > 0 || unfilled > 0;
+    const baselineRulesRow = document.getElementById('backtestConfigBaselineRulesRow');
+    if (baselineRulesRow) baselineRulesRow.hidden = !showBaselineRules;
+    if (showBaselineRules) {
+        setBacktestConfigText(
+            'backtestConfigBaselineRules',
+            `Delayed ${delayed} · Unfilled ${unfilled}`,
         );
     }
     setBacktestConfigText('backtestConfigUniverse', universe);

--- a/docs/superpowers/plans/2026-08-12-ashare-market-rules.md
+++ b/docs/superpowers/plans/2026-08-12-ashare-market-rules.md
@@ -1,0 +1,222 @@
+# A-Share Daily Market Rules Implementation Plan
+
+**Date:** 2026-08-12  
+**Branch:** `feat/ashare-market-rules`  
+**Base:** latest `origin/main` at implementation start  
+**Design:** `docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md`
+
+## Objective
+
+Enforce official iFinD full-day suspension and daily upper/lower price-limit data in
+ATL's A-share historical backtests. Apply the same rule contract to Agent orders and the
+buy-and-hold baseline without changing Alpaca or vn.py behavior. Keep the platform
+simulation-only and keep every credential and unsanitized production response out of
+Git.
+
+## Guardrails
+
+- Do not infer suspension or limit prices from OHLCV.
+- Do not hard-code an unverified iFinD indicator or response field.
+- Fail an A-share run before execution when rule data is unavailable or incomplete.
+- Keep all repository and GitHub text in English.
+- Do not log request headers, tokens, account details, or raw production payloads.
+- Do not commit `.env`, database, response capture, or temporary fixture files.
+- Preserve current A-share lot-size, T+1, FX, and transaction-cost behavior.
+- Preserve all Alpaca and vn.py execution behavior and response shapes.
+
+## Task 1: Verify the Official iFinD Rule Command
+
+**Read/inspect:**
+
+- iFinD SuperCommand indicator generator or an authorized generated HTTP command
+- `dashboard/backend/infrastructure/market_data/ifind_client.py`
+- `dashboard/backend/tests/infrastructure/market_data/test_ifind_client.py`
+
+**Steps:**
+
+1. Generate or inspect the official command for daily suspension status, upper-limit
+   price, and lower-limit price.
+2. Run the narrowest authorized request for one registered A-share and a short historical
+   date window.
+3. Record only a sanitized structural summary: endpoint category, request field names,
+   top-level response keys, table keys, indicator keys, value types, and row counts.
+4. Confirm how full-day suspension is represented and whether prices/status share one
+   endpoint or require separate official requests.
+5. Keep the raw response outside the repository and delete temporary captures after the
+   fixture shape is encoded.
+
+**Stop condition:** No implementation proceeds until all vendor-specific names and value
+encodings are verified. If the account lacks a required field permission, report the
+permission failure and do not substitute inferred rules.
+
+## Task 2: Add the Daily Rule Domain Contract and Adapter
+
+**Create:**
+
+- `dashboard/backend/domain/backtesting/market_rules.py`
+- `dashboard/backend/infrastructure/market_data/ifind_market_rules.py`
+- `dashboard/backend/tests/infrastructure/market_data/test_ifind_market_rules.py`
+- `dashboard/backend/tests/domain/backtesting/test_market_rules.py`
+
+**Modify:**
+
+- `dashboard/backend/infrastructure/market_data/ifind_client.py`
+- `dashboard/backend/infrastructure/market_data/ifind_ashare.py`
+- corresponding client/provider tests
+
+**Steps:**
+
+1. Write failing tests for immutable `DailyMarketRule` and `MarketRuleCalendar` lookup.
+2. Write sanitized fixture tests for normal, suspended, malformed, duplicate,
+   missing-symbol, and missing-date responses.
+3. Implement the verified iFinD client request without exposing vendor fields outside the
+   adapter.
+4. Normalize official values into native-CNY decimals and explicit booleans.
+5. Validate coverage against every registered symbol and every combined-clock market
+   date.
+6. Raise a dedicated sanitized `MarketRuleDataError` for transport, permission, schema,
+   or coverage failures.
+
+**Verification:** Run the new client, adapter, provider, and domain test modules plus
+`git diff --check`.
+
+**Commit:** `feat(market-data): load official A-share daily rules`
+
+## Task 3: Enforce Rules in Shared Order Execution
+
+**Modify:**
+
+- `dashboard/backend/domain/trading/execution.py`
+- `dashboard/backend/domain/backtesting/portfolio_manager.py`
+- `dashboard/backend/domain/backtesting/engine.py`
+- `dashboard/backend/tests/domain/trading/test_execution.py`
+- `dashboard/backend/tests/backtesting/test_ifind_ashare_engine.py`
+
+**Steps:**
+
+1. Add failing tests for suspended BUY/SELL, upper-limit BUY, lower-limit SELL, and
+   permitted opposite directions.
+2. Pass the daily rule from engine to portfolio manager and shared executor only for the
+   iFinD A-share profile.
+3. Run market-rule gates before lot-size, T+1, cash, and cost checks.
+4. Use tick-safe native-CNY decimal comparison against the reference execution price.
+5. Emit `suspended`, `limit_up_buy_blocked`, or `limit_down_sell_blocked` with zero
+   execution, zero fees, and complete rule audit fields.
+6. Aggregate the three Agent rejection counts in run metadata.
+7. Add Alpaca/vn.py characterization tests proving no market-rule gate leaks into their
+   paths.
+
+**Verification:** Run execution, portfolio, engine, and A-share integration tests.
+
+**Commit:** `feat(backtest): enforce A-share suspension and price limits`
+
+## Task 4: Apply the Same Rules to Buy-and-Hold
+
+**Modify:**
+
+- `dashboard/backend/baseline_generator.py`
+- `dashboard/backend/domain/backtesting/engine.py`
+- `dashboard/backend/tests/test_baseline_generator_offline.py`
+- `dashboard/backend/tests/integration/test_ifind_ashare_backtest.py`
+
+**Steps:**
+
+1. Add failing tests where a baseline symbol is suspended or upper-limit blocked at its
+   first bar and becomes eligible later.
+2. Track pending initial allocations per symbol.
+3. Retry a pending allocation only on a later symbol bar with a valid rule.
+4. Recalculate price, affordable lot quantity, fees, and available cash at retry time.
+5. Keep baseline rejection audit separate from Agent events.
+6. Record delayed and end-of-run unfilled allocation counts in baseline metadata.
+7. Confirm ordinary US and unrestricted baselines retain byte-for-byte-equivalent
+   behavior where practical.
+
+**Verification:** Run baseline and A-share integration tests.
+
+**Commit:** `feat(backtest): delay blocked A-share baseline buys`
+
+## Task 5: Persist and Expose Rule Audits
+
+**Modify:**
+
+- `dashboard/backend/database.py`
+- `dashboard/backend/database_postgres.py`
+- `dashboard/backend/api/routers/backtests.py`
+- database, migration, router, and metadata tests
+
+**Steps:**
+
+1. Add nullable order-event/trade audit columns for rule date, suspended state, native
+   upper-limit price, and native lower-limit price using existing lazy-migration
+   patterns.
+2. Keep SQLite and PostgreSQL schemas and queries in parity.
+3. Serialize the market-rule profile/version, enabled state, rejection totals, and
+   baseline delay summary through the run APIs.
+4. Map `MarketRuleDataError` to a sanitized English iFinD failure containing
+   `Market rule data unavailable`.
+5. Ensure old rows and non-A-share runs omit optional fields rather than fabricating
+   values.
+
+**Verification:** Run database parity, lazy migration, router, and metadata tests.
+
+**Commit:** `feat(backtest): persist A-share market-rule audits`
+
+## Task 6: Display English Rule Outcomes
+
+**Modify:**
+
+- `dashboard/frontend/app.html`
+- `dashboard/frontend/app.js`
+- `dashboard/frontend/styles.css` only if existing styles cannot support the audit line
+- frontend contract tests, especially Trading Log and iFinD A-share tests
+
+**Steps:**
+
+1. Display `A-share market rules: Enabled` in Run config only when the run carries the
+   rule profile.
+2. Map stable rejection codes to `Suspended`, `Buy blocked at upper limit`, and
+   `Sell blocked at lower limit`.
+3. Display official native-CNY limit prices on rejected rows without showing fake fees.
+4. Display non-zero rule rejection totals and baseline delay/unfilled counts compactly.
+5. Preserve layout at desktop and mobile widths and avoid a new decorative panel.
+6. Bump the frontend cache key only if the repository's delivery pattern requires it.
+
+**Verification:** Run frontend contract tests, `node --check dashboard/frontend/app.js`,
+and browser verification on desktop and mobile.
+
+**Commit:** `feat(frontend): show A-share market-rule outcomes`
+
+## Task 7: End-to-End and Regression Validation
+
+**Steps:**
+
+1. Run all focused iFinD, execution, baseline, database, API, and frontend tests.
+2. Run the complete backend test suite.
+3. Run frontend syntax checks and `git diff --check`.
+4. Start ATL with a temporary database and fixed offline fixtures.
+5. Manually verify one normal fill and each of the three market-rule rejection states.
+6. Verify no fees/cash/position mutation on rejected rows and correct retry behavior in
+   baseline metadata.
+7. Run one controlled live iFinD rule-data fetch and, if a suitable historical event is
+   available, one local A-share backtest. Keep credentials and raw response data local.
+8. Inspect `git status`, changed-file list, and sensitive-file patterns before commit or
+   push.
+
+**Stop condition:** Do not open a PR while any focused/full test fails, UI audit output is
+ambiguous, or the production iFinD command remains unverified.
+
+## Task 8: Sync, Push, and Open the PR
+
+**Steps:**
+
+1. Fetch `origin/main` and inspect intervening commits.
+2. Rebase the feature branch when overlap is safe; resolve with full focused regression
+   tests if overlap exists.
+3. Push `feat/ashare-market-rules`.
+4. Open a new English PR; do not amend merged PR #317.
+5. Describe official data dependency, strict-failure behavior, Agent/baseline parity,
+   simulation-only scope, and regression evidence.
+6. Wait for GitHub checks and address failures before handoff.
+
+**PR title:** `feat(backtest): enforce A-share daily market rules`
+

--- a/docs/superpowers/plans/2026-08-12-ashare-market-rules.md
+++ b/docs/superpowers/plans/2026-08-12-ashare-market-rules.md
@@ -7,15 +7,17 @@
 
 ## Objective
 
-Enforce official iFinD full-day suspension and daily upper/lower price-limit data in
-ATL's A-share historical backtests. Apply the same rule contract to Agent orders and the
+Enforce official iFinD full-day suspension and closing price-limit observations in ATL's
+A-share historical backtests. Apply the same rule contract to Agent orders and the
 buy-and-hold baseline without changing Alpaca or vn.py behavior. Keep the platform
 simulation-only and keep every credential and unsanitized production response out of
 Git.
 
 ## Guardrails
 
-- Do not infer suspension or limit prices from OHLCV.
+- Do not infer suspension or theoretical limit prices from prior close, board rules, or
+  OHLCV.
+- Do not apply an official end-of-day limit state to an earlier intraday bar.
 - Do not hard-code an unverified iFinD indicator or response field.
 - Fail an A-share run before execution when rule data is unavailable or incomplete.
 - Keep all repository and GitHub text in English.
@@ -34,20 +36,23 @@ Git.
 
 **Steps:**
 
-1. Generate or inspect the official command for daily suspension status, upper-limit
-   price, and lower-limit price.
+1. Generate or inspect the official commands for daily trading status, daily closing
+   limit status, official daily close, and real-time upper/lower limit prices.
 2. Run the narrowest authorized request for one registered A-share and a short historical
    date window.
 3. Record only a sanitized structural summary: endpoint category, request field names,
    top-level response keys, table keys, indicator keys, value types, and row counts.
-4. Confirm how full-day suspension is represented and whether prices/status share one
-   endpoint or require separate official requests.
-5. Keep the raw response outside the repository and delete temporary captures after the
+4. Confirm that historical quotation exposes daily trading/limit status and close, while
+   real-time quotation alone exposes `upperLimit` and `downLimit`.
+5. Confirm that requesting daily status fields from high-frequency history returns no
+   point-in-time values, so closing state must never be backfilled onto earlier bars.
+6. Keep the raw response outside the repository and delete temporary captures after the
    fixture shape is encoded.
 
 **Stop condition:** No implementation proceeds until all vendor-specific names and value
 encodings are verified. If the account lacks a required field permission, report the
-permission failure and do not substitute inferred rules.
+permission failure and do not substitute inferred rules. Do not claim historical
+intraday price-limit enforcement from daily closing data.
 
 ## Task 2: Add the Daily Rule Domain Contract and Adapter
 
@@ -71,11 +76,14 @@ permission failure and do not substitute inferred rules.
    missing-symbol, and missing-date responses.
 3. Implement the verified iFinD client request without exposing vendor fields outside the
    adapter.
-4. Normalize official values into native-CNY decimals and explicit booleans.
+4. Normalize official values into an explicit suspension boolean, closing limit enum,
+   and native-CNY official close.
 5. Validate coverage against every registered symbol and every combined-clock market
    date.
-6. Raise a dedicated sanitized `MarketRuleDataError` for transport, permission, schema,
-   or coverage failures.
+6. Derive the unique final hourly timestamp per active symbol-date and validate its close
+   against the official daily close to the profile price tick.
+7. Raise a dedicated sanitized `MarketRuleDataError` for transport, permission, schema,
+   coverage, or close-alignment failures.
 
 **Verification:** Run the new client, adapter, provider, and domain test modules plus
 `git diff --check`.
@@ -94,12 +102,13 @@ permission failure and do not substitute inferred rules.
 
 **Steps:**
 
-1. Add failing tests for suspended BUY/SELL, upper-limit BUY, lower-limit SELL, and
-   permitted opposite directions.
+1. Add failing tests for suspended BUY/SELL, closing upper-limit BUY, closing lower-limit
+   SELL, permitted opposite directions, and earlier-bar non-blocking.
 2. Pass the daily rule from engine to portfolio manager and shared executor only for the
    iFinD A-share profile.
 3. Run market-rule gates before lot-size, T+1, cash, and cost checks.
-4. Use tick-safe native-CNY decimal comparison against the reference execution price.
+4. Use tick-safe native-CNY decimal comparison against the official daily close and
+   require the validated final hourly timestamp for closing gates.
 5. Emit `suspended`, `limit_up_buy_blocked`, or `limit_down_sell_blocked` with zero
    execution, zero fees, and complete rule audit fields.
 6. Aggregate the three Agent rejection counts in run metadata.
@@ -121,8 +130,8 @@ permission failure and do not substitute inferred rules.
 
 **Steps:**
 
-1. Add failing tests where a baseline symbol is suspended or upper-limit blocked at its
-   first bar and becomes eligible later.
+1. Add failing tests where a baseline symbol is suspended or closing-upper-limit blocked
+   at its first eligible bar and becomes eligible later.
 2. Track pending initial allocations per symbol.
 3. Retry a pending allocation only on a later symbol bar with a valid rule.
 4. Recalculate price, affordable lot quantity, fees, and available cash at retry time.
@@ -146,9 +155,9 @@ permission failure and do not substitute inferred rules.
 
 **Steps:**
 
-1. Add nullable order-event/trade audit columns for rule date, suspended state, native
-   upper-limit price, and native lower-limit price using existing lazy-migration
-   patterns.
+1. Add nullable order-event/trade audit columns for rule date, suspended state, closing
+   limit state, official native-CNY close, and closing-gate effective state using
+   existing lazy-migration patterns.
 2. Keep SQLite and PostgreSQL schemas and queries in parity.
 3. Serialize the market-rule profile/version, enabled state, rejection totals, and
    baseline delay summary through the run APIs.
@@ -176,7 +185,8 @@ permission failure and do not substitute inferred rules.
    rule profile.
 2. Map stable rejection codes to `Suspended`, `Buy blocked at upper limit`, and
    `Sell blocked at lower limit`.
-3. Display official native-CNY limit prices on rejected rows without showing fake fees.
+3. Display the official native-CNY close and closing limit state on rejected rows without
+   showing fake fees.
 4. Display non-zero rule rejection totals and baseline delay/unfilled counts compactly.
 5. Preserve layout at desktop and mobile widths and avoid a new decorative panel.
 6. Bump the frontend cache key only if the repository's delivery pattern requires it.
@@ -194,7 +204,8 @@ and browser verification on desktop and mobile.
 2. Run the complete backend test suite.
 3. Run frontend syntax checks and `git diff --check`.
 4. Start ATL with a temporary database and fixed offline fixtures.
-5. Manually verify one normal fill and each of the three market-rule rejection states.
+5. Manually verify one normal fill, each of the three market-rule rejection states, and
+   one earlier bar on a closing-limit day that remains eligible.
 6. Verify no fees/cash/position mutation on rejected rows and correct retry behavior in
    baseline metadata.
 7. Run one controlled live iFinD rule-data fetch and, if a suitable historical event is
@@ -219,4 +230,3 @@ ambiguous, or the production iFinD command remains unverified.
 6. Wait for GitHub checks and address failures before handoff.
 
 **PR title:** `feat(backtest): enforce A-share daily market rules`
-

--- a/docs/superpowers/plans/2026-08-12-ashare-market-rules.md
+++ b/docs/superpowers/plans/2026-08-12-ashare-market-rules.md
@@ -46,7 +46,9 @@ Git.
    real-time quotation alone exposes `upperLimit` and `downLimit`.
 5. Confirm that requesting daily status fields from high-frequency history returns no
    point-in-time values, so closing state must never be backfilled onto earlier bars.
-6. Keep the raw response outside the repository and delete temporary captures after the
+6. Confirm that blank history rows can be resolved only through the authorized same-date
+   basic-data trading and limit-status indicators.
+7. Keep the raw response outside the repository and delete temporary captures after the
    fixture shape is encoded.
 
 **Stop condition:** No implementation proceeds until all vendor-specific names and value
@@ -78,11 +80,15 @@ intraday price-limit enforcement from daily closing data.
    adapter.
 4. Normalize official values into an explicit suspension boolean, closing limit enum,
    and native-CNY official close.
-5. Validate coverage against every registered symbol and every combined-clock market
+5. Use iFinD's documented unadjusted settings for both high-frequency bars and daily
+   closes so the two price paths share one executable-price basis.
+6. Batch blank history rows by date and fetch only their official basic-data status
+   supplement; never infer a blank row.
+7. Validate coverage against every registered symbol and every combined-clock market
    date.
-6. Derive the unique final hourly timestamp per active symbol-date and validate its close
+8. Derive the unique final hourly timestamp per active symbol-date and validate its close
    against the official daily close to the profile price tick.
-7. Raise a dedicated sanitized `MarketRuleDataError` for transport, permission, schema,
+9. Raise a dedicated sanitized `MarketRuleDataError` for transport, permission, schema,
    coverage, or close-alignment failures.
 
 **Verification:** Run the new client, adapter, provider, and domain test modules plus

--- a/docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md
+++ b/docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md
@@ -73,6 +73,26 @@ iFinD omits all OHLCV rows for that date. The provider also records the final ho
 timestamp for each active symbol-date so the execution layer never applies an end-of-day
 observation to an earlier decision.
 
+### Known limitation: unadjusted prices carry corporate actions
+
+Both feeds are requested unadjusted — `CPS=no` on high-frequency, `CPS=1` on daily —
+because the audit has to show the official close a limit was set against, and because
+the daily-close alignment check can only compare two series adjusted the same way.
+The hourly series was previously requested `CPS=forward1`, so this change re-bases
+every A-share price the engine consumes.
+
+Nothing in the backend applies dividends or splits. A held position through a
+除权除息 date therefore shows the ex-rights drop as a real overnight loss — in the
+agent equity curve, in the buy-and-hold baseline, and in the reported return — with
+no offsetting cash credit. A 10-for-3 bonus issue, ordinary in June–July, reads as a
+~23% loss that did not happen. `forward1` previously smoothed this away.
+
+Correcting it means real corporate-action handling and is out of scope here. What is
+in scope is not hiding it: `response_to_market_rules` compares consecutive official
+closes per symbol and warns when an overnight move exceeds every A-share daily band
+(21%, above the 20% STAR/ChiNext limit), which trading cannot produce. Suspensions
+break the comparison chain, since a halt legitimately lets a price gap on resumption.
+
 ### Official iFinD command verification
 
 iFinD's public documentation states that supported indicator names and generated

--- a/docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md
+++ b/docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md
@@ -1,0 +1,237 @@
+# A-Share Daily Market Rules Design
+
+**Date:** 2026-08-12  
+**Status:** Product design approved; written-spec review pending  
+**Scope:** iFinD-backed A-share historical backtests and paper simulation
+
+## Goal
+
+Make ATL's iFinD A-share backtests enforce official daily suspension and price-limit
+rules before applying the existing board-lot, T+1, cash, position, slippage, and fee
+rules. The result must remain deterministic, auditable, and simulation-only.
+
+This iteration covers:
+
+- full-day suspension status;
+- official daily upper-limit and lower-limit prices;
+- direction-aware order blocking;
+- the same rules for Agent portfolios and the buy-and-hold baseline;
+- API, persistence, and English UI audit output; and
+- strict failure when official market-rule data is unavailable or incomplete.
+
+This iteration does not cover intraday temporary suspensions, auction queues,
+order-book liquidity, partial queue fills, live A-share paper trading, broker
+connectivity, or real-money orders.
+
+## Confirmed Product Decisions
+
+1. Official iFinD rule data is authoritative. ATL must not infer suspension or price
+   limits from OHLCV alone.
+2. A missing, malformed, unauthorized, or incomplete rule response fails the A-share
+   backtest before execution. ATL must never silently fall back to unrestricted fills.
+3. A full-day suspension blocks both buys and sells.
+4. At the official upper-limit price, buys are blocked and sells may continue through
+   the remaining execution checks.
+5. At the official lower-limit price, sells are blocked and buys may continue through
+   the remaining execution checks.
+6. The buy-and-hold baseline follows the same market rules. If its initial buy is
+   blocked, it retries at the next eligible bar instead of bypassing the rule or
+   abandoning the position permanently.
+7. All repository documentation, code-facing text, API reasons, and UI copy are in
+   English. No credential or unsanitized iFinD response is persisted or logged.
+
+## Data Architecture
+
+### Separate price data from rule data
+
+The existing iFinD provider continues to return normalized 60-minute OHLCV frames.
+A second daily data path fetches official market-rule observations for the same
+registered universe and date range.
+
+The adapter normalizes the daily response into an immutable lookup keyed by symbol and
+market date:
+
+```text
+(symbol, trading_date) -> DailyMarketRule
+```
+
+`DailyMarketRule` contains:
+
+- `symbol`;
+- `trading_date` in `Asia/Shanghai`;
+- `suspended`;
+- `upper_limit_price` in native CNY;
+- `lower_limit_price` in native CNY; and
+- source/version metadata sufficient to audit which rule contract was used.
+
+The rule calendar remains separate from each hourly DataFrame. Daily values are not
+duplicated across four bars, and a suspension day remains representable even when
+iFinD omits all OHLCV rows for that date.
+
+### Official iFinD command verification
+
+iFinD's public documentation states that supported indicator names and generated
+commands are obtained through SuperCommand. Before production code fixes any indicator
+name, the implementation loop must generate or inspect the authorized command and
+capture a sanitized response shape. Tests use fixtures derived from that shape; no
+access token, refresh token, account identifier, or full raw production response is
+committed.
+
+The client may use one or more official iFinD endpoints, but the normalized domain
+contract above must not expose vendor-specific field names to the execution engine.
+
+## Validation and Strict Failure
+
+Before a run starts executing orders, ATL validates the entire requested A-share rule
+calendar. Required market dates are the `Asia/Shanghai` dates present in the combined
+registered-universe backtest clock, not the dates present in each symbol's own OHLCV
+frame. Therefore, a suspended symbol still requires an explicit rule on a date when
+other symbols supply the hourly clock.
+
+1. every registered symbol is represented;
+2. every registered symbol has a rule for every required market date;
+3. suspension values are unambiguous booleans;
+4. active dates have finite, positive upper- and lower-limit prices;
+5. `lower_limit_price < upper_limit_price`; and
+6. prices conform to the A-share CNY price tick after normalization.
+
+If authentication, permission, transport, response-shape, coverage, or value validation
+fails, the provider raises a sanitized market-rule-data error. The API maps it to the
+existing iFinD backtest error boundary with a user-facing English message containing
+`Market rule data unavailable`. The run does not enter order execution and does not
+produce a misleading partial result.
+
+Logs may include the endpoint category, error class, symbol count, and date range. They
+must not include credentials, request headers, full raw payloads, or sensitive account
+details.
+
+## Execution Semantics
+
+The shared executor receives an optional daily rule. Non-iFinD profiles pass no rule and
+retain their current behavior.
+
+For iFinD A-share orders, checks run in this order:
+
+1. required rule exists and is valid;
+2. full-day suspension;
+3. direction-aware price-limit gate;
+4. existing board-lot validation;
+5. existing T+1, holdings, and available-position validation;
+6. existing cash and affordability validation; and
+7. existing slippage, fees, cash movement, and fill recording.
+
+The price-limit comparison uses the transaction's reference execution price and the
+official native-CNY limit prices, with tick-safe decimal comparison. It does not infer a
+limit event merely because a bar's high or low touched a boundary.
+
+Rejection reasons are stable machine-readable English values:
+
+- `suspended`;
+- `limit_up_buy_blocked`; and
+- `limit_down_sell_blocked`.
+
+A market-rule rejection executes zero shares, charges zero costs, and leaves cash,
+positions, T+1 balances, and cost totals unchanged. Its audit record includes the
+applicable official limit prices and rule date.
+
+## Agent and Baseline Flow
+
+The Agent portfolio queries the rule calendar for the order symbol and the market date
+of each hourly decision before calling the shared executor.
+
+The buy-and-hold baseline uses the same calendar and execution semantics. Initial target
+allocations remain pending per symbol when a buy is blocked by suspension or the upper
+limit. The baseline retries the pending allocation on later bars until it fills or the
+run ends. A retry uses the then-current price, market rule, available cash, lot size, and
+transaction costs; it does not backdate a fill.
+
+Baseline rule rejections are auditable but do not pollute the Agent's trading log or
+Agent rejection totals. Baseline-specific summary metadata reports delayed or unfilled
+initial allocations where needed for result interpretation.
+
+## Persistence and API Contract
+
+Order-event persistence in SQLite and PostgreSQL adds nullable market-rule audit fields
+without rewriting historical runs:
+
+- rule date;
+- suspended flag;
+- native upper-limit price; and
+- native lower-limit price.
+
+Existing reporting-currency conversion remains separate. Official price limits are
+stored in native CNY and may additionally be converted for reporting when the current
+currency audit layer supports that field.
+
+Run metadata includes:
+
+- market-rule profile/version;
+- market-rule enforcement enabled state;
+- counts for suspension, upper-limit buy, and lower-limit sell rejections; and
+- baseline delayed/unfilled allocation counts when non-zero.
+
+Older runs and Alpaca/vn.py runs keep their current response shape unless nullable or
+optional fields are already part of the shared API model.
+
+## User Interface
+
+The existing backtest Run config displays a compact line:
+
+```text
+A-share market rules: Enabled
+```
+
+The Trading Log renders market-rule rejections with concise English labels:
+
+- `Suspended`;
+- `Buy blocked at upper limit`; or
+- `Sell blocked at lower limit`.
+
+The row exposes the official native-CNY upper and lower prices when applicable. Rejected
+orders continue to show zero executed shares and no transaction costs.
+
+The run summary displays non-zero counts for the three rejection categories. It must not
+introduce a new decorative dashboard or expose vendor payload details.
+
+## Testing Strategy
+
+All automated iFinD tests use fixed, sanitized offline fixtures. No CI test calls a live
+iFinD endpoint.
+
+Coverage includes:
+
+1. adapter normalization for active, suspended, malformed, missing-symbol, and
+   missing-date responses;
+2. strict provider failure for transport, authentication, permission, schema, and
+   incomplete-coverage errors;
+3. suspended BUY and SELL rejection;
+4. upper-limit BUY rejection and SELL continuation;
+5. lower-limit SELL rejection and BUY continuation;
+6. normal-price orders retaining current lot-size, T+1, cash, and cost behavior;
+7. zero fees and zero portfolio mutation for rule rejections;
+8. tick-safe price comparisons;
+9. buy-and-hold retry on the next eligible bar and clear end-of-run unfilled metadata;
+10. SQLite/PostgreSQL migration and parity tests;
+11. API serialization and sanitized error mapping;
+12. English Trading Log and Run config rendering; and
+13. Alpaca and vn.py regression tests proving no A-share rule leakage.
+
+After offline coverage passes, a controlled local validation may call the authorized
+iFinD account for a narrow universe/date range. The operator verifies the sanitized
+shape, one normal day, and any available historical suspension or limit case. Local
+credentials and captured raw responses remain outside Git.
+
+## Acceptance Criteria
+
+The iteration is complete when:
+
+- official iFinD daily rule data gates every iFinD A-share Agent order;
+- official rules also gate buy-and-hold initial allocations with later retries;
+- incomplete official rule data prevents the run from starting;
+- all three rejection types are persisted and visible in English;
+- rejected orders do not mutate the portfolio or transaction-cost totals;
+- existing A-share lot-size, T+1, FX, and cost behavior remains intact;
+- Alpaca and vn.py behavior remains unchanged;
+- focused and full backend tests pass;
+- frontend syntax and rendering checks pass; and
+- no credential, raw sensitive response, or local database is committed.

--- a/docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md
+++ b/docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md
@@ -6,18 +6,19 @@
 
 ## Goal
 
-Make ATL's iFinD A-share backtests enforce official daily suspension and price-limit
-rules before applying the existing board-lot, T+1, cash, position, slippage, and fee
-rules. The result must remain deterministic, auditable, and simulation-only.
+Make ATL's iFinD A-share backtests enforce official full-day suspension and official
+closing price-limit observations before applying the existing board-lot, T+1, cash,
+position, slippage, and fee rules. The result must remain deterministic, auditable, free
+of look-ahead bias, and simulation-only.
 
 This iteration covers:
 
 - full-day suspension status;
-- official daily upper-limit and lower-limit prices;
+- official closing upper-limit and lower-limit observations;
 - direction-aware order blocking;
 - the same rules for Agent portfolios and the buy-and-hold baseline;
 - API, persistence, and English UI audit output; and
-- strict failure when official market-rule data is unavailable or incomplete.
+- strict failure when required official market-rule data is unavailable or incomplete.
 
 This iteration does not cover intraday temporary suspensions, auction queues,
 order-book liquidity, partial queue fills, live A-share paper trading, broker
@@ -25,15 +26,17 @@ connectivity, or real-money orders.
 
 ## Confirmed Product Decisions
 
-1. Official iFinD rule data is authoritative. ATL must not infer suspension or price
-   limits from OHLCV alone.
+1. Official iFinD rule data is authoritative. ATL must not infer suspension or a
+   theoretical limit price from prior close, board percentages, or OHLCV alone.
 2. A missing, malformed, unauthorized, or incomplete rule response fails the A-share
    backtest before execution. ATL must never silently fall back to unrestricted fills.
 3. A full-day suspension blocks both buys and sells.
-4. At the official upper-limit price, buys are blocked and sells may continue through
-   the remaining execution checks.
-5. At the official lower-limit price, sells are blocked and buys may continue through
-   the remaining execution checks.
+4. An official daily `upper limit` observation applies only to the final 60-minute bar
+   whose close matches the official daily close. Buys are blocked there; earlier bars
+   are not backfilled with the end-of-day state. Sells continue through the remaining
+   execution checks.
+5. An official daily `lower limit` observation follows the same final-bar rule. Sells
+   are blocked there; buys continue through the remaining execution checks.
 6. The buy-and-hold baseline follows the same market rules. If its initial buy is
    blocked, it retries at the next eligible bar instead of bypassing the rule or
    abandoning the position permanently.
@@ -60,22 +63,32 @@ market date:
 - `symbol`;
 - `trading_date` in `Asia/Shanghai`;
 - `suspended`;
-- `upper_limit_price` in native CNY;
-- `lower_limit_price` in native CNY; and
+- `closing_limit_state` (`none`, `upper`, or `lower`);
+- `official_close_price` in native CNY; and
 - source/version metadata sufficient to audit which rule contract was used.
 
 The rule calendar remains separate from each hourly DataFrame. Daily values are not
 duplicated across four bars, and a suspension day remains representable even when
-iFinD omits all OHLCV rows for that date.
+iFinD omits all OHLCV rows for that date. The provider also records the final hourly
+timestamp for each active symbol-date so the execution layer never applies an end-of-day
+observation to an earlier decision.
 
 ### Official iFinD command verification
 
 iFinD's public documentation states that supported indicator names and generated
-commands are obtained through SuperCommand. Before production code fixes any indicator
-name, the implementation loop must generate or inspect the authorized command and
-capture a sanitized response shape. Tests use fixtures derived from that shape; no
-access token, refresh token, account identifier, or full raw production response is
-committed.
+commands are obtained through SuperCommand. Authorized verification established the
+following contract:
+
+- historical quotation provides `ths_trading_status_stock` and
+  `ths_up_and_down_status_stock` at daily frequency;
+- historical quotation also provides the unadjusted official daily `close`;
+- high-frequency history does not return those two status fields even when requested;
+  and
+- `upperLimit` and `downLimit` are real-time quotation fields, not documented historical
+  quotation or high-frequency fields.
+
+Tests use fixtures derived from the sanitized verified response shape; no access token,
+refresh token, account identifier, or full raw production response is committed.
 
 The client may use one or more official iFinD endpoints, but the normalized domain
 contract above must not expose vendor-specific field names to the execution engine.
@@ -91,9 +104,12 @@ other symbols supply the hourly clock.
 1. every registered symbol is represented;
 2. every registered symbol has a rule for every required market date;
 3. suspension values are unambiguous booleans;
-4. active dates have finite, positive upper- and lower-limit prices;
-5. `lower_limit_price < upper_limit_price`; and
-6. prices conform to the A-share CNY price tick after normalization.
+4. active dates have a finite, positive official daily close;
+5. limit status is exactly `none`, `upper`, or `lower` after normalization;
+6. every active symbol-date has a unique final hourly timestamp;
+7. the final hourly close matches the official daily close to the A-share CNY price
+   tick; and
+8. prices conform to the A-share CNY price tick after normalization.
 
 If authentication, permission, transport, response-shape, coverage, or value validation
 fails, the provider raises a sanitized market-rule-data error. The API maps it to the
@@ -114,15 +130,18 @@ For iFinD A-share orders, checks run in this order:
 
 1. required rule exists and is valid;
 2. full-day suspension;
-3. direction-aware price-limit gate;
+3. direction-aware closing price-limit gate, only on the validated final hourly bar;
 4. existing board-lot validation;
 5. existing T+1, holdings, and available-position validation;
 6. existing cash and affordability validation; and
 7. existing slippage, fees, cash movement, and fill recording.
 
 The price-limit comparison uses the transaction's reference execution price and the
-official native-CNY limit prices, with tick-safe decimal comparison. It does not infer a
-limit event merely because a bar's high or low touched a boundary.
+official native-CNY daily close, with tick-safe decimal comparison. It does not infer a
+theoretical limit price and does not treat the end-of-day status as if it had been known
+on earlier bars. Intraday limit touches that do not persist to the official close remain
+outside this iteration because the documented historical HTTP responses do not expose a
+point-in-time limit status or historical upper/lower limit price.
 
 Rejection reasons are stable machine-readable English values:
 
@@ -131,8 +150,8 @@ Rejection reasons are stable machine-readable English values:
 - `limit_down_sell_blocked`.
 
 A market-rule rejection executes zero shares, charges zero costs, and leaves cash,
-positions, T+1 balances, and cost totals unchanged. Its audit record includes the
-applicable official limit prices and rule date.
+positions, T+1 balances, and cost totals unchanged. Its audit record includes the rule
+date, closing limit state, official close, and whether the closing gate was effective.
 
 ## Agent and Baseline Flow
 
@@ -156,12 +175,13 @@ without rewriting historical runs:
 
 - rule date;
 - suspended flag;
-- native upper-limit price; and
-- native lower-limit price.
+- closing limit state;
+- official native-CNY close; and
+- closing-gate effective state.
 
-Existing reporting-currency conversion remains separate. Official price limits are
-stored in native CNY and may additionally be converted for reporting when the current
-currency audit layer supports that field.
+Existing reporting-currency conversion remains separate. Official closes are stored in
+native CNY and may additionally be converted for reporting when the current currency
+audit layer supports that field.
 
 Run metadata includes:
 
@@ -187,8 +207,8 @@ The Trading Log renders market-rule rejections with concise English labels:
 - `Buy blocked at upper limit`; or
 - `Sell blocked at lower limit`.
 
-The row exposes the official native-CNY upper and lower prices when applicable. Rejected
-orders continue to show zero executed shares and no transaction costs.
+The row exposes the official native-CNY close and closing limit state when applicable.
+Rejected orders continue to show zero executed shares and no transaction costs.
 
 The run summary displays non-zero counts for the three rejection categories. It must not
 introduce a new decorative dashboard or expose vendor payload details.
@@ -202,14 +222,15 @@ Coverage includes:
 
 1. adapter normalization for active, suspended, malformed, missing-symbol, and
    missing-date responses;
-2. strict provider failure for transport, authentication, permission, schema, and
-   incomplete-coverage errors;
+2. strict provider failure for transport, authentication, permission, schema,
+   incomplete-coverage, and final-bar/daily-close mismatch errors;
 3. suspended BUY and SELL rejection;
 4. upper-limit BUY rejection and SELL continuation;
 5. lower-limit SELL rejection and BUY continuation;
 6. normal-price orders retaining current lot-size, T+1, cash, and cost behavior;
 7. zero fees and zero portfolio mutation for rule rejections;
-8. tick-safe price comparisons;
+8. tick-safe close comparisons and a regression proving end-of-day state does not block
+   an earlier bar;
 9. buy-and-hold retry on the next eligible bar and clear end-of-run unfilled metadata;
 10. SQLite/PostgreSQL migration and parity tests;
 11. API serialization and sanitized error mapping;
@@ -225,7 +246,8 @@ credentials and captured raw responses remain outside Git.
 
 The iteration is complete when:
 
-- official iFinD daily rule data gates every iFinD A-share Agent order;
+- official iFinD daily rule data gates every iFinD A-share Agent order without applying
+  closing observations before the final bar;
 - official rules also gate buy-and-hold initial allocations with later retries;
 - incomplete official rule data prevents the run from starting;
 - all three rejection types are persisted and visible in English;

--- a/docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md
+++ b/docs/superpowers/specs/2026-08-12-ashare-market-rules-design.md
@@ -82,8 +82,14 @@ following contract:
 - historical quotation provides `ths_trading_status_stock` and
   `ths_up_and_down_status_stock` at daily frequency;
 - historical quotation also provides the unadjusted official daily `close`;
+- high-frequency and daily close requests both use iFinD's documented unadjusted
+  settings (`CPS=no` and `CPS=1`, respectively), so execution prices, board lots,
+  costs, and close alignment all use actual historical CNY prices;
 - high-frequency history does not return those two status fields even when requested;
-  and
+- suspended dates may appear as blank status/close rows in historical quotation, while
+  the authorized same-date basic-data indicators return an explicit suspension
+  description and `suspended` limit state; this is the only permitted fallback for
+  blank daily rows; and
 - `upperLimit` and `downLimit` are real-time quotation fields, not documented historical
   quotation or high-frequency fields.
 


### PR DESCRIPTION
## Summary
- load official iFinD daily trading status, closing limit status, and unadjusted close data for registered A-share universes
- enforce full-day suspensions and direction-aware closing limit gates for Agent and buy-and-hold simulation
- persist and display native-CNY rule audits, rejection totals, and delayed or unfilled baseline allocations

## Data and execution integrity
- use unadjusted iFinD prices (`CPS=no` for high-frequency data and `CPS=1` for daily data)
- supplement only blank official status fields through same-date basic data
- fail before execution when market-rule coverage or final-bar close alignment is invalid
- do not infer historical intraday limit touches or theoretical limit prices
- leave Alpaca and vn.py paths unchanged

## Scope
ATL remains a backtest and paper-simulation platform. This change does not place live orders.

## Validation
- `python -m pytest dashboard/backend/tests -q`: 2729 passed, 66 skipped
- `node --check dashboard/frontend/app.js`
- `git diff --check`
- desktop and 390x844 browser QA with offline fixtures