### PR TITLE
fix: repair baseline patching in the load-test harness

### DIFF
--- a/dashboard/backend/domain/backtesting/baseline_worker.py
+++ b/dashboard/backend/domain/backtesting/baseline_worker.py
@@ -33,6 +33,10 @@ from dashboard.backend.domain.backtesting.engine import HourlyBacktester
 
 BASELINE_QUEUE_MAX = int(os.getenv("BASELINE_QUEUE_MAX", "500"))
 QUEUE_DEPTH_WARN = 25
+# A per-item warning cannot report a total contract break (repo rule): this is
+# what makes a wholesale failure (e.g. an upstream signature change breaking
+# every job) loud instead of just a stream of per-job warnings nobody reads.
+_ESCALATION_THRESHOLD = 3
 
 _STOP = object()
 
@@ -59,6 +63,13 @@ _worker_lock = threading.Lock()
 # (start, end, mode) -> {"buy_and_hold": id, "djia": id}. Single-consumer, so
 # unlocked access is safe; grows one tiny entry per distinct config.
 _completed: Dict[Tuple[str, str, str], Dict[str, str]] = {}
+# Both counters are written only by the single drain thread (same
+# single-consumer reasoning as _completed above), so they need no lock either.
+# _consecutive_failures resets to 0 on any success and drives the escalation
+# print below; _total_failures never resets — it's the plain integer a caller
+# like stress_serve.py reads for a shutdown summary.
+_consecutive_failures = 0
+_total_failures = 0
 
 
 def submit(job: BaselineJob) -> bool:
@@ -88,16 +99,25 @@ def _ensure_worker() -> None:
 
 
 def _drain_forever(q: "queue.Queue") -> None:
+    global _consecutive_failures, _total_failures
     while True:
         job = q.get()
         try:
             if job is _STOP:
                 return
             _run_job(job)
+            _consecutive_failures = 0
         # SystemExit guard mirrors the old in-finalize catch: a daemon thread
         # swallows SystemExit silently, which would kill the worker forever.
         except (Exception, SystemExit) as exc:
             print(f"⚠️ Baseline generation failed (run saved): {exc}")
+            _consecutive_failures += 1
+            _total_failures += 1
+            if _consecutive_failures == _ESCALATION_THRESHOLD:
+                print(
+                    f"🔥 Baseline worker: {_consecutive_failures} consecutive "
+                    f"failures — last error: {exc}"
+                )
         finally:
             q.task_done()
 
@@ -144,10 +164,12 @@ def wait_idle(timeout: float = 30.0) -> bool:
 
 def _reset_for_tests(maxsize: Optional[int] = None) -> None:
     """Fresh queue + dedup cache; wakes a worker blocked on the old queue."""
-    global _queue, _worker_thread
+    global _queue, _worker_thread, _consecutive_failures, _total_failures
     with _worker_lock:
         old_q = _queue
         _completed.clear()
+        _consecutive_failures = 0
+        _total_failures = 0
         _queue = queue.Queue(
             maxsize=maxsize if maxsize is not None else BASELINE_QUEUE_MAX)
         if _worker_thread is not None and _worker_thread.is_alive():

--- a/dashboard/backend/tests/test_baseline_failure_visibility.py
+++ b/dashboard/backend/tests/test_baseline_failure_visibility.py
@@ -1,0 +1,95 @@
+"""Baseline worker: wholesale-failure visibility (T4).
+
+A per-item warning ("Baseline generation failed") cannot report a total
+contract break -- it survived an entire measurement ladder unnoticed because
+nobody reads a stream of per-job warnings. This asserts the escalation line
+that fires once a small consecutive-failure threshold is crossed, that any
+success resets it, and that the plain total-failure counter a caller like
+stress_serve.py reads for a shutdown summary keeps accumulating regardless.
+"""
+
+import pytest
+
+from dashboard.backend.domain.backtesting import baseline_worker as bw
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    bw._reset_for_tests()
+    yield
+    bw._reset_for_tests()
+
+
+def _job(run_id):
+    return bw.BaselineJob(
+        run_id=run_id, session_id=f"sess_{run_id}", start_date="2026-04-15",
+        end_date="2026-04-16", mode="safe_trading", all_data={"AAPL": object()},
+        publish=lambda ids: None,
+    )
+
+
+def test_escalation_fires_once_at_threshold_and_last_exception_is_named(capsys, monkeypatch):
+    def _boom(job):
+        raise RuntimeError(f"boom for {job.run_id}")
+
+    monkeypatch.setattr(bw, "_run_job", _boom)
+
+    for i in range(bw._ESCALATION_THRESHOLD):
+        assert bw.submit(_job(f"bad{i}"))
+    assert bw.wait_idle(10)
+
+    out = capsys.readouterr().out
+    # The existing per-job line is untouched -- it still fires every time.
+    assert out.count("Baseline generation failed") == bw._ESCALATION_THRESHOLD
+    # The escalation line fires exactly once, at the threshold crossing.
+    assert out.count("consecutive failures") == 1
+    assert f"{bw._ESCALATION_THRESHOLD} consecutive failures" in out
+    assert "boom for bad2" in out  # names the LAST exception, not the first
+    assert bw._consecutive_failures == bw._ESCALATION_THRESHOLD
+    assert bw._total_failures == bw._ESCALATION_THRESHOLD
+
+
+def test_success_resets_consecutive_counter_but_not_total(capsys, monkeypatch):
+    def _boom(job):
+        raise RuntimeError(f"boom for {job.run_id}")
+
+    monkeypatch.setattr(bw, "_run_job", _boom)
+    for i in range(bw._ESCALATION_THRESHOLD):
+        assert bw.submit(_job(f"bad{i}"))
+    assert bw.wait_idle(10)
+    assert bw._consecutive_failures == bw._ESCALATION_THRESHOLD
+    capsys.readouterr()  # drain
+
+    def _ok(job):
+        return None
+
+    monkeypatch.setattr(bw, "_run_job", _ok)
+    assert bw.submit(_job("good"))
+    assert bw.wait_idle(10)
+    assert bw._consecutive_failures == 0            # reset by the success
+    assert bw._total_failures == bw._ESCALATION_THRESHOLD  # NOT reset by the success
+
+    # A fresh run of ESCALATION_THRESHOLD consecutive failures escalates
+    # again -- the reset genuinely re-arms the check rather than latching.
+    monkeypatch.setattr(bw, "_run_job", _boom)
+    for i in range(bw._ESCALATION_THRESHOLD):
+        assert bw.submit(_job(f"bad2-{i}"))
+    assert bw.wait_idle(10)
+    out2 = capsys.readouterr().out
+    assert out2.count("consecutive failures") == 1
+    assert bw._total_failures == 2 * bw._ESCALATION_THRESHOLD
+
+
+def test_fewer_than_threshold_failures_do_not_escalate(capsys, monkeypatch):
+    def _boom(job):
+        raise RuntimeError(f"boom for {job.run_id}")
+
+    monkeypatch.setattr(bw, "_run_job", _boom)
+    for i in range(bw._ESCALATION_THRESHOLD - 1):
+        assert bw.submit(_job(f"bad{i}"))
+    assert bw.wait_idle(10)
+
+    out = capsys.readouterr().out
+    assert out.count("Baseline generation failed") == bw._ESCALATION_THRESHOLD - 1
+    assert "consecutive failures" not in out
+    assert bw._consecutive_failures == bw._ESCALATION_THRESHOLD - 1

--- a/dashboard/backend/tests/test_baseline_failure_visibility.py
+++ b/dashboard/backend/tests/test_baseline_failure_visibility.py
@@ -80,6 +80,32 @@ def test_success_resets_consecutive_counter_but_not_total(capsys, monkeypatch):
     assert bw._total_failures == 2 * bw._ESCALATION_THRESHOLD
 
 
+def test_failures_past_threshold_do_not_reprint_escalation(capsys, monkeypatch):
+    """Escalation must fire on the threshold CROSSING only, not stay armed.
+
+    A `>=` comparison at the crossing check would reprint the escalation line
+    on every failure once _consecutive_failures reaches the threshold -- the
+    exact log-flood the brief warns a per-item warning must not become. Drive
+    two more failures past the threshold and count occurrences in stdout
+    (not just presence) to catch that regression.
+    """
+    def _boom(job):
+        raise RuntimeError(f"boom for {job.run_id}")
+
+    monkeypatch.setattr(bw, "_run_job", _boom)
+
+    overrun = bw._ESCALATION_THRESHOLD + 2
+    for i in range(overrun):
+        assert bw.submit(_job(f"bad{i}"))
+    assert bw.wait_idle(10)
+
+    out = capsys.readouterr().out
+    assert out.count("Baseline generation failed") == overrun
+    assert out.count("consecutive failures") == 1   # still exactly once, past the threshold
+    assert bw._consecutive_failures == overrun
+    assert bw._total_failures == overrun
+
+
 def test_fewer_than_threshold_failures_do_not_escalate(capsys, monkeypatch):
     def _boom(job):
         raise RuntimeError(f"boom for {job.run_id}")

--- a/dashboard/scripts/loadtest/README.md
+++ b/dashboard/scripts/loadtest/README.md
@@ -12,10 +12,49 @@ Terminal 1 (from the repo root):
 
     N_AGENTS=100 python dashboard/scripts/loadtest/stress_serve.py
     # prints:  artifacts dir: /tmp/atl_loadtest_XXXX
+    # on shutdown (Ctrl-C), prints a SHUTDOWN SUMMARY line naming how many
+    # baseline jobs failed during the run (0 on a clean run).
 
 Terminal 2:
 
     python dashboard/scripts/loadtest/drive_agents.py 100 --artifacts /tmp/atl_loadtest_XXXX
+
+## Flags
+
+- `--windows shared|distinct` (default `shared`) on `drive_agents.py`.
+  `shared` gives every agent the same date range, so background baseline
+  generation dedups to a single queued job for the whole run. `distinct`
+  offsets each agent's start date by its index (same span), so every agent
+  gets its own baseline config — N serialized baseline backtests instead of
+  one. Use `distinct` to see baseline-worker cost scale with agent count
+  instead of being hidden by dedup.
+- `N_AGENTS` (env var, default `100`) on `stress_serve.py` — how many
+  protocol agents to pre-seed.
+
+## ⚠ Figures produced before 2026-08-18 are a floor, not a measurement
+
+Until 2026-08-18, `stress_serve.py` patched `create_market_data_provider`
+with a **one-argument** lambda against the real **two-argument**
+`create_market_data_provider(data_source, universe)` signature —
+`HourlyBacktester.__init__` always calls it positionally with both args, so
+every call raised `TypeError`. Background baseline generation
+(`baseline_worker.py`) swallows job failures as a per-item printed warning
+and keeps draining, so this broke **every baseline job, every run, on every
+rung of the ladder**, silently: no baseline `HourlyBacktester` was ever
+actually allocated. The 2026-08-18 ladder rungs (and everything before them)
+are in this category — their CPU and RSS numbers understate real load,
+because a real workload's baseline generation does allocate.
+
+The patch is now `lambda *a, **k: FakeAlpacaLoader()`, matching the real
+signature, and `baseline_worker.py` now escalates loudly (a printed line
+naming the count and last exception) if 3 baseline jobs fail consecutively,
+so a regression like this can't go unnoticed again. `stress_serve.py` also
+prints a shutdown summary of total baseline failures.
+
+The fresh 100-agent run taken after an **ad-hoc local repair** of this same
+bug (0.522 CPU-s, 311 MB RSS) is **not** in the understated category — it
+was measured with baselines actually running. Do not average it with the
+earlier rungs; they are not measuring the same thing.
 
 ## Acceptance target (100 agents, 21-step runs, local dev hardware)
 

--- a/dashboard/scripts/loadtest/README.md
+++ b/dashboard/scripts/loadtest/README.md
@@ -31,6 +31,16 @@ Terminal 2:
 - `N_AGENTS` (env var, default `100`) on `stress_serve.py` — how many
   protocol agents to pre-seed.
 
+Baseline generation is asynchronous: finalize enqueues the job and returns
+immediately, so the run is already `completed` before the worker even
+dequeues it, and `drive_agents.py`'s reported wall time never waits on
+baselines. `distinct`'s extra cost is real (N serialized `HourlyBacktester`
+builds instead of one deduped build) but structurally invisible to that
+timer. The signal that `distinct` is doing more work is the server-side
+baseline-job count (1 unique config under `shared` vs. N under `distinct`,
+visible in `stress_serve.py`'s stdout), not the wall time `drive_agents.py`
+prints.
+
 ## ⚠ Figures produced before 2026-08-18 are a floor, not a measurement
 
 Until 2026-08-18, `stress_serve.py` patched `create_market_data_provider`

--- a/dashboard/scripts/loadtest/drive_agents.py
+++ b/dashboard/scripts/loadtest/drive_agents.py
@@ -9,6 +9,7 @@ Usage:
     python dashboard/scripts/loadtest/drive_agents.py 100 --artifacts /tmp/atl_loadtest_xxx
 """
 import argparse
+import datetime
 import json
 import os
 import statistics
@@ -27,6 +28,12 @@ parser.add_argument("--artifacts", required=True,
 parser.add_argument("--base", default="http://127.0.0.1:8402")
 parser.add_argument("--allow-remote", action="store_true",
                     help="required to target anything but localhost")
+parser.add_argument("--windows", choices=("shared", "distinct"), default="shared",
+                    help="shared (default): every agent backtests the same "
+                         "date range, so baseline generation dedups to one "
+                         "queued job. distinct: each agent's start date is "
+                         "offset by its index (same span), forcing N "
+                         "serialized baseline jobs instead of one.")
 args = parser.parse_args()
 
 host = urllib.parse.urlparse(args.base).hostname or ""
@@ -45,6 +52,24 @@ deadline_losses = []  # steps auto-held because our decision arrived too late
 server_holds = []     # server-reported timeout_holds per completed run (T3+)
 run_walls = []        # end-to-end seconds per completed run
 failures = []
+
+# "shared" reproduces the original hardcoded window byte-for-byte, for every
+# agent, so existing measurements stay comparable. "distinct" offsets each
+# agent's start date by its index (same 2-day span -> 3 trading-day window),
+# giving each its own baseline config -- the difference between one queued
+# baseline backtest for the whole run and N serialized ones.
+_WINDOW_START = datetime.date(2026, 6, 1)
+_WINDOW_END = datetime.date(2026, 6, 3)
+_WINDOW_SPAN = _WINDOW_END - _WINDOW_START
+
+
+def date_window(idx):
+    if args.windows == "distinct":
+        start = _WINDOW_START + datetime.timedelta(days=idx)
+        end = start + _WINDOW_SPAN
+    else:
+        start, end = _WINDOW_START, _WINDOW_END
+    return start.isoformat(), end.isoformat()
 
 
 def req(method, path, key, body=None):
@@ -73,11 +98,12 @@ def record(kind, ms, status):
         samples.append((kind, ms, status))
 
 
-def drive(agent):
+def drive(agent, idx):
     key = agent["api_key"]
+    start_date, end_date = date_window(idx)
     t_run = time.perf_counter()
     status, body, ms = req("POST", "/api/v1/runs", key, {
-        "config": {"start_date": "2026-06-01", "end_date": "2026-06-03"},
+        "config": {"start_date": start_date, "end_date": end_date},
     })
     record("create_run", ms, status)
     if status != 200:
@@ -160,9 +186,11 @@ def dist(label, vals):
 
 
 rss0, thr0 = server_stats()
-print(f"\n===== {M} concurrent agents =====  (server before: {rss0} MB RSS, {thr0} threads)")
+print(f"\n===== {M} concurrent agents ===== (windows={args.windows})  "
+      f"(server before: {rss0} MB RSS, {thr0} threads)")
 t0 = time.perf_counter()
-threads = [threading.Thread(target=drive, args=(a,)) for a in AGENTS[:M]]
+threads = [threading.Thread(target=drive, args=(a, i))
+           for i, a in enumerate(AGENTS[:M])]
 for t in threads:
     t.start()
 for t in threads:

--- a/dashboard/scripts/loadtest/stress_serve.py
+++ b/dashboard/scripts/loadtest/stress_serve.py
@@ -55,9 +55,15 @@ class FakeAlpacaLoader:
 
 import dashboard.backend.domain.backtesting.external_run_service as ebs  # noqa: E402
 import dashboard.backend.domain.backtesting.engine as engine_mod  # noqa: E402
+import dashboard.backend.domain.backtesting.baseline_worker as baseline_worker  # noqa: E402
 
 ebs.AlpacaDataLoader = FakeAlpacaLoader
-engine_mod.create_market_data_provider = lambda ds=None: FakeAlpacaLoader()
+# HourlyBacktester.__init__ always calls create_market_data_provider(data_source,
+# universe) positionally with BOTH args (engine.py), even though both are
+# defaulted in the real signature. A one-arg lambda here raised TypeError on
+# every call — silently, because baseline generation swallows job failures
+# (baseline_worker.py) and nothing else in the harness ever hits this path.
+engine_mod.create_market_data_provider = lambda *a, **k: FakeAlpacaLoader()
 
 from dashboard.backend.domain.agents.repository import agent_store  # noqa: E402
 
@@ -81,4 +87,14 @@ print(f"seeded {N} agents; serving on 127.0.0.1:8402", flush=True)
 
 import uvicorn  # noqa: E402
 
-uvicorn.run("dashboard.backend.app:app", host="127.0.0.1", port=8402, log_level="warning")
+try:
+    uvicorn.run("dashboard.backend.app:app", host="127.0.0.1", port=8402, log_level="warning")
+finally:
+    # Read the counter, don't scrape stdout — a harness break must be as loud
+    # as the production one baseline_worker now raises on its own.
+    failed = baseline_worker._total_failures
+    if failed:
+        print(f"⚠️  SHUTDOWN SUMMARY: {failed} baseline job(s) failed during this run "
+              f"— see warnings above", flush=True)
+    else:
+        print("SHUTDOWN SUMMARY: 0 baseline job failures", flush=True)


### PR DESCRIPTION
`stress_serve.py` patched `create_market_data_provider` with a one-argument lambda, but
`engine.py` calls it positionally with two, so every background baseline job raised
`TypeError`. `baseline_worker` swallowed each one as a per-item warning and kept no failure
counter at all, so an entire measurement ladder ran with no baseline ever generated and
nobody noticed. Those CPU and RSS figures are floors.

- Repairs the patch (`lambda *a, **k:`).
- **Production, not just the harness:** a consecutive-failure counter in `baseline_worker`,
  escalating once on crossing 3 and resetting on any success. A per-item warning cannot
  report a total contract break.
- Harness shutdown banner reads that counter (never scrapes stdout) and prints an explicit
  all-clear at zero, so a silent exit is not ambiguous.
- `--windows shared|distinct` on `drive_agents.py`; `shared` reproduces the previous
  hardcoded range byte-for-byte so old measurements stay comparable.
- README states which recorded figures are floors, and that baseline cost is invisible to
  the client wall clock (finalize enqueues and returns) — the signal is the baseline-job count.

T4 of the burst-capacity-safety plan. Full suite 3132 passed / 84 skipped / 0 failed.