### PR TITLE
fix: evict terminal legacy backtest sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -230,6 +230,11 @@ DATABASE_PATH=dashboard/storage/data/backtest.db
 # MAX_LEGACY_ACTIVE_PER_SESSION=5
 # MAX_LEGACY_ACTIVE_GLOBAL=50
 
+# How long a terminal legacy /api/v1/backtest/* session is kept in memory before
+# the reaper sweep drops it. Reads for an evicted run fall back to the persisted
+# row, so this only buys an in-flight reader some slack. Seconds. Default 300.
+# LEGACY_SESSION_RETENTION_SECONDS=300
+
 # Auth cache TTL for agent API keys (seconds; +-20% jitter; 0 disables).
 # Rotation/deletion invalidates immediately; other agent-record edits
 # propagate within the TTL. Default 10.

--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -223,6 +223,18 @@ async def startup_event():
         print(f"⚠️ v2 sweep registration error: {e}")
 
     try:
+        # Same reaper pass also TTL-evicts terminal legacy /api/v1/backtest/*
+        # sessions, which have no registry of their own to be walked by.
+        from dashboard.backend.domain.backtesting.external_run_service import (
+            sweep_terminal_sessions,
+        )
+        from dashboard.backend.domain.runs.service import register_reaper_sweep
+        register_reaper_sweep(sweep_terminal_sessions)
+        print("🧹 legacy session sweep registered with the reaper")
+    except Exception as e:
+        print(f"⚠️ legacy session sweep registration error: {e}")
+
+    try:
         from dashboard.backend.domain.runs.service import start_reaper
         start_reaper()
         print("🧹 Run reaper started")

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -99,6 +99,16 @@ _lock = threading.Lock()
 MAX_LEGACY_ACTIVE_PER_SESSION = int(os.getenv("MAX_LEGACY_ACTIVE_PER_SESSION", "5"))
 MAX_LEGACY_ACTIVE_GLOBAL = int(os.getenv("MAX_LEGACY_ACTIVE_GLOBAL", "50"))
 
+# Neither of the caps above bounds a session once it goes terminal --
+# _count_active_locked skips anything in TERMINAL_STATUSES, and reap_runs
+# only walks _runs (the protocol registry), which this legacy surface never
+# populates. A terminal session left in _sessions is otherwise permanent,
+# each one still pinning a loaded bar window. sweep_terminal_sessions()
+# below rides the existing reaper pass to drop them after this many seconds.
+LEGACY_SESSION_RETENTION_SECONDS = int(
+    os.getenv("LEGACY_SESSION_RETENTION_SECONDS", "300")
+)
+
 
 class BacktestCapacityError(Exception):
     """Legacy start refused: a session or the server is at capacity.
@@ -236,6 +246,10 @@ class ExternalBacktestSession:
         self.price_cache: Dict[str, Dict[Any, float]] = {}
 
         self.step_opened_at: Optional[datetime] = None
+        # Stamped by sweep_terminal_sessions() the first time it sees this
+        # session in a terminal status; None until then. Explicit default so
+        # the attribute is discoverable rather than a bare getattr() away.
+        self.terminal_seen_at: Optional[datetime] = None
         self.last_decision_source: Optional[str] = None
         self.decision_log: List[Dict[str, Any]] = []
         self.last_executed: List[Dict[str, Any]] = []
@@ -1081,6 +1095,57 @@ def evict_session(backtest_id: str) -> bool:
     evicting a terminal session is safe. Returns True if one was removed."""
     with _lock:
         return _sessions.pop(backtest_id, None) is not None
+
+
+def sweep_terminal_sessions() -> int:
+    """TTL eviction for terminal sessions left in ``_sessions``.
+
+    ``_sessions`` is written by ``start_backtest`` for both the legacy
+    ``/api/v1/backtest/*`` surface and the protocol surface (via
+    ``run_service.create_run``). The protocol side is separately reaped by
+    ``reap_runs`` walking ``_runs`` and calling ``evict_session`` once a run
+    goes terminal, but the legacy surface has no such registry, and neither
+    of the ``MAX_LEGACY_ACTIVE_*`` caps sees a terminal session either (they
+    filter on ``TERMINAL_STATUSES``). Left alone, a terminal legacy session
+    sits in memory forever, still pinning a loaded bar window. This sweep is
+    the backstop for both: it walks the whole dict rather than filtering to
+    legacy-only, which is correct because reap_runs already evicts terminal
+    protocol sessions before invoking registered sweeps like this one -- it
+    only ever sees a protocol session here if that eviction failed, where the
+    TTL is a second line of defense, not the primary path.
+
+    Stamps ``terminal_seen_at`` the first time a session is seen terminal
+    (never evicting on that same pass) rather than expecting a terminal
+    transition to stamp it -- a finalize/cancel path that forgets to stamp
+    would otherwise leak silently instead of just running one sweep late.
+    Read paths for a completed run persist to the DB (see ``evict_session``'s
+    docstring), so dropping the in-memory session here is safe.
+
+    Called by the registered reaper sweep in app.py; not a new thread.
+    Pops directly rather than calling ``evict_session`` because that also
+    acquires ``_lock``, which is not reentrant -- calling it from in here
+    would deadlock the reaper thread. Returns the number of sessions
+    evicted this pass; idempotent.
+    """
+    now = _utcnow()
+    dropped = 0
+    with _lock:
+        for backtest_id, s in list(_sessions.items()):
+            # Defensive: _sessions is shared with the protocol surface, and a
+            # foreign/fake object injected there (e.g. in tests) may not
+            # carry .status at all. Treat that as "not terminal" and skip --
+            # never let a missing attribute here raise through the reaper.
+            status = getattr(s, "status", None)
+            if status not in TERMINAL_STATUSES:
+                continue
+            if s.terminal_seen_at is None:
+                s.terminal_seen_at = now
+                continue
+            age = (now - s.terminal_seen_at).total_seconds()
+            if age >= LEGACY_SESSION_RETENTION_SECONDS:
+                _sessions.pop(backtest_id, None)
+                dropped += 1
+    return dropped
 
 
 def get_current_step(backtest_id: str) -> Optional[Dict[str, Any]]:

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -90,6 +90,7 @@ os.environ.pop("MAX_LEGACY_ACTIVE_PER_SESSION", None)
 os.environ.pop("MAX_LEGACY_ACTIVE_GLOBAL", None)
 os.environ.pop("ALPACA_HTTP_TIMEOUT_SECONDS", None)
 os.environ.pop("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS", None)
+os.environ.pop("LEGACY_SESSION_RETENTION_SECONDS", None)
 # Read once at import into users.DEFAULT_MAX_CONCURRENT_BACKTESTS, which every
 # entitlement default and every per-account cap test resolves through.
 os.environ.pop("DEFAULT_MAX_CONCURRENT_BACKTESTS", None)

--- a/dashboard/backend/tests/test_legacy_session_sweep.py
+++ b/dashboard/backend/tests/test_legacy_session_sweep.py
@@ -1,0 +1,207 @@
+"""T3: TTL sweep for terminal legacy /api/v1/backtest/* sessions.
+
+``_sessions`` is written by ``start_backtest`` for both the legacy surface
+and the protocol surface, and unlike the protocol run registry (``_runs``,
+reaped by walking it directly) nothing else ever drops a legacy entry once
+it goes terminal -- each one pins a loaded bar window forever.
+``sweep_terminal_sessions`` rides the existing 60s reaper pass, stamping
+``terminal_seen_at`` on first sighting and evicting once
+``LEGACY_SESSION_RETENTION_SECONDS`` has elapsed since then.
+
+Uses a lightweight fake session (only the attributes the sweep touches)
+rather than a real ``ExternalBacktestSession`` for the pure sweep-logic
+cases -- no market data or DB needed to exercise eviction timing. The
+persisted-row test below is the one that needs a real DB, since it pins the
+safety claim in ``evict_session``'s docstring: a completed run's data
+survives its in-memory session being dropped.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import dashboard.backend.database as db_module
+import dashboard.backend.domain.backtesting.external_run_service as ebs
+import dashboard.backend.domain.runs.service as run_service
+
+
+class _FakeSession:
+    """Stand-in for ExternalBacktestSession carrying only what the sweep
+    reads/writes: ``status`` and ``terminal_seen_at``."""
+
+    def __init__(self, status):
+        self.status = status
+        self.terminal_seen_at = None
+
+
+@pytest.fixture(autouse=True)
+def isolated_sessions(monkeypatch):
+    """Every test gets its own ``_sessions`` dict so it can't see leftovers
+    from -- or leak state into -- any other test in the suite."""
+    monkeypatch.setattr(ebs, "_sessions", {})
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """A controllable stand-in for ``_utcnow`` -- a mutable single-element
+    list so tests can advance it after monkeypatch has captured the lambda."""
+    t = [datetime(2026, 1, 1, tzinfo=timezone.utc)]
+    monkeypatch.setattr(ebs, "_utcnow", lambda: t[0])
+    return t
+
+
+def test_terminal_session_not_evicted_on_first_sweep(monkeypatch, clock):
+    # TTL=0 deliberately: with no continue after the first-sighting stamp,
+    # age would be (now - now) == 0 >= 0 and evict immediately even though
+    # the clock never advanced. A TTL of 300 wouldn't catch that -- 0 < 300
+    # regardless -- so this has to use 0 to actually pin "never evict on the
+    # same pass a session is first seen terminal".
+    monkeypatch.setattr(ebs, "LEGACY_SESSION_RETENTION_SECONDS", 0)
+    ebs._sessions["bt_1"] = _FakeSession("completed")
+
+    dropped = ebs.sweep_terminal_sessions()
+
+    assert dropped == 0
+    assert "bt_1" in ebs._sessions
+    assert ebs._sessions["bt_1"].terminal_seen_at == clock[0]
+
+
+def test_terminal_session_evicted_after_ttl_elapses(monkeypatch, clock):
+    monkeypatch.setattr(ebs, "LEGACY_SESSION_RETENTION_SECONDS", 300)
+    ebs._sessions["bt_1"] = _FakeSession("completed")
+
+    ebs.sweep_terminal_sessions()  # first sighting -- stamps, does not evict
+
+    clock[0] += timedelta(seconds=299)
+    assert ebs.sweep_terminal_sessions() == 0
+    assert "bt_1" in ebs._sessions
+
+    clock[0] += timedelta(seconds=2)  # now 301s since the stamp
+    assert ebs.sweep_terminal_sessions() == 1
+    assert "bt_1" not in ebs._sessions
+
+
+def test_non_terminal_session_never_evicted(monkeypatch, clock):
+    monkeypatch.setattr(ebs, "LEGACY_SESSION_RETENTION_SECONDS", 0)
+    ebs._sessions["bt_running"] = _FakeSession("running")
+
+    for _ in range(5):
+        assert ebs.sweep_terminal_sessions() == 0
+        clock[0] += timedelta(seconds=1000)
+
+    assert "bt_running" in ebs._sessions
+    assert ebs._sessions["bt_running"].terminal_seen_at is None
+
+
+def test_sweep_is_idempotent_and_returns_drop_count(monkeypatch, clock):
+    monkeypatch.setattr(ebs, "LEGACY_SESSION_RETENTION_SECONDS", 0)
+    ebs._sessions["bt_a"] = _FakeSession("completed")
+    ebs._sessions["bt_b"] = _FakeSession("running")
+
+    assert ebs.sweep_terminal_sessions() == 0  # first sighting of bt_a
+    clock[0] += timedelta(seconds=1)
+    assert ebs.sweep_terminal_sessions() == 1  # bt_a evicted, TTL=0
+    assert ebs.sweep_terminal_sessions() == 0  # idempotent: nothing left
+    assert set(ebs._sessions) == {"bt_b"}
+
+
+def test_persisted_row_readable_after_session_evicted(monkeypatch, tmp_path, clock):
+    """Pins the safety claim in ``evict_session``'s docstring: a completed
+    run's DB row (and everything built from it) stays readable after the
+    sweep drops its in-memory session."""
+    monkeypatch.setattr(ebs, "LEGACY_SESSION_RETENTION_SECONDS", 0)
+    test_db = db_module.BacktestDatabase(db_path=tmp_path / "sweep_persist.db")
+    monkeypatch.setattr(ebs, "db", test_db)
+    test_db.insert_run(
+        run_id="run_sweep_persist", session_id="sess_persist", agent_name="a",
+        mode="safe_trading", start_date="2026-04-15", end_date="2026-04-16",
+        initial_equity=10000.0, final_equity=10500.0,
+    )
+    ebs._sessions["bt_persist"] = _FakeSession("completed")
+
+    before = ebs.get_run_result("run_sweep_persist", "sess_persist")
+    assert before is not None
+    assert before["run"]["run_id"] == "run_sweep_persist"
+
+    ebs.sweep_terminal_sessions()  # first sighting
+    clock[0] += timedelta(seconds=1)
+    dropped = ebs.sweep_terminal_sessions()
+    assert dropped == 1
+    assert "bt_persist" not in ebs._sessions
+
+    after = ebs.get_run_result("run_sweep_persist", "sess_persist")
+    assert after is not None
+    assert after["run"]["run_id"] == "run_sweep_persist"
+    assert after["metrics"]["final_equity"] == 10500.0
+
+
+def test_cap_count_unaffected_by_sweep(monkeypatch, clock):
+    """A terminal session already doesn't count toward
+    ``_count_active_locked`` (it filters on TERMINAL_STATUSES), so capacity
+    accounting must be identical before and after a sweep pass evicts it."""
+    monkeypatch.setattr(ebs, "LEGACY_SESSION_RETENTION_SECONDS", 0)
+    ebs._sessions["bt_a"] = _FakeSession("completed")
+    ebs._sessions["bt_b"] = _FakeSession("running")
+
+    before = ebs.count_active_sessions()
+    assert before == 1  # only bt_b is non-terminal
+
+    ebs.sweep_terminal_sessions()  # first sighting, stamps bt_a
+    clock[0] += timedelta(seconds=1)
+    ebs.sweep_terminal_sessions()  # evicts bt_a
+
+    after = ebs.count_active_sessions()
+    assert after == before == 1
+
+
+def test_sweep_does_not_raise_through_a_real_reaper_pass(monkeypatch, clock, capsys):
+    """Registered sweeps run inside reap_runs' try/except (runs/service.py)
+    which swallows any exception into a printed warning while the reaper
+    keeps reporting healthy. A raise here would be a silent no-op, not a
+    loud failure -- this pins that a genuine terminal session never trips it."""
+    monkeypatch.setattr(ebs, "LEGACY_SESSION_RETENTION_SECONDS", 300)
+    monkeypatch.setattr(run_service, "_extra_reaper_sweeps", [])
+    run_service.register_reaper_sweep(ebs.sweep_terminal_sessions)
+    ebs._sessions["bt_reap"] = _FakeSession("completed")
+
+    run_service.reap_runs()
+
+    captured = capsys.readouterr()
+    assert "registered sweep failed" not in captured.out
+    assert "bt_reap" in ebs._sessions  # first sighting this pass, not evicted
+
+
+def test_foreign_session_without_status_is_skipped_not_raised(monkeypatch, clock, capsys):
+    """A ``_sessions`` entry with no ``status`` attribute must be skipped.
+
+    ``_sessions`` is shared with the protocol surface and is monkeypatched
+    directly by other suites: ``test_run_lifecycle_unification.py`` injects a
+    fake carrying only ``drain_expired``/``get_status`` -- no ``status`` at
+    all -- and then runs a real ``reap_runs()`` pass. A bare ``s.status`` read
+    in the sweep raises ``AttributeError`` there, which reap_runs swallows
+    into one ``registered sweep failed`` line while continuing to report
+    healthy -- the sweep would silently never work. Treat a missing status as
+    "not terminal" and leave the entry alone.
+    """
+
+    class _NoStatusSession:
+        def drain_expired(self):
+            return "waiting_decision"
+
+        def get_status(self):
+            return {"status": "waiting_decision"}
+
+    monkeypatch.setattr(ebs, "LEGACY_SESSION_RETENTION_SECONDS", 0)
+    monkeypatch.setattr(run_service, "_extra_reaper_sweeps", [])
+    run_service.register_reaper_sweep(ebs.sweep_terminal_sessions)
+    ebs._sessions["bt_foreign"] = _NoStatusSession()
+    ebs._sessions["bt_done"] = _FakeSession("completed")
+
+    run_service.reap_runs()
+
+    assert "registered sweep failed" not in capsys.readouterr().out
+
+    clock[0] += timedelta(seconds=1)
+    assert ebs.sweep_terminal_sessions() == 1  # bt_done only
+    assert "bt_foreign" in ebs._sessions
+    assert "bt_done" not in ebs._sessions


### PR DESCRIPTION
`reap_runs()` evicts terminal engine sessions by walking `_runs`, which the legacy
`/api/v1/backtest/*` surface never populates. `MAX_LEGACY_ACTIVE_*` cannot bound them
either — `_count_active_locked` filters on `TERMINAL_STATUSES`. So a terminal legacy
session sits in `_sessions` forever, each one pinning a loaded bar window.

`sweep_terminal_sessions()` rides the existing 60 s reaper pass (no new thread): stamps
`terminal_seen_at` on first sighting, evicts once `LEGACY_SESSION_RETENTION_SECONDS`
(default 300) has elapsed. Stamping on first sighting rather than in `_finalize`/`cancel`
means a terminal path that forgets to stamp runs one sweep late instead of leaking silently.

Three details fail *silently* if got wrong, since registered sweeps run inside `reap_runs`'
`try/except`: it pops `_sessions` directly (calling `evict_session()` would re-acquire the
non-reentrant `_lock` and hang the reaper); reads status via `getattr` (other suites inject
fakes with no `status` at all); and stamps with `_utcnow()`, never naive `datetime.utcnow()`.

T3 of the burst-capacity-safety plan. 8 new tests; full suite 3149 passed / 84 skipped / 0 failed.