### PR TITLE
fix: close final-review findings on burst-capacity work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,8 +231,11 @@ DATABASE_PATH=dashboard/storage/data/backtest.db
 # MAX_LEGACY_ACTIVE_GLOBAL=50
 
 # How long a terminal legacy /api/v1/backtest/* session is kept in memory before
-# the reaper sweep drops it. Reads for an evicted run fall back to the persisted
-# row, so this only buys an in-flight reader some slack. Seconds. Default 300.
+# the reaper sweep drops it. Once evicted, {backtest_id}-keyed reads (status,
+# decisions, steps/current) 404 -- there is no DB fallback for those. Only the
+# run's result/trades/decisions stay readable, via the DB-backed
+# GET /api/v1/backtest/runs/{run_id}/result (and /trades, /decisions). This
+# only buys an in-flight {backtest_id} reader some slack. Seconds. Default 300.
 # LEGACY_SESSION_RETENTION_SECONDS=300
 
 # Auth cache TTL for agent API keys (seconds; +-20% jitter; 0 disables).

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -105,9 +105,31 @@ MAX_LEGACY_ACTIVE_GLOBAL = int(os.getenv("MAX_LEGACY_ACTIVE_GLOBAL", "50"))
 # populates. A terminal session left in _sessions is otherwise permanent,
 # each one still pinning a loaded bar window. sweep_terminal_sessions()
 # below rides the existing reaper pass to drop them after this many seconds.
-LEGACY_SESSION_RETENTION_SECONDS = int(
-    os.getenv("LEGACY_SESSION_RETENTION_SECONDS", "300")
-)
+#
+# Parsed defensively, same shape as ``_max_active_dashboard_backtests`` in
+# ``api/routers/backtests.py``: a typo'd operator value must not raise at
+# import, so a bad value falls back to the default with a log line. No range
+# check -- unlike a concurrency cap, there is no "0 is a legitimate setting,
+# negative is a typo" distinction to enforce here.
+_DEFAULT_LEGACY_SESSION_RETENTION_SECONDS = 300
+
+
+def _legacy_session_retention_seconds() -> int:
+    raw = os.getenv("LEGACY_SESSION_RETENTION_SECONDS")
+    if raw is None or not str(raw).strip():
+        return _DEFAULT_LEGACY_SESSION_RETENTION_SECONDS
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        print(
+            "LEGACY_SESSION_RETENTION_SECONDS is not an integer "
+            f"({raw!r}); using {_DEFAULT_LEGACY_SESSION_RETENTION_SECONDS}",
+            flush=True,
+        )
+        return _DEFAULT_LEGACY_SESSION_RETENTION_SECONDS
+
+
+LEGACY_SESSION_RETENTION_SECONDS = _legacy_session_retention_seconds()
 
 
 class BacktestCapacityError(Exception):
@@ -454,9 +476,14 @@ class ExternalBacktestSession:
         steps is not the agent's curve; this is the one place that says so.
         """
         last_index = first_index + count - 1
+        # agent_name is caller-supplied on the legacy surface (StartBacktestRequest,
+        # no character restriction beyond length) and that surface authenticates
+        # nothing -- an embedded \n/\r would forge additional log lines. Strip them
+        # at the interpolation site rather than trusting the value.
+        safe_agent_name = self.agent_name.replace("\r", " ").replace("\n", " ")
         print(
             f"⚠️ decision deadline: auto-held {count} step(s) for {self.backtest_id}\n"
-            f"   (agent={self.agent_name}, steps={first_index}..{last_index}, "
+            f"   (agent={safe_agent_name}, steps={first_index}..{last_index}, "
             f"total_holds={self.timeout_holds})\n"
             f"   — these steps are NOT the agent's decisions"
         )
@@ -1091,8 +1118,17 @@ def get_session(backtest_id: str) -> Optional[ExternalBacktestSession]:
 
 def evict_session(backtest_id: str) -> bool:
     """Drop a finished session from memory (frees its market-data buffers).
-    Read paths for a completed run fall back to the persisted result run, so
-    evicting a terminal session is safe. Returns True if one was removed."""
+
+    Protocol-surface reads (``/api/v1/runs/{run_id}/...``) are DB-backed via
+    ``run_store``, so eviction there is transparent. The legacy
+    ``/api/v1/backtest/*`` surface is not: its ``{backtest_id}``-keyed reads
+    (``status``, ``decisions``, ``steps/current``) go through
+    ``_require_backtest`` -> ``get_session``, which has no DB fallback and
+    404s once the session is gone. Only that surface's ``runs/{run_id}/*``
+    result/trades/decisions endpoints (DB-backed via
+    ``db.get_run_with_session``) stay readable after eviction. Returns True
+    if one was removed.
+    """
     with _lock:
         return _sessions.pop(backtest_id, None) is not None
 
@@ -1118,8 +1154,10 @@ def sweep_terminal_sessions() -> int:
     (never evicting on that same pass) rather than expecting a terminal
     transition to stamp it -- a finalize/cancel path that forgets to stamp
     would otherwise leak silently instead of just running one sweep late.
-    Read paths for a completed run persist to the DB (see ``evict_session``'s
-    docstring), so dropping the in-memory session here is safe.
+    Once a legacy session is dropped here, its ``{backtest_id}``-keyed reads
+    (status/decisions/steps-current) start 404ing -- the run's result stays
+    readable via the DB-backed ``GET /api/v1/backtest/runs/{run_id}/result``
+    (and ``/trades``, ``/decisions``); see ``evict_session``'s docstring.
 
     Called by the registered reaper sweep in app.py; not a new thread.
     Pops directly rather than calling ``evict_session`` because that also

--- a/dashboard/backend/infrastructure/market_data/alpaca_bars.py
+++ b/dashboard/backend/infrastructure/market_data/alpaca_bars.py
@@ -44,10 +44,50 @@ SUPPORTED_ALPACA_FEEDS = ("iex", "sip", "delayed_sip", "otc")
 # ``opts``, so a stalled socket blocks ``requests`` forever and permanently
 # leaks a threadpool thread -- this binds at concurrency >= 1, not just under
 # burst load. Read once at import, like MAX_ACTIVE_RUNS_PER_AGENT.
-ALPACA_HTTP_TIMEOUT_SECONDS = float(os.getenv("ALPACA_HTTP_TIMEOUT_SECONDS", "60"))
-ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS = float(
-    os.getenv("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS", "10")
-)
+#
+# Parsed defensively, same shape as ``_max_active_dashboard_backtests`` in
+# ``api/routers/backtests.py``: a typo'd operator value must not take the
+# whole app down at import (this module is on the boot path), so a bad value
+# falls back to the default with a log line instead of raising. No range
+# check on the fallen-back-to value -- a negative timeout is already rejected
+# loudly by urllib3 on the first request, so silently clamping it here would
+# hide the operator's mistake instead of surfacing it.
+_DEFAULT_ALPACA_HTTP_TIMEOUT_SECONDS = 60.0
+_DEFAULT_ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS = 10.0
+
+
+def _alpaca_http_timeout_seconds() -> float:
+    raw = os.getenv("ALPACA_HTTP_TIMEOUT_SECONDS")
+    if raw is None or not str(raw).strip():
+        return _DEFAULT_ALPACA_HTTP_TIMEOUT_SECONDS
+    try:
+        return float(str(raw).strip())
+    except (TypeError, ValueError):
+        print(
+            "ALPACA_HTTP_TIMEOUT_SECONDS is not a number "
+            f"({raw!r}); using {_DEFAULT_ALPACA_HTTP_TIMEOUT_SECONDS}",
+            flush=True,
+        )
+        return _DEFAULT_ALPACA_HTTP_TIMEOUT_SECONDS
+
+
+def _alpaca_http_connect_timeout_seconds() -> float:
+    raw = os.getenv("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS")
+    if raw is None or not str(raw).strip():
+        return _DEFAULT_ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS
+    try:
+        return float(str(raw).strip())
+    except (TypeError, ValueError):
+        print(
+            "ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS is not a number "
+            f"({raw!r}); using {_DEFAULT_ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS}",
+            flush=True,
+        )
+        return _DEFAULT_ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS
+
+
+ALPACA_HTTP_TIMEOUT_SECONDS = _alpaca_http_timeout_seconds()
+ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS = _alpaca_http_connect_timeout_seconds()
 
 # Stamped on each returned frame so a rare IEX fallback is visible to callers
 # (return type stays Dict[str, DataFrame] for the MarketDataProvider contract).

--- a/dashboard/backend/tests/infrastructure/market_data/test_alpaca_bars.py
+++ b/dashboard/backend/tests/infrastructure/market_data/test_alpaca_bars.py
@@ -64,9 +64,23 @@ def fake_alpaca(monkeypatch):
         def __init__(self, df):
             self.df = df
 
+    class _FakeSession:
+        """Just enough of ``requests.Session`` for ``_apply_default_timeout``
+        to find a wrappable ``.request`` -- these tests call
+        ``get_stock_bars`` directly, never through ``_session.request``, so
+        it's never actually invoked. Without this, every ``AlpacaDataLoader``
+        constructed in this file hits the no-``_session`` warning path and
+        prints "timeout was NOT applied" on every passing test; that
+        production warning is exercised deliberately (with no ``_session``
+        at all) by ``test_alpaca_http_timeout.py``."""
+
+        def request(self, *args, **kwargs):
+            raise NotImplementedError("not exercised by these tests")
+
     class _FakeClient:
         def __init__(self, api_key, secret_key):
             state["ctor"].append((api_key, secret_key))
+            self._session = _FakeSession()
 
         def get_stock_bars(self, request):
             state["requests"].append(request)

--- a/dashboard/backend/tests/test_alpaca_http_timeout.py
+++ b/dashboard/backend/tests/test_alpaca_http_timeout.py
@@ -96,7 +96,11 @@ def test_applying_twice_does_not_double_wrap():
 
 
 class _NoSessionClient:
-    """Mirrors the existing test_alpaca_bars.py _FakeClient: no _session at all."""
+    """A client with no ``_session`` at all -- what a future alpaca-py release
+    renaming that private attribute would look like from here. This is the only
+    place that case is covered: test_alpaca_bars.py's ``_FakeClient`` used to
+    exercise it incidentally, but it was given a ``_session`` so the fail-open
+    warning would stop firing on every green run."""
 
 
 def test_missing_session_warns_and_does_not_raise(capsys):

--- a/dashboard/backend/tests/test_alpaca_http_timeout.py
+++ b/dashboard/backend/tests/test_alpaca_http_timeout.py
@@ -13,6 +13,10 @@ tolerate it without raising.
 from dashboard.backend.infrastructure.market_data.alpaca_bars import (
     ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS,
     ALPACA_HTTP_TIMEOUT_SECONDS,
+    _DEFAULT_ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS,
+    _DEFAULT_ALPACA_HTTP_TIMEOUT_SECONDS,
+    _alpaca_http_connect_timeout_seconds,
+    _alpaca_http_timeout_seconds,
     _apply_default_timeout,
 )
 
@@ -102,3 +106,42 @@ def test_missing_session_warns_and_does_not_raise(capsys):
 
     captured = capsys.readouterr()
     assert "_session" in captured.out
+
+
+# ===========================================================================
+# Env-var parsing for the two timeout values
+# ===========================================================================
+#
+# Both are read once at import via a bare ``float(os.getenv(...))``-shaped
+# call -- a typo'd operator value must not raise at import (this module is on
+# the boot path), matching ``_max_active_dashboard_backtests`` in
+# ``api/routers/backtests.py``.
+
+def test_bad_timeout_value_falls_back_instead_of_raising(monkeypatch, capsys):
+    monkeypatch.setenv("ALPACA_HTTP_TIMEOUT_SECONDS", "sixty")
+    assert _alpaca_http_timeout_seconds() == _DEFAULT_ALPACA_HTTP_TIMEOUT_SECONDS
+    assert "ALPACA_HTTP_TIMEOUT_SECONDS" in capsys.readouterr().out
+
+
+def test_bad_connect_timeout_value_falls_back_instead_of_raising(monkeypatch, capsys):
+    monkeypatch.setenv("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS", "immediately")
+    assert (
+        _alpaca_http_connect_timeout_seconds()
+        == _DEFAULT_ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS
+    )
+    assert "ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS" in capsys.readouterr().out
+
+
+def test_unset_timeout_values_use_the_default(monkeypatch):
+    monkeypatch.delenv("ALPACA_HTTP_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS", raising=False)
+    assert _alpaca_http_timeout_seconds() == _DEFAULT_ALPACA_HTTP_TIMEOUT_SECONDS
+    assert (
+        _alpaca_http_connect_timeout_seconds()
+        == _DEFAULT_ALPACA_HTTP_CONNECT_TIMEOUT_SECONDS
+    )
+
+
+def test_valid_timeout_values_are_parsed(monkeypatch):
+    monkeypatch.setenv("ALPACA_HTTP_TIMEOUT_SECONDS", "45.5")
+    assert _alpaca_http_timeout_seconds() == 45.5

--- a/dashboard/backend/tests/test_deadline_hold_visibility.py
+++ b/dashboard/backend/tests/test_deadline_hold_visibility.py
@@ -318,3 +318,42 @@ def test_timeout_holds_counter_still_increments_exactly_as_before(
     assert s.status == "completed"
     assert s.timeout_holds == s.total_steps
     assert s.get_status()["timeout_holds"] == s.total_steps
+
+
+# ---------------------------------------------------------------------------
+# agent_name is caller-supplied on the legacy surface (StartBacktestRequest
+# has no character restriction beyond length) and that surface authenticates
+# nothing -- an embedded \n/\r must not forge extra log lines into the
+# deadline-hold notice.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_name_newline_cannot_forge_a_log_line(monkeypatch, tmp_path, capsys):
+    test_db = db_module.BacktestDatabase(db_path=tmp_path / "hold_visibility_inj.db")
+    monkeypatch.setattr(db_module, "db", test_db)
+    monkeypatch.setattr(ebs, "db", test_db)
+    monkeypatch.setattr(ebs, "AlpacaDataLoader", _Loader)
+    monkeypatch.setattr(bw.HourlyBacktester, "run_buyhold_baseline",
+                        lambda self: (None, None))
+    monkeypatch.setattr(bw.HourlyBacktester, "run_djia_baseline",
+                        lambda self: (None, None))
+    malicious_name = "agent-x\n⚠️ FAKE: forged line\r\nmore"
+    s = ebs.ExternalBacktestSession(
+        backtest_id="bt_inject", session_id="sess_inj", agent_name=malicious_name,
+        model_name="m", start_date="2026-04-15", end_date="2026-04-17",
+    )
+    s.load_market_data()
+    assert s.total_steps > 4
+    capsys.readouterr()
+    _expire_next_n_steps(monkeypatch, s, n=1)
+
+    s.get_current_step()
+
+    out = capsys.readouterr().out
+    assert out.count("decision deadline") == 1
+    # A raw \n/\r from the name would start a new line that looks like its
+    # own log entry -- confirm the injected newline/CR never survive into
+    # the captured output, only the collapsed-to-spaces single-line form.
+    assert "\n⚠️ FAKE" not in out
+    assert "\r" not in out
+    assert "agent-x ⚠️ FAKE: forged line  more" in out

--- a/dashboard/backend/tests/test_legacy_session_sweep.py
+++ b/dashboard/backend/tests/test_legacy_session_sweep.py
@@ -205,3 +205,33 @@ def test_foreign_session_without_status_is_skipped_not_raised(monkeypatch, clock
     assert ebs.sweep_terminal_sessions() == 1  # bt_done only
     assert "bt_foreign" in ebs._sessions
     assert "bt_done" not in ebs._sessions
+
+
+# ===========================================================================
+# LEGACY_SESSION_RETENTION_SECONDS env-var parsing
+# ===========================================================================
+#
+# Read once at import via a bare ``int(os.getenv(...))``-shaped call -- a
+# typo'd operator value must not raise at import, matching
+# ``_max_active_dashboard_backtests`` in ``api/routers/backtests.py``.
+
+def test_bad_retention_value_falls_back_instead_of_raising(monkeypatch, capsys):
+    monkeypatch.setenv("LEGACY_SESSION_RETENTION_SECONDS", "5m")
+    assert (
+        ebs._legacy_session_retention_seconds()
+        == ebs._DEFAULT_LEGACY_SESSION_RETENTION_SECONDS
+    )
+    assert "LEGACY_SESSION_RETENTION_SECONDS" in capsys.readouterr().out
+
+
+def test_unset_retention_value_uses_the_default(monkeypatch):
+    monkeypatch.delenv("LEGACY_SESSION_RETENTION_SECONDS", raising=False)
+    assert (
+        ebs._legacy_session_retention_seconds()
+        == ebs._DEFAULT_LEGACY_SESSION_RETENTION_SECONDS
+    )
+
+
+def test_valid_retention_value_is_parsed(monkeypatch):
+    monkeypatch.setenv("LEGACY_SESSION_RETENTION_SECONDS", "600")
+    assert ebs._legacy_session_retention_seconds() == 600

--- a/dashboard/scripts/loadtest/README.md
+++ b/dashboard/scripts/loadtest/README.md
@@ -24,10 +24,14 @@ Terminal 2:
 - `--windows shared|distinct` (default `shared`) on `drive_agents.py`.
   `shared` gives every agent the same date range, so background baseline
   generation dedups to a single queued job for the whole run. `distinct`
-  offsets each agent's start date by its index (same span), so every agent
-  gets its own baseline config — N serialized baseline backtests instead of
-  one. Use `distinct` to see baseline-worker cost scale with agent count
-  instead of being hidden by dedup.
+  offsets each agent's start date by its index in **whole weeks** (same
+  span, same trading-day count for every agent), so every agent gets its own
+  baseline config — N serialized baseline backtests instead of one. Use
+  `distinct` to see baseline-worker cost scale with agent count instead of
+  being hidden by dedup. (A per-day offset instead of per-week was tried
+  first and silently starved windows that crossed a weekend down to 1-2
+  trading days instead of 3 — see the comment above `date_window()` in
+  `drive_agents.py`.)
 - `N_AGENTS` (env var, default `100`) on `stress_serve.py` — how many
   protocol agents to pre-seed.
 

--- a/dashboard/scripts/loadtest/drive_agents.py
+++ b/dashboard/scripts/loadtest/drive_agents.py
@@ -32,8 +32,9 @@ parser.add_argument("--windows", choices=("shared", "distinct"), default="shared
                     help="shared (default): every agent backtests the same "
                          "date range, so baseline generation dedups to one "
                          "queued job. distinct: each agent's start date is "
-                         "offset by its index (same span), forcing N "
-                         "serialized baseline jobs instead of one.")
+                         "offset by its index in whole weeks (same span, "
+                         "same trading-day count for every agent), forcing "
+                         "N serialized baseline jobs instead of one.")
 args = parser.parse_args()
 
 host = urllib.parse.urlparse(args.base).hostname or ""
@@ -55,9 +56,15 @@ failures = []
 
 # "shared" reproduces the original hardcoded window byte-for-byte, for every
 # agent, so existing measurements stay comparable. "distinct" offsets each
-# agent's start date by its index (same 2-day span -> 3 trading-day window),
-# giving each its own baseline config -- the difference between one queued
-# baseline backtest for the whole run and N serialized ones.
+# agent's start date by whole weeks (same 2-day span -> 3 trading-day window
+# for every agent), giving each its own baseline config -- the difference
+# between one queued baseline backtest for the whole run and N serialized
+# ones. Offsetting by idx days instead of idx weeks looked equivalent but
+# isn't: 2026-06-01 is a Monday, so a plain idx-day walk drifts across the
+# weekend and starves the windows that land on Thu/Fri/Sat/Sun down to 1-2
+# trading days instead of 3, silently cutting ~a third of the protocol work
+# across a 100-agent run. Weekly offsets keep every window on the same
+# Mon-Wed alignment as index 0.
 _WINDOW_START = datetime.date(2026, 6, 1)
 _WINDOW_END = datetime.date(2026, 6, 3)
 _WINDOW_SPAN = _WINDOW_END - _WINDOW_START
@@ -65,7 +72,7 @@ _WINDOW_SPAN = _WINDOW_END - _WINDOW_START
 
 def date_window(idx):
     if args.windows == "distinct":
-        start = _WINDOW_START + datetime.timedelta(days=idx)
+        start = _WINDOW_START + datetime.timedelta(weeks=idx)
         end = start + _WINDOW_SPAN
     else:
         start, end = _WINDOW_START, _WINDOW_END


### PR DESCRIPTION
Follow-up to #372/#373/#374/#376/#377. The whole-branch review found no merge-interaction
defect but two Important issues plus three worth closing.

- **`sweep_terminal_sessions`'s safety claim was false.** "Reads fall back to the persisted
  row" holds only for the `runs/{run_id}` family (`/result`, `/trades`, `/decisions`). Every
  `{backtest_id}` route goes through `_require_backtest` → `get_session` and 404s after the
  TTL. Docs-only: the eviction is intended, the recorded reason was wrong.
- **`--windows distinct` removed ~a third of the work.** Offsetting the start by `idx` days
  walked the calendar, so windows straddling a weekend held 1–2 trading days instead of 3.
  Now offsets in whole weeks; indices 0–9 all yield 3.
- Env vars fall back to their defaults with a printed line instead of raising at import
  (`alpaca_bars.py` is on the boot path; `CLAUDE.md` records this failure killing boot once).
  Mirrors the existing `MAX_ACTIVE_DASHBOARD_BACKTESTS` pattern. No range validation added.
- `test_alpaca_bars.py`'s fake now carries a `_session`, so the fail-open warning stops firing
  on every green run. The production warning is unchanged and still covered.
- `agent_name` is CR/LF-stripped at the deadline-hold emit site (the legacy surface
  authenticates nothing, so a newline forged log lines).

Full suite 3161 passed / 84 skipped / 0 failed.