### PR TITLE
docs: measured hosting capacity, replacing spec §5 arithmetic

### DIFF
--- a/dashboard/scripts/loadtest/README.md
+++ b/dashboard/scripts/loadtest/README.md
@@ -41,9 +41,22 @@ dequeues it, and `drive_agents.py`'s reported wall time never waits on
 baselines. `distinct`'s extra cost is real (N serialized `HourlyBacktester`
 builds instead of one deduped build) but structurally invisible to that
 timer. The signal that `distinct` is doing more work is the server-side
-baseline-job count (1 unique config under `shared` vs. N under `distinct`,
-visible in `stress_serve.py`'s stdout), not the wall time `drive_agents.py`
-prints.
+count of baselines the worker actually **executed** (1 unique config under
+`shared` vs. N under `distinct`), not the wall time `drive_agents.py` prints.
+
+Count executions, and count them with this exact grep:
+
+    grep -c "Running Buy & Hold baseline" <the stress_serve.py log>
+
+⚠ **Do not read that off the queue-depth line, which is the loud number and
+says the opposite.** Dedup lives at the *consumer* — `_run_job` keys
+`_completed` on `(start_date, end_date, mode)` and skips the work
+(`baseline_worker.py`) — while `submit()` enqueues unconditionally. So under
+`shared` the queue genuinely does grow to ~N and stdout fills with
+`⚠️ Baseline queue depth N — worker backlog` warnings (a 100-agent run
+printed 24 of them, peaking at 37) while exactly **one** baseline executed.
+Those are cheap cache-hit jobs draining, not a capacity problem — but read
+as "the server-side baseline-job count" they look exactly like broken dedup.
 
 ## ⚠ Figures produced before 2026-08-18 are a floor, not a measurement
 
@@ -70,7 +83,48 @@ bug (0.522 CPU-s, 311 MB RSS) is **not** in the understated category — it
 was measured with baselines actually running. Do not average it with the
 earlier rungs; they are not measuring the same thing.
 
+## Emulating a hosting tier
+
+The dev box has 12 cores; every tier this project can afford has one or a
+fraction of one. Running unconstrained measures hardware nobody deploys on,
+so confine the **server** and pin the driver to other cores:
+
+    # Render Standard (1.0 CPU)
+    N_AGENTS=100 taskset -c 0 python dashboard/scripts/loadtest/stress_serve.py
+
+    # Render Free (0.1 CPU)
+    systemd-run --user --scope -p CPUQuota=10% \
+        env N_AGENTS=100 python dashboard/scripts/loadtest/stress_serve.py
+
+    # driver, in both cases
+    taskset -c 2-11 python dashboard/scripts/loadtest/drive_agents.py 100 --artifacts /tmp/atl_loadtest_XXXX
+
+Verify the quota actually binds before trusting a run (a busy-loop probe
+should burn ~0.1 CPU-s per wall-second). Results: spec §5.
+
+This is *not* a substitute for running against Render, but it is the closest
+thing available, because **the harness cannot be pointed at a deployed
+instance**: every hermetic property above is an in-process monkeypatch inside
+`stress_serve.py` (the market-data provider swap, the `DATABASE_PATH`
+redirect, the seeded agents and their keys). `--allow-remote` only relaxes a
+hostname guard — it supplies none of them. Against a real deployment the
+driver would find no agents, and the runs it created would hit real Alpaca
+and write to real stores.
+
+⚠ **Do not extrapolate one tier's numbers to another by dividing CPU-seconds
+by the tier's CPU budget.** That method was used to size this stack and was
+wrong in *both* directions — 2× pessimistic on Standard, 35% optimistic on
+Free. A cgroup quota does not slow work down smoothly; it freezes the process
+for ~90 ms of every 100 ms, including mid-transaction, so throttled CPU does
+less useful work per CPU-second than dedicated CPU. Measure each tier.
+
 ## Acceptance target (100 agents, 21-step runs, local dev hardware)
 
 0 timeout_holds, 0 failures, create p95 < 1 s, decision p95 < 1 s,
 total wall < 60 s, server RSS growth < 100 MB.
+
+⚠ **`timeout_holds` is not self-sufficient evidence.** Until 2026-08-18 the
+driver reported an unreadable count as `0`, so this criterion could not fail;
+it now reports `unknown`. Always cross-check it against the independent
+count in the server log — `grep -c "decision deadline"` — and when the two
+disagree, believe the log. A Free-tier run printed `0` against 7 in the log.

--- a/dashboard/scripts/loadtest/README.md
+++ b/dashboard/scripts/loadtest/README.md
@@ -123,8 +123,27 @@ less useful work per CPU-second than dedicated CPU. Measure each tier.
 0 timeout_holds, 0 failures, create p95 < 1 s, decision p95 < 1 s,
 total wall < 60 s, server RSS growth < 100 MB.
 
-⚠ **`timeout_holds` is not self-sufficient evidence.** Until 2026-08-18 the
-driver reported an unreadable count as `0`, so this criterion could not fail;
-it now reports `unknown`. Always cross-check it against the independent
-count in the server log — `grep -c "decision deadline"` — and when the two
-disagree, believe the log. A Free-tier run printed `0` against 7 in the log.
+⚠ **Auto-holds have three instruments and none of them is complete.** Rank
+them in this order and take the largest:
+
+1. **Client-observed deadline losses** — `drive_agents.py` counts a loss only
+   when the server answers a decision with **409 + "deadline"/"finalized"**,
+   i.e. the server itself reporting that it auto-held the step under the
+   agent. Authoritative and cannot be fabricated. Trust this one first.
+2. **The server log** — `grep -c "decision deadline"`. A **lower bound**: it
+   misses the path where `get_status` applies the hold *before* the
+   instrumented loop in `get_current_step` runs, so the loop sees no delta
+   and logs nothing. Measured: a 25-agent Standard run logged **0** while the
+   client observed **1**. Issue #375 is a second, separate blind spot (the
+   fourth deadline branch in `submit_decisions`, silent on the legacy and v2
+   surfaces).
+3. **The `timeout_holds` counter** — weakest. Until 2026-08-18 an unreadable
+   count printed as `0`, so this criterion could not fail; it now prints
+   `unknown`. At load it is unknown for essentially every run (a 100-agent
+   Standard run: `unknown [100/100 runs unreadable]`), because the live
+   session it reads from has usually been swept by the time the run is
+   polled.
+
+A run is only clean when **all three** are zero. Earlier guidance in this
+repo said "when they disagree, believe the log" — that is wrong, and was
+corrected once the client-observed count was seen to exceed it.

--- a/dashboard/scripts/loadtest/drive_agents.py
+++ b/dashboard/scripts/loadtest/drive_agents.py
@@ -3,7 +3,10 @@
 Each agent: POST /api/v1/runs (3 trading days ~= 21 hourly steps), then loop
 GET steps/next -> POST decision until completed. Records per-endpoint latency,
 end-to-end run wall time, errors, steps lost to the decision deadline, and the
-server-reported timeout_holds counter (present once T3 ships; 0 before).
+server-reported timeout_holds counter. That counter prints as ``unknown``
+when it cannot be read, never as 0 — and it is not self-sufficient evidence
+either way: cross-check it against the ``decision deadline`` lines the server
+logs, which count holds independently. When the two disagree, believe the log.
 
 Usage:
     python dashboard/scripts/loadtest/drive_agents.py 100 --artifacts /tmp/atl_loadtest_xxx
@@ -161,9 +164,17 @@ def drive(agent, idx):
         if res.get("run_status") == "completed":
             break
     status, view, _ = req("GET", f"/api/v1/runs/{run_id}", key)
-    holds = 0
+    # Stays None when the count could not be read *at all*: a non-200, a run
+    # whose live session has already been swept (`engine_status` is None once
+    # it is gone — runs/service.py), or a payload without the field. Folding
+    # any of those into 0 made this metric report "no holds" exactly when the
+    # server is most loaded, i.e. when holds actually happen: a Free-tier run
+    # printed 0 here while the server log carried 7. Unknown is not zero.
+    holds = None
     if status == 200:
-        holds = (view.get("engine_status") or {}).get("timeout_holds") or 0
+        raw = (view.get("engine_status") or {}).get("timeout_holds")
+        if raw is not None:
+            holds = int(raw)
     with lock:
         run_walls.append(time.perf_counter() - t_run)
         deadline_losses.append(lost)
@@ -218,8 +229,13 @@ print("end-to-end run wall time (s):")
 dist("full_run", run_walls)
 total_lost = sum(deadline_losses)
 runs_hit = sum(1 for x in deadline_losses if x)
+known_holds = [h for h in server_holds if h is not None]
+unreadable = len(server_holds) - len(known_holds)
+holds_txt = str(sum(known_holds)) if known_holds else "unknown"
+if unreadable:
+    holds_txt += f" [{unreadable}/{len(server_holds)} runs unreadable]"
 print(f"completed runs: {len(run_walls)}/{M}  |  client-observed deadline losses: "
-      f"{total_lost} (across {runs_hit} runs)  |  server timeout_holds: {sum(server_holds)}")
+      f"{total_lost} (across {runs_hit} runs)  |  server timeout_holds: {holds_txt}")
 if failures:
     print(f"FAILURES: {len(failures)}")
     for f in failures[:8]:

--- a/docs/superpowers/plans/2026-08-18-burst-capacity-safety.md
+++ b/docs/superpowers/plans/2026-08-18-burst-capacity-safety.md
@@ -361,12 +361,50 @@ and was swallowed as a warning. The harness is the instrument T5 depends on.
 
 ## T5 — Validation against a real Render instance
 
+> ## ✅ EXECUTED 2026-08-18 — but **not against Render**, and the answers moved
+>
+> The capacity question is **answered**; the steps below are kept for the record and
+> annotated with what actually happened. Results live in **spec §5**.
+>
+> **Why not Render.** The harness cannot be pointed at a deployed instance. Every
+> hermetic property is an in-process monkeypatch inside `stress_serve.py`, not client
+> configuration: `:66` swaps `create_market_data_provider` for `FakeAlpacaLoader`;
+> `:17-20` redirects `DATABASE_PATH` and pops the Postgres URLs; `:70-79` seeds the
+> agents and writes the keys `drive_agents.py:45` requires. `--allow-remote`
+> (`drive_agents.py:41-42`) only relaxes a hostname guard — it supplies none of that.
+> Aimed at Render the run would register 100 junk agents in the prod content DB, hit
+> **real Alpaca** (the create payload carries only dates, so the server default feed
+> applies; the sole synthetic provider, `vnpy_simulation`, is absent from the image
+> because `Dockerfile:9` installs `requirements.txt` only), and write into the real
+> run-history store — while loading **prod**, the only Render service there is. That
+> measures a different system than §5 describes.
+>
+> **What was run instead.** The same harness, unmodified, with the *server* confined to
+> each tier's CPU budget on the dev box (`taskset -c 0` ≈ Standard 1.0 CPU;
+> `systemd-run --user --scope -p CPUQuota=10%` ≈ Free 0.1 CPU) and the driver pinned to
+> other cores. That reproduces the one variable that matters while keeping every
+> hermetic property intact. Ladders at N = 12/16/20/25/50/100.
+>
+> **The premise also changed.** T5 was scoped to a 100-agent *burst*. The operator's
+> actual plan is ~12 hosted agents **sustained**, growing with users — see spec §1.
+> §5 now answers that question.
+>
+> **Three things this found that the plan did not anticipate:**
+> 1. `timeout_holds == 0` — a Step 3 acceptance criterion — was **structurally
+>    unfalsifiable**. Fixed in `drive_agents.py` before any verdict was recorded.
+> 2. Free fails by **SQLite write-lock timeouts**, not by the predicted deadline breach,
+>    and it fails between 16 and 25 concurrent runs rather than at 100.
+> 3. Per-run CPU is a property *of the tier*, not of the code (0.31 CPU-s dedicated vs
+>    0.57 throttled), which is why Step 3's "~52 s prediction" was wrong.
+
 **Not a code change. Do not start it until T1–T4 have merged.**
 
 Every number in the spec comes from a 12-core dev box plus arithmetic. Nothing in this
 workstream has ever run on Render.
 
-- [ ] **Step 1:** Deploy `main` (with T1–T4) to a Render **Standard** instance.
+- [~] **Step 1:** ~~Deploy `main` (with T1–T4) to a Render **Standard** instance.~~
+      **Not done — and should not be.** Superseded by CPU-limited emulation; see the
+      EXECUTED block above. The only Render service is prod.
 - [ ] **Step 2:** Run the fixed harness at **25 agents** first, `--windows shared`.
       Record wall time, failures, `timeout_holds`, **create p95, decision p95, RSS at
       start and at end** (growth, not just peak — see Step 3).
@@ -378,6 +416,12 @@ workstream has ever run on Render.
       environment where they mean anything and the first run whose baselines actually
       execute, so this is what finally closes Task 12 Step 2. Task 12's own rule applies:
       if a criterion misses, diagnose — do not relax it.
+      **→ Run under CPU-limited emulation instead (spec §5). Standard: 100/100, zero
+      failures, zero locks, RSS +89 MB. Two corrections to this step's own text: the
+      `timeout_holds == 0` criterion could not fail as written and had to be fixed first,
+      and the "~52 s prediction" it measures against was itself wrong (per-run CPU is a
+      property of the tier). Task 12's rule was followed — the `create p95` miss was
+      diagnosed as burst-start queueing, not relaxed.**
 - [ ] **Step 4:** Run **100 agents `--windows distinct`** once, purely to measure the
       baseline-worker serialization from F5. Expected to be materially slower; that is
       the datum, not a failure.

--- a/docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md
+++ b/docs/superpowers/specs/2026-08-18-burst-capacity-safety-design.md
@@ -15,6 +15,13 @@ The predecessor made 100 concurrent protocol agents *survivable*. This spec cove
 residue that the acceptance run surfaced: four verified defects, and the hosting decision
 for a **100-agent burst** (a demo/launch moment, not sustained load).
 
+⚠ **The burst framing was wrong about the product, and §5 has been re-scoped.** The
+operator's actual plan is to **keep roughly a dozen agents hosted continuously and grow
+that number as users arrive** — sustained load, not a launch moment. That is a different
+question from the one this spec originally asked, and it has a different answer: §5 now
+carries a measured Free-tier ceiling for *sustained concurrency* rather than an
+arithmetic burst estimate. Read §5, not this paragraph, for the hosting decision.
+
 **Explicitly out of scope, by decision:** per-run CPU optimization. It was measured
 (§4) and is real, but the burst target does not need it. Recorded here so a later
 reader does not re-derive it.
@@ -42,7 +49,7 @@ smoke) is likewise still outstanding — nothing in this workstream has run on R
 | Measurement | Result |
 |---|---|
 | 100 agents, fresh process | **35.6 s wall, 100/100 completed, 0 failures**, worst request 5.6 s |
-| `timeout_holds` | **0 in every rung** (1 → 100 agents) — the #208–#212 deadline fix is validated |
+| `timeout_holds` | **0 in every rung** (1 → 100 agents) — ⚠ **not evidence**, see below |
 | Peak RSS | 311 MB on the fresh 100-agent run (never above 360 MB in any configuration) |
 | CPU per run (ladder, over HTTP) | 0.440 / 0.406 / 0.412 / 0.432 / 0.420 CPU-s at 1 / 10 / 25 / 50 / 100 agents — **linear** across a 100× concurrency range |
 | CPU per run, working figure | **0.522 CPU-s** — the *only* run whose baselines actually executed (the ladder rungs ran with baselines silently disabled by F4, so 0.406–0.440 is a floor). 0.522 is the value used for every tier calculation below |
@@ -55,6 +62,37 @@ baselines, `baseline_worker.py:105-129`). The **ladder rungs** are the floors: t
 (0.406–0.440) *and* their RSS were measured with baselines silently failing. Do not
 extend the F4 discount to 0.522/311 MB, and do not treat the ladder's numbers as
 comparable to them.
+
+⚠ **The `timeout_holds` row was never evidence, and this was found the hard way.** Until
+2026-08-18 the driver folded three distinct *unknowns* into the same `0` that means "no
+holds" — a non-200 on the final GET, a swept live session (`engine_status` is `None` once
+it is gone), and an absent field. That read has been there since the harness's first
+commit (`11a102b`), so **every rung above, and the predecessor's whole ladder, reported a
+number that could not fail.** It reads zero hardest under the load that produces holds: a
+Free-tier run printed `0` while the server log carried **7**. Fixed in
+`drive_agents.py` (unknown now prints as `unknown`, never `0`).
+
+This does not mean the #208–#212 deadline fix is broken — on an unsaturated 12-core box
+those zeros were most likely true. It means these runs could not tell a working fix from
+an unreadable counter, so they never validated it.
+
+**Auto-holds have three instruments, and none of them is complete.** Rank them and take
+the largest:
+
+1. **Client-observed deadline losses** (`drive_agents.py:152-155`) — counted only when
+   the server answers a decision with **409 + "deadline"/"finalized"**, i.e. the server
+   itself reporting the auto-hold. Authoritative; trust first.
+2. **T2's `decision deadline` log lines** — a **lower bound**. It misses the path where
+   `get_status` applies the hold *before* the instrumented loop in `get_current_step`
+   runs, leaving that loop no delta to report. Measured in §5: a 25-agent Standard run
+   logged **0** while the client observed **1**. Issue #375 is a separate second blind
+   spot (the fourth deadline branch in `submit_decisions`).
+3. **The `timeout_holds` counter** — weakest, and at load it is `unknown` for essentially
+   every run.
+
+⚠ An earlier draft of this section said "when they disagree, believe the log." That was
+written before the Standard 25-agent run showed the log *under*-counting, and is wrong.
+The log is a floor, not a truth.
 
 RSS nonetheless stays unsettled, for different reasons: 311 MB is **one run**, on a
 12-core dev box, against `FakeAlpacaLoader`/`synth_bars` synthetic frames rather than real
@@ -217,40 +255,170 @@ sites from drifting — do not fold it into any connection-pooling change.
 **Why it is deferred:** 1.51× moves free tier from ~7.6 to ~11.5 sustained agents.
 It does not reach 100 by any path. For the burst target it is unnecessary (§5).
 
-## 5. Hosting decision
+⚠ **Both of those agent counts are wrong** — they are `0.522 ÷ 0.1` arithmetic, the
+method §5 falsified. **Measured**, Free clears **20** concurrent active runs before the
+first failure, not 7.6. The deferral still holds, but not for the reason given: the
+optimization was sized as the thing that would lift Free from "under the operator's
+target" to "just over it", and Free was already over it. What actually bounds Free is
+SQLite write-lock contention under CPU throttling (§5), which shaving 33% off per-run
+CPU does not address — the lock is held across a *freeze*, not across compute. Do not
+revive this optimization as a way to raise Free's agent ceiling.
 
-Per-run cost is **0.522 CPU-s** over HTTP (§2). For a **burst** of 100 agents running
-once — 52.2 CPU-s of request work in total:
+## 5. Hosting decision — MEASURED 2026-08-18
 
-| Tier | CPU | Burst wall time | Worst request (extrapolated) | Verdict |
-|---|---|---|---|---|
-| Free | 0.1 | ~520 s | **~82 s** | **Breaches the 60 s deadline** → silent auto-holds |
-| Standard | 1.0 | ~52 s | ~8 s | **Adequate, but with no headroom** |
+> **This section was arithmetic and it was wrong in both directions.** It predicted
+> Standard at ~52 s (measured 26–49 s), Free at ~520 s (measured 702 s), and — more
+> importantly — the **wrong failure mode at the wrong load**. Replaced with measurement.
+> The method it used, `CPU-seconds ÷ CPU budget`, must not be reused; see *Why the
+> arithmetic failed*.
 
-Both columns are arithmetic, and the derivation is stated so it can be checked:
-wall = 52.2 ÷ CPU; worst request = 5.6 s × (predicted wall ÷ 35.6 s measured wall).
+### What is being sized
 
-The deadline, not throughput, is the failure boundary: a step served later than
-`EXTERNAL_AGENT_DECISION_TIMEOUT_SECONDS` (60) is auto-held and attributed to the agent
-anyway (F2). Free tier is expected to breach it under a 100-agent burst; Standard is not.
-That is what makes deferring §4 safe — **but the margin is thinner than the table alone
-suggests, and T5 exists to settle it**:
+**N is the number of concurrently *active runs*, not registered agents.** A dozen hosted
+agents that each step hourly are a negligible load; a dozen agents all backtesting at the
+same moment is the worst case, and that is what N means below.
 
-- **The 52 s figure consumes the whole CPU.** 52.2 CPU-s of request work on 1.0 CPU in
-  ~52 s is ~100% utilisation with nothing left for the baseline worker, the 60 s reaper,
-  DB writes, or any concurrent dashboard traffic. It is a lower bound on wall time, not a
-  budget.
-- **The baseline worker's CPU is in none of these numbers** (F4). Even the shared-window
-  demo of §7 still queues one full `HourlyBacktester` run.
-- **Scaling a *tail* latency linearly is not sound**, and the ~82 s / ~8 s column should
-  be read as an order-of-magnitude estimate, not a measurement. It assumes the
-  tail-to-total ratio (5.6 ⁄ 35.6 ≈ 16%) survives the move from a 12-core box to
-  cgroup-throttled fractional CPU, where FIFO queueing against a near-single-threaded
-  resource can grow the tail *super*-linearly. If anything it **understates** the Free
-  tier's worst case; the Free verdict is directionally safe regardless, which is the only
-  load-bearing use of the number here.
+The operator's target is **~12 sustained, growing with users** (§1) — not the 100-agent
+burst this spec was originally scoped to.
 
-Sustained 100 agents is a different question and is not answered here.
+### Method
+
+The hermetic harness (`dashboard/scripts/loadtest/`), unmodified, on merged `main`
+(`e8473fe`), `--windows shared`, with the **server** confined to each tier's CPU budget
+and the driver pinned to other cores:
+
+- **Standard** ≈ `taskset -c 0` (1.0 CPU)
+- **Free** ≈ `systemd-run --user --scope -p CPUQuota=10%` (0.1 CPU); quota enforcement
+  verified first with a busy-loop probe (0.52 CPU-s over 5 s wall = 10.4%)
+
+Server CPU read directly from `/proc/<pid>/stat` (process-wide, all threads). Not Render
+itself — the harness cannot be pointed at a deployed instance; see the plan's T5 block.
+
+### Free tier (0.1 CPU) — the ceiling is 20
+
+| N | wall | server CPU | CPU/run | util of quota | completed | failures | `database is locked` | holds (log / client) |
+|---|---|---|---|---|---|---|---|---|
+| 12 | 68.9 s | 6.9 | 0.575 | 100% | **12/12** | **0** | 0 | 0 / 0 |
+| 16 | 89.1 s | 8.9 | 0.556 | 100% | **16/16** | **0** | 0 | 0 / 0 |
+| 20 | 141.0 s | 11.2 | 0.560 | 79% | **20/20** | **0** | 0 | 0 / 0 |
+| 25 | 141.3 s | 14.0 | 0.560 | 99% | 22/25 | **3** | **6** | 0 / 0 |
+| 50 | 313.6 s | 28.3 | 0.566 | 90% | 36/50 | **14** | **26** | 2 / 1 |
+| 100 | 702.4 s | ~70 † | ~0.70 † | ~100% † | 81/100 | **19** | **34** | 7 / 7 |
+
+† The N=100 row's CPU is **inferred** from wall × quota; that run predates the direct
+`/proc` instrumentation. Every other row is measured.
+
+**Clean through 20 concurrent; first failures at 25.** But "clean" is not "comfortable":
+the server runs **at or near its full 0.1 CPU quota across the whole range**, so there is
+no headroom for dashboard traffic, the leaderboard refresh, or the baseline worker.
+Latency is already seconds — `decision` p95 2.0 s at N=12, 3.7 s at N=20.
+
+The two rungs below 100% are the informative ones. N=50 (90%) and N=20 (79%) are *not*
+spare capacity: both lost wall-clock to blocking rather than compute — N=50 to lock waits
+(26 of them), N=20 to one long stall (below). CPU going idle on this stack is a symptom,
+not headroom.
+
+RSS stayed 276–303 MB across the whole range, so the 512 MB ceiling is **not** the
+constraint at any point. This failure is purely CPU.
+
+### Standard tier (1.0 CPU)
+
+| N | wall | server CPU | CPU/run | util | completed | failures | locks | create p95 | decision p95 |
+|---|---|---|---|---|---|---|---|---|---|
+| 12 | 77.5 s | 3.7 | 0.308 | 4.8% | **12/12** | **0** | 0 | 529 ms | 120 ms |
+| 25 | 73.9 s | 6.8 | 0.272 | 9.2% | **25/25** | **0** | 0 | 259 ms | 269 ms |
+| 100 | 48.8 s | 31.0 | 0.310 | 63.5% | **100/100** | **0** | 0 | 1494 ms | 1014 ms |
+
+**Zero failures and zero lock errors at every rung, including 100.** At N=100 the server
+used 63.5% of one CPU, so even the burst case leaves headroom. An earlier, less
+instrumented run of the same configuration finished in 26.6 s with `create` p95 1157 ms
+and `decision` p95 884 ms; the difference is contention for core 0 with other work on the
+dev box, which makes this emulation a **floor** for Standard rather than a ceiling.
+
+Wall time here is dominated by an outlier stall, not by CPU — see *The ~68 s stall*.
+
+### Why the arithmetic failed
+
+**Per-run CPU is a property of the tier, not of the code.** Measured directly:
+
+| | CPU-s per run |
+|---|---|
+| 1.0 CPU, dedicated (`taskset`) | **0.31** |
+| 0.1 CPU, throttled (`CPUQuota`) | **0.57** (≈1.9×) |
+| 12-core dev box (the figure §2 used) | 0.522 |
+
+A cgroup quota does not slow a process down smoothly — it **freezes** it for ~90 ms of
+every 100 ms period, including mid-transaction and mid-critical-section. Throttled CPU
+therefore does less useful work per CPU-second than dedicated CPU. Dividing one
+per-run constant by each tier's budget assumes exactly the opposite, so it overestimated
+the fast tier (0.522 vs the true 0.31) and underestimated the throttled one (0.522 vs the
+true 0.57). The 12-core figure happened to sit between them, which is why the result
+looked plausible.
+
+Use each tier's own measured per-run cost, or measure the tier.
+
+### The failure mode is not the one that was predicted
+
+§5 predicted Free would fail by **breaching the 60 s decision deadline → silent
+auto-holds**. It does not. It fails by **SQLite write-lock timeouts**, at a quarter of
+the predicted load, with *zero* auto-holds at the threshold:
+
+```
+sqlite3.OperationalError: database is locked
+  → database.py:645 insert_run          (via external_run_service _finalize → _advance_step → submit_decisions)
+  → domain/runs/repository.py:433 finalize_step   (via runs/service.py:971 submit_decision)
+```
+
+Both sit on the agent's decision path (`api/routers/runs.py:157`) and both carry a ~5 s
+busy timeout (`repository.py:79` explicitly; `database.py:119` via Python's default). A
+writer frozen by the quota still holds the lock, so every other writer exhausts its
+timeout and the agent gets a bare **500**.
+
+**This is throttling contention, not concurrency contention** — 100 concurrent writers on
+a full CPU produce **zero** lock errors, while 25 on a tenth of a CPU produce six.
+
+⚠ **On prod the two sites diverge, and the hotter one cannot be relieved.** `insert_run`
+moves to Postgres when `AGENT_RUNS_DATABASE_URL` is set. `finalize_step` writes
+`protocol_steps`, which has **no Postgres twin** (`domain/runs/` has no `*_postgres.py`)
+and always lives on local SQLite — and it runs once per *step*, ~21× more often than
+`insert_run` runs per *run*. Configuration cannot move the hot site.
+
+### The ~68 s stall — reproduced, unexplained
+
+Three runs across both tiers showed a single request stalling for a fixed ~68–70 s while
+the server was **idle**:
+
+| run | stalled endpoint | duration | server util |
+|---|---|---|---|
+| Standard N=12 | `steps/next` | 68.6 s | 4.8% |
+| Standard N=25 | `decision` | 69.6 s | 9.2% |
+| Free N=50 | `steps/next` | 68.2 s | 9.0% |
+
+At Standard N=12, eleven of twelve runs finished in ~2.9 s and one took 77.4 s, with only
+3.7 CPU-s consumed in total — so this is a **wait, not work**, and the near-identical
+duration across unrelated configurations argues against a scheduling artifact.
+`get_current_step` does not long-poll (`external_run_service.py:491`), so a 68 s response
+is a genuine server-side stall. It exceeds the 60 s decision deadline, and at Standard
+N=25 it produced a real client-observed auto-hold.
+
+**Not diagnosed.** Recorded here so it is not rediscovered as a "flake"; it deserves its
+own investigation.
+
+### Verdict
+
+**Standard, standing — not a per-event flip.** The operator's plan is sustained hosting,
+so the relevant comparison is headroom, not survival:
+
+- Free clears a dozen concurrent runs, but **at or near its full CPU quota throughout**,
+  with second-scale latencies and a hard wall at 25 where agents start receiving 500s.
+  Nothing is left for the dashboard the agents are hosted behind.
+- Standard clears 100 concurrent at 63.5% utilisation with no failures and no lock
+  errors — roughly **5× the target load, with headroom to grow into**.
+
+The upgrade trigger is not "a dozen agents"; it is **any expectation of more than ~20
+concurrent active runs**, or of Free's CPU being shared with anything else.
+
+Sustained 100 agents remains a different question and is still not answered here.
 
 **Horizontal scaling stays closed.** Run state is module-level (`_sessions`,
 `external_run_service.py:67`; `_runs`, `runs/service.py:49`) and the heartbeat path
@@ -380,10 +548,19 @@ aggregate-failure counter in `baseline_worker` that escalates to one unmissable 
 
 ### T5 — Validation against a real Render instance
 
+✅ **Executed 2026-08-18, under CPU-limited emulation rather than on Render** (the
+harness cannot target a deployed instance — see the plan's T5 block). §5 carries the
+results and has been rewritten around them. It did disagree with §5, and §5 was wrong,
+exactly as the rule below required.
+
 Nothing in this workstream has ever run on Render. Everything in §2 and §5 is a
 12-core dev box plus arithmetic. Deploy to Standard, run the fixed harness at 100
 agents, and assert: zero failures, `timeout_holds == 0`, RSS below the instance
 ceiling. **If T5 disagrees with §5, §5 is wrong**, not T5.
+
+⚠ Two of the assertions in that sentence were themselves defective: `timeout_holds == 0`
+could not fail as written (§2), and "RSS below the instance ceiling" was never the
+binding constraint on either tier (§5).
 
 T5 also carries the three predecessor criteria §2 could not close, because this is the
 first environment on which they mean anything: **create p95 < 1000 ms, decision p95 <


### PR DESCRIPTION
Closes T5. Section 5 of the burst-capacity spec was arithmetic; this replaces it with measurement, after the operator clarified the target is **~12 agents hosted continuously and growing**, not a launch burst.

**Measured** (harness unmodified, server CPU-limited, CPU read from `/proc`):

| tier | ceiling | at target load |
|---|---|---|
| Free (0.1 CPU) | **20** concurrent active runs; fails at 25 | works, but at ~full quota, seconds-scale latency |
| Standard (1.0 CPU) | 100 concurrent clean, 0 lock errors | 63.5% CPU — ~5× headroom |

Four corrections:

- **Wrong failure mode.** Free fails on `sqlite3 database is locked` (`insert_run`, `finalize_step`), not the predicted 60 s deadline breach — at a quarter of the predicted load, with zero auto-holds at the threshold. Throttling contention, not concurrency: 100 writers on a full CPU → 0 lock errors; 25 on a tenth → 6. `finalize_step` has no Postgres twin, so the hotter site can't be configured away.
- **Wrong method.** Per-run CPU is a property of the tier (0.31 dedicated vs 0.57 throttled), so `CPU-seconds ÷ budget` overestimated Standard and underestimated Free.
- **`timeout_holds` could not fail.** Present since the harness's first commit; every prior run citing it was reading a metric with no failure mode. Fixed, and §2 now ranks the three hold instruments. Retracts an earlier claim that the server log is authoritative — it under-counts.
- **§4's "7.6 sustained agents"** was the same arithmetic. Measured: 20.

Also records a reproduced but **undiagnosed** ~68 s request stall on an idle server (3 occurrences, both tiers) — worth its own issue.

Docs + load-test harness only; no production code, no routes, no tests depend on it.