### PR TITLE
docs: note where logout returns you

### DIFF
--- a/docs/source/lab/accounts.rst
+++ b/docs/source/lab/accounts.rst
@@ -33,6 +33,9 @@ Sign in and out
 - **Log out** appears both in that menu and at the bottom of the **Account**
   page. Either one ends the session on this device only; your other devices
   stay signed in.
+- Logging out takes you back to the public homepage — the page you see before
+  signing in. Your browser's **Back** button will not return you to the
+  dashboard you just left; sign in again to get back to it.
 
 
 Manage your profile


### PR DESCRIPTION
#356 changed logout to redirect to the landing page. `accounts.rst` described
logout but not where you land, so the docs were left incomplete rather than wrong.

Adds one bullet: logout returns you to the public homepage, and Back will not
restore the dashboard (the redirect uses `replace()`).

Docs-only. Built with `sphinx-build -n -E` — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014K97GJdZ2yxAwQ3mhDaGBG