### PR TITLE
fix: bound Alpaca HTTP requests with a timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,6 +207,12 @@ DATABASE_PATH=dashboard/storage/data/backtest.db
 # in memory for reuse across backtest runs (LRU beyond this). Default 4.
 # MARKET_DATA_CACHE_MAX_ENTRIES=4
 
+# Bound every Alpaca market-data HTTP request. alpaca-py issues requests with no
+# timeout, so one stalled socket leaks a threadpool thread for the life of the
+# process. Connect/read seconds. Defaults 10 / 60.
+# ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS=10
+# ALPACA_HTTP_TIMEOUT_SECONDS=60
+
 # Max queued background baseline-generation jobs (drops beyond this; the run
 # itself is unaffected). Default 500.
 # BASELINE_QUEUE_MAX=500

--- a/dashboard/backend/infrastructure/market_data/alpaca_bars.py
+++ b/dashboard/backend/infrastructure/market_data/alpaca_bars.py
@@ -39,6 +39,16 @@ DEFAULT_ALPACA_FEED = "sip"
 # Canonical feed names, matching ``alpaca.data.enums.DataFeed`` ``.value``.
 SUPPORTED_ALPACA_FEEDS = ("iex", "sip", "delayed_sip", "otc")
 
+# alpaca-py 0.43.2 issues every HTTP request via
+# ``self._session.request(method, url, **opts)`` with no ``timeout`` in
+# ``opts``, so a stalled socket blocks ``requests`` forever and permanently
+# leaks a threadpool thread -- this binds at concurrency >= 1, not just under
+# burst load. Read once at import, like MAX_ACTIVE_RUNS_PER_AGENT.
+ALPACA_HTTP_TIMEOUT_SECONDS = float(os.getenv("ALPACA_HTTP_TIMEOUT_SECONDS", "60"))
+ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS = float(
+    os.getenv("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS", "10")
+)
+
 # Stamped on each returned frame so a rare IEX fallback is visible to callers
 # (return type stays Dict[str, DataFrame] for the MarketDataProvider contract).
 FRAME_ATTR_FEED = "alpaca_feed"
@@ -197,6 +207,38 @@ def feed_provenance(bars: Dict[str, pd.DataFrame]) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _apply_default_timeout(client: Any) -> None:
+    """Wrap ``client._session.request`` so every call gets a default timeout.
+
+    alpaca-py builds ``requests.Session.request`` with no ``timeout`` kwarg,
+    so a stalled socket hangs forever and permanently leaks a threadpool
+    thread. If a future alpaca-py release renames or drops ``_session``, fail
+    open (warn, don't raise) rather than silently restoring the unbounded
+    behavior this exists to prevent -- but make that loud, since a quiet
+    warning nobody reads is exactly how the original bug went unnoticed.
+    """
+    session = getattr(client, "_session", None)
+    original_request = getattr(session, "request", None)
+    if session is None or original_request is None:
+        print(
+            "WARNING: Alpaca client has no usable _session.request; "
+            "ALPACA_HTTP_TIMEOUT_SECONDS default timeout was NOT applied"
+        )
+        return
+
+    if getattr(original_request, "_atl_default_timeout_applied", False):
+        return
+
+    def _request_with_default_timeout(*args, **kwargs):
+        kwargs.setdefault(
+            "timeout", (ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS, ALPACA_HTTP_TIMEOUT_SECONDS)
+        )
+        return original_request(*args, **kwargs)
+
+    _request_with_default_timeout._atl_default_timeout_applied = True
+    session.request = _request_with_default_timeout
+
+
 class AlpacaDataLoader:
     """Fetches historical hourly bars from Alpaca API."""
 
@@ -218,6 +260,7 @@ class AlpacaDataLoader:
             from alpaca.data.timeframe import TimeFrame
 
             self.client = StockHistoricalDataClient(self.api_key, self.secret_key)
+            _apply_default_timeout(self.client)
             self.StockBarsRequest = StockBarsRequest
             self.TimeFrame = TimeFrame
             self.DataFeed = DataFeed

--- a/dashboard/backend/infrastructure/market_data/alpaca_bars.py
+++ b/dashboard/backend/infrastructure/market_data/alpaca_bars.py
@@ -221,8 +221,10 @@ def _apply_default_timeout(client: Any) -> None:
     original_request = getattr(session, "request", None)
     if session is None or original_request is None:
         print(
-            "WARNING: Alpaca client has no usable _session.request; "
-            "ALPACA_HTTP_TIMEOUT_SECONDS default timeout was NOT applied"
+            "WARNING: Alpaca client has no usable _session.request "
+            "(likely an alpaca-py version change) -- "
+            "ALPACA_HTTP_TIMEOUT_SECONDS default timeout was NOT applied; "
+            "Alpaca HTTP requests are unbounded until this is fixed"
         )
         return
 

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -88,6 +88,8 @@ os.environ.pop("MAX_ACTIVE_DASHBOARD_BACKTESTS", None)
 os.environ.pop("AGENT_AUTH_CACHE_TTL_SECONDS", None)
 os.environ.pop("MAX_LEGACY_ACTIVE_PER_SESSION", None)
 os.environ.pop("MAX_LEGACY_ACTIVE_GLOBAL", None)
+os.environ.pop("ALPACA_HTTP_TIMEOUT_SECONDS", None)
+os.environ.pop("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS", None)
 # Read once at import into users.DEFAULT_MAX_CONCURRENT_BACKTESTS, which every
 # entitlement default and every per-account cap test resolves through.
 os.environ.pop("DEFAULT_MAX_CONCURRENT_BACKTESTS", None)

--- a/dashboard/backend/tests/test_alpaca_http_timeout.py
+++ b/dashboard/backend/tests/test_alpaca_http_timeout.py
@@ -1,0 +1,95 @@
+"""Tests for the default HTTP timeout applied to the Alpaca client's session.
+
+alpaca-py 0.43.2 calls ``self._session.request(method, url, **opts)`` with no
+``timeout`` in ``opts``, so a stalled socket blocks ``requests`` forever and
+permanently leaks a threadpool thread (binds at concurrency >= 1). These tests
+exercise ``_apply_default_timeout`` directly against plain fake objects -- no
+real ``AlpacaDataLoader``, no alpaca-py import, no network. See
+``test_alpaca_bars.py``'s ``_FakeClient`` for why the no-``_session`` case
+matters: that fixture has no ``_session`` attribute, so this function must
+tolerate it without raising.
+"""
+
+from dashboard.backend.infrastructure.market_data.alpaca_bars import (
+    ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS,
+    ALPACA_HTTP_TIMEOUT_SECONDS,
+    _apply_default_timeout,
+)
+
+
+class _FakeSession:
+    """Records every call made through ``request``."""
+
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return kwargs
+
+
+class _FakeClient:
+    def __init__(self, session):
+        self._session = session
+
+
+def test_default_timeout_applied_when_absent():
+    session = _FakeSession()
+    client = _FakeClient(session)
+
+    _apply_default_timeout(client)
+    client._session.request("GET", "https://data.alpaca.markets/v2/stocks/bars")
+
+    assert len(session.calls) == 1
+    _, _, kwargs = session.calls[0]
+    assert kwargs["timeout"] == (
+        ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS,
+        ALPACA_HTTP_TIMEOUT_SECONDS,
+    )
+
+
+def test_caller_supplied_timeout_is_not_overridden():
+    session = _FakeSession()
+    client = _FakeClient(session)
+
+    _apply_default_timeout(client)
+    client._session.request(
+        "GET", "https://data.alpaca.markets/v2/stocks/bars", timeout=(1, 2)
+    )
+
+    assert len(session.calls) == 1
+    _, _, kwargs = session.calls[0]
+    assert kwargs["timeout"] == (1, 2)
+
+
+def test_applying_twice_does_not_double_wrap():
+    session = _FakeSession()
+    client = _FakeClient(session)
+
+    _apply_default_timeout(client)
+    # Guard attribute must be set on the wrapped request so a second call is a
+    # no-op rather than wrapping the wrapper.
+    assert getattr(client._session.request, "_atl_default_timeout_applied", False) is True
+
+    _apply_default_timeout(client)
+    client._session.request("GET", "https://data.alpaca.markets/v2/stocks/bars")
+
+    assert len(session.calls) == 1
+    _, _, kwargs = session.calls[0]
+    assert kwargs["timeout"] == (
+        ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS,
+        ALPACA_HTTP_TIMEOUT_SECONDS,
+    )
+
+
+class _NoSessionClient:
+    """Mirrors the existing test_alpaca_bars.py _FakeClient: no _session at all."""
+
+
+def test_missing_session_warns_and_does_not_raise(capsys):
+    client = _NoSessionClient()
+
+    _apply_default_timeout(client)  # must not raise
+
+    captured = capsys.readouterr()
+    assert "_session" in captured.out

--- a/dashboard/backend/tests/test_alpaca_http_timeout.py
+++ b/dashboard/backend/tests/test_alpaca_http_timeout.py
@@ -71,7 +71,16 @@ def test_applying_twice_does_not_double_wrap():
     # no-op rather than wrapping the wrapper.
     assert getattr(client._session.request, "_atl_default_timeout_applied", False) is True
 
+    # Capture the bound callable *after* the first apply, before any call is
+    # made. len(session.calls) and the recorded timeout are both
+    # depth-invariant -- stacked *args/**kwargs wrappers still bottom out in
+    # exactly one call to the fake, so neither can distinguish one wrapper
+    # from three. Identity of session.request is the assertion that actually
+    # fails if the early-return guard is removed.
+    wrapped = client._session.request
     _apply_default_timeout(client)
+    assert client._session.request is wrapped
+
     client._session.request("GET", "https://data.alpaca.markets/v2/stocks/bars")
 
     assert len(session.calls) == 1


### PR DESCRIPTION
`AlpacaDataLoader` built `StockHistoricalDataClient` with no HTTP timeout. alpaca-py
0.43.2 calls `self._session.request(method, url, **opts)` and never sets `timeout`, so
`requests` defaults to blocking forever — one stalled socket permanently leaks a
threadpool thread. Binds at concurrency >= 1, not just under load.

`_apply_default_timeout(client)` wraps `client._session.request` with
`kwargs.setdefault("timeout", (connect, read))`, so a caller-supplied timeout still wins.
New vars `ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS` (10) / `ALPACA_HTTP_TIMEOUT_SECONDS` (60),
documented in `.env.example` and stripped in `tests/conftest.py`.

`_session` is a private alpaca-py attribute, so its absence is a fail-open **with a loud
warning** — a silent skip would restore the unbounded behaviour this exists to prevent.

T1 of the burst-capacity-safety plan. Full suite 3132 passed / 84 skipped / 0 failed.