### PR TITLE
fix(ui): return to landing page on logout

### DIFF
--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -190,7 +190,7 @@ def test_cache_busters_bumped():
     # the next bump, so the exact one looks like the broken guard and gets
     # "fixed" by loosening it. That collision has already cost this repo one
     # round of follow-ups (#347/#348).
-    assert "app.js?v=112" in APP_HTML
+    assert "app.js?v=113" in APP_HTML
     assert "styles.css?v=113" in APP_HTML
     assert "js/leaderboard.js?v=28" in APP_HTML
     assert "home-page.js?v=46" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_logout_redirect.py
+++ b/dashboard/backend/tests/test_frontend_logout_redirect.py
@@ -1,0 +1,95 @@
+"""Logging out has to hand the user back to the landing page.
+
+index.html states the routing rule in its own words -- "Landing is for
+first-time / logged-out visitors only. Logged-in users go straight to the
+dashboard." -- and enforces the signed-in half itself: a visit to `/` carrying a
+cached auth-user probes /api/auth/me and `location.replace`s to /app on 200.
+Only that half was ever built. `logoutUser` cleared the session and left the
+user standing on the signed-in shell, where /app's home re-renders as the "Guest
+Account" demo portfolio -- byte-identical to what a never-signed-in visitor
+sees, reached by the one action whose entire point was to leave.
+`syncHeaderBrand` already repoints the brand at `/` on sign-out, so the app knew
+home had moved; it just never took the user there.
+
+The asymmetry matters more than the missing hop: /app is reachable by guests on
+purpose (backtests work signed-out), so nothing *breaks*, and that is exactly why
+it survived. A logout with no visible consequence beyond the header swapping to
+"Sign in" reads as a logout that failed.
+
+Source-text guards because /app has no build step and CI has no browser (the
+convention set by test_ai_hedge_fund_frontend.py). No cache-buster assertion
+lives here on purpose -- test_frontend_fast_boot.py owns that invariant alone.
+"""
+
+from pathlib import Path
+
+from dashboard.backend.tests._frontend_source import fn_body
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_LANDING_HTML = (_FRONTEND / "index.html").read_text(encoding="utf-8")
+
+
+def test_logout_returns_the_user_to_the_landing_page():
+    """The missing half of the contract. Without it the user lands on /app's
+    guest home -- the same screen a first-time visitor gets -- so the only
+    feedback that logout worked is the header swapping to "Sign in"."""
+    body = fn_body("async function logoutUser")
+
+    assert "location.replace('/')" in body, (
+        "logoutUser must send the signed-out user back to the landing page"
+    )
+
+
+def test_logout_uses_replace_so_back_cannot_restore_the_signed_in_shell():
+    """`href = '/'` would leave /app in history: one Back press re-renders the
+    shell the user just left. `replace` drops it, and mirrors the verb the
+    landing's own redirect uses."""
+    body = fn_body("async function logoutUser")
+
+    assert "location.href" not in body, "use location.replace, not location.href"
+
+
+def test_logout_clears_local_session_state_before_redirecting():
+    """Ordering is load-bearing, not style. The landing bounces any visit that
+    still has a cached auth-user straight back to /app, so redirecting first and
+    clearing second is a round trip to the page the user was trying to leave.
+    clearActiveAgentSession is in the same bind: it is pure localStorage
+    cleanup, and the redirect tears the page down before a later call runs."""
+    body = fn_body("async function logoutUser")
+    redirect_at = body.index("location.replace('/')")
+
+    assert body.index("clearAuthState()") < redirect_at, (
+        "clearAuthState() must run before the redirect or the landing bounces "
+        "the user straight back to /app"
+    )
+    assert body.index("clearActiveAgentSession()") < redirect_at, (
+        "the active-agent keys must be cleared before the page is torn down"
+    )
+
+
+def test_logout_awaits_the_server_before_leaving_the_page():
+    """The redirect tears down the tab. Fire-and-forget would race the POST that
+    invalidates the cookie against the unload, leaving a live server-side
+    session behind a UI that says signed out."""
+    body = fn_body("async function logoutUser")
+
+    assert body.index("await AuthAPI.logout()") < body.index("location.replace('/')")
+
+
+def test_session_expiry_does_not_evict_guests_from_the_app():
+    """clearAuthState is the choke point *every* sign-out path funnels through,
+    including refreshAuthUser's 401 branch -- which fires on every guest page
+    load. A redirect there would bounce each first-time visitor off /app before
+    they saw it. The redirect belongs to the deliberate action, not the state
+    change."""
+    body = fn_body("function clearAuthState")
+
+    assert "location.replace" not in body
+    assert "location.href" not in body
+
+
+def test_landing_still_redirects_signed_in_visitors():
+    """The other half of the pair. If this ever goes away, the guard above is
+    enforcing a round trip to nowhere."""
+    assert "window.location.replace(APP_URL)" in _LANDING_HTML
+    assert "var APP_URL = '/app';" in _LANDING_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -1943,7 +1943,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=27" defer></script>
-    <script src="app.js?v=112" defer></script>
+    <script src="app.js?v=113" defer></script>
     <script src="js/leaderboard.js?v=28" defer></script>
     <script src="home-page.js?v=46" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -4025,10 +4025,23 @@ async function logoutUser() {
   } finally {
     clearAuthState();
     clearActiveAgentSession();
-    await loadAgents();
-    if (currentPage === 'account' || currentPage === 'admin') {
-      navigateToPage('home');
-    }
+    // Signed out, home is the landing page again. index.html sends a visit
+    // carrying a cached auth-user straight to /app ("Landing is for first-time
+    // / logged-out visitors only"); this is the return trip, which was never
+    // built. Without it logout leaves the user on the signed-in shell, whose
+    // home re-renders as the "Guest Account" demo portfolio -- the screen a
+    // never-signed-in visitor gets -- so the only sign anything happened is the
+    // header swapping to "Sign in".
+    //
+    // Ordering is load-bearing: the two clears above must run first, or the
+    // landing sees a cached auth-user and bounces straight back to /app.
+    // replace() rather than href so Back cannot restore the shell just left,
+    // and it matches the verb the landing's own redirect uses.
+    //
+    // Nothing follows it: the old loadAgents() re-fetch and account/admin page
+    // hop both dressed a page that is being torn down, and awaiting a request
+    // first only delays the one action the user asked for.
+    window.location.replace('/');
   }
 }
 


### PR DESCRIPTION
Logging out left the user on `/app`, whose home re-renders as the "Guest Account" demo portfolio — the same screen a never-signed-in visitor gets. Only feedback that anything happened was the header swapping to "Sign in".

Not a stale-state bug: every module resets correctly post-logout. It was the correct guest render on the wrong surface.

`index.html` declares the rule ("Landing is for first-time / logged-out visitors only") and enforces only the signed-in half — `/` with a cached `auth-user` redirects to `/app`. The return trip was never built. `syncHeaderBrand` already repoints the brand to `/` on sign-out, so the app knew home had moved.

**Redirect goes in `logoutUser`, not `clearAuthState`** — the latter is also reached from `refreshAuthUser`'s 401 branch on every guest page load, and `/app` supports guests on purpose (backtests work signed-out). A redirect there would evict first-time visitors. Guard test pins this.

Clears run before the redirect (else the landing bounces back to `/app`); `replace` not `href` so Back can't restore the shell.

Behavior note: logout now returns to `/` from any page, not just home.

Verified in headless Chromium (logout from home + account page, no bounce loop, guest `/app` unaffected). 6 new guards, red 3/6 in the right shape before the fix. Suite: 2885 passed, 78 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014K97GJdZ2yxAwQ3mhDaGBG