### PR TITLE
docs: burst capacity and safety spec + plan

### DIFF
--- a/docs/superpowers/plans/2026-08-18-burst-capacity-safety.md
+++ b/docs/superpowers/plans/2026-08-18-burst-capacity-safety.md
@@ -8,10 +8,26 @@
 
 **Spec:** `docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md`
 **Predecessor:** `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md`
-(four tiers merged; its Task 12 acceptance run executed 2026-08-18 — close it out in T0).
+(four tiers merged; its Task 12 acceptance run **partially** executed 2026-08-18 — 3 of
+6 Step 2 criteria captured, Step 3 prod smoke not run. T0 records that honestly; T5
+closes the rest).
 
-**Architecture:** four independent one-file changes plus a validation run. Each is its
-own branch and PR; none depends on another, so they can land in any order.
+**Architecture:** four small changes plus a validation run, one branch and PR each.
+They are independent in *content* but **not in files, so they are not order-free**:
+
+| | Files touched | Shares with |
+|---|---|---|
+| T0 | predecessor plan, `market_data_store.py` (comment) | — |
+| T1 | `alpaca_bars.py`, `conftest.py`, `.env.example`, +1 test | T3 (`conftest.py`, `.env.example`) |
+| T2 | `external_run_service.py`, +1 test | T3 (`external_run_service.py`) |
+| T3 | `external_run_service.py`, `app.py`, `conftest.py`, `.env.example`, +1 test | T1, T2 |
+| T4 | `stress_serve.py`, `drive_agents.py`, `README.md`, `baseline_worker.py`, +1 test | — |
+
+**Land T2 before T3**, and rebase T3 on merged `main` before pushing. `main` has no
+branch protection and the observed norm is that open PRs get merged promptly, so two
+branches editing `external_run_service.py` and `conftest.py` will collide. A careless
+conflict resolution on `conftest.py` silently drops an env-strip line — which is the
+exact failure the strips exist to prevent, and it fails *open* rather than red.
 
 **Tech stack:** Python 3.13 / FastAPI / threading / requests / pytest.
 
@@ -23,7 +39,16 @@ own branch and PR; none depends on another, so they can land in any order.
   deployed uvicorn. Assert with `capsys`, never `caplog`.
 - **Env vars read once at import** (mirroring `MAX_ACTIVE_RUNS_PER_AGENT`); tests
   monkeypatch the module constant; every new var is stripped in
-  `dashboard/backend/tests/conftest.py`.
+  `dashboard/backend/tests/conftest.py` (append to the scale-knob block at
+  `conftest.py:80-93`, same `os.environ.pop("VAR", None)` shape).
+- **Every new var is documented in `.env.example` in the same commit** — a module
+  constant plus a conftest strip is not a documented default. Follow the existing
+  convention there (comment block explaining purpose + default, then a commented-out
+  `# VAR=value`, then a blank line); `MARKET_DATA_CACHE_MAX_ENTRIES` at
+  `.env.example:206-208` is the model, and the predecessor plan carried this same step
+  explicitly (`plans/2026-07-24-…md:1131-1136`). `.env.example` is the canonical home for
+  these; only promote to the repo `CLAUDE.md` "Environment & credentials" section
+  (`CLAUDE.md:53`) if an operator would need to reason about the knob during an incident.
 - **New defaults, copy verbatim:** `ALPACA_HTTP_TIMEOUT_SECONDS` = `"60"`;
   `ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS` = `"10"`;
   `LEGACY_SESSION_RETENTION_SECONDS` = `"300"`.
@@ -39,25 +64,50 @@ own branch and PR; none depends on another, so they can land in any order.
 
 ---
 
-## T0 — Close out the predecessor plan (docs only)
+## T0 — Record the predecessor's acceptance result (docs + one source comment)
 
 Branch: `docs/close-scale-acceptance`
 
 The predecessor's status header still says the acceptance run was never executed, and
 its Tier-1 rationale cites a dataset size that measurement refuted. Both mislead the
-next reader.
+next reader. **This task does not close Task 12** — half its criteria were never
+captured, and a gate recorded as closed teaches every later reader that the gate works.
 
-**Files:** `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md`
+**Files:** `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md`,
+`dashboard/backend/domain/backtesting/market_data_store.py` (comment only).
 
-- [ ] **Step 1: Update the status header (line 3).** Replace "**Still pending:** Task 12
-      acceptance …" with the executed result: 100 agents / 35.6 s / 100 completed /
-      0 failures / `timeout_holds` 0 in every rung, dated 2026-08-18, linking this plan.
-      Note that the run was performed with the harness bug of T3 below still present,
-      so its CPU figures are a floor.
-- [ ] **Step 2: Correct the `~50 MB` dataset claim** in the Tier-1 comment block
-      (around line 615). Measured ~1.7 MB. Keep `MARKET_DATA_CACHE_MAX_ENTRIES=4` —
-      only the stated justification changes.
-- [ ] **Step 3:** `git status`, commit, PR.
+- [ ] **Step 1: Update the status header (line 3) to a *partial* result.** Replace
+      "**Still pending:** Task 12 acceptance …" with what actually happened, dated
+      2026-08-18 and linking this plan:
+  - **Executed and met** (Step 2): 100 agents / 35.6 s wall / 100 completed / 0 failures
+    / `timeout_holds` 0 in every rung.
+  - **Still pending** (Step 2): `create p95`, `decision p95` and **RSS growth** were
+    never captured — peak RSS was recorded instead, which is a different quantity.
+    Carried into this plan's T5.
+  - **Still pending** (Step 3): the post-deploy prod smoke was not run at all.
+  - Caveat, stated precisely — **two different executions sit behind these numbers, and
+    only one is a floor.** The **ladder sweep** (1→100 agents), which is where
+    `timeout_holds 0 in every rung` comes from, ran with the **T4** harness bug present,
+    so its CPU figures (0.406–0.440 CPU-s) *and* its RSS are floors. The wall-time and
+    completion numbers above come from a separate **fresh 100-agent run** taken after an
+    ad-hoc local repair of that bug; its CPU (0.522 CPU-s) and RSS (311 MB) are **not**
+    floors. Do not write a blanket "all figures are a floor" caveat — conflating the two
+    is exactly what produced the 0.47 error (spec §2).
+  - Keep the wording "Still pending" for the three uncaptured criteria and the smoke.
+    Task 12 says "do not relax the criteria"; three unmeasured criteria are not three met
+    ones, and this header is the only place a later reader looks.
+- [ ] **Step 2: Correct the `~50 MB` dataset claim in the plan** — the fenced Tier-1
+      comment block at lines 614-618. Measured ~1.7 MB (a floor: the source print counts
+      `all_data` frames only, on synthetic harness bars — see spec §2). Keep
+      `MARKET_DATA_CACHE_MAX_ENTRIES=4`; only the stated justification changes.
+- [ ] **Step 3: Correct the same claim in the shipped source.** Lines 614-618 of the plan
+      are a *verbatim quote of a live source comment* at
+      `dashboard/backend/domain/backtesting/market_data_store.py:34-37`. Fixing only the
+      plan leaves the wrong number — and its "~200 MB worst case against the 512 MB free
+      tier" headroom claim, off by ~30× — in the file a capacity reviewer actually opens.
+      Comment text only; no behaviour change, no test change.
+- [ ] **Step 4:** `git status` (confirm the seed DB and its `-wal`/`-shm` sidecars are
+      clean — this task imports no backend module, so they should be), commit, PR.
 
 ---
 
@@ -71,8 +121,9 @@ alpaca-py 0.43.2 calls `self._session.request(method, url, **opts)` with none in
 concurrency ≥ 1.
 
 **Files:** modify `dashboard/backend/infrastructure/market_data/alpaca_bars.py`,
-`dashboard/backend/tests/conftest.py`; create
+`dashboard/backend/tests/conftest.py`, `.env.example`; create
 `dashboard/backend/tests/test_alpaca_http_timeout.py`.
+⚠ `conftest.py` and `.env.example` are also touched by T3 — see the Architecture note.
 
 - [ ] **Step 1: Write the failing tests.**
   - A fake client object exposing a `_session` whose `request` records its kwargs →
@@ -97,9 +148,20 @@ concurrency ≥ 1.
   and returns if absent or lacking `request`, returns early if already wrapped, then
   installs a wrapper doing `kwargs.setdefault("timeout", (connect, read))`. Call it
   immediately after the `StockHistoricalDataClient(...)` construction at line 220.
-- [ ] **Step 4: Strip both vars in `tests/conftest.py`** alongside the existing scale knobs.
-- [ ] **Step 5:** Run the new file, then `test_market_data*`, then the full suite.
-- [ ] **Step 6:** `git status`, commit, PR — `fix: bound Alpaca HTTP requests with a timeout`.
+- [ ] **Step 4: Strip both vars in `tests/conftest.py`** alongside the existing scale
+      knobs (the block at `conftest.py:80-93`).
+- [ ] **Step 5: Document both vars in `.env.example`**, in the same commit, following the
+      convention there:
+
+  ```
+  # Bound every Alpaca market-data HTTP request. alpaca-py issues requests with no
+  # timeout, so one stalled socket leaks a threadpool thread for the life of the
+  # process. Connect/read seconds. Defaults 10 / 60.
+  # ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS=10
+  # ALPACA_HTTP_TIMEOUT_SECONDS=60
+  ```
+- [ ] **Step 6:** Run the new file, then `test_market_data*`, then the full suite.
+- [ ] **Step 7:** `git status`, commit, PR — `fix: bound Alpaca HTTP requests with a timeout`.
 
 ---
 
@@ -113,6 +175,7 @@ auto-held steps is not the agent's curve.
 
 **Files:** modify `dashboard/backend/domain/backtesting/external_run_service.py`;
 create `dashboard/backend/tests/test_deadline_hold_visibility.py`.
+⚠ `external_run_service.py` is also touched by T3 — land this one first.
 
 - [ ] **Step 1: Write the failing tests.**
   - Drive a session past its deadline (monkeypatch `DECISION_TIMEOUT_SECONDS` or the
@@ -120,25 +183,53 @@ create `dashboard/backend/tests/test_deadline_hold_visibility.py`.
     and the hold count.
   - **One line per poll, not per step:** force ≥ 3 steps to expire in a single drain
     and assert exactly one `decision deadline` line is printed, carrying `3`.
-  - A run with no expired step prints nothing.
+  - **The same for `drain_expired()`** — call it directly on a session with ≥ 3 expired
+    steps and assert it prints one equivalent line. This is the reaper's path and the
+    one with no agent watching; a test that only drives `get_current_step` would pass
+    against an implementation that leaves it silent.
+  - **The same for `get_status()`** — expire one step, call `session.get_status()`
+    directly, assert one line. This is the site an implementer will miss and the one the
+    live protocol path actually uses (`runs/service.py:384`, `:749`, `:781`).
+  - **Through the router, not just the session.** Drive a real
+    `run_service.get_step(run_id, step_id)` past a deadline and assert a line is printed.
+    This is the assertion that catches the pre-emption bug: `get_step` calls
+    `session.get_status()` first, which applies the hold and advances `step_index`, so
+    its `session.step_index == seq` guard then fails and `get_current_step()` — the loop
+    everyone thinks of instrumenting — is never reached for that poll. A session-level
+    test suite passes happily against an implementation that is silent here.
+  - **The printed step range names the steps that were actually held.** Open at step
+    index *i*, expire 3 steps, assert the line carries `i..i+2` — **not** the
+    post-drain index. `_advance_step` increments `self.step_index` (`:601`) inside the
+    loop, so an index read after the loop names a step that was never held. This is the
+    only assertion that distinguishes a correct implementation from the obvious wrong one.
+  - A run with no expired step prints nothing (both call sites).
   - `timeout_holds` still increments exactly as before (guard against the counter
     being disturbed).
 - [ ] **Step 2: Run them; verify they fail.**
-- [ ] **Step 3: Implement.** `_maybe_apply_timeout` keeps its current signature and
-      stays silent. The `while self._maybe_apply_timeout():` loop in
-      `get_current_step` counts iterations and, after the loop, prints once when the
-      count is non-zero:
+- [ ] **Step 3: Implement at all three sites.** `_maybe_apply_timeout` keeps its current
+      signature and stays silent — it is called from inside the two loops, so printing
+      there would produce one line per step. Factor the emit into a small helper and call
+      it from **all three**: `get_current_step` (`:430-434`), `drain_expired`
+      (`:734-742`), and `get_status` (`:710-712`). The first two run the identical
+      `while` loop; `get_status` calls `_maybe_apply_timeout()` **once, unlooped**, so
+      there it emits at most one line per hold with no volume concern. The helper must
+      **not** acquire `_step_lock` — all three callers already hold it, and re-acquiring
+      a non-reentrant `threading.Lock` deadlocks. Capture the starting `self.step_index`
+      **before** the loop (or before the single call), count holds, and print once
+      afterwards when the count is non-zero:
 
   ```
   ⚠️ decision deadline: auto-held {n} step(s) for {backtest_id}
-     (agent={agent_name}, step_index={i}, total_holds={t})
+     (agent={agent_name}, steps={first}..{last}, total_holds={t})
      — these steps are NOT the agent's decisions
   ```
 
-  Check `drain_expired()` (line 734) for the same loop shape and give it the same
-  treatment if it drains independently.
-- [ ] **Step 4:** Run the new file, then `test_run_lifecycle_unification.py`,
-      `test_protocol_api.py`, then the full suite.
+  One request can legitimately produce two lines — `get_step` calls `get_status()` and
+  then possibly `get_current_step()`, and each may hold different steps. That is correct
+  and the tests should not forbid it; what they must forbid is *zero* lines.
+- [ ] **Step 4:** Run the new file, then `test_deadline_and_holds.py` (the existing
+      coverage for this path — it already exercises `drain_expired` directly),
+      `test_run_lifecycle_unification.py`, `test_protocol_api.py`, then the full suite.
 - [ ] **Step 5:** `git status`, commit, PR — `fix: log decision-deadline auto-holds`.
 
 ---
@@ -152,8 +243,20 @@ legacy `/api/v1/backtest/*` surface never populates. `MAX_LEGACY_ACTIVE_GLOBAL` 
 bound them either — `_count_active_locked` (`:919`) skips terminal sessions. Unbounded.
 
 **Files:** modify `dashboard/backend/domain/backtesting/external_run_service.py`,
-`dashboard/backend/app.py`, `dashboard/backend/tests/conftest.py`; create
-`dashboard/backend/tests/test_legacy_session_sweep.py`.
+`dashboard/backend/app.py`, `dashboard/backend/tests/conftest.py`, `.env.example`;
+create `dashboard/backend/tests/test_legacy_session_sweep.py`.
+⚠ Shares `external_run_service.py` with T2 and `conftest.py`/`.env.example` with T1 —
+land this **last** and rebase on merged `main` first (see the Architecture note).
+
+**Scope note — `_sessions` is not legacy-only.** Its single write site is
+`_sessions[backtest_id] = session` (`:990`) in `start_backtest` (`:947`), which serves
+the legacy route *and* the protocol surface via `run_service.create_run`. The sweep
+walks the whole dict anyway, which is correct because `reap_runs` evicts terminal
+protocol sessions at `runs/service.py:434-436` **before** invoking registered sweeps at
+`:466-470` — so the sweep only ever sees one if that eviction failed, where the TTL is a
+backstop. Do not reorder those blocks, and do not add a legacy-only filter expecting it
+to be a no-op. v2 is unaffected either way: `execution/backtest_backend.py:74-78`
+constructs its session directly and never registers it, so this sweep cannot bound v2.
 
 - [ ] **Step 1: Write the failing tests.**
   - A terminal session is **not** evicted on the first sweep (TTL clock starts) and
@@ -166,25 +269,46 @@ bound them either — `_count_active_locked` (`:919`) skips terminal sessions. U
   - **Regression guard:** a terminal session left in `_sessions` does not count toward
     `_count_active_locked`, so capacity is unaffected either way — assert the cap
     behaves identically before and after a sweep.
+  - **The sweep does not raise through the reaper.** Register it, run a real
+    `reap_runs()` pass with a terminal session present, and assert `capsys` contains **no**
+    `registered sweep failed` line. Without this, the `AttributeError` of Step 3 is
+    swallowed into a warning and every other test in this file still passes.
 - [ ] **Step 2: Run them; verify they fail.**
-- [ ] **Step 3: Implement `sweep_terminal_sessions()`** in `external_run_service.py`.
+- [ ] **Step 3: Add `self.terminal_seen_at: Optional[datetime] = None` to
+      `ExternalBacktestSession.__init__`** (`:184-253`, alongside `self.step_opened_at`
+      at `:238`). **The attribute does not exist today** — a sweep that reads
+      `s.terminal_seen_at` before anything writes it raises `AttributeError`, and because
+      registered sweeps run inside `reap_runs`' `try/except` (`runs/service.py:466-470`)
+      that surfaces only as `⚠️ reap_runs: registered sweep failed: …` while the reaper
+      keeps reporting healthy. The sweep would silently never work. (A
+      `getattr(s, "terminal_seen_at", None)` read is the alternative; prefer the explicit
+      `__init__` default so the attribute is discoverable.)
+- [ ] **Step 4: Implement `sweep_terminal_sessions()`** in `external_run_service.py`.
       Under `_lock`, iterate `list(_sessions.items())`; skip
-      `s.status not in TERMINAL_STATUSES`; stamp `s.terminal_seen_at = _utcnow()` on
-      first sighting and `continue`; pop once
+      `s.status not in TERMINAL_STATUSES`; stamp `s.terminal_seen_at = _utcnow()`
+      (`:117-118`) on first sighting and `continue`; pop once
       `(now - terminal_seen_at) >= LEGACY_SESSION_RETENTION_SECONDS`. Return the count.
       First-sighting rather than stamping in `_finalize`/`cancel` deliberately: it
       cannot be missed by a terminal path that forgets to stamp.
-- [ ] **Step 4: Register it** in `app.py` beside the existing
-      `register_reaper_sweep(reap_v2_runs)` (`app.py:219-220`). No new thread; it rides
-      the 60 s reaper pass.
-- [ ] **Step 5: Strip `LEGACY_SESSION_RETENTION_SECONDS`** in `tests/conftest.py`.
-- [ ] **Step 6:** Run the new file, then `test_run_lifecycle_unification.py`,
+- [ ] **Step 5: Register it** in `app.py` beside the existing
+      `register_reaper_sweep(reap_v2_runs)` (the call is at `app.py:220`). No new thread;
+      it rides the 60 s reaper pass.
+- [ ] **Step 6: Strip `LEGACY_SESSION_RETENTION_SECONDS`** in `tests/conftest.py`
+      (the scale-knob block at `:80-93`) **and document it in `.env.example`**:
+
+  ```
+  # How long a terminal legacy /api/v1/backtest/* session is kept in memory before
+  # the reaper sweep drops it. Reads for an evicted run fall back to the persisted
+  # row, so this only buys an in-flight reader some slack. Seconds. Default 300.
+  # LEGACY_SESSION_RETENTION_SECONDS=300
+  ```
+- [ ] **Step 7:** Run the new file, then `test_run_lifecycle_unification.py`,
       `test_architecture_boundaries.py`, then the full suite.
-- [ ] **Step 7:** `git status`, commit, PR — `fix: evict terminal legacy backtest sessions`.
+- [ ] **Step 8:** `git status`, commit, PR — `fix: evict terminal legacy backtest sessions`.
 
 ---
 
-## T4 — Fix the load-test harness
+## T4 — Fix the load-test harness, and make a wholesale baseline failure loud
 
 Branch: `fix/loadtest-harness-baselines`
 
@@ -193,23 +317,45 @@ lambda against a two-argument signature, so every baseline through every rung fa
 and was swallowed as a warning. The harness is the instrument T5 depends on.
 
 **Files:** modify `dashboard/scripts/loadtest/stress_serve.py`,
-`dashboard/scripts/loadtest/drive_agents.py`, `dashboard/scripts/loadtest/README.md`.
+`dashboard/scripts/loadtest/drive_agents.py`, `dashboard/scripts/loadtest/README.md`,
+`dashboard/backend/domain/backtesting/baseline_worker.py`; create
+`dashboard/backend/tests/test_baseline_failure_visibility.py`.
 
-- [ ] **Step 1:** `stress_serve.py:60` → `lambda *a, **k: FakeAlpacaLoader()`.
-- [ ] **Step 2: Make a swallowed baseline failure loud in the harness.** The bug
-      survived a full ladder because the failure printed a warning nobody read. Have
-      `stress_serve.py` count `Baseline generation failed` occurrences and print a
-      summary banner at shutdown, so a future harness break cannot be mistaken for a
-      clean run.
-- [ ] **Step 3: Add `--windows shared|distinct` to `drive_agents.py`** (default
+- [ ] **Step 1:** `stress_serve.py:60` → `lambda *a, **k: FakeAlpacaLoader()`. The real
+      `create_market_data_provider(data_source=ALPACA, universe=None)` takes two
+      arguments; the current `lambda ds=None:` takes one.
+- [ ] **Step 2: Make a wholesale baseline failure loud *in production*, not just in the
+      harness.** `_drain_forever` prints `⚠️ Baseline generation failed (run saved): {exc}`
+      per job (`baseline_worker.py:100`) inside `except (Exception, SystemExit)` and
+      continues; the module keeps **no failure counter at all** — `_completed`
+      (`:56-61`) records only successes. That per-item warning is exactly why F4 survived
+      a whole ladder unnoticed, and fixing it only in `stress_serve.py` leaves prod as
+      blind as the harness was: an upstream break failing *every* baseline would still be
+      a stream of warnings nobody reads. Repo rule: **a per-item warning cannot report a
+      total contract break.**
+  - Add a consecutive-failure counter to `baseline_worker`, reset on any success. On
+    crossing a small threshold, print one unmissable escalation line naming the count and
+    the last exception. `print()`, not `logger` — logger output is invisible under
+    deployed uvicorn.
+  - Test it: monkeypatch `_run_job` to always raise, submit N jobs, assert via `capsys`
+    that the escalation line appears exactly once and that a subsequent success resets
+    the counter.
+- [ ] **Step 3: Then** have `stress_serve.py` count `Baseline generation failed`
+      occurrences and print a summary banner at shutdown, so a future *harness* break
+      cannot be mistaken for a clean run.
+- [ ] **Step 4: Add `--windows shared|distinct` to `drive_agents.py`** (default
       `shared`). `shared` gives every agent one date range; `distinct` gives each its
       own. This is the switch F5's diagnosis needs and the difference between one
       queued baseline backtest and N serialized ones.
-- [ ] **Step 4: Update the README** — document both flags and state plainly that
-      figures produced before this fix are a floor.
-- [ ] **Step 5: Smoke-run at 10 agents both ways**, confirming baselines now complete
+- [ ] **Step 5: Update the README** — document both flags and state plainly which figures
+      are floors: anything produced by the **unrepaired** harness understates both CPU and
+      RSS, because the baseline worker's `HourlyBacktester` never allocated. The
+      2026-08-18 ladder rungs are in that category; the fresh 100-agent run (0.522 CPU-s,
+      311 MB) was taken after an ad-hoc local repair and is not. Say so explicitly, so a
+      later reader does not average the two.
+- [ ] **Step 6: Smoke-run at 10 agents both ways**, confirming baselines now complete
       (no warning banner) and that `distinct` is visibly slower than `shared`.
-- [ ] **Step 6:** `git status`, commit, PR — `fix: repair baseline patching in the load-test harness`.
+- [ ] **Step 7:** `git status`, commit, PR — `fix: repair baseline patching in the load-test harness`.
 
 ---
 
@@ -222,17 +368,29 @@ workstream has ever run on Render.
 
 - [ ] **Step 1:** Deploy `main` (with T1–T4) to a Render **Standard** instance.
 - [ ] **Step 2:** Run the fixed harness at **25 agents** first, `--windows shared`.
-      Record wall time, failures, `timeout_holds`, peak RSS.
+      Record wall time, failures, `timeout_holds`, **create p95, decision p95, RSS at
+      start and at end** (growth, not just peak — see Step 3).
 - [ ] **Step 3:** If 25 is clean, run **100 agents**, `--windows shared`.
       **Acceptance:** zero failures, `timeout_holds == 0`, RSS below the instance
-      ceiling, wall time within ~2× the ~47 s prediction.
+      ceiling, wall time within ~2× the ~52 s prediction — **plus the three predecessor
+      criteria that were never captured** (`plans/2026-07-24-…md:2729`): `create p95 <
+      1000 ms`, `decision p95 < 1000 ms`, `RSS growth < 100 MB`. This is the first
+      environment where they mean anything and the first run whose baselines actually
+      execute, so this is what finally closes Task 12 Step 2. Task 12's own rule applies:
+      if a criterion misses, diagnose — do not relax it.
 - [ ] **Step 4:** Run **100 agents `--windows distinct`** once, purely to measure the
       baseline-worker serialization from F5. Expected to be materially slower; that is
       the datum, not a failure.
-- [ ] **Step 5: Record results** in this plan's status header. **If they contradict the
-      spec's §5 table, the spec is wrong** — correct §5 rather than explaining the
-      measurement away.
-- [ ] **Step 6:** Only then decide whether the deferred §4 optimization is needed.
+- [ ] **Step 5: Run the predecessor's outstanding Step 3 prod smoke** — one 100-agent
+      smoke against **prod** with a throwaway config window, watching the startup lines
+      (`market-data dataset built`, `pg pool created`) and `timeout_holds` in results
+      (`plans/2026-07-24-…md:2731-2733`). Manual/observational, no repo change. This is
+      the last outstanding piece of Task 12.
+- [ ] **Step 6: Record results** in this plan's status header **and update the
+      predecessor's line-3 header** from partial to closed — only once Steps 3 and 5 have
+      both passed. **If they contradict the spec's §5 table, the spec is wrong** —
+      correct §5 rather than explaining the measurement away.
+- [ ] **Step 7:** Only then decide whether the deferred §4 optimization is needed.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-18-burst-capacity-safety.md
+++ b/docs/superpowers/plans/2026-08-18-burst-capacity-safety.md
@@ -1,0 +1,249 @@
+# Burst Capacity & Safety — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development`
+> (recommended) or `superpowers:executing-plans` to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** make a 100-agent burst safe and observable, with no per-run CPU optimization.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md`
+**Predecessor:** `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md`
+(four tiers merged; its Task 12 acceptance run executed 2026-08-18 — close it out in T0).
+
+**Architecture:** four independent one-file changes plus a validation run. Each is its
+own branch and PR; none depends on another, so they can land in any order.
+
+**Tech stack:** Python 3.13 / FastAPI / threading / requests / pytest.
+
+## Global constraints
+
+- **Wire contract frozen.** No new run/step status literals. New payload *keys* are fine.
+- **No new HTTP routes.** The three route-contract freeze tests must pass untouched.
+- **`print()`, not `logger`** — `dashboard.backend.*` logger output is invisible under
+  deployed uvicorn. Assert with `capsys`, never `caplog`.
+- **Env vars read once at import** (mirroring `MAX_ACTIVE_RUNS_PER_AGENT`); tests
+  monkeypatch the module constant; every new var is stripped in
+  `dashboard/backend/tests/conftest.py`.
+- **New defaults, copy verbatim:** `ALPACA_HTTP_TIMEOUT_SECONDS` = `"60"`;
+  `ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS` = `"10"`;
+  `LEGACY_SESSION_RETENTION_SECONDS` = `"300"`.
+- `domain/` must not import `api/` or `app.py` (`test_architecture_boundaries.py`).
+- **Never `git add -A`** — a bare backend import runs lazy `ALTER`s against the committed
+  seed `dashboard/storage/data/backtest.db`. `git status` before every commit; if the
+  seed DB or its `-wal`/`-shm` sidecars are dirty, `git checkout --` them.
+- Run from the repo root: `~/atl-venv/bin/python -m pytest dashboard/backend/tests/ -q`.
+- One branch + PR per task, cut from up-to-date `origin/main`. Short PR titles.
+  **Merging to `main` auto-deploys prod.** Never push to a branch whose PR merged.
+- Commit messages use the repo's `feat:`/`fix:`/`test:`/`docs:` convention with the
+  session's standard `Co-Authored-By:` / `Claude-Session:` trailers.
+
+---
+
+## T0 — Close out the predecessor plan (docs only)
+
+Branch: `docs/close-scale-acceptance`
+
+The predecessor's status header still says the acceptance run was never executed, and
+its Tier-1 rationale cites a dataset size that measurement refuted. Both mislead the
+next reader.
+
+**Files:** `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md`
+
+- [ ] **Step 1: Update the status header (line 3).** Replace "**Still pending:** Task 12
+      acceptance …" with the executed result: 100 agents / 35.6 s / 100 completed /
+      0 failures / `timeout_holds` 0 in every rung, dated 2026-08-18, linking this plan.
+      Note that the run was performed with the harness bug of T3 below still present,
+      so its CPU figures are a floor.
+- [ ] **Step 2: Correct the `~50 MB` dataset claim** in the Tier-1 comment block
+      (around line 615). Measured ~1.7 MB. Keep `MARKET_DATA_CACHE_MAX_ENTRIES=4` —
+      only the stated justification changes.
+- [ ] **Step 3:** `git status`, commit, PR.
+
+---
+
+## T1 — Default HTTP timeout on the Alpaca client
+
+Branch: `fix/alpaca-http-timeout`
+
+**Why:** `alpaca_bars.py:220` builds `StockHistoricalDataClient` with no timeout;
+alpaca-py 0.43.2 calls `self._session.request(method, url, **opts)` with none in `opts`.
+`requests` then blocks forever and permanently leaks a threadpool thread. Binds at
+concurrency ≥ 1.
+
+**Files:** modify `dashboard/backend/infrastructure/market_data/alpaca_bars.py`,
+`dashboard/backend/tests/conftest.py`; create
+`dashboard/backend/tests/test_alpaca_http_timeout.py`.
+
+- [ ] **Step 1: Write the failing tests.**
+  - A fake client object exposing a `_session` whose `request` records its kwargs →
+    after `_apply_default_timeout`, a call with no `timeout` receives
+    `(connect, read)` from the module constants.
+  - A caller-supplied `timeout=` is **not** overridden.
+  - Applying twice does not double-wrap (assert via the guard attribute, and that one
+    call still records exactly one timeout kwarg).
+  - A client object with **no** `_session` attribute → returns without raising **and
+    prints a warning** containing `_session`. This is the F2 lesson: an upstream rename
+    must not silently restore unbounded behaviour.
+- [ ] **Step 2: Run them; verify they fail.**
+- [ ] **Step 3: Implement.** Module constants read once at import:
+
+  ```python
+  ALPACA_HTTP_TIMEOUT_SECONDS = float(os.getenv("ALPACA_HTTP_TIMEOUT_SECONDS", "60"))
+  ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS = float(
+      os.getenv("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS", "10"))
+  ```
+
+  `_apply_default_timeout(client)` fetches `getattr(client, "_session", None)`, warns
+  and returns if absent or lacking `request`, returns early if already wrapped, then
+  installs a wrapper doing `kwargs.setdefault("timeout", (connect, read))`. Call it
+  immediately after the `StockHistoricalDataClient(...)` construction at line 220.
+- [ ] **Step 4: Strip both vars in `tests/conftest.py`** alongside the existing scale knobs.
+- [ ] **Step 5:** Run the new file, then `test_market_data*`, then the full suite.
+- [ ] **Step 6:** `git status`, commit, PR — `fix: bound Alpaca HTTP requests with a timeout`.
+
+---
+
+## T2 — Make decision-deadline auto-holds visible
+
+Branch: `fix/log-decision-deadline-holds`
+
+**Why:** `_maybe_apply_timeout` (`external_run_service.py:421`) reattributes a step to
+`decision_source="timeout_hold"` with no output whatsoever. A published curve containing
+auto-held steps is not the agent's curve.
+
+**Files:** modify `dashboard/backend/domain/backtesting/external_run_service.py`;
+create `dashboard/backend/tests/test_deadline_hold_visibility.py`.
+
+- [ ] **Step 1: Write the failing tests.**
+  - Drive a session past its deadline (monkeypatch `DECISION_TIMEOUT_SECONDS` or the
+    clock), poll `get_current_step`, assert `capsys` output contains the backtest id
+    and the hold count.
+  - **One line per poll, not per step:** force ≥ 3 steps to expire in a single drain
+    and assert exactly one `decision deadline` line is printed, carrying `3`.
+  - A run with no expired step prints nothing.
+  - `timeout_holds` still increments exactly as before (guard against the counter
+    being disturbed).
+- [ ] **Step 2: Run them; verify they fail.**
+- [ ] **Step 3: Implement.** `_maybe_apply_timeout` keeps its current signature and
+      stays silent. The `while self._maybe_apply_timeout():` loop in
+      `get_current_step` counts iterations and, after the loop, prints once when the
+      count is non-zero:
+
+  ```
+  ⚠️ decision deadline: auto-held {n} step(s) for {backtest_id}
+     (agent={agent_name}, step_index={i}, total_holds={t})
+     — these steps are NOT the agent's decisions
+  ```
+
+  Check `drain_expired()` (line 734) for the same loop shape and give it the same
+  treatment if it drains independently.
+- [ ] **Step 4:** Run the new file, then `test_run_lifecycle_unification.py`,
+      `test_protocol_api.py`, then the full suite.
+- [ ] **Step 5:** `git status`, commit, PR — `fix: log decision-deadline auto-holds`.
+
+---
+
+## T3 — Sweep terminal legacy sessions
+
+Branch: `fix/evict-terminal-legacy-sessions`
+
+**Why:** `reap_runs()` evicts terminal engine sessions by walking `_runs`, which the
+legacy `/api/v1/backtest/*` surface never populates. `MAX_LEGACY_ACTIVE_GLOBAL` cannot
+bound them either — `_count_active_locked` (`:919`) skips terminal sessions. Unbounded.
+
+**Files:** modify `dashboard/backend/domain/backtesting/external_run_service.py`,
+`dashboard/backend/app.py`, `dashboard/backend/tests/conftest.py`; create
+`dashboard/backend/tests/test_legacy_session_sweep.py`.
+
+- [ ] **Step 1: Write the failing tests.**
+  - A terminal session is **not** evicted on the first sweep (TTL clock starts) and
+    **is** evicted on a sweep after `LEGACY_SESSION_RETENTION_SECONDS` (monkeypatch the
+    constant to `0` or advance the clock).
+  - A non-terminal session is never evicted regardless of age.
+  - The sweep is idempotent and returns the number dropped.
+  - Reading a run whose session was evicted still works via the persisted row
+    (this is the safety claim in `evict_session`'s docstring — pin it).
+  - **Regression guard:** a terminal session left in `_sessions` does not count toward
+    `_count_active_locked`, so capacity is unaffected either way — assert the cap
+    behaves identically before and after a sweep.
+- [ ] **Step 2: Run them; verify they fail.**
+- [ ] **Step 3: Implement `sweep_terminal_sessions()`** in `external_run_service.py`.
+      Under `_lock`, iterate `list(_sessions.items())`; skip
+      `s.status not in TERMINAL_STATUSES`; stamp `s.terminal_seen_at = _utcnow()` on
+      first sighting and `continue`; pop once
+      `(now - terminal_seen_at) >= LEGACY_SESSION_RETENTION_SECONDS`. Return the count.
+      First-sighting rather than stamping in `_finalize`/`cancel` deliberately: it
+      cannot be missed by a terminal path that forgets to stamp.
+- [ ] **Step 4: Register it** in `app.py` beside the existing
+      `register_reaper_sweep(reap_v2_runs)` (`app.py:219-220`). No new thread; it rides
+      the 60 s reaper pass.
+- [ ] **Step 5: Strip `LEGACY_SESSION_RETENTION_SECONDS`** in `tests/conftest.py`.
+- [ ] **Step 6:** Run the new file, then `test_run_lifecycle_unification.py`,
+      `test_architecture_boundaries.py`, then the full suite.
+- [ ] **Step 7:** `git status`, commit, PR — `fix: evict terminal legacy backtest sessions`.
+
+---
+
+## T4 — Fix the load-test harness
+
+Branch: `fix/loadtest-harness-baselines`
+
+**Why:** `stress_serve.py:60` patches `create_market_data_provider` with a one-argument
+lambda against a two-argument signature, so every baseline through every rung failed
+and was swallowed as a warning. The harness is the instrument T5 depends on.
+
+**Files:** modify `dashboard/scripts/loadtest/stress_serve.py`,
+`dashboard/scripts/loadtest/drive_agents.py`, `dashboard/scripts/loadtest/README.md`.
+
+- [ ] **Step 1:** `stress_serve.py:60` → `lambda *a, **k: FakeAlpacaLoader()`.
+- [ ] **Step 2: Make a swallowed baseline failure loud in the harness.** The bug
+      survived a full ladder because the failure printed a warning nobody read. Have
+      `stress_serve.py` count `Baseline generation failed` occurrences and print a
+      summary banner at shutdown, so a future harness break cannot be mistaken for a
+      clean run.
+- [ ] **Step 3: Add `--windows shared|distinct` to `drive_agents.py`** (default
+      `shared`). `shared` gives every agent one date range; `distinct` gives each its
+      own. This is the switch F5's diagnosis needs and the difference between one
+      queued baseline backtest and N serialized ones.
+- [ ] **Step 4: Update the README** — document both flags and state plainly that
+      figures produced before this fix are a floor.
+- [ ] **Step 5: Smoke-run at 10 agents both ways**, confirming baselines now complete
+      (no warning banner) and that `distinct` is visibly slower than `shared`.
+- [ ] **Step 6:** `git status`, commit, PR — `fix: repair baseline patching in the load-test harness`.
+
+---
+
+## T5 — Validation against a real Render instance
+
+**Not a code change. Do not start it until T1–T4 have merged.**
+
+Every number in the spec comes from a 12-core dev box plus arithmetic. Nothing in this
+workstream has ever run on Render.
+
+- [ ] **Step 1:** Deploy `main` (with T1–T4) to a Render **Standard** instance.
+- [ ] **Step 2:** Run the fixed harness at **25 agents** first, `--windows shared`.
+      Record wall time, failures, `timeout_holds`, peak RSS.
+- [ ] **Step 3:** If 25 is clean, run **100 agents**, `--windows shared`.
+      **Acceptance:** zero failures, `timeout_holds == 0`, RSS below the instance
+      ceiling, wall time within ~2× the ~47 s prediction.
+- [ ] **Step 4:** Run **100 agents `--windows distinct`** once, purely to measure the
+      baseline-worker serialization from F5. Expected to be materially slower; that is
+      the datum, not a failure.
+- [ ] **Step 5: Record results** in this plan's status header. **If they contradict the
+      spec's §5 table, the spec is wrong** — correct §5 rather than explaining the
+      measurement away.
+- [ ] **Step 6:** Only then decide whether the deferred §4 optimization is needed.
+
+---
+
+## Deliberately not in this plan
+
+- **Per-run CPU optimization** (memo + dict rows, 1.51× measured). Deferred by decision;
+  numbers are in spec §4 so nobody re-derives them.
+- **Raising the anyio threadpool.** Refuted by A/B on the same binary: 40 → 35.6 s /
+  0 failures; 160 → 30.3 s / **2 failures**. Do not retry.
+- **Any protocol-surface leak fix.** Refuted by measurement — 200 sequential runs, flat
+  CPU, plateaued RSS.
+- **A fix for F5.** Mechanism unidentified; T5 Step 4 gathers the evidence first.
+- **Horizontal scaling / extra workers.** Architecturally closed while `_sessions` and
+  `_runs` are module-level and the heartbeat path fails orphaned runs.

--- a/docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md
+++ b/docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md
@@ -1,0 +1,239 @@
+# Burst Capacity & Safety — Design
+
+**Date:** 2026-08-18
+**Predecessor:** `docs/superpowers/specs/2026-07-24-agent-scale-sustainability-design.md`
+(plan: `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md` — four tiers
+merged as #208/#209/#211/#212; its **Task 12 acceptance run was executed 2026-08-18**,
+results below).
+
+---
+
+## 1. What this is
+
+The predecessor made 100 concurrent protocol agents *survivable*. This spec covers the
+residue that the acceptance run surfaced: four verified defects, and the hosting decision
+for a **100-agent burst** (a demo/launch moment, not sustained load).
+
+**Explicitly out of scope, by decision:** per-run CPU optimization. It was measured
+(§4) and is real, but the burst target does not need it. Recorded here so a later
+reader does not re-derive it.
+
+## 2. Measured baseline (2026-08-18)
+
+The predecessor's acceptance criteria were never run until now. They pass.
+
+| Measurement | Result |
+|---|---|
+| 100 agents, fresh process | **35.6 s wall, 100/100 completed, 0 failures**, worst request 5.6 s |
+| `timeout_holds` | **0 in every rung** (1 → 100 agents) — the #208–#212 deadline fix is validated |
+| Peak RSS | 311 MB (never above 360 MB in any configuration) |
+| CPU per run (ladder, over HTTP) | 0.406 / 0.412 / 0.432 / 0.420 CPU-s across a 100× concurrency range — **linear** |
+| CPU per run, working figure | **~0.47 CPU-s** — the ladder ran with baselines silently disabled (F4), so its numbers are a floor; 0.47 is the value used for every tier calculation below |
+
+**Layer decomposition** (same 21-step run, three ways):
+
+| Layer | CPU/run |
+|---|---|
+| Engine only (direct calls, no ASGI) | 32.5 ms |
+| Full ASGI stack (routing, deps, validation, JSON) | 293 ms |
+| Real HTTP under concurrency | ~470 ms |
+
+The engine is ~7% of the bill. Attribution of the ASGI run: pandas 42%,
+FastAPI + Starlette + pydantic + json **~8% combined**. The cost is not the web
+framework; it is work the request path does over pandas objects.
+
+### Correction to prior records
+
+Two things previously recorded in session memory are wrong and are corrected here:
+
+- **`market_data_store.py:158` prints a misleading per-dataset size.** A scan read it
+  as "~50 MB per month-long DJIA-30 dataset", and the predecessor plan repeats that
+  figure at `plans/2026-07-24-...md:615` to justify `MARKET_DATA_CACHE_MAX_ENTRIES=4`.
+  Measured: **~1.7 MB**. The cache sizing is still fine; the stated reason is not.
+- **There is no process-age leak on the protocol surface.** 200 sequential protocol
+  runs: CPU/run flat (251 → 248 ms), RSS plateaus at 292 MB, `_sessions`/`_runs`
+  sawtooth as the reaper reclaims them, gc object count flat. The 181 s aged-process
+  result from the acceptance run is real but its **mechanism remains unidentified** —
+  see F5.
+
+## 3. Findings — verified at source
+
+**F1. No HTTP timeout anywhere in the Alpaca fetch chain.**
+`alpaca_bars.py:220` constructs `StockHistoricalDataClient(api_key, secret_key)`.
+That constructor exposes no timeout parameter, and alpaca-py 0.43.2's
+`RESTClient._one_request` calls `self._session.request(method, url, **opts)` with no
+timeout in `opts`. `requests` with no timeout blocks forever. One stalled socket
+permanently leaks a threadpool thread. **Binds at concurrency ≥ 1**, so it is not a
+scale issue at all — it is a standing availability bug.
+
+**F2. Decision-deadline auto-holds are completely silent.**
+`external_run_service.py:421 _maybe_apply_timeout` calls
+`_advance_step(executable=[], decision_source="timeout_hold")` and returns. No print,
+no log, no metric. The step is attributed to a decision the agent never made. The
+`timeout_holds` counter exists but is only visible to someone who fetches
+`GET /api/v1/runs/{id}` and reads `engine_status`. This is the exact pattern
+`CLAUDE.md`'s "Fail-closed is not fail-visible" section exists to prevent.
+
+**F3. Terminal legacy sessions accumulate without bound.**
+`reap_runs()` (`domain/runs/service.py:417`) evicts terminal engine sessions — but it
+iterates `_runs`, the *protocol* registry. The legacy `/api/v1/backtest/*` surface
+writes no `protocol_runs` row and no `_runs` entry, so its sessions are never reached.
+`MAX_LEGACY_ACTIVE_GLOBAL=50` does not bound them either: `_count_active_locked`
+(`external_run_service.py:919`) counts only `s.status not in TERMINAL_STATUSES`, so a
+terminal session is invisible to the very cap that would have limited it. Each retained
+session pins its `all_data` reference past LRU eviction.
+
+**F4. The repo's own load-test harness silently disables baselines.**
+`dashboard/scripts/loadtest/stress_serve.py:60` patches
+`create_market_data_provider` with a **1-argument lambda** while the real signature
+takes two. Every baseline generation through the whole ladder failed with
+`<lambda>() takes from 0 to 1 positional arguments but 2 were given`, printed as a
+warning and swallowed. Any CPU figure produced by the unpatched harness is an
+**underestimate**, including the predecessor's acceptance numbers.
+
+**F5. The aged-process tail is real but unexplained.**
+The acceptance run measured 35.6 s on a fresh process vs 181 s (5 failures, one 134.9 s
+request) on one that had already served 186 runs. §2 refutes the leak hypothesis. The
+leading remaining hypothesis is the **baseline worker**: `baseline_worker.py` drains a
+queue with a *single* thread and dedups by `(start_date, end_date, mode)`. The
+sequential probe used one window, so 199 of 200 jobs hit the dedup cache; the aged
+process served runs across many windows, where each distinct window is a full
+`HourlyBacktester` run serialized behind that one thread. **Untested.** No fix is
+specified for it — diagnosis first.
+
+## 4. Optimization headroom — measured, then deferred
+
+Recorded so it is not re-litigated. `_market_data_at` is called **147 times per run**
+(7 per step) and returns rows derived from the shared read-only dataset, so its result
+is identical for every run on that window.
+
+| Variant | CPU/run (ASGI) | vs shipped |
+|---|---|---|
+| As shipped | 293 ms | 1.00× |
+| + memoise `_market_data_at` per `(dataset, timestamp)` | 204 ms | 1.44× |
+| + memoised rows as plain dicts rather than pandas Series | 194 ms | **1.51×** |
+
+Both variants produced **bit-identical step observations and final metrics** across 15
+runs. A further candidate exists (`sqlite3.connect()` per operation — 104 connections
+per run, `database.py:62` and `:119`) and is unmeasured.
+
+**Why it is deferred:** 1.51× moves free tier from ~7.6 to ~11.5 sustained agents.
+It does not reach 100 by any path. For the burst target it is unnecessary (§5).
+
+## 5. Hosting decision
+
+Per-run cost is ~0.47 CPU-s over HTTP. For a **burst** of 100 agents running once:
+
+| Tier | CPU | Burst wall time | Worst request (extrapolated) | Verdict |
+|---|---|---|---|---|
+| Free | 0.1 | ~470 s | **~82 s** | **Breaches the 60 s deadline** → silent auto-holds |
+| Standard | 1.0 | ~47 s | ~8 s | **Adequate as-shipped** |
+
+The deadline, not throughput, is the failure boundary: a step served later than
+`EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS` (60) is auto-held and attributed to the agent
+anyway (F2). Free tier is expected to breach it under a 100-agent burst; Standard is not,
+**without any CPU work**. This is what makes deferring §4 safe.
+
+Sustained 100 agents is a different question and is not answered here.
+
+**Horizontal scaling stays closed.** Run state is module-level (`_sessions`,
+`external_run_service.py:67`; `_runs`, `runs/service.py:49`) and the heartbeat path
+*fails* orphaned runs rather than migrating them. Every tier above Standard buys
+nothing until run state leaves process memory.
+
+## 6. Design
+
+Five work items. T1–T3 are behaviour changes; T4–T5 restore trust in the instrument
+and then use it.
+
+### T1 — Default HTTP timeout on the Alpaca client
+
+Wrap the client's `requests.Session.request` immediately after construction, injecting
+`timeout` when the caller did not supply one.
+
+```python
+ALPACA_HTTP_TIMEOUT_SECONDS = float(os.getenv("ALPACA_HTTP_TIMEOUT_SECONDS", "60"))
+ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS = float(
+    os.getenv("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS", "10"))
+```
+
+The wrapper is idempotent (guarded by an attribute flag) and **prints a warning if it
+cannot find `_session`** — an upstream rename must not silently restore the unbounded
+behaviour, which is the same failure class F2 describes.
+
+### T2 — Make deadline auto-holds visible
+
+`get_current_step` drains expired steps in a `while` loop, so one poll can apply many
+holds. Count them in the loop and emit **one** line after it, never one per step
+(21 steps × 100 agents = 2,100 lines otherwise):
+
+```
+⚠️ decision deadline: auto-held N step(s) for <backtest_id> (agent=<name>,
+   step_index=<i>, total_holds=<t>) — these steps are NOT the agent's decisions
+```
+
+Rationale is integrity, not diagnostics: a published curve containing auto-held steps
+is not the agent's curve, which is the same concern the H6 guard exists for.
+
+### T3 — Sweep terminal legacy sessions
+
+Add `sweep_terminal_sessions()` to `external_run_service.py`, registered in `app.py`
+next to `register_reaper_sweep(reap_v2_runs)` (`app.py:219`) so it runs on the existing
+60 s reaper pass. No new thread.
+
+Retention TTL (`LEGACY_SESSION_RETENTION_SECONDS`, default `300`) rather than immediate
+eviction: a client may still be reading a completed run. The clock starts at the first
+sweep that observes the session terminal, so no `_finalize`/`cancel` path can miss it.
+Reads for an evicted run already fall back to the persisted row — `evict_session`'s own
+docstring carries that safety argument.
+
+### T4 — Fix the load-test harness
+
+`stress_serve.py:60` → `lambda *a, **k: FakeAlpacaLoader()`. Add a `--windows
+shared|distinct` flag to `drive_agents.py`: shared collapses baseline work to one job
+via the dedup cache, distinct forces N jobs through the single worker thread. That
+switch is what F5's diagnosis needs, and it is the difference between a cheap and an
+expensive demo (§7).
+
+### T5 — Validation against a real Render instance
+
+Nothing in this workstream has ever run on Render. Everything in §2 and §5 is a
+12-core dev box plus arithmetic. Deploy to Standard, run the fixed harness at 100
+agents, and assert: zero failures, `timeout_holds == 0`, RSS below the instance
+ceiling. **If T5 disagrees with §5, §5 is wrong**, not T5.
+
+## 7. Operational note — share the window
+
+`baseline_worker` dedups by `(start_date, end_date, mode)` behind one thread. 100 demo
+agents on **one** window queue a single baseline backtest; 100 agents on **distinct**
+windows queue 100 serialized ones. Give the demo agents a shared date range.
+
+## 8. Architecture review
+
+| | | |
+|---|---|---|
+| Q0 principle | Additive safety on a working design; no new subsystems, no new routes | **PASS** |
+| Q1 scalability | Bounded by CPU, linear, measured; no new bottleneck introduced | **PASS** |
+| Q2 customizability | Every new knob is an env var with a documented default | **PASS** |
+| Q3 failure story | T1 bounds a hung socket; T2 makes a corrupt-provenance event audible; T3 bounds retention | **PASS** |
+| Q4 observability | T2 is the fix; T5 is the only real-environment evidence and does not exist yet | **CONCERN** — accepted, T5 closes it |
+| Q5 cost | $25/mo Standard, at demo time only. §4 deferred with measurements recorded | **PASS** |
+| Q6 trust boundaries | Unchanged. No new routes, no auth changes, no new unauthenticated surface | **PASS** |
+| Q7 reality check | T1–T4 each touch one file; T3 reuses the existing sweep hook rather than adding a thread | **PASS** |
+
+**Planning call:** the walking skeleton is specable — every box, contract and failure
+mode is named. Build it. F5 stays a diagnosis task, not an implementation task,
+precisely because its mechanism is unidentified.
+
+## 9. Constraints inherited from the predecessor
+
+- **Wire contract frozen.** No new status literals; new payload *keys* are fine.
+- **No new HTTP routes** — three route-contract freeze tests must pass untouched.
+- **`print()`, not `logger`** — logger output is invisible under deployed uvicorn.
+  Assert with `capsys`, never `caplog`.
+- **Env vars read once at import**; every new one stripped in `tests/conftest.py`.
+- `domain/` must not import `api/` or `app.py`.
+- Do not modify the committed seed `dashboard/storage/data/backtest.db`; `git status`
+  after any session that imports backend modules.
+- Branch per item, cut from up-to-date `origin/main`. Merging to `main` auto-deploys
+  prod.

--- a/docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md
+++ b/docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md
@@ -3,8 +3,9 @@
 **Date:** 2026-08-18
 **Predecessor:** `docs/superpowers/specs/2026-07-24-agent-scale-sustainability-design.md`
 (plan: `docs/superpowers/plans/2026-07-24-agent-scale-sustainability.md` — four tiers
-merged as #208/#209/#211/#212; its **Task 12 acceptance run was executed 2026-08-18**,
-results below).
+merged as #208/#209/#211/#212; its **Task 12 acceptance run was partially executed
+2026-08-18** — 3 of 6 Step 2 criteria captured, Step 3 prod smoke not run — results
+below).
 
 ---
 
@@ -20,36 +21,100 @@ reader does not re-derive it.
 
 ## 2. Measured baseline (2026-08-18)
 
-The predecessor's acceptance criteria were never run until now. They pass.
+The predecessor's Task 12 acceptance was executed for the first time on 2026-08-18.
+**Three of its six Step 2 criteria are met, three were never captured, and its Step 3
+prod smoke was not run at all.** The gate is partially closed, not closed.
+
+| Task 12 Step 2 criterion (`plans/2026-07-24-…md:2729`) | Status |
+|---|---|
+| 0 server `timeout_holds` | **Met** — 0 in every rung |
+| 0 FAILURES | **Met** — 100/100 completed on a fresh process |
+| total wall < 60 s | **Met** — 35.6 s |
+| create p95 < 1000 ms | **Not captured** — only per-*run* p95 and worst-request were recorded |
+| decision p95 < 1000 ms | **Not captured** — same |
+| RSS growth < 100 MB | **Not captured** — *peak* RSS was recorded, which is a different quantity |
+
+Task 12 states: "If any criterion misses, diagnose before merging (systematic-debugging)
+— do not relax the criteria." Three unmeasured criteria are not three met criteria, so
+they are carried into T5 (§6) rather than written off here. Step 3 (post-deploy prod
+smoke) is likewise still outstanding — nothing in this workstream has run on Render.
 
 | Measurement | Result |
 |---|---|
 | 100 agents, fresh process | **35.6 s wall, 100/100 completed, 0 failures**, worst request 5.6 s |
 | `timeout_holds` | **0 in every rung** (1 → 100 agents) — the #208–#212 deadline fix is validated |
-| Peak RSS | 311 MB (never above 360 MB in any configuration) |
-| CPU per run (ladder, over HTTP) | 0.406 / 0.412 / 0.432 / 0.420 CPU-s across a 100× concurrency range — **linear** |
-| CPU per run, working figure | **~0.47 CPU-s** — the ladder ran with baselines silently disabled (F4), so its numbers are a floor; 0.47 is the value used for every tier calculation below |
+| Peak RSS | 311 MB on the fresh 100-agent run (never above 360 MB in any configuration) |
+| CPU per run (ladder, over HTTP) | 0.440 / 0.406 / 0.412 / 0.432 / 0.420 CPU-s at 1 / 10 / 25 / 50 / 100 agents — **linear** across a 100× concurrency range |
+| CPU per run, working figure | **0.522 CPU-s** — the *only* run whose baselines actually executed (the ladder rungs ran with baselines silently disabled by F4, so 0.406–0.440 is a floor). 0.522 is the value used for every tier calculation below |
+
+⚠ **Which rows carry the F4 caveat, precisely.** The harness bug was repaired before the
+fresh 100-agent run — that repair is *why* its CPU/run is 0.522 rather than the ladder's
+~0.42 — so the 0.522 and 311 MB figures are the ones taken with baselines actually
+executing (`baseline_worker._run_job` building an `HourlyBacktester` and running two
+baselines, `baseline_worker.py:105-129`). The **ladder rungs** are the floors: their CPU
+(0.406–0.440) *and* their RSS were measured with baselines silently failing. Do not
+extend the F4 discount to 0.522/311 MB, and do not treat the ladder's numbers as
+comparable to them.
+
+RSS nonetheless stays unsettled, for different reasons: 311 MB is **one run**, on a
+12-core dev box, against `FakeAlpacaLoader`/`synth_bars` synthetic frames rather than real
+Alpaca DJIA-30 bars, on a **single shared window**. Many distinct windows and a 512 MB
+instance are both untested. That is what §8 Q1 and T5 treat as open — not an F4 discount.
 
 **Layer decomposition** (same 21-step run, three ways):
 
-| Layer | CPU/run |
+| Layer | Figure |
 |---|---|
-| Engine only (direct calls, no ASGI) | 32.5 ms |
-| Full ASGI stack (routing, deps, validation, JSON) | 293 ms |
-| Real HTTP under concurrency | ~470 ms |
+| Engine only (direct calls, no ASGI) | 32.5 ms CPU/run |
+| Full ASGI stack (routing, deps, validation, JSON) | 293 ms CPU/run |
+| Real HTTP under concurrency | ~470 ms — **per-request latency, not CPU/run** |
 
-The engine is ~7% of the bill. Attribution of the ASGI run: pandas 42%,
+⚠ That last row is the trap that produced the 0.47 error corrected below. It is a
+*latency*, and the per-run CPU figure it was mistaken for is **0.522**. Do not read down
+this column as if all three rows were the same quantity.
+
+The engine is **~11%** of the bill — 32.5 ÷ 293, the only two rows that are the same
+quantity. ⚠ This was previously recorded as "~7%", which is 32.5 ÷ 470: the *same*
+latency-as-CPU conflation the warning above describes, surviving one sentence further
+down. Do not restore it, and do not divide 32.5 by 0.522 either — the 0.522 run had
+baselines executing and the 293 ms profile did not, so they are not the same scope.
+Attribution of the ASGI run: pandas 42%,
 FastAPI + Starlette + pydantic + json **~8% combined**. The cost is not the web
 framework; it is work the request path does over pandas objects.
 
 ### Correction to prior records
 
-Two things previously recorded in session memory are wrong and are corrected here:
+Three things previously recorded are wrong and are corrected here:
 
-- **`market_data_store.py:158` prints a misleading per-dataset size.** A scan read it
-  as "~50 MB per month-long DJIA-30 dataset", and the predecessor plan repeats that
-  figure at `plans/2026-07-24-...md:615` to justify `MARKET_DATA_CACHE_MAX_ENTRIES=4`.
+- **The "~50 MB per month-long DJIA-30 dataset" figure is wrong.** It originates in a
+  *source comment*, `dashboard/backend/domain/backtesting/market_data_store.py:34-37`,
+  which justifies `MARKET_DATA_CACHE_MAX_ENTRIES=4` by "4 entries caps the worst case at
+  ~200 MB". The predecessor plan reproduces that comment verbatim inside a fenced block
+  at `plans/2026-07-24-…md:614-618`, so **the doc and the shipped code carry the same
+  wrong number** — correcting only the plan leaves it live in the file a future capacity
+  reviewer opens (T0 Step 3 fixes the source comment for that reason).
   Measured: **~1.7 MB**. The cache sizing is still fine; the stated reason is not.
+  Two limits on that measurement, both of which make it a floor:
+  its only source is the per-build print at `market_data_store.py:157-159`, whose size
+  expression (`:157`) is `sum(df.memory_usage(deep=True) …) for df in all_data.values()`
+  — it counts the
+  `all_data` frames and **not** the `timestamps` list or the `price_cache`
+  (`Dict[symbol, Dict[timestamp, float]]`, `:192-205`), both of which the cached
+  `MarketDataset` also retains (`:46-57`); and it was taken under the load harness, which
+  substitutes `FakeAlpacaLoader`/`synth_bars` (`stress_serve.py:27,48`) for real bars, so
+  it is a *synthetic* window rather than a real Alpaca DJIA-30 one. It refutes ~50 MB
+  comfortably; it is not a settled per-dataset budget.
+- **The working CPU/run figure was 0.47; it should be 0.522.** 0.47 corresponds to no
+  per-run measurement: it is above the ladder floor (0.406–0.440) and below the only run
+  whose baselines executed (0.522). It appears to have been lifted from the
+  layer-decomposition row below — "Real HTTP under concurrency ~470 ms" — which is a
+  per-request *latency*, not a per-run *CPU-second*. The error propagated into §5's
+  burst-wall column while that table's worst-request column was computed from 0.522,
+  leaving the two columns mutually inconsistent. §5 now uses 0.522 throughout.
+  It propagated a **second** time, into the engine's share of the bill above
+  ("~7%" = 32.5 ÷ 470, corrected to ~11% = 32.5 ÷ 293). Both consumers of 470 have now
+  been found and fixed; the lesson is that one conflated figure is rarely quoted once,
+  so correcting the number is not the same as correcting the document.
 - **There is no process-age leak on the protocol surface.** 200 sequential protocol
   runs: CPU/run flat (251 → 248 ms), RSS plateaus at 292 MB, `_sessions`/`_runs`
   sawtooth as the reaper reclaims them, gc object count flat. The 181 s aged-process
@@ -66,13 +131,27 @@ timeout in `opts`. `requests` with no timeout blocks forever. One stalled socket
 permanently leaks a threadpool thread. **Binds at concurrency ≥ 1**, so it is not a
 scale issue at all — it is a standing availability bug.
 
-**F2. Decision-deadline auto-holds are completely silent.**
+**F2. Decision-deadline auto-holds emit nothing at the moment they happen.**
 `external_run_service.py:421 _maybe_apply_timeout` calls
 `_advance_step(executable=[], decision_source="timeout_hold")` and returns. No print,
-no log, no metric. The step is attributed to a decision the agent never made. The
-`timeout_holds` counter exists but is only visible to someone who fetches
-`GET /api/v1/runs/{id}` and reads `engine_status`. This is the exact pattern
-`CLAUDE.md`'s "Fail-closed is not fail-visible" section exists to prevent.
+no log, no metric. The step is attributed to a decision the agent never made.
+
+Be precise about what *is* already there, so the fix does not rebuild it: the
+`timeout_holds` **count** is durable and well surfaced — `_finalize` writes it into
+`agent_runs.metadata` (`:646`) and it is read back in `build_final_metrics` (`:176`) and
+`get_run_result` (`:1112`), and served live from `get_current_step` (`:450`) and
+`get_status` (`:721`). The gap is narrower and worse than "invisible":
+
+- **Nothing is emitted at hold time**, so a hold is only discoverable by someone who
+  already suspects one and goes looking for the number.
+- **The count is an aggregate.** It says three steps were auto-held; it never says
+  *which* three, so a published curve cannot be reconciled against the log after the fact.
+- **The reaper path is silent too** — `drain_expired` (`:734-742`) runs the identical
+  `while self._maybe_apply_timeout():` loop, and that is the path with no agent watching
+  (see T2).
+
+This is the pattern `CLAUDE.md`'s "Fail-closed is not fail-visible" section exists to
+prevent: the state is recorded, but nothing announces the event that produced it.
 
 **F3. Terminal legacy sessions accumulate without bound.**
 `reap_runs()` (`domain/runs/service.py:417`) evicts terminal engine sessions — but it
@@ -80,8 +159,22 @@ iterates `_runs`, the *protocol* registry. The legacy `/api/v1/backtest/*` surfa
 writes no `protocol_runs` row and no `_runs` entry, so its sessions are never reached.
 `MAX_LEGACY_ACTIVE_GLOBAL=50` does not bound them either: `_count_active_locked`
 (`external_run_service.py:919`) counts only `s.status not in TERMINAL_STATUSES`, so a
-terminal session is invisible to the very cap that would have limited it. Each retained
-session pins its `all_data` reference past LRU eviction.
+terminal session is invisible to the very cap that would have limited it.
+
+**Size the harm honestly.** `adopt_dataset` (`:268`) assigns *references* into the shared
+cached dataset — `self.all_data = dataset.all_data` (`:279-281`, likewise `timestamps`
+and `price_cache`) — and its own docstring says so outright: *"SHARED + READ-ONLY:
+all_data/timestamps/price_cache belong to the store and other sessions."* Both entry
+paths reach it: `load_market_data` (`:259`) and `start_backtest`'s peek fast path
+(`:999`). So N terminal sessions on one window pin **one** dataset, not N.
+The market-data bound is therefore (distinct windows × dataset size), and the correction
+above revises that size from ~50 MB to ~1.7 MB. The genuinely unbounded growth is the
+**per-session** state: `decision_log`, `last_executed`, `context_ref_by_step`, the
+`PortfolioManager` and its trades (`:216-241`). That is small per session and never
+reclaimed, which makes this a slow leak on a long-lived instance rather than the
+fast one a per-session dataset copy would imply. It is worth fixing for exactly that
+reason — an instance that is never restarted has no other floor — but it should not be
+prioritised above T1/T2 on a memory argument the same document has just refuted.
 
 **F4. The repo's own load-test harness silently disables baselines.**
 `dashboard/scripts/loadtest/stress_serve.py:60` patches
@@ -115,24 +208,47 @@ is identical for every run on that window.
 
 Both variants produced **bit-identical step observations and final metrics** across 15
 runs. A further candidate exists (`sqlite3.connect()` per operation — 104 connections
-per run, `database.py:62` and `:119`) and is unmeasured.
+per run, `database.py:119` in `_get_connection`) and is unmeasured. The *other*
+`sqlite3.connect()` in that file, `:62`, is **not** a candidate: it is inside
+`enable_wal()`, runs once per `BacktestDatabase.__init__` (`:112`) and closes in its own
+`finally` (`:66`). Its docstring calls it the single definition that keeps the two call
+sites from drifting — do not fold it into any connection-pooling change.
 
 **Why it is deferred:** 1.51× moves free tier from ~7.6 to ~11.5 sustained agents.
 It does not reach 100 by any path. For the burst target it is unnecessary (§5).
 
 ## 5. Hosting decision
 
-Per-run cost is ~0.47 CPU-s over HTTP. For a **burst** of 100 agents running once:
+Per-run cost is **0.522 CPU-s** over HTTP (§2). For a **burst** of 100 agents running
+once — 52.2 CPU-s of request work in total:
 
 | Tier | CPU | Burst wall time | Worst request (extrapolated) | Verdict |
 |---|---|---|---|---|
-| Free | 0.1 | ~470 s | **~82 s** | **Breaches the 60 s deadline** → silent auto-holds |
-| Standard | 1.0 | ~47 s | ~8 s | **Adequate as-shipped** |
+| Free | 0.1 | ~520 s | **~82 s** | **Breaches the 60 s deadline** → silent auto-holds |
+| Standard | 1.0 | ~52 s | ~8 s | **Adequate, but with no headroom** |
+
+Both columns are arithmetic, and the derivation is stated so it can be checked:
+wall = 52.2 ÷ CPU; worst request = 5.6 s × (predicted wall ÷ 35.6 s measured wall).
 
 The deadline, not throughput, is the failure boundary: a step served later than
 `EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS` (60) is auto-held and attributed to the agent
-anyway (F2). Free tier is expected to breach it under a 100-agent burst; Standard is not,
-**without any CPU work**. This is what makes deferring §4 safe.
+anyway (F2). Free tier is expected to breach it under a 100-agent burst; Standard is not.
+That is what makes deferring §4 safe — **but the margin is thinner than the table alone
+suggests, and T5 exists to settle it**:
+
+- **The 52 s figure consumes the whole CPU.** 52.2 CPU-s of request work on 1.0 CPU in
+  ~52 s is ~100% utilisation with nothing left for the baseline worker, the 60 s reaper,
+  DB writes, or any concurrent dashboard traffic. It is a lower bound on wall time, not a
+  budget.
+- **The baseline worker's CPU is in none of these numbers** (F4). Even the shared-window
+  demo of §7 still queues one full `HourlyBacktester` run.
+- **Scaling a *tail* latency linearly is not sound**, and the ~82 s / ~8 s column should
+  be read as an order-of-magnitude estimate, not a measurement. It assumes the
+  tail-to-total ratio (5.6 ⁄ 35.6 ≈ 16%) survives the move from a 12-core box to
+  cgroup-throttled fractional CPU, where FIFO queueing against a near-single-threaded
+  resource can grow the tail *super*-linearly. If anything it **understates** the Free
+  tier's worst case; the Free verdict is directionally safe regardless, which is the only
+  load-bearing use of the number here.
 
 Sustained 100 agents is a different question and is not answered here.
 
@@ -143,8 +259,10 @@ nothing until run state leaves process memory.
 
 ## 6. Design
 
-Five work items. T1–T3 are behaviour changes; T4–T5 restore trust in the instrument
-and then use it.
+Five work items. T1–T3 are behaviour changes; T4 restores trust in the instrument (and
+carries one production change of its own — the wholesale-failure detector below); T5
+uses it. **They are not one file each and not order-free** — see §8 Q7 and the plan's
+Architecture note.
 
 ### T1 — Default HTTP timeout on the Alpaca client
 
@@ -163,31 +281,84 @@ behaviour, which is the same failure class F2 describes.
 
 ### T2 — Make deadline auto-holds visible
 
-`get_current_step` drains expired steps in a `while` loop, so one poll can apply many
-holds. Count them in the loop and emit **one** line after it, never one per step
-(21 steps × 100 agents = 2,100 lines otherwise):
+**Three call sites, not one.** `_maybe_apply_timeout` is reached from three places, all
+of which already hold `self._step_lock`:
+
+| Site | Shape | Who drives it |
+|---|---|---|
+| `get_current_step` (`:430-434`) | `while` loop — many holds per call | a polling agent |
+| `drain_expired` (`:734-742`) | identical `while` loop | the reaper (`runs/service.py:432`) and `execution/backtest_backend.py:267` every pass |
+| `get_status` (`:710-712`) | **one unlooped call** | the protocol router, on essentially every request |
+
+**All three must emit**, and the third is the one an implementer will miss.
+
+- **The reaper path carries the worst case.** An agent that crashes at step 3 of 21 has
+  its remaining 18 steps auto-held by a background thread with nobody polling and nobody
+  watching, and the finalized curve is then published as that agent's.
+- **The `get_status` path carries the *most traffic*, and it silently pre-empts the
+  instrumented one.** `runs/service.py:384` calls it inside `_sync_status` — its own
+  comment reads `# applies timeout side-effects` — reached from ~10 router-driven sites
+  (an eleventh `_sync_status` call, `runs/service.py:433`, is inside `reap_runs` and
+  belongs to the reaper row above, not to router traffic), plus `get_step` (`:749`) and
+  `submit_decision` (`:781`, `# apply timeout side effects`).
+  Worse, `get_step` calls `session.get_status()` **first** and only then guards
+  `if session.status == "waiting_decision" and session.step_index == seq` before calling
+  `get_current_step()`. A hold applied inside that `get_status()` has already advanced
+  `step_index` (`:601`), so the guard fails and the instrumented loop is **never reached
+  for the very poll that produced the hold**. Instrumenting only the two `while` loops
+  would therefore leave the normal live-agent path exactly as silent as it is today —
+  which is the whole of F2.
+
+Because `get_status` applies at most one hold per call, emitting there costs at most one
+line per genuine hold; there is no volume argument against it. The shared helper must
+**not** re-acquire `_step_lock` — every one of the three callers already holds it.
+
+Count holds in the loop and emit **one** line after it, never one per step
+(21 steps × 100 agents = 2,100 lines otherwise). **Capture the step index before the
+loop** — `_maybe_apply_timeout` → `_advance_step` increments `self.step_index` (`:601`),
+so an index read afterwards names a step that was *not* held:
 
 ```
 ⚠️ decision deadline: auto-held N step(s) for <backtest_id> (agent=<name>,
-   step_index=<i>, total_holds=<t>) — these steps are NOT the agent's decisions
+   steps=<first>..<last>, total_holds=<t>) — these steps are NOT the agent's decisions
 ```
 
 Rationale is integrity, not diagnostics: a published curve containing auto-held steps
-is not the agent's curve, which is the same concern the H6 guard exists for.
+is not the agent's curve, which is the same concern the H6 guard exists for. A range is
+what makes the line answer that question — an auditor reconciling a curve against the log
+needs to know *which* steps were not the agent's, and a single post-drain index cannot
+say. The count is already durable (F2); the range is the part that is new.
 
 ### T3 — Sweep terminal legacy sessions
 
 Add `sweep_terminal_sessions()` to `external_run_service.py`, registered in `app.py`
-next to `register_reaper_sweep(reap_v2_runs)` (`app.py:219`) so it runs on the existing
+next to `register_reaper_sweep(reap_v2_runs)` (`app.py:220`) so it runs on the existing
 60 s reaper pass. No new thread.
 
 Retention TTL (`LEGACY_SESSION_RETENTION_SECONDS`, default `300`) rather than immediate
 eviction: a client may still be reading a completed run. The clock starts at the first
 sweep that observes the session terminal, so no `_finalize`/`cancel` path can miss it.
 Reads for an evicted run already fall back to the persisted row — `evict_session`'s own
-docstring carries that safety argument.
+docstring (`:1040-1043`) carries that safety argument.
 
-### T4 — Fix the load-test harness
+**`_sessions` is not a legacy-only registry — say so before implementing.** It has a
+single write site, `_sessions[backtest_id] = session` (`:990`) inside `start_backtest`
+(`:947`), which serves the legacy `/api/v1/backtest/*` route *and* the protocol surface
+via `run_service.create_run`. A sweep that walks all of `_sessions` therefore sees
+protocol sessions too. It is still correct to walk the whole dict, for a reason worth
+recording because it is an ordering dependency:
+
+- **Within one reaper pass, protocol sessions are already gone.** `reap_runs` evicts
+  terminal engine sessions from its `_runs` walk at `runs/service.py:434-436` and only
+  *then* invokes registered sweeps at `:466-470`. The sweep sees a protocol session only
+  if that eviction failed — where the TTL is a backstop, not a regression. Do not reorder
+  those two blocks.
+- **v2 is out of scope either way, and cannot be brought in.** `BacktestBackend`
+  constructs its `ExternalBacktestSession` directly (`execution/backtest_backend.py:74-78`)
+  and never registers it in `_sessions`, so this sweep can never bound v2 sessions. v2's
+  bound is the archive-on-terminal path, which already exists.
+
+### T4 — Fix the load-test harness, and make a wholesale baseline failure loud
 
 `stress_serve.py:60` → `lambda *a, **k: FakeAlpacaLoader()`. Add a `--windows
 shared|distinct` flag to `drive_agents.py`: shared collapses baseline work to one job
@@ -195,12 +366,30 @@ via the dedup cache, distinct forces N jobs through the single worker thread. Th
 switch is what F5's diagnosis needs, and it is the difference between a cheap and an
 expensive demo (§7).
 
+**The wholesale-failure detector belongs in `baseline_worker`, not only in the harness.**
+F4 survived an entire ladder because `_drain_forever` prints
+`⚠️ Baseline generation failed (run saved): {exc}` per job (`baseline_worker.py:100`) and
+continues; the module keeps no failure counter of any kind — `_completed` (`:56-61`)
+records only successes. Fixing this in `stress_serve.py` alone would leave *production*
+exactly as blind as the harness was: an upstream break in which every baseline fails
+while runs still finalize would remain a stream of per-item warnings nobody reads. This
+is the repo's own rule that **a per-item warning cannot report a total contract break**,
+and it applies to the finding F4 was derived from, not just to F2. So: a consecutive- or
+aggregate-failure counter in `baseline_worker` that escalates to one unmissable line, and
+*separately* a shutdown banner in the harness.
+
 ### T5 — Validation against a real Render instance
 
 Nothing in this workstream has ever run on Render. Everything in §2 and §5 is a
 12-core dev box plus arithmetic. Deploy to Standard, run the fixed harness at 100
 agents, and assert: zero failures, `timeout_holds == 0`, RSS below the instance
 ceiling. **If T5 disagrees with §5, §5 is wrong**, not T5.
+
+T5 also carries the three predecessor criteria §2 could not close, because this is the
+first environment on which they mean anything: **create p95 < 1000 ms, decision p95 <
+1000 ms, and RSS *growth* < 100 MB** (growth across the run, not peak). Capturing them
+here — with baselines actually executing — is what finally closes Task 12 Step 2. Step 3
+(post-deploy prod smoke) is the same call against prod and stays outstanding until run.
 
 ## 7. Operational note — share the window
 
@@ -213,13 +402,13 @@ windows queue 100 serialized ones. Give the demo agents a shared date range.
 | | | |
 |---|---|---|
 | Q0 principle | Additive safety on a working design; no new subsystems, no new routes | **PASS** |
-| Q1 scalability | Bounded by CPU, linear, measured; no new bottleneck introduced | **PASS** |
-| Q2 customizability | Every new knob is an env var with a documented default | **PASS** |
-| Q3 failure story | T1 bounds a hung socket; T2 makes a corrupt-provenance event audible; T3 bounds retention | **PASS** |
+| Q1 scalability | CPU is bounded, linear and measured, and no new bottleneck is introduced — but **memory is not settled**: 311 MB is a single dev-box run on synthetic bars and one shared window, and the predecessor's `RSS growth` criterion was never captured at all | **CONCERN** — T5 measures RSS growth on the target instance |
+| Q2 customizability | Every new knob is an env var with a documented default — documented in **`.env.example`**, which is where this repo's operational knobs live and where the predecessor plan put its own (`MARKET_DATA_CACHE_MAX_ENTRIES` at `.env.example:206-208`). T1 and T3 each carry that step; a constant that exists only in a source file and a conftest strip is not a documented default | **PASS** — conditional on those steps landing |
+| Q3 failure story | T1 bounds a hung socket; T2 makes a corrupt-provenance event audible; T3 bounds retention | **PASS** — conditional on T2 covering **all three** `_maybe_apply_timeout` sites; two out of three leaves the live protocol path silent |
 | Q4 observability | T2 is the fix; T5 is the only real-environment evidence and does not exist yet | **CONCERN** — accepted, T5 closes it |
 | Q5 cost | $25/mo Standard, at demo time only. §4 deferred with measurements recorded | **PASS** |
 | Q6 trust boundaries | Unchanged. No new routes, no auth changes, no new unauthenticated surface | **PASS** |
-| Q7 reality check | T1–T4 each touch one file; T3 reuses the existing sweep hook rather than adding a thread | **PASS** |
+| Q7 reality check | T3 reuses the existing sweep hook rather than adding a thread. But **the items are not one file each and not order-free**: T2 and T3 both modify `external_run_service.py`; T1 and T3 both modify `tests/conftest.py`; T3 also touches `app.py`; T4 touches five (four modified — `stress_serve.py`, `drive_agents.py`, `README.md`, `baseline_worker.py` — plus one new test) | **CONCERN** — land T2 before T3, and rebase T3 on merged `main`; see the plan's Architecture note |
 
 **Planning call:** the walking skeleton is specable — every box, contract and failure
 mode is named. Build it. F5 stays a diagnosis task, not an implementation task,


### PR DESCRIPTION
Records the 100-agent acceptance run the July scale plan left pending, and scopes what it surfaced.

**Spec:** `docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md`
**Plan:** `docs/superpowers/plans/2026-08-18-burst-capacity-safety.md`

Four defects verified at source and scoped into tasks: no HTTP timeout in the Alpaca chain (binds at concurrency 1 — a standing availability bug, not a scale one); decision-deadline auto-holds emit nothing at hold time; terminal legacy sessions are unbounded (the reaper walks `_runs`, which that surface never populates); the load-test harness silently disabled every baseline. A fifth — the 181 s aged-process tail — is real but unexplained, and stays a diagnosis task.

The tasks are **not** one file each and not order-free: T2 and T3 both edit `external_run_service.py`, T1 and T3 both edit `conftest.py`. Land T2 before T3 and rebase T3 on merged `main`.

Per-run CPU optimization is measured (1.51x) and deferred — a 100-agent burst does not need it.

Three prior claims corrected: the ~50MB-per-dataset figure (measured ~1.7MB, and live in a source comment as well as the July plan); the supposed protocol-surface process-age leak (refuted over 200 sequential runs); and the working CPU/run figure, 0.47 → 0.522 — 0.47 was a per-request *latency* read as a per-run CPU-second, and it had two consumers, not one.

Docs only. No code, no routes, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZowvejC9is51BM4hgZSab
