### PR TITLE
fix(agents): isolate account-bound agents across login/logout

### DIFF
--- a/dashboard/backend/api/dependencies.py
+++ b/dashboard/backend/api/dependencies.py
@@ -66,15 +66,38 @@ def _require_agent_access(
     api_key: Optional[str] = None,
     reclaim_on_session_match: bool = False,
 ) -> Dict[str, Any]:
+    agent, _owned = _resolve_agent_access(
+        agent_id,
+        ctx,
+        api_key=api_key,
+        reclaim_on_session_match=reclaim_on_session_match,
+    )
+    return agent
+
+
+def _resolve_agent_access(
+    agent_id: str,
+    ctx: Dict[str, Any],
+    *,
+    api_key: Optional[str] = None,
+    reclaim_on_session_match: bool = False,
+) -> tuple[Dict[str, Any], bool]:
+    """``(agent, owned)``. See ``AgentService.resolve_access``.
+
+    Routes that only *read* or edit the agent can use ``_require_agent_access``
+    and ignore the flag. Routes that write ownership must not: a grant that came
+    from a bare ``session_id`` match is not proof of ownership, and binding an
+    account on it cannot be undone by the real owner.
+    """
     # The agent's own API key is a valid credential for its own agent — this is
     # how API-only clients (which have no logged-in user or browser session)
     # authorize state-changing operations on the agent they own.
     if api_key:
         keyed = agent_service.resolve_api_key(api_key)
         if keyed and keyed.get("agent_id") == agent_id:
-            return keyed
+            return keyed, True
     try:
-        return agent_service.require_access(
+        return agent_service.resolve_access(
             agent_id,
             user_id=ctx.get("user_id"),
             browser_session=ctx.get("browser_session"),

--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -32,6 +32,7 @@ from dashboard.backend.domain.agents.credential_store import (
     agent_credential_store,
 )
 from dashboard.backend.domain.agents.service import (
+    AgentAccessDeniedError,
     AgentNotFoundError,
     AgentServiceError,
     MarketplaceTemplateNotFoundError,
@@ -47,6 +48,7 @@ from dashboard.backend.api.dependencies import (
     _owner_context,
     _require_agent_access,
     _require_owner_context,
+    _resolve_agent_access,
 )
 from dashboard.backend.api.rate_limit import FixedWindowRateLimiter, client_key
 from dashboard.backend.domain.portfolios.service import portfolio_service
@@ -363,6 +365,8 @@ def import_session_agent(
         )
     except NoExternalRunsError:
         raise HTTPException(status_code=404, detail="No external backtest runs for this session")
+    except AgentAccessDeniedError:
+        raise HTTPException(status_code=403, detail="Agent belongs to another account")
 
     result = {"agent": agent_service.agent_with_stats(agent), "imported": imported}
     if imported and agent.get("api_key"):
@@ -696,10 +700,16 @@ def activate_agent(
 ):
     """Return session info for switching the dashboard to this agent."""
     ctx = _require_owner_context(request, authorization)
-    agent = _require_agent_access(agent_id, ctx, reclaim_on_session_match=True)
+    agent, owned = _resolve_agent_access(
+        agent_id, ctx, reclaim_on_session_match=True
+    )
+    # Claiming binds owner_user_id, and owns_agent refuses browser-only access
+    # to a bound row -- so a claim made off a bare session_id match would lock
+    # the agent's real owner out with no way back. Only bind when the caller
+    # proved ownership with a real credential.
     agent_service.activate_agent(
         agent_id,
-        user_id=ctx.get("user_id"),
+        user_id=ctx.get("user_id") if owned else None,
         browser_session=ctx.get("browser_session"),
     )
     return {

--- a/dashboard/backend/domain/agents/repository.py
+++ b/dashboard/backend/domain/agents/repository.py
@@ -278,20 +278,35 @@ class AgentStore:
             conn = self._get_connection()
             cursor = conn.cursor()
             cursor.execute(
+                # Same no-steal guard as claim_agent: this is the fourth writer
+                # of owner_user_id and is reachable from
+                # POST /agents/import-session, whose session_id comes straight
+                # off a caller-supplied header. A bare COALESCE would let any
+                # non-null caller id replace the existing owner.
                 """
                 UPDATE external_agents
                 SET name = ?, model_name = ?, last_used_at = ?,
-                    owner_user_id = COALESCE(?, owner_user_id),
+                    owner_user_id = CASE
+                        WHEN owner_user_id IS NULL AND ? IS NOT NULL THEN ?
+                        ELSE owner_user_id
+                    END,
                     owner_browser_session = COALESCE(?, owner_browser_session)
                 WHERE session_id = ?
+                  AND (
+                        owner_user_id IS NULL
+                        OR (? IS NOT NULL AND owner_user_id = ?)
+                      )
                 """,
                 (
                     name.strip(),
                     model_name.strip() or "local-model",
                     _utcnow_iso(),
                     owner_user_id,
+                    owner_user_id,
                     owner_browser_session,
                     session_id,
+                    owner_user_id,
+                    owner_user_id,
                 ),
             )
             conn.commit()
@@ -378,12 +393,19 @@ class AgentStore:
                     (trading_session_id, owner_user_id),
                 )
             elif owner_browser_session:
+                # ``owner_browser_session = session_id`` is the import-session
+                # shape (see api/dependencies.py::_owner_context): those rows
+                # have no separate browser credential, so requiring the caller's
+                # browser id to match would hide an agent the caller does own.
                 _add_rows(
                     """
                     SELECT * FROM external_agents
                     WHERE session_id = ?
-                      AND owner_browser_session = ?
                       AND owner_user_id IS NULL
+                      AND (
+                            owner_browser_session = ?
+                            OR owner_browser_session = session_id
+                          )
                     ORDER BY created_at DESC
                     """,
                     (trading_session_id, owner_browser_session),
@@ -670,14 +692,6 @@ class AgentStore:
         conn.commit()
         conn.close()
         return deleted
-
-    def count_agents(self) -> int:
-        conn = self._get_connection()
-        cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) AS n FROM external_agents")
-        row = cursor.fetchone()
-        conn.close()
-        return int(row["n"] if row else 0)
 
     def owns_agent(
         self,

--- a/dashboard/backend/domain/agents/repository.py
+++ b/dashboard/backend/domain/agents/repository.py
@@ -349,24 +349,45 @@ class AgentStore:
                     (owner_browser_session,),
                 )
         elif owner_browser_session:
+            # Logged-out list: only *guest* agents for this browser. Account-
+            # bound rows keep owner_browser_session stamped at create time; if
+            # we matched on browser alone, logout would re-surface every agent
+            # the previous signed-in user created on this machine.
             _add_rows(
                 """
                 SELECT * FROM external_agents
                 WHERE owner_browser_session = ?
+                  AND owner_user_id IS NULL
                 ORDER BY created_at DESC
                 """,
                 (owner_browser_session,),
             )
 
         if trading_session_id:
-            _add_rows(
-                """
-                SELECT * FROM external_agents
-                WHERE session_id = ?
-                ORDER BY created_at DESC
-                """,
-                (trading_session_id,),
-            )
+            # session_id is not an ownership credential. Only fold in the
+            # active trading session when it already belongs to this caller
+            # (same user, or an unclaimed browser agent).
+            if owner_user_id is not None:
+                _add_rows(
+                    """
+                    SELECT * FROM external_agents
+                    WHERE session_id = ?
+                      AND owner_user_id = ?
+                    ORDER BY created_at DESC
+                    """,
+                    (trading_session_id, owner_user_id),
+                )
+            elif owner_browser_session:
+                _add_rows(
+                    """
+                    SELECT * FROM external_agents
+                    WHERE session_id = ?
+                      AND owner_browser_session = ?
+                      AND owner_user_id IS NULL
+                    ORDER BY created_at DESC
+                    """,
+                    (trading_session_id, owner_browser_session),
+                )
 
         conn.close()
         # Each _add_rows call is independently sorted, but the groups are
@@ -463,17 +484,38 @@ class AgentStore:
         owner_user_id: Optional[int] = None,
         owner_browser_session: Optional[str] = None,
     ) -> None:
+        """Bind ownership without stealing another account's agent.
+
+        ``owner_user_id`` is only written when the row is still unclaimed.
+        ``owner_browser_session`` may refresh on rows this user already owns
+        (or unclaimed rows). A different account's agent is a no-op.
+        """
         conn = self._get_connection()
         cursor = conn.cursor()
         cursor.execute(
             """
             UPDATE external_agents
-            SET owner_user_id = COALESCE(?, owner_user_id),
+            SET owner_user_id = CASE
+                    WHEN owner_user_id IS NULL AND ? IS NOT NULL THEN ?
+                    ELSE owner_user_id
+                END,
                 owner_browser_session = COALESCE(?, owner_browser_session),
                 last_used_at = ?
             WHERE agent_id = ?
+              AND (
+                    owner_user_id IS NULL
+                    OR (? IS NOT NULL AND owner_user_id = ?)
+                  )
             """,
-            (owner_user_id, owner_browser_session, _utcnow_iso(), agent_id),
+            (
+                owner_user_id,
+                owner_user_id,
+                owner_browser_session,
+                _utcnow_iso(),
+                agent_id,
+                owner_user_id,
+                owner_user_id,
+            ),
         )
         conn.commit()
         conn.close()
@@ -485,18 +527,37 @@ class AgentStore:
         owner_user_id: Optional[int] = None,
         owner_browser_session: Optional[str] = None,
     ) -> None:
-        """Re-bind an agent to the current browser/user (dashboard session proof)."""
+        """Re-bind browser ownership for a guest or already-owned agent.
+
+        Refuses to touch a row owned by a different user — that path used to
+        let activate/restore steal agents across accounts on a shared browser.
+        """
         conn = self._get_connection()
         cursor = conn.cursor()
         cursor.execute(
             """
             UPDATE external_agents
-            SET owner_user_id = COALESCE(?, owner_user_id),
+            SET owner_user_id = CASE
+                    WHEN owner_user_id IS NULL AND ? IS NOT NULL THEN ?
+                    ELSE owner_user_id
+                END,
                 owner_browser_session = ?,
                 last_used_at = ?
             WHERE agent_id = ?
+              AND (
+                    owner_user_id IS NULL
+                    OR (? IS NOT NULL AND owner_user_id = ?)
+                  )
             """,
-            (owner_user_id, owner_browser_session, _utcnow_iso(), agent_id),
+            (
+                owner_user_id,
+                owner_user_id,
+                owner_browser_session,
+                _utcnow_iso(),
+                agent_id,
+                owner_user_id,
+                owner_user_id,
+            ),
         )
         conn.commit()
         conn.close()
@@ -610,6 +671,14 @@ class AgentStore:
         conn.close()
         return deleted
 
+    def count_agents(self) -> int:
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) AS n FROM external_agents")
+        row = cursor.fetchone()
+        conn.close()
+        return int(row["n"] if row else 0)
+
     def owns_agent(
         self,
         agent: Dict[str, Any],
@@ -634,16 +703,20 @@ class AgentStore:
         conn.close()
         if not row:
             return False
-        if owner_user_id is not None and row["owner_user_id"] == owner_user_id:
-            return True
+        bound_user = row["owner_user_id"]
+        # Account-bound agents are only accessible to that account. Matching
+        # owner_browser_session alone used to let any later login (or logout)
+        # on the same browser GET/activate/claim another user's agents.
+        if bound_user is not None:
+            return owner_user_id is not None and bound_user == owner_user_id
         if owner_browser_session and row["owner_browser_session"] == owner_browser_session:
             return True
         # NOTE: session_id is NOT an ownership credential. It is an internal
         # trading-session identifier that is discoverable (it used to be returned
         # by the public /builtin listing), so matching it against a caller-supplied
         # session would let anyone who learned it take over the agent. Ownership
-        # requires owner_user_id or owner_browser_session (a real, private
-        # credential), or the agent API key (checked at the route layer).
+        # requires owner_user_id (for bound agents) or owner_browser_session (for
+        # still-unclaimed guest agents), or the agent API key (route layer).
         return False
 
 

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -296,24 +296,40 @@ class PostgresAgentStore:
                             (owner_browser_session,),
                         )
                 elif owner_browser_session:
+                    # Logged-out list: only guest agents for this browser (see
+                    # SQLite twin for the full rationale).
                     _add_rows(
                         """
                         SELECT * FROM external_agents
                         WHERE owner_browser_session = %s
+                          AND owner_user_id IS NULL
                         ORDER BY created_at DESC
                         """,
                         (owner_browser_session,),
                     )
 
                 if trading_session_id:
-                    _add_rows(
-                        """
-                        SELECT * FROM external_agents
-                        WHERE session_id = %s
-                        ORDER BY created_at DESC
-                        """,
-                        (trading_session_id,),
-                    )
+                    if owner_user_id is not None:
+                        _add_rows(
+                            """
+                            SELECT * FROM external_agents
+                            WHERE session_id = %s
+                              AND owner_user_id = %s
+                            ORDER BY created_at DESC
+                            """,
+                            (trading_session_id, owner_user_id),
+                        )
+                    elif owner_browser_session:
+                        _add_rows(
+                            """
+                            SELECT * FROM external_agents
+                            WHERE session_id = %s
+                              AND owner_browser_session = %s
+                              AND owner_user_id IS NULL
+                            ORDER BY created_at DESC
+                            """,
+                            (trading_session_id, owner_browser_session),
+                        )
 
         # Each _add_rows call is independently sorted, but the groups are
         # appended query-by-query, so a recent unclaimed browser agent could
@@ -406,17 +422,33 @@ class PostgresAgentStore:
         owner_user_id: Optional[int] = None,
         owner_browser_session: Optional[str] = None,
     ) -> None:
+        """Bind ownership without stealing another account's agent."""
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
                     UPDATE external_agents
-                    SET owner_user_id = COALESCE(%s, owner_user_id),
+                    SET owner_user_id = CASE
+                            WHEN owner_user_id IS NULL AND %s IS NOT NULL THEN %s
+                            ELSE owner_user_id
+                        END,
                         owner_browser_session = COALESCE(%s, owner_browser_session),
                         last_used_at = %s
                     WHERE agent_id = %s
+                      AND (
+                            owner_user_id IS NULL
+                            OR (%s IS NOT NULL AND owner_user_id = %s)
+                          )
                     """,
-                    (owner_user_id, owner_browser_session, _utcnow_iso(), agent_id),
+                    (
+                        owner_user_id,
+                        owner_user_id,
+                        owner_browser_session,
+                        _utcnow_iso(),
+                        agent_id,
+                        owner_user_id,
+                        owner_user_id,
+                    ),
                 )
 
     def reclaim_agent(
@@ -426,18 +458,33 @@ class PostgresAgentStore:
         owner_user_id: Optional[int] = None,
         owner_browser_session: Optional[str] = None,
     ) -> None:
-        """Re-bind an agent to the current browser/user (dashboard session proof)."""
+        """Re-bind browser ownership for a guest or already-owned agent."""
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
                     UPDATE external_agents
-                    SET owner_user_id = COALESCE(%s, owner_user_id),
+                    SET owner_user_id = CASE
+                            WHEN owner_user_id IS NULL AND %s IS NOT NULL THEN %s
+                            ELSE owner_user_id
+                        END,
                         owner_browser_session = %s,
                         last_used_at = %s
                     WHERE agent_id = %s
+                      AND (
+                            owner_user_id IS NULL
+                            OR (%s IS NOT NULL AND owner_user_id = %s)
+                          )
                     """,
-                    (owner_user_id, owner_browser_session, _utcnow_iso(), agent_id),
+                    (
+                        owner_user_id,
+                        owner_user_id,
+                        owner_browser_session,
+                        _utcnow_iso(),
+                        agent_id,
+                        owner_user_id,
+                        owner_user_id,
+                    ),
                 )
 
     def rotate_api_key(self, agent_id: str) -> Optional[str]:
@@ -541,6 +588,13 @@ class PostgresAgentStore:
                 deleted = cur.rowcount > 0
         return deleted
 
+    def count_agents(self) -> int:
+        with self._get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COUNT(*) AS n FROM external_agents")
+                row = cur.fetchone()
+        return int(row["n"] if row else 0)
+
     def owns_agent(
         self,
         agent: Dict[str, Any],
@@ -565,14 +619,16 @@ class PostgresAgentStore:
                 row = cur.fetchone()
         if not row:
             return False
-        if owner_user_id is not None and row["owner_user_id"] == owner_user_id:
-            return True
+        bound_user = row["owner_user_id"]
+        # Account-bound agents are only accessible to that account (see SQLite twin).
+        if bound_user is not None:
+            return owner_user_id is not None and bound_user == owner_user_id
         if owner_browser_session and row["owner_browser_session"] == owner_browser_session:
             return True
         # NOTE: session_id is NOT an ownership credential. It is an internal
         # trading-session identifier that is discoverable (it used to be returned
         # by the public /builtin listing), so matching it against a caller-supplied
         # session would let anyone who learned it take over the agent. Ownership
-        # requires owner_user_id or owner_browser_session (a real, private
-        # credential), or the agent API key (checked at the route layer).
+        # requires owner_user_id (for bound agents) or owner_browser_session (for
+        # still-unclaimed guest agents), or the agent API key (route layer).
         return False

--- a/dashboard/backend/domain/agents/repository_postgres.py
+++ b/dashboard/backend/domain/agents/repository_postgres.py
@@ -228,20 +228,36 @@ class PostgresAgentStore:
             with self._get_connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
+                        # Same no-steal guard as claim_agent: this is the fourth
+                        # writer of owner_user_id and is reachable from
+                        # POST /agents/import-session, whose session_id comes
+                        # straight off a caller-supplied header. A bare COALESCE
+                        # would let any non-null caller id replace the owner.
                         """
                         UPDATE external_agents
                         SET name = %s, model_name = %s, last_used_at = %s,
-                            owner_user_id = COALESCE(%s, owner_user_id),
+                            owner_user_id = CASE
+                                WHEN owner_user_id IS NULL AND %s::integer IS NOT NULL
+                                    THEN %s
+                                ELSE owner_user_id
+                            END,
                             owner_browser_session = COALESCE(%s, owner_browser_session)
                         WHERE session_id = %s
+                          AND (
+                                owner_user_id IS NULL
+                                OR (%s::integer IS NOT NULL AND owner_user_id = %s)
+                              )
                         """,
                         (
                             name.strip(),
                             model_name.strip() or "local-model",
                             _utcnow_iso(),
                             owner_user_id,
+                            owner_user_id,
                             owner_browser_session,
                             session_id,
+                            owner_user_id,
+                            owner_user_id,
                         ),
                     )
             return self.get_agent_by_session(session_id) or existing
@@ -320,12 +336,17 @@ class PostgresAgentStore:
                             (trading_session_id, owner_user_id),
                         )
                     elif owner_browser_session:
+                        # owner_browser_session = session_id is the
+                        # import-session shape (see SQLite twin).
                         _add_rows(
                             """
                             SELECT * FROM external_agents
                             WHERE session_id = %s
-                              AND owner_browser_session = %s
                               AND owner_user_id IS NULL
+                              AND (
+                                    owner_browser_session = %s
+                                    OR owner_browser_session = session_id
+                                  )
                             ORDER BY created_at DESC
                             """,
                             (trading_session_id, owner_browser_session),
@@ -426,10 +447,18 @@ class PostgresAgentStore:
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
+                    # The ``::integer`` casts are load-bearing, not decoration.
+                    # psycopg sends ``None`` with an unspecified type OID, and a
+                    # bare ``$n IS NOT NULL`` gives Postgres no context to infer
+                    # from, so an anonymous caller (owner_user_id=None) would hit
+                    # 42P08 "could not determine data type of parameter". The
+                    # SQLite twin cannot reproduce this -- its parameters are
+                    # untyped -- so only the @pg_only tier guards it.
                     """
                     UPDATE external_agents
                     SET owner_user_id = CASE
-                            WHEN owner_user_id IS NULL AND %s IS NOT NULL THEN %s
+                            WHEN owner_user_id IS NULL AND %s::integer IS NOT NULL
+                                THEN %s
                             ELSE owner_user_id
                         END,
                         owner_browser_session = COALESCE(%s, owner_browser_session),
@@ -437,7 +466,7 @@ class PostgresAgentStore:
                     WHERE agent_id = %s
                       AND (
                             owner_user_id IS NULL
-                            OR (%s IS NOT NULL AND owner_user_id = %s)
+                            OR (%s::integer IS NOT NULL AND owner_user_id = %s)
                           )
                     """,
                     (
@@ -462,10 +491,14 @@ class PostgresAgentStore:
         with self._get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
+                    # ``::integer`` casts: see claim_agent. This path is reached
+                    # with owner_user_id=None on every logged-out reclaim, so an
+                    # uncast parameter would 500 the common case.
                     """
                     UPDATE external_agents
                     SET owner_user_id = CASE
-                            WHEN owner_user_id IS NULL AND %s IS NOT NULL THEN %s
+                            WHEN owner_user_id IS NULL AND %s::integer IS NOT NULL
+                                THEN %s
                             ELSE owner_user_id
                         END,
                         owner_browser_session = %s,
@@ -473,7 +506,7 @@ class PostgresAgentStore:
                     WHERE agent_id = %s
                       AND (
                             owner_user_id IS NULL
-                            OR (%s IS NOT NULL AND owner_user_id = %s)
+                            OR (%s::integer IS NOT NULL AND owner_user_id = %s)
                           )
                     """,
                     (
@@ -587,13 +620,6 @@ class PostgresAgentStore:
                 )
                 deleted = cur.rowcount > 0
         return deleted
-
-    def count_agents(self) -> int:
-        with self._get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT COUNT(*) AS n FROM external_agents")
-                row = cur.fetchone()
-        return int(row["n"] if row else 0)
 
     def owns_agent(
         self,

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -230,6 +230,36 @@ class AgentService:
         trading_session: Optional[str] = None,
         reclaim_on_session_match: bool = False,
     ) -> Dict[str, Any]:
+        agent, _owned = self.resolve_access(
+            agent_id,
+            user_id=user_id,
+            browser_session=browser_session,
+            trading_session=trading_session,
+            reclaim_on_session_match=reclaim_on_session_match,
+        )
+        return agent
+
+    def resolve_access(
+        self,
+        agent_id: str,
+        *,
+        user_id: Optional[int] = None,
+        browser_session: Optional[str] = None,
+        trading_session: Optional[str] = None,
+        reclaim_on_session_match: bool = False,
+    ) -> Tuple[Dict[str, Any], bool]:
+        """``(agent, owned)`` -- ``owned`` is False for a session-match grant.
+
+        A matching ``session_id`` is enough to *reach* an unclaimed agent (the
+        legacy dashboard reclaim, pinned by
+        ``test_patch_agent_legacy_session_owner``), but it is not an ownership
+        credential. Callers that write ownership -- activate, which claims the
+        agent for the signed-in user -- must not treat it as one: binding an
+        account on a bare session match is irreversible now that
+        ``owns_agent`` refuses browser-only access to bound rows, so it would
+        lock the real owner out for good rather than losing a tug-of-war they
+        can win back.
+        """
         agent = self.agents.get_agent(agent_id)
         if not agent:
             raise AgentNotFoundError()
@@ -238,7 +268,7 @@ class AgentService:
             owner_user_id=user_id,
             owner_browser_session=browser_session,
         ):
-            return agent
+            return agent, True
         if (
             reclaim_on_session_match
             and trading_session
@@ -250,13 +280,15 @@ class AgentService:
             # already-bound agent (activate/restore used to COALESCE overwrite).
             if agent.get("owner_user_id") is not None:
                 raise AgentAccessDeniedError()
+            # Refresh the browser stamp only. owner_user_id stays NULL: this
+            # grant rests on a session id, not a credential, and an account
+            # binding made here cannot be undone by the real owner.
             self.agents.reclaim_agent(
                 agent_id,
-                owner_user_id=user_id,
                 owner_browser_session=browser_session,
             )
             reclaimed = self.agents.get_agent(agent_id)
-            return reclaimed or agent
+            return (reclaimed or agent), False
         raise AgentAccessDeniedError()
 
     # ------------------------------------------------------------------
@@ -622,6 +654,15 @@ class AgentService:
         resolved_model = (model_name or latest.get("llm_model") or "local-model").strip()
 
         existing = self.agents.get_agent_by_session(session_id)
+        # session_id here is the caller-supplied owner context, so re-importing
+        # a session that already belongs to another account must not silently
+        # rename it, re-own it, or hand its record back to the caller.
+        if (
+            existing
+            and existing.get("owner_user_id") is not None
+            and existing.get("owner_user_id") != user_id
+        ):
+            raise AgentAccessDeniedError()
         agent = self.agents.register_or_get_agent(
             session_id=session_id,
             name=resolved_name,

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -245,6 +245,11 @@ class AgentService:
             and browser_session
             and agent.get("session_id") == trading_session
         ):
+            # Only reclaim still-unclaimed guest agents. Matching session_id
+            # must never let a later account on the same browser steal an
+            # already-bound agent (activate/restore used to COALESCE overwrite).
+            if agent.get("owner_user_id") is not None:
+                raise AgentAccessDeniedError()
             self.agents.reclaim_agent(
                 agent_id,
                 owner_user_id=user_id,

--- a/dashboard/backend/tests/domain/agents/test_repository_move.py
+++ b/dashboard/backend/tests/domain/agents/test_repository_move.py
@@ -305,6 +305,66 @@ def test_claim_agent_and_browser_claim(store):
     assert store.claim_browser_agents_to_user("", 1) == 0
 
 
+def test_register_or_get_agent_does_not_steal_another_account(store):
+    """The fourth writer of owner_user_id.
+
+    register_or_get_agent is reachable from POST /agents/import-session, whose
+    session_id is read straight off a caller-supplied header. A bare
+    ``COALESCE(?, owner_user_id)`` takes the first non-null value, so any
+    signed-in caller could re-own (and rename) another account's agent.
+    """
+    created = store.create_agent(
+        name="Owned", owner_user_id=1, owner_browser_session="b-owner"
+    )
+    store.register_or_get_agent(
+        session_id=created["session_id"],
+        name="Renamed by thief",
+        model_name="thief-model",
+        owner_user_id=2,
+        owner_browser_session="b-thief",
+    )
+    row = store.get_agent(created["agent_id"])
+    assert row["owner_user_id"] == 1
+    assert row["name"] == "Owned"
+
+    # The real owner still gets the idempotent name/model refresh.
+    store.register_or_get_agent(
+        session_id=created["session_id"],
+        name="Renamed by owner",
+        model_name="m",
+        owner_user_id=1,
+    )
+    assert store.get_agent(created["agent_id"])["name"] == "Renamed by owner"
+
+
+def test_list_agents_session_fold_keeps_import_session_rows(store):
+    """Regression: the anonymous session fold must not require a browser match.
+
+    import-session rows are stamped owner_browser_session = session_id, so a
+    browser that later sends its own X-Browser-Id matches neither the browser
+    fold nor a browser-equality session fold -- the agent vanishes from
+    My Agents even though its owner is looking right at it.
+    """
+    imported = store.register_or_get_agent(
+        session_id="sess-import", name="I", owner_browser_session="sess-import"
+    )
+    listed = store.list_agents(
+        owner_browser_session="browser-abc", trading_session_id="sess-import"
+    )
+    assert [a["agent_id"] for a in listed] == [imported["agent_id"]]
+
+    # Still no leak: another browser's guest agent stays hidden even when its
+    # session id is known, and account-bound rows never appear anonymously.
+    other = store.create_agent(name="O", owner_browser_session="b-other")
+    assert store.list_agents(
+        owner_browser_session="browser-abc", trading_session_id=other["session_id"]
+    ) == []
+    bound = store.create_agent(name="Bound", owner_user_id=9, owner_browser_session="sess-b")
+    assert store.list_agents(
+        owner_browser_session="browser-abc", trading_session_id=bound["session_id"]
+    ) == []
+
+
 def test_claim_agent_does_not_steal_another_account(store):
     created = store.create_agent(
         name="A", owner_user_id=1, owner_browser_session="b1"

--- a/dashboard/backend/tests/domain/agents/test_repository_move.py
+++ b/dashboard/backend/tests/domain/agents/test_repository_move.py
@@ -219,10 +219,26 @@ def test_list_agents_owner_filters(store):
     by_browser = store.list_agents(owner_browser_session="browser-1")
     assert [a["agent_id"] for a in by_browser] == [b_browser["agent_id"]]
 
-    by_session = store.list_agents(trading_session_id=a_user["session_id"])
+    # trading_session_id alone is not enough — must also match ownership.
+    assert store.list_agents(trading_session_id=a_user["session_id"]) == []
+    by_session = store.list_agents(
+        owner_user_id=1, trading_session_id=a_user["session_id"]
+    )
     assert [a["agent_id"] for a in by_session] == [a_user["agent_id"]]
 
     assert store.list_agents() == []
+
+
+def test_anonymous_list_hides_account_bound_browser_agents(store):
+    """Logout must not re-surface agents the previous signed-in user created."""
+    bound = store.create_agent(
+        name="Bound", owner_user_id=1, owner_browser_session="b1"
+    )
+    guest = store.create_agent(name="Guest", owner_browser_session="b1")
+    listed = store.list_agents(owner_browser_session="b1")
+    ids = {a["agent_id"] for a in listed}
+    assert guest["agent_id"] in ids
+    assert bound["agent_id"] not in ids
 
 
 def test_list_agents_signed_in_includes_unclaimed_browser_agents(store):
@@ -289,6 +305,16 @@ def test_claim_agent_and_browser_claim(store):
     assert store.claim_browser_agents_to_user("", 1) == 0
 
 
+def test_claim_agent_does_not_steal_another_account(store):
+    created = store.create_agent(
+        name="A", owner_user_id=1, owner_browser_session="b1"
+    )
+    store.claim_agent(
+        created["agent_id"], owner_user_id=2, owner_browser_session="b1"
+    )
+    assert store.get_agent(created["agent_id"])["owner_user_id"] == 1
+
+
 def test_delete_agent(store):
     created = store.create_agent(name="A")
     assert store.delete_agent(created["agent_id"]) is True
@@ -304,6 +330,10 @@ def test_owns_agent(store):
     # session_id is NOT an ownership credential — it is discoverable, so matching
     # it must never grant ownership (regression guard for the takeover bug).
     assert store.owns_agent(stored, owner_browser_session=stored["session_id"]) is False
-    # The real owner_browser_session IS recognized — owns_agent reads it straight
-    # from the row (the public agent dict omits it as a private credential).
-    assert store.owns_agent(stored, owner_browser_session="bz") is True
+    # Once bound to an account, browser id alone must not grant access — that is
+    # how logout / a later login on the same machine took over another user's agents.
+    assert store.owns_agent(stored, owner_browser_session="bz") is False
+
+    guest = store.create_agent(name="G", owner_browser_session="guest-b")
+    assert store.owns_agent(guest, owner_browser_session="guest-b") is True
+    assert store.owns_agent(guest, owner_user_id=5) is False

--- a/dashboard/backend/tests/domain/agents/test_service.py
+++ b/dashboard/backend/tests/domain/agents/test_service.py
@@ -246,6 +246,33 @@ def test_require_access_rejects_bare_session_id(svc):
     assert got["agent_id"] == agent["agent_id"]
 
 
+def test_require_access_reclaim_does_not_steal_bound_agent(svc):
+    """Matching trading session + browser must not reassign another account."""
+    agent = svc.create_agent(
+        name="A",
+        model_name="m",
+        owner_user_id=1,
+        owner_browser_session="b-owner",
+    )
+    with pytest.raises(AgentAccessDeniedError):
+        svc.require_access(
+            agent["agent_id"],
+            user_id=2,
+            browser_session="b-thief",
+            trading_session=agent["session_id"],
+            reclaim_on_session_match=True,
+        )
+    assert svc.get_agent(agent["agent_id"])["owner_user_id"] == 1
+
+
+def test_activate_does_not_overwrite_other_owner(svc):
+    agent = svc.create_agent(
+        name="A", model_name="m", owner_user_id=1, owner_browser_session="b1"
+    )
+    svc.activate_agent(agent["agent_id"], user_id=2, browser_session="b1")
+    assert svc.get_agent(agent["agent_id"])["owner_user_id"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Claim
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/tests/domain/agents/test_service.py
+++ b/dashboard/backend/tests/domain/agents/test_service.py
@@ -265,6 +265,67 @@ def test_require_access_reclaim_does_not_steal_bound_agent(svc):
     assert svc.get_agent(agent["agent_id"])["owner_user_id"] == 1
 
 
+def test_session_match_grant_never_binds_an_account(svc):
+    """A session_id match grants access but must not claim the agent.
+
+    ``owns_agent`` now refuses browser-only access to a bound row, so an
+    account binding made off a bare session match is irreversible: the real
+    owner's browser credential stops working with no way back. Access itself
+    stays open (test_patch_agent_legacy_session_owner pins that contract) --
+    only the ownership write is withheld.
+    """
+    agent = svc.create_agent(
+        name="A", model_name="m", owner_user_id=None, owner_browser_session="b-victim"
+    )
+    got, owned = svc.resolve_access(
+        agent["agent_id"],
+        user_id=2,
+        browser_session="b-thief",
+        trading_session=agent["session_id"],
+        reclaim_on_session_match=True,
+    )
+    assert got["agent_id"] == agent["agent_id"]
+    assert owned is False
+    assert svc.get_agent(agent["agent_id"])["owner_user_id"] is None
+    # Still reversible: the original browser wins it back on its own session id.
+    _, owned_back = svc.resolve_access(
+        agent["agent_id"],
+        browser_session="b-victim",
+        trading_session=agent["session_id"],
+        reclaim_on_session_match=True,
+    )
+    assert owned_back is False
+    assert svc.agents.owns_agent(agent, owner_browser_session="b-victim") is True
+
+
+def test_resolve_access_reports_real_credentials_as_owned(svc):
+    """The flag must be True for the credentials that legitimately claim."""
+    guest = svc.create_agent(
+        name="G", model_name="m", owner_user_id=None, owner_browser_session="b1"
+    )
+    assert svc.resolve_access(guest["agent_id"], browser_session="b1")[1] is True
+
+    bound = svc.create_agent(
+        name="B", model_name="m", owner_user_id=7, owner_browser_session="b2"
+    )
+    assert svc.resolve_access(bound["agent_id"], user_id=7)[1] is True
+
+
+def test_import_session_rejects_another_accounts_agent(svc):
+    """import-session must not rename, re-own, or hand back a bound agent."""
+    _insert_ext_run(svc.db, run_id="ext_1", session_id="sess-a", agent_name="orig")
+    owned = svc.agents.register_or_get_agent(
+        session_id="sess-a", name="orig", owner_user_id=1
+    )
+    with pytest.raises(AgentAccessDeniedError):
+        svc.import_session(
+            session_id="sess-a", user_id=2, name="stolen", model_name="m"
+        )
+    row = svc.get_agent(owned["agent_id"])
+    assert row["owner_user_id"] == 1
+    assert row["name"] == "orig"
+
+
 def test_activate_does_not_overwrite_other_owner(svc):
     agent = svc.create_agent(
         name="A", model_name="m", owner_user_id=1, owner_browser_session="b1"

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -514,14 +514,16 @@ def test_claim_and_reclaim_agent_postgres(pg_agent_store):
 
     pg_agent_store.claim_agent(created["agent_id"], owner_user_id=7)
     assert pg_agent_store.owns_agent(created, owner_user_id=7) is True
-    # COALESCE kept the original browser session (no owner_browser_session arg).
-    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_old") is True
-
-    pg_agent_store.reclaim_agent(created["agent_id"], owner_browser_session="bs_new")
-    # reclaim overwrote it: the new session matches, the old one no longer does.
-    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_new") is True
+    # Bound to a user: browser id alone must not grant ownership.
     assert pg_agent_store.owns_agent(created, owner_browser_session="bs_old") is False
-    # The user binding from claim survives reclaim (owner_user_id is COALESCEd).
+
+    pg_agent_store.reclaim_agent(
+        created["agent_id"], owner_user_id=7, owner_browser_session="bs_new"
+    )
+    # reclaim refreshed the browser stamp for the same user; browser-only
+    # access stays denied while the agent remains account-bound.
+    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_new") is False
+    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_old") is False
     assert pg_agent_store.owns_agent(created, owner_user_id=7) is True
 
 

--- a/dashboard/backend/tests/test_agent_store_postgres.py
+++ b/dashboard/backend/tests/test_agent_store_postgres.py
@@ -528,6 +528,56 @@ def test_claim_and_reclaim_agent_postgres(pg_agent_store):
 
 
 @pg_only
+def test_claim_reclaim_accept_null_owner_user_id_postgres(pg_agent_store):
+    """A logged-out caller passes owner_user_id=None through both writers.
+
+    psycopg sends None with an unspecified type OID, so a bare
+    ``%s IS NOT NULL`` in the no-steal guard cannot be type-inferred and
+    Postgres aborts the statement with 42P08 ("could not determine data type of
+    parameter"). Every anonymous activate/restore takes this path, so the
+    uncast form 500s the common case in prod while the SQLite twin -- whose
+    parameters are untyped -- stays green. Only this tier can see it.
+    """
+    created = pg_agent_store.create_agent(name="Anon", owner_browser_session="bs_old")
+
+    # No user id anywhere: the guard must still parse and still bind nothing.
+    pg_agent_store.reclaim_agent(created["agent_id"], owner_browser_session="bs_new")
+    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_new") is True
+    assert pg_agent_store.get_agent(created["agent_id"])["owner_user_id"] is None
+
+    pg_agent_store.claim_agent(created["agent_id"], owner_browser_session="bs_third")
+    assert pg_agent_store.owns_agent(created, owner_browser_session="bs_third") is True
+    assert pg_agent_store.get_agent(created["agent_id"])["owner_user_id"] is None
+
+
+@pg_only
+def test_register_or_get_agent_does_not_steal_account_postgres(pg_agent_store):
+    """import-session must not re-own an agent bound to a different account."""
+    created = pg_agent_store.create_agent(
+        name="Owned", owner_user_id=1, owner_browser_session="bs_owner"
+    )
+    pg_agent_store.register_or_get_agent(
+        session_id=created["session_id"],
+        name="Renamed",
+        model_name="thief-model",
+        owner_user_id=2,
+        owner_browser_session="bs_thief",
+    )
+    row = pg_agent_store.get_agent(created["agent_id"])
+    assert row["owner_user_id"] == 1
+    assert row["name"] == "Owned"
+
+    # The real owner still gets the idempotent update.
+    pg_agent_store.register_or_get_agent(
+        session_id=created["session_id"],
+        name="Renamed by owner",
+        model_name="m",
+        owner_user_id=1,
+    )
+    assert pg_agent_store.get_agent(created["agent_id"])["name"] == "Renamed by owner"
+
+
+@pg_only
 def test_create_agent_stores_default_scopes_verbatim_postgres(pg_agent_store):
     """#137 gap 2: scopes is an authorization surface with no @pg_only assertion.
 

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -195,6 +195,84 @@ def test_import_session_from_backtest_runs(client):
     assert len(listed.json()["agents"]) == 1
 
 
+def test_import_session_rejects_another_accounts_session(client):
+    """import-session derives its session_id from a caller-supplied header.
+
+    Nothing there proves ownership, so re-importing a session already bound to
+    another account must 403 rather than silently re-own and rename it.
+    """
+    session_id = str(uuid.uuid4())
+    import dashboard.backend.database as db_module
+
+    db_module.db.insert_run(
+        run_id="ext_test_import_403",
+        session_id=session_id,
+        agent_name="victim-strategy",
+        mode="backtest",
+        start_date="2026-04-15",
+        end_date="2026-04-16",
+        initial_equity=100000,
+        final_equity=101000,
+        total_return=0.01,
+        sharpe_ratio=0.5,
+        max_drawdown=-0.02,
+        num_trades=3,
+        llm_model="rsi-demo",
+    )
+
+    signup = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "import-owner@example.com",
+            "display_name": "Import Owner",
+            "password": "securepass123",
+        },
+    )
+    assert signup.status_code == 200
+    owner_token = _cookie_session_token(client)
+    owned = client.post(
+        "/api/v1/agents/import-session",
+        json={},
+        headers={
+            "X-Session-Id": session_id,
+            "Authorization": f"Bearer {owner_token}",
+        },
+    )
+    assert owned.status_code == 200
+    agent_id = owned.json()["agent"]["agent_id"]
+
+    client.cookies.clear()
+    signup2 = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "import-thief@example.com",
+            "display_name": "Import Thief",
+            "password": "securepass123",
+        },
+    )
+    assert signup2.status_code == 200
+    thief_token = _cookie_session_token(client)
+    stolen = client.post(
+        "/api/v1/agents/import-session",
+        json={"name": "stolen"},
+        headers={
+            "X-Session-Id": session_id,
+            "Authorization": f"Bearer {thief_token}",
+        },
+    )
+    assert stolen.status_code == 403
+
+    listed = client.get(
+        "/api/v1/agents",
+        headers={
+            "X-Session-Id": session_id,
+            "Authorization": f"Bearer {owner_token}",
+        },
+    )
+    agents = {a["agent_id"]: a for a in listed.json()["agents"]}
+    assert agents[agent_id]["name"] == "victim-strategy"
+
+
 def test_claim_account_links_browser_agents(client):
     browser_session = str(uuid.uuid4())
     anon_headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}

--- a/dashboard/backend/tests/test_agents_api.py
+++ b/dashboard/backend/tests/test_agents_api.py
@@ -235,6 +235,62 @@ def test_claim_account_links_browser_agents(client):
     assert listed.json()["agents"][0]["agent_id"] == agent_id
 
 
+def test_logout_list_hides_account_bound_agents(client):
+    """Same browser after logout must not keep seeing the signed-in user's agents."""
+    browser_session = str(uuid.uuid4())
+    anon_headers = {"X-Session-Id": browser_session, "X-Browser-Id": browser_session}
+
+    signup = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "bound-logout@example.com",
+            "display_name": "Bound Logout",
+            "password": "securepass123",
+        },
+    )
+    assert signup.status_code == 200
+    token = _cookie_session_token(client)
+    auth_headers = {
+        **anon_headers,
+        "Authorization": f"Bearer {token}",
+    }
+
+    created = client.post(
+        "/api/v1/agents",
+        json={"name": "account-agent"},
+        headers=auth_headers,
+    )
+    assert created.status_code == 200
+    agent_id = created.json()["agent"]["agent_id"]
+
+    listed_auth = client.get("/api/v1/agents", headers=auth_headers)
+    assert any(a["agent_id"] == agent_id for a in listed_auth.json()["agents"])
+
+    # Drop auth cookie/session so the next list is anonymous on the same browser.
+    client.cookies.clear()
+    listed_anon = client.get("/api/v1/agents", headers=anon_headers)
+    assert listed_anon.status_code == 200
+    assert all(a["agent_id"] != agent_id for a in listed_anon.json()["agents"])
+
+    # A second account on the same browser must not inherit the first's agents.
+    signup2 = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "other-logout@example.com",
+            "display_name": "Other Logout",
+            "password": "securepass123",
+        },
+    )
+    assert signup2.status_code == 200
+    token2 = _cookie_session_token(client)
+    listed_other = client.get(
+        "/api/v1/agents",
+        headers={**anon_headers, "Authorization": f"Bearer {token2}"},
+    )
+    assert listed_other.status_code == 200
+    assert all(a["agent_id"] != agent_id for a in listed_other.json()["agents"])
+
+
 def test_signed_in_list_includes_unclaimed_browser_foundation_agent(client):
     """Regression: logout shows guest starter; signup must still see it pre-claim."""
     browser_session = str(uuid.uuid4())

--- a/dashboard/backend/tests/test_frontend_account_page.py
+++ b/dashboard/backend/tests/test_frontend_account_page.py
@@ -126,6 +126,37 @@ def test_logging_out_resets_the_email_change_form():
     assert "resetEmailChangeForm = reset" in js
 
 
+def test_active_agent_is_only_cleared_on_a_real_sign_out():
+    """A transient /api/auth/me failure must not cost the agent selection.
+
+    refreshAuthUser() funnels *every* failure through clearAuthState() from a
+    bare catch -- a Render free-tier cold start or a first-request-after-idle
+    500 included -- and it runs immediately after restoreActiveAgentSession()
+    on boot. Clearing the active agent inside clearAuthState() therefore
+    silently undoes the restore for a signed-in user whose boot probe merely
+    timed out. The wipe belongs on the paths that prove the session is gone:
+    the logout button, and a 401.
+    """
+    from dashboard.backend.tests._frontend_source import fn_body
+
+    clear_auth = fn_body("function clearAuthState")
+    assert "ACTIVE_AGENT_KEY" not in clear_auth
+    assert "trading-session-id" not in clear_auth
+
+    clear_agent = fn_body("function clearActiveAgentSession")
+    assert "localStorage.removeItem(ACTIVE_AGENT_KEY)" in clear_agent
+    assert "trading-session-id" in clear_agent
+
+    assert "clearActiveAgentSession()" in fn_body("async function logoutUser")
+
+    refresh = fn_body("async function refreshAuthUser")
+    assert "error?.status === 401" in refresh
+    assert "clearActiveAgentSession()" in refresh
+    # The status has to actually reach the caller -- AuthAPI.request throws a
+    # bare Error, so without this the 401 gate is dead code that never fires.
+    assert "error.status = response.status" in fn_body("  async request(path")
+
+
 def test_cache_bust_versions_were_bumped():
     """Parsed >= rather than a literal ==: these counters are bumped by unrelated
     work too, and an equality assert turns CI red on every open PR the moment

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -179,5 +179,5 @@ def test_slow_boot_notice_is_wired():
 
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
-    assert "app.js?v=77" in APP_HTML
+    assert "app.js?v=86" in APP_HTML
     assert "styles.css?v=87" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -179,5 +179,5 @@ def test_slow_boot_notice_is_wired():
 
 def test_cache_busters_bumped():
     # Floor advances whenever app.js/styles.css change and their ?v= must ship.
-    assert "app.js?v=86" in APP_HTML
+    assert "app.js?v=87" in APP_HTML
     assert "styles.css?v=87" in APP_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1760,7 +1760,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=27" defer></script>
-    <script src="app.js?v=77" defer></script>
+    <script src="app.js?v=86" defer></script>
     <script src="js/leaderboard.js?v=19" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1760,7 +1760,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=27" defer></script>
-    <script src="app.js?v=86" defer></script>
+    <script src="app.js?v=87" defer></script>
     <script src="js/leaderboard.js?v=19" defer></script>
     <script src="home-page.js?v=37" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -3026,7 +3026,11 @@ const AuthAPI = {
 
     if (!response.ok) {
       const message = data?.detail || data?.error || `HTTP ${response.status}`;
-      throw new Error(typeof message === 'string' ? message : JSON.stringify(message));
+      const error = new Error(typeof message === 'string' ? message : JSON.stringify(message));
+      // Callers need to tell "session is gone" (401) apart from "the server is
+      // cold/broken" (5xx, network) -- the message alone cannot carry that.
+      error.status = response.status;
+      throw error;
     }
 
     return data;
@@ -3147,13 +3151,17 @@ async function claimAgentsForUser({ reload = true } = {}) {
   }
 }
 
-function clearAuthState() {
-  clearLegacyAuthToken();
-  localStorage.removeItem(AUTH_USER_KEY);
-  window.AUTH_USER = null;
-  // Drop the previous account's active agent so logout / the next login does
-  // not keep sending that agent's trading session_id (list/activate used to
-  // treat it as enough to surface or reclaim another user's agents).
+// Drop the previous account's active agent so logout / the next login does not
+// keep sending that agent's trading session_id (list/activate used to treat it
+// as enough to surface or reclaim another user's agents).
+//
+// Deliberately NOT part of clearAuthState(): refreshAuthUser() funnels *every*
+// /api/auth/me failure through that function, including a free-tier cold start
+// or a first-request-after-idle 500. Wiping the agent selection there would
+// silently undo the restoreActiveAgentSession() that ran moments earlier on
+// boot. Only a real sign-out (logout, or a 401 that proves the session is gone)
+// should reach this.
+function clearActiveAgentSession() {
   localStorage.removeItem(ACTIVE_AGENT_KEY);
   localStorage.removeItem(ACTIVE_AGENT_NAME_KEY);
   window.ACTIVE_AGENT = null;
@@ -3162,6 +3170,12 @@ function clearAuthState() {
     localStorage.setItem('trading-session-id', browserOwnerId);
     window.SESSION_ID = browserOwnerId;
   }
+}
+
+function clearAuthState() {
+  clearLegacyAuthToken();
+  localStorage.removeItem(AUTH_USER_KEY);
+  window.AUTH_USER = null;
   // The email-change form keeps its stage in a closure keyed to nobody: left
   // alone, the next user to sign in on this tab resumes the previous user's
   // half-finished change. Reset here -- every sign-out path (logout button,
@@ -3628,6 +3642,7 @@ async function logoutUser() {
     console.warn('Logout request failed:', error.message);
   } finally {
     clearAuthState();
+    clearActiveAgentSession();
     await loadAgents();
     if (currentPage === 'account') {
       navigateToPage('home');
@@ -3903,6 +3918,11 @@ async function refreshAuthUser() {
       console.warn('Auth session expired:', error.message);
     }
     clearAuthState();
+    // Only a 401 proves the session is really gone. A network error or a 5xx
+    // cold start must not cost the user their active agent selection.
+    if (error?.status === 401) {
+      clearActiveAgentSession();
+    }
   }
 }
 

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -3151,6 +3151,17 @@ function clearAuthState() {
   clearLegacyAuthToken();
   localStorage.removeItem(AUTH_USER_KEY);
   window.AUTH_USER = null;
+  // Drop the previous account's active agent so logout / the next login does
+  // not keep sending that agent's trading session_id (list/activate used to
+  // treat it as enough to surface or reclaim another user's agents).
+  localStorage.removeItem(ACTIVE_AGENT_KEY);
+  localStorage.removeItem(ACTIVE_AGENT_NAME_KEY);
+  window.ACTIVE_AGENT = null;
+  const browserOwnerId = localStorage.getItem(BROWSER_OWNER_KEY) || window.BROWSER_OWNER_ID;
+  if (browserOwnerId) {
+    localStorage.setItem('trading-session-id', browserOwnerId);
+    window.SESSION_ID = browserOwnerId;
+  }
   // The email-change form keeps its stage in a closure keyed to nobody: left
   // alone, the next user to sign in on this tab resumes the previous user's
   // half-finished change. Reset here -- every sign-out path (logout button,


### PR DESCRIPTION
## Summary
- Anonymous browser agent listing no longer returns agents already bound to another account.
- `owns_agent` / `claim` / `reclaim` refuse cross-account takeover on a shared browser.
- Logout clears the active agent trading session so the next login cannot inherit it.

## Why
Same-browser account switching (and logout) could surface another user's agents, and activate/claim could reassign `owner_user_id`. This is live on `main` today.

## Test plan
- [x] `pytest dashboard/backend/tests/domain/agents/test_repository_move.py dashboard/backend/tests/domain/agents/test_service.py dashboard/backend/tests/test_agents_api.py -q`
- [ ] On one browser: create agents while logged in as A → logout → list should not show A's agents
- [ ] Log in as B on the same browser → B must not see or activate A's agents

Made with [Cursor](https://cursor.com)