### PR TITLE
feat(leaderboard): nof1-style board frame on both charts

### DIFF
--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -442,3 +442,50 @@ console.log(JSON.stringify(out));
     assert second["name"] == "SPY"
     assert second["value"] == "V5"
     assert second["color"] == "#00ff00", "no _style on this dataset -- falls back to borderColor"
+
+
+def test_the_frame_factories_are_explicit_cross_file_exports():
+    """Same contract as `buildEquityCurvesFromEntries`: explicit, not the
+    implicit global these classic scripts share. On rename the implicit form
+    degrades to a chart with no frame, and a frame that silently stops drawing
+    looks exactly like a frame nobody asked for."""
+    assert "window.createEndpointLabelPlugin = createEndpointLabelPlugin;" in _SRC
+    assert "window.createAxisArrowPlugin = createAxisArrowPlugin;" in _SRC
+    assert "window.createEndpointLabelPlugin" in _HOME_SRC
+    assert "window.createAxisArrowPlugin" in _HOME_SRC
+
+
+def test_screen_zero_installs_the_frame_on_its_chart():
+    """Not merely defined next to it. The plugins array is what makes it draw."""
+    assert "homeBoardFramePlugins()" in _HOME_SRC
+    chart_call = _HOME_SRC[_HOME_SRC.index("new window.Chart(") :][:400]
+    assert "plugins: homeBoardFramePlugins()" in chart_call
+
+
+def test_screen_zero_says_so_when_the_frame_is_missing():
+    """A missing export degrades to a frameless chart, which is a plausible
+    design rather than a break -- so it needs a signal, exactly like the missing
+    curve-builder case this module already warns about."""
+    fn = _HOME_SRC[_HOME_SRC.index("function homeBoardFramePlugins()") :][:700]
+    assert "console.warn" in fn
+    assert "return []" in fn
+
+
+def test_screen_zero_does_not_grow_a_pointer_gate():
+    """`Interaction.modes.nearest` delegates to getNearestItems, which returns []
+    unless `chart.isPointInArea(position)` -- so the widened gutter is already
+    inert for this panel's tooltip. A hand-rolled gate here would be dead code
+    imitating the Leaderboard tab, which needs one only because it sets
+    `events: []`."""
+    assert "pointermove" not in _HOME_SRC
+    assert "resolveHoverTarget" not in _HOME_SRC
+
+
+def test_screen_zero_keeps_its_percent_pill_by_taking_the_default():
+    """The factory's default formatter is percent to two decimals, which is what
+    the rank row beside each curve renders (`homeFormatReturnPct`). Passing a
+    formatter here would be a second chance to render the same number two ways
+    -- the reason this module borrows both axis formatters rather than writing
+    its own."""
+    fn = _HOME_SRC[_HOME_SRC.index("function homeBoardFramePlugins()") :][:700]
+    assert "formatValue" not in fn

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -489,3 +489,19 @@ def test_screen_zero_keeps_its_percent_pill_by_taking_the_default():
     its own."""
     fn = _HOME_SRC[_HOME_SRC.index("function homeBoardFramePlugins()") :][:700]
     assert "formatValue" not in fn
+
+
+def test_the_shared_fraction_is_the_default_and_any_override_says_why():
+    """Both surfaces take 0.4 unless a rendered check found otherwise. If screen
+    0 overrides, the number must arrive as the factory's documented option --
+    not as a second constant, and not by moving the shared default, which would
+    silently narrow the plot on a full-width board to fix a panel."""
+    assert "const BOARD_GUTTER_FRACTION = 0.4;" in _SRC
+    fn = _HOME_SRC[_HOME_SRC.index("function homeBoardFramePlugins()") :][:900]
+    if "gutterFraction" in fn:
+        assert re.search(r"Measured at \S", fn), (
+            "an override must carry the measurement that justified it"
+        )
+    assert "BOARD_GUTTER_FRACTION" not in _HOME_SRC, (
+        "the fraction is the frame's; screen 0 either takes it or passes an option"
+    )

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -185,23 +185,46 @@ function makeCtx() {
     return json.loads(proc.stdout)
 
 
-def test_the_gutter_is_two_fifths_of_a_wide_chart():
-    """Spec §4.1: plot 60%, gutter 40%, as a FRACTION of measured width so the
-    ratio survives every breakpoint rather than holding at one design size."""
+def test_the_two_fifths_split_is_a_ceiling_not_the_gutter_width():
+    """Post-review change (2026-08-19, fix-gutter-cap): a 1600px Leaderboard tab
+    at the raw 40% reserved 640px for a ~200px label block -- 440px of the plot
+    rendering as an empty column. The design owner's fix keeps 40% as the
+    UPPER BOUND the rail may take, not the width it always takes: past the
+    measured floor, the gutter only grows `BOARD_GUTTER_SLACK` further, then
+    stops, and the plot gets the rest back.
+
+    This is the WIDE regime: `width * fraction` (1200 * 0.4 = 480) is far past
+    `floor + BOARD_GUTTER_SLACK`, so the ceiling binds and the gutter is
+    `floor + slack`, not 480."""
     result = _run_node(
         """
+const floor = boardLabelBlockWidth(makeChart(1200, 420), makeLabels(9));
 const frame = boardFrameLayout(makeChart(1200, 420), makeLabels(9), 0.4);
-console.log(JSON.stringify({ gutter: frame.gutter, draw: frame.drawLabels }));
+console.log(JSON.stringify({ floor, gutter: frame.gutter, draw: frame.drawLabels }));
 """
     )
-    assert result["gutter"] == pytest.approx(480.0)
+    assert result["floor"] == pytest.approx(132.0)
+    assert result["gutter"] == pytest.approx(result["floor"] + 36.0), (
+        "the wide-chart gutter must be floor + BOARD_GUTTER_SLACK, not 40% of the "
+        "canvas -- a regression back to the raw fraction reintroduces the 440px "
+        "dead column this change exists to remove"
+    )
     assert result["draw"] is True
 
 
 def test_a_long_label_raises_the_gutter_above_the_fraction():
-    """The 40% is a target, not a ceiling: at middling widths it clips, so the
-    measured label block is a floor under it. Same width for both, so the only
-    variable is the label."""
+    """The measured floor is a hard lower bound on the gutter no matter how the
+    fraction/slack ceiling above it is computed: a label block too big to fit
+    under `width * fraction` still gets the room it measures, never less.
+
+    Same width for both labels, so the only variable is the label. The SHORT
+    label lands in the wide regime (`width * fraction` clears `floor + slack`,
+    so the ceiling binds at `floor + slack`, not at 40% of 400 -- re-read
+    against the new rule, this sub-case's expected value changed from the old
+    160.0 to 120.0). The LONG label's floor (186) alone exceeds `width *
+    fraction` (160), so it is unaffected by the slack change at all: this
+    sub-case still passes unchanged, because case 3 (floor > width * fraction)
+    was never reachable by the ceiling in the first place."""
     result = _run_node(
         """
 const short = boardFrameLayout(makeChart(400, 420), makeLabels(3, 'AI', '+1%'), 0.4);
@@ -210,8 +233,47 @@ const long = boardFrameLayout(
 console.log(JSON.stringify({ short: short.gutter, long: long.gutter }));
 """
     )
-    assert result["short"] == pytest.approx(160.0), "40% of 400 clears the short label"
-    assert result["long"] > 160.0, "the measured block must be able to push past 40%"
+    assert result["short"] == pytest.approx(120.0), (
+        "40% of 400 (160) is past floor(84) + slack(36) = 120, so the wide-regime "
+        "ceiling caps it at 120, not the raw 160"
+    )
+    assert result["long"] == pytest.approx(186.0), (
+        "unaffected by the slack change: the long label's floor alone (186) "
+        "already exceeds 40% of 400 (160), so this was always the floor case"
+    )
+    assert result["long"] > result["short"], "the measured block must be able to push past 40%"
+
+
+def test_the_ceiling_has_three_regimes():
+    """The post-review formula (`fix-gutter-cap-brief.md`) is
+    `max(floor, min(width * fraction, floor + BOARD_GUTTER_SLACK))`, read as
+    three regimes over the same 9-label set (floor == 132 throughout, only the
+    canvas width changes):
+
+    1. WIDE (`width * fraction >= floor + slack`, 1200px): the ceiling binds
+       at `floor + slack` = 168, well under the raw 40% (480).
+    2. TIGHT (`floor <= width * fraction < floor + slack`, 350px): 40% of 350
+       is 140, inside `[132, 168)` -- the fraction itself binds, same as the
+       pre-change rule, because the ceiling never has to intervene here.
+    3. OVERFLOWING (`width * fraction < floor`, 300px): 40% of 300 is 120,
+       under the floor -- `Math.max(floor, ...)` wins and the gutter is
+       exactly 132, the floor, not 120. This is the load-bearing outer
+       `Math.max` from the brief: dropping it would clip the label text,
+       which is the one failure this whole frame exists to avoid."""
+    result = _run_node(
+        """
+console.log(JSON.stringify({
+  wide: boardFrameLayout(makeChart(1200, 420), makeLabels(9), 0.4).gutter,
+  tight: boardFrameLayout(makeChart(350, 420), makeLabels(9), 0.4).gutter,
+  overflowing: boardFrameLayout(makeChart(300, 420), makeLabels(9), 0.4).gutter,
+}));
+"""
+    )
+    assert result["wide"] == pytest.approx(168.0), "floor(132) + slack(36), not 40% of 1200 (480)"
+    assert result["tight"] == pytest.approx(140.0), "40% of 350 -- the fraction itself, uncapped"
+    assert result["overflowing"] == pytest.approx(132.0), (
+        "exactly the floor, not 40% of 300 (120) -- the clipping guard"
+    )
 
 
 def test_a_chart_too_narrow_for_its_labels_drops_them_rather_than_clipping():

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -1,0 +1,206 @@
+"""Guards for the shared nof1-derived board frame (2026-08-19 spec §4).
+
+One visual contract, two vanilla Chart.js implementations plus a Recharts one.
+The duplication is forced by the stacks and accepted; leaving the *numbers*
+unguarded is not, which is what test_the_two_surfaces_agree_on_the_numbers_that
+_must_agree already establishes for this pair.
+
+The geometry is exercised under node against the SHIPPING source, extracted by
+name -- so a rename or deletion reddens these instead of leaving them passing
+against a copy that no longer runs. Same harness shape as
+test_frontend_leaderboard_hover.py.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_LEADERBOARD_JS = _FRONTEND / "js" / "leaderboard.js"
+_HOME_JS = _FRONTEND / "home-page.js"
+_SRC = _LEADERBOARD_JS.read_text(encoding="utf-8")
+_HOME_SRC = _HOME_JS.read_text(encoding="utf-8")
+
+
+def _extract_function(name: str) -> str:
+    """The source of ``function <name>(...) { ... }``, brace-matched."""
+    marker = f"function {name}("
+    start = _SRC.index(marker)
+    depth = 0
+    index = _SRC.index("{", _SRC.index(")", start))
+    while True:
+        if _SRC[index] == "{":
+            depth += 1
+        elif _SRC[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return _SRC[start : index + 1]
+        index += 1
+
+
+def _board_constants() -> str:
+    """Every ``const BOARD_* = <literal>;`` line, in source order.
+
+    Extracted rather than restated: a number that only exists in this file is a
+    number the guard cannot be wrong about.
+    """
+    lines = [
+        ln
+        for ln in _SRC.splitlines()
+        if re.match(r"^const BOARD_[A-Z_]+ = .+;$", ln)
+    ]
+    assert lines, "no BOARD_* constants found -- the frame was renamed or deleted"
+    return "\n".join(lines)
+
+
+def _run_node(script: str):
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available")
+    harness = "\n".join(
+        [
+            _board_constants(),
+            _extract_function("boardFrameLayout"),
+            _extract_function("boardLabelBlockWidth"),
+            _extract_function("boardPillTextColor"),
+            # Stub 2d context: every glyph is 6px wide. Enough to exercise the
+            # width arithmetic without a canvas, and deliberately NOT a real
+            # measurement -- the point of measuring at runtime is that no test
+            # has to know the font metrics.
+            """
+function makeChart(width, height) {
+  return {
+    width,
+    height,
+    ctx: {
+      save() {}, restore() {}, font: '',
+      measureText(text) { return { width: String(text).length * 6 }; },
+    },
+  };
+}
+function makeLabels(n, name, value) {
+  return Array.from({ length: n }, (_, i) => ({
+    i, name: name || 'Model ' + i, value: value || '+1.00%',
+  }));
+}
+""",
+            script,
+        ]
+    )
+    proc = subprocess.run(
+        [node, "-e", harness], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_the_gutter_is_two_fifths_of_a_wide_chart():
+    """Spec §4.1: plot 60%, gutter 40%, as a FRACTION of measured width so the
+    ratio survives every breakpoint rather than holding at one design size."""
+    result = _run_node(
+        """
+const frame = boardFrameLayout(makeChart(1200, 420), makeLabels(9), 0.4);
+console.log(JSON.stringify({ gutter: frame.gutter, draw: frame.drawLabels }));
+"""
+    )
+    assert result["gutter"] == pytest.approx(480.0)
+    assert result["draw"] is True
+
+
+def test_a_long_label_raises_the_gutter_above_the_fraction():
+    """The 40% is a target, not a ceiling: at middling widths it clips, so the
+    measured label block is a floor under it. Same width for both, so the only
+    variable is the label."""
+    result = _run_node(
+        """
+const short = boardFrameLayout(makeChart(400, 420), makeLabels(3, 'AI', '+1%'), 0.4);
+const long = boardFrameLayout(
+  makeChart(400, 420), makeLabels(3, 'DeepSeek V4 Pro', '-12.34%'), 0.4);
+console.log(JSON.stringify({ short: short.gutter, long: long.gutter }));
+"""
+    )
+    assert result["short"] == pytest.approx(160.0), "40% of 400 clears the short label"
+    assert result["long"] > 160.0, "the measured block must be able to push past 40%"
+
+
+def test_a_chart_too_narrow_for_its_labels_drops_them_rather_than_clipping():
+    """A 390px phone card cannot carry `DeepSeek V4 Pro -12.34%`. Clipping is the
+    failure this repo keeps re-learning (the chip strip cut four of five names
+    with no scrollbar and nothing failing), so the frame gives the space back and
+    draws the arrow alone. Both surfaces keep a complete key elsewhere."""
+    result = _run_node(
+        """
+const frame = boardFrameLayout(
+  makeChart(300, 420), makeLabels(5, 'DeepSeek V4 Pro', '-12.34%'), 0.4);
+console.log(JSON.stringify({ gutter: frame.gutter, draw: frame.drawLabels }));
+"""
+    )
+    assert result["draw"] is False
+    assert result["gutter"] == pytest.approx(18.0), "arrow padding only"
+
+
+def test_a_chart_too_short_to_stack_its_labels_drops_them_too():
+    """Screen 0's panel clamps to `clamp(140px, 26vh, 280px)` and draws nine
+    curves. Nine labels at the 13px minimum need 117px of plot; at the 140px
+    floor there is not that much once the x-axis is taken out."""
+    result = _run_node(
+        """
+console.log(JSON.stringify({
+  tall: boardFrameLayout(makeChart(900, 280), makeLabels(9), 0.4).drawLabels,
+  short: boardFrameLayout(makeChart(900, 140), makeLabels(9), 0.4).drawLabels,
+}));
+"""
+    )
+    assert result["tall"] is True
+    assert result["short"] is False
+
+
+def test_the_stagger_gap_tightens_before_it_gives_up():
+    """20px is the comfortable gap and 13px the legibility floor. Between them
+    the gap shrinks to fit rather than jumping straight to no labels."""
+    result = _run_node(
+        """
+console.log(JSON.stringify({
+  roomy: boardFrameLayout(makeChart(900, 600), makeLabels(4), 0.4).gap,
+  tight: boardFrameLayout(makeChart(900, 200), makeLabels(9), 0.4).gap,
+}));
+"""
+    )
+    assert result["roomy"] == pytest.approx(20.0)
+    assert 13.0 <= result["tight"] < 20.0
+
+
+def test_no_labels_means_no_gap_to_stagger_by():
+    """An empty board reserves nothing. Guards the divide-by-zero the gap
+    formula would otherwise hit on `labels.length === 0`."""
+    result = _run_node(
+        """
+const frame = boardFrameLayout(makeChart(900, 400), [], 0.4);
+console.log(JSON.stringify({ gutter: frame.gutter, draw: frame.drawLabels, gap: frame.gap }));
+"""
+    )
+    assert result["draw"] is False
+    assert result["gap"] == 0
+
+
+def test_pill_ink_follows_the_swatch_luminance():
+    """Every palette entry today is a light tint on a dark page, so hardcoded
+    dark ink would read -- until the first mid-dark colour lands, which is a
+    one-line edit to dashboard/config/leaderboard.json away and would produce
+    navy-on-navy with nothing failing."""
+    result = _run_node(
+        """
+console.log(JSON.stringify({
+  amber: boardPillTextColor('#FBBF24'),
+  slate: boardPillTextColor('#94A3B8'),
+  deep: boardPillTextColor('#1E3A8A'),
+}));
+"""
+    )
+    assert result["amber"] == "#0b1220"
+    assert result["slate"] == "#0b1220"
+    assert result["deep"] == "#f8fafc"

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -64,6 +64,8 @@ def _run_node(script: str):
     harness = "\n".join(
         [
             _board_constants(),
+            _extract_function("hexToRgb"),
+            _extract_function("boardXAxisHeight"),
             _extract_function("boardFrameLayout"),
             _extract_function("boardLabelBlockWidth"),
             _extract_function("boardPillTextColor"),
@@ -117,6 +119,14 @@ function makeChart(datasets, metas) {
   return {
     data: { datasets },
     getDatasetMeta(i) { return (metas && metas[i]) || { data: [] }; },
+    // Chart.js v4's own rule, not a convenience: `meta.hidden` wins only when
+    // it is an actual boolean, otherwise the dataset's flag. Stubbing this
+    // rather than a bare `!hidden` is what keeps the test honest about the
+    // contract boardVisibleEndpoints now delegates to.
+    isDatasetVisible(i) {
+      const meta = this.getDatasetMeta(i);
+      return typeof meta.hidden === 'boolean' ? !meta.hidden : !datasets[i].hidden;
+    },
   };
 }
 """,
@@ -145,13 +155,17 @@ def _run_plugin_node(script: str):
     harness = "\n".join(
         [
             _board_constants(),
+            _extract_function("hexToRgb"),
             _extract_function("hexToRgba"),
+            _extract_function("boardXAxisHeight"),
             _extract_function("shortName"),
             _extract_function("boardSeriesColor"),
             _extract_function("boardPillTextColor"),
             _extract_function("boardLabelBlockWidth"),
             _extract_function("boardFrameLayout"),
             _extract_function("boardVisibleEndpoints"),
+            _extract_function("boardLayoutLabels"),
+            _extract_function("boardWatchGutterFont"),
             _extract_function("boardSignedPercent"),
             _extract_function("boardDefaultValueText"),
             _extract_function("boardRoundRect"),
@@ -203,7 +217,7 @@ const frame = boardFrameLayout(makeChart(1200, 420), makeLabels(9), 0.4);
 console.log(JSON.stringify({ floor, gutter: frame.gutter, draw: frame.drawLabels }));
 """
     )
-    assert result["floor"] == pytest.approx(132.0)
+    assert result["floor"] == pytest.approx(144.0)
     assert result["gutter"] == pytest.approx(result["floor"] + 36.0), (
         "the wide-chart gutter must be floor + BOARD_GUTTER_SLACK, not 40% of the "
         "canvas -- a regression back to the raw fraction reintroduces the 440px "
@@ -219,12 +233,14 @@ def test_a_long_label_raises_the_gutter_above_the_fraction():
 
     Same width for both labels, so the only variable is the label. The SHORT
     label lands in the wide regime (`width * fraction` clears `floor + slack`,
-    so the ceiling binds at `floor + slack`, not at 40% of 400 -- re-read
-    against the new rule, this sub-case's expected value changed from the old
-    160.0 to 120.0). The LONG label's floor (186) alone exceeds `width *
-    fraction` (160), so it is unaffected by the slack change at all: this
-    sub-case still passes unchanged, because case 3 (floor > width * fraction)
-    was never reachable by the ceiling in the first place."""
+    so the ceiling binds at `floor + slack`, not at 40% of 400). The LONG
+    label's floor (198) alone exceeds `width * fraction` (160), so the ceiling
+    never intervenes: case 3 (floor > width * fraction) is the floor's own.
+
+    Both floors carry `BOARD_TICK_CLEARANCE` since 2026-08-19 -- the gutter is
+    not the empty canvas the band note used to claim -- and it is reserved for
+    every label so that only the descending ones have to spend it. That moved
+    the short floor 84 -> 96 and the long one 186 -> 198."""
     result = _run_node(
         """
 const short = boardFrameLayout(makeChart(400, 420), makeLabels(3, 'AI', '+1%'), 0.4);
@@ -233,13 +249,13 @@ const long = boardFrameLayout(
 console.log(JSON.stringify({ short: short.gutter, long: long.gutter }));
 """
     )
-    assert result["short"] == pytest.approx(120.0), (
-        "40% of 400 (160) is past floor(84) + slack(36) = 120, so the wide-regime "
-        "ceiling caps it at 120, not the raw 160"
+    assert result["short"] == pytest.approx(132.0), (
+        "40% of 400 (160) is past floor(96) + slack(36) = 132, so the wide-regime "
+        "ceiling caps it at 132, not the raw 160"
     )
-    assert result["long"] == pytest.approx(186.0), (
-        "unaffected by the slack change: the long label's floor alone (186) "
-        "already exceeds 40% of 400 (160), so this was always the floor case"
+    assert result["long"] == pytest.approx(198.0), (
+        "the long label's floor alone (198) already exceeds 40% of 400 (160), "
+        "so this is the floor case and the ceiling never applies"
     )
     assert result["long"] > result["short"], "the measured block must be able to push past 40%"
 
@@ -247,31 +263,34 @@ console.log(JSON.stringify({ short: short.gutter, long: long.gutter }));
 def test_the_ceiling_has_three_regimes():
     """The post-review formula (`fix-gutter-cap-brief.md`) is
     `max(floor, min(width * fraction, floor + BOARD_GUTTER_SLACK))`, read as
-    three regimes over the same 9-label set (floor == 132 throughout, only the
+    three regimes over the same 9-label set (floor == 144 throughout, only the
     canvas width changes):
 
     1. WIDE (`width * fraction >= floor + slack`, 1200px): the ceiling binds
-       at `floor + slack` = 168, well under the raw 40% (480).
-    2. TIGHT (`floor <= width * fraction < floor + slack`, 350px): 40% of 350
-       is 140, inside `[132, 168)` -- the fraction itself binds, same as the
-       pre-change rule, because the ceiling never has to intervene here.
+       at `floor + slack` = 180, well under the raw 40% (480).
+    2. TIGHT (`floor <= width * fraction < floor + slack`, 400px): 40% of 400
+       is 160, inside `[144, 180)` -- the fraction itself binds, because the
+       ceiling never has to intervene here. (This case was 350px until
+       `BOARD_TICK_CLEARANCE` raised the floor 132 -> 144: 40% of 350 is 140,
+       which is now BELOW the floor and therefore regime 3, not regime 2. The
+       width moved so the case still exercises the regime it names.)
     3. OVERFLOWING (`width * fraction < floor`, 300px): 40% of 300 is 120,
        under the floor -- `Math.max(floor, ...)` wins and the gutter is
-       exactly 132, the floor, not 120. This is the load-bearing outer
+       exactly 144, the floor, not 120. This is the load-bearing outer
        `Math.max` from the brief: dropping it would clip the label text,
        which is the one failure this whole frame exists to avoid."""
     result = _run_node(
         """
 console.log(JSON.stringify({
   wide: boardFrameLayout(makeChart(1200, 420), makeLabels(9), 0.4).gutter,
-  tight: boardFrameLayout(makeChart(350, 420), makeLabels(9), 0.4).gutter,
+  tight: boardFrameLayout(makeChart(400, 420), makeLabels(9), 0.4).gutter,
   overflowing: boardFrameLayout(makeChart(300, 420), makeLabels(9), 0.4).gutter,
 }));
 """
     )
-    assert result["wide"] == pytest.approx(168.0), "floor(132) + slack(36), not 40% of 1200 (480)"
-    assert result["tight"] == pytest.approx(140.0), "40% of 350 -- the fraction itself, uncapped"
-    assert result["overflowing"] == pytest.approx(132.0), (
+    assert result["wide"] == pytest.approx(180.0), "floor(144) + slack(36), not 40% of 1200 (480)"
+    assert result["tight"] == pytest.approx(160.0), "40% of 400 -- the fraction itself, uncapped"
+    assert result["overflowing"] == pytest.approx(144.0), (
         "exactly the floor, not 40% of 300 (120) -- the clipping guard"
     )
 
@@ -444,9 +463,39 @@ def test_the_arrow_is_drawn_past_the_plot_and_not_as_an_axis_tick():
     arrow = _extract_function("createAxisArrowPlugin")
     assert "chart.width" in arrow, "the arrow tip is on the canvas edge, not chartArea"
     assert "BOARD_ARROW_HEAD_LENGTH" in arrow and "BOARD_ARROW_HEAD_HALF" in arrow
-    assert "afterDraw(chart)" in arrow, (
-        "chrome above the data: afterDatasetsDraw would let a curve running along "
-        "the floor sit on top of the baseline"
+
+
+def test_the_axis_baseline_is_drawn_under_the_endpoint_labels():
+    """The baseline runs the FULL canvas width, straight through the reserved
+    gutter -- so whichever plugin draws last owns those pixels.
+
+    On `afterDraw` the arrow drew after every `afterDatasetsDraw` hook and
+    struck a line through any label the stack pushes below `chartArea.bottom`
+    (measured on a 1440x268 tab, 12 low-clustered curves: chartArea.bottom
+    247.6, a label at y=241 whose pill spans 233.5-248.5). Two things have to
+    hold for the fix, and only together: the hook is `afterDatasetsDraw`, and
+    the arrow is registered BEFORE the label plugin at every call site, since
+    Chart.js runs a hook in array order.
+
+    Moving the hook does not cost the property the old comment protected --
+    datasets are already drawn by `afterDatasetsDraw`, so a curve running along
+    the floor still sits under the baseline."""
+    arrow = _extract_function("createAxisArrowPlugin")
+    assert "afterDatasetsDraw(chart)" in arrow, (
+        "afterDraw put the baseline on top of every descended endpoint label"
+    )
+    assert "afterDraw(chart)" not in arrow
+
+    # The tab's `plugins: [...]` array, not the function definitions above it.
+    registered = _SRC[_SRC.index("plugins: ["):]
+    assert registered.index("createAxisArrowPlugin") < registered.index(
+        "createEndpointLabelPlugin"
+    ), "leaderboard.js lists the label plugin first -- the baseline paints over it"
+
+    # Screen 0 aliases both factories off `window` before returning them.
+    assert "return [arrow(), labels()];" in _HOME_SRC, (
+        "home-page.js reordered or renamed its frame array -- the arrow must "
+        "still be listed before the labels"
     )
 
 
@@ -852,6 +901,7 @@ const chart = {
     if (i !== 0) return { hidden: true, data: [] };
     return { hidden: false, data: [{ x: 10, y: 50 }, { x: 20, y: 40 }, { x: 30, y: 60 }] };
   },
+  isDatasetVisible(i) { return !this.getDatasetMeta(i).hidden; },
   chartArea: { left: 0, top: 0, right: 540, bottom: 386 },
 };
 
@@ -870,7 +920,7 @@ const drawBlockWidth = (valueCall.x - BOARD_PILL_PAD_X + pillWidth) - labelX;
 
 const measuredBlock =
   boardLabelBlockWidth(chart, [{ name: nameCall.text, value: valueCall.text }]) -
-  BOARD_GUTTER_TEXT_INSET - BOARD_GUTTER_TRAILING_PAD;
+  BOARD_GUTTER_TEXT_INSET - BOARD_TICK_CLEARANCE - BOARD_GUTTER_TRAILING_PAD;
 
 console.log(JSON.stringify({
   nameText: nameCall.text, valueText: valueCall.text, drawBlockWidth, measuredBlock,
@@ -920,6 +970,7 @@ const chart = {
     const y = [50, 90, NaN][i]; // Bravo (index 2, last) is the malformed point
     return { hidden: false, data: [{ x: 10, y: 10 }, { x: 20, y: 20 }, { x: 30, y }] };
   },
+  isDatasetVisible(i) { return !this.getDatasetMeta(i).hidden; },
   chartArea: { left: 0, top: 0, right: 540, bottom: 386 },
 };
 
@@ -932,10 +983,246 @@ const texts = chart.ctx.fillTextCalls.map((c) => c.text);
 console.log(JSON.stringify({ drawLabels: chart.$boardFrame.drawLabels, texts }));
 """
     )
-    assert out["drawLabels"] is True, "the gutter is still reserved -- 3 valid label texts"
+    assert out["drawLabels"] is True, (
+        "the gutter is still reserved -- beforeLayout drops the NaN series too "
+        "now (boardLayoutLabels), leaving 2 real labels rather than 3"
+    )
     assert "Alpha" in out["texts"], "the good series before the NaN one must still draw"
     assert "Charlie" in out["texts"], "the good series after the NaN one must still draw"
     assert not any("Bravo" in t for t in out["texts"]), (
         "the NaN series itself must not draw a label at a garbage position"
     )
     assert len(out["texts"]) == 4, "exactly 2 surviving labels x (name, value)"
+
+
+# ---------------------------------------------------------------------------
+# Post-review fixes, 2026-08-19. Each case below is a defect the review found
+# in the frame as first written; they are grouped here rather than filed beside
+# their neighbours so the reasoning stays with the change that motivated it.
+# ---------------------------------------------------------------------------
+
+def test_the_minimum_pitch_is_at_least_one_pill_tall():
+    """`BOARD_LABEL_GAP_MIN` was 13 against a 15px pill, so at any pitch in
+    `[13, 15)` the guard passed and consecutive FILLED colour pills overlapped
+    by up to 2px.
+
+    That is not a legibility judgement anyone can tune -- the guard was reading
+    "is 11px text still separable?" when the binding constraint is geometric:
+    two opaque rounded rects at a pitch under their own height intersect, at
+    any font size. Screen 0 reaches it for real (9 series into `clamp(140px,
+    26vh, 280px)` is a 152-168px canvas at a 585-645px viewport), which is the
+    case below. Deriving the constant is what stops the two being edited apart
+    again."""
+    result = _run_node(
+        """
+console.log(JSON.stringify({
+  gapMin: BOARD_LABEL_GAP_MIN,
+  pill: BOARD_PILL_HEIGHT,
+  // Screen 0 at a 600px-tall viewport: 9 curves, 26vh -> a 156px canvas.
+  screenZero: boardFrameLayout(makeChart(420, 156), makeLabels(9), 0.4),
+}));
+"""
+    )
+    assert result["gapMin"] >= result["pill"], (
+        "a pitch shorter than the pill itself makes adjacent pills overlap; the "
+        "frame must degrade to arrow-only instead"
+    )
+    assert result["screenZero"]["drawLabels"] is False, (
+        "9 labels into a 156px canvas is a ~13px pitch -- pills would overlap, "
+        "so the frame gives the gutter back"
+    )
+    assert result["screenZero"]["gutter"] == 18, "arrow-only reserves BOARD_ARROW_PAD"
+
+
+def test_the_axis_allowance_yields_to_the_rendered_scale_height():
+    """`BOARD_XAXIS_ALLOWANCE` is the FIRST-FRAME estimate, not a permanent
+    stand-in. 34 was a guess and the tab's axis renders at 20.4px, so it spent
+    14px of stacking room that exists -- and that height is what both the gap
+    divisor and the fits-the-canvas guard are computed from, so the frame gave
+    up on labels earlier than its own geometry required.
+
+    Chart.js leaves the previous layout's scale on the chart, so from the second
+    update onwards the real number is readable. Reading it also means a change
+    to the tick font moves this by itself rather than leaving a literal wrong --
+    the `BoardPreview.tsx` `width={56}` failure, in the other direction."""
+    result = _run_node(
+        """
+const bare = { width: 900, height: 268, ctx: makeChart(0, 0).ctx };
+const laidOut = { ...bare, scales: { x: { height: 20.4 } } };
+const junk = { ...bare, scales: { x: { height: NaN } } };
+console.log(JSON.stringify({
+  fallback: boardXAxisHeight(bare),
+  rendered: boardXAxisHeight(laidOut),
+  junk: boardXAxisHeight(junk),
+  gapBefore: boardFrameLayout(bare, makeLabels(12), 0.4).gap,
+  gapAfter: boardFrameLayout(laidOut, makeLabels(12), 0.4).gap,
+}));
+"""
+    )
+    assert result["fallback"] == 34, "no scale yet -- the first-frame estimate stands in"
+    assert result["rendered"] == pytest.approx(20.4), "the rendered axis height wins"
+    assert result["junk"] == 34, "a non-finite scale height falls back rather than poisoning the gap"
+    assert result["gapAfter"] > result["gapBefore"], (
+        "reading the real axis height must give the stack back the room the "
+        "34px estimate was over-reserving"
+    )
+
+
+def test_a_numeric_layout_padding_survives_the_gutter_write():
+    """`layout: { padding: 12 }` is legal Chart.js shorthand for uniform
+    padding. `typeof 12 === 'object'` is false, so the hook replaced it with
+    `{}` and set only `.right` -- the chart silently lost its top, left and
+    bottom padding and rendered flush to those edges.
+
+    Neither caller in this repo passes a number, which is exactly why this
+    needs a test: `createEndpointLabelPlugin` is exported on `window` so other
+    surfaces can adopt the frame, and this is the shape one of them will use."""
+    out = _run_plugin_node(
+        """
+function chartWith(padding) {
+  return {
+    width: 900, height: 420, options: { layout: { padding } }, ctx: makeCtx(),
+    $boardFrame: null,
+    data: { datasets: [{ label: 'A', hidden: false, data: [0, 0.1], borderColor: '#F97316' }] },
+    getDatasetMeta() { return { hidden: false, data: [{ x: 10, y: 50 }, { x: 20, y: 40 }] }; },
+    isDatasetVisible() { return true; },
+    chartArea: { left: 0, top: 0, right: 540, bottom: 386 },
+  };
+}
+const plugin = createEndpointLabelPlugin();
+const numeric = chartWith(12);
+plugin.beforeLayout(numeric);
+const object = chartWith({ top: 8 });
+plugin.beforeLayout(object);
+console.log(JSON.stringify({
+  numeric: numeric.options.layout.padding,
+  object: object.options.layout.padding,
+}));
+"""
+    )
+    assert out["numeric"]["top"] == 12, "the numeric shorthand's other three sides were dropped"
+    assert out["numeric"]["left"] == 12
+    assert out["numeric"]["bottom"] == 12
+    assert out["numeric"]["right"] > 12, "the gutter still has to be written"
+    assert out["object"]["top"] == 8, "an object padding is still mutated in place"
+
+
+def test_a_label_hanging_into_the_axis_strip_clears_the_last_tick():
+    """The gutter is not the empty canvas the band note used to claim. Chart.js
+    centres the LAST x tick on `chartArea.right` and reserves its right-half
+    overhang inside our own `layout.padding.right` -- ~18px here, ~21px on
+    screen 0's larger ticks -- so a label that hangs below `chartArea.bottom`
+    lands in the tick strip at overlapping x. Scales draw before
+    `afterDatasetsDraw`, so the label wins those pixels rather than being
+    occluded; a colour dot on the tail of a tick label is still a collision.
+
+    Only the descending labels spend the clearance, and it is reserved for all
+    of them, so paying it here can never push a block out of the gutter."""
+    out = _run_plugin_node(
+        """
+function chartAt(anchorY) {
+  return {
+    width: 900, height: 200, options: {}, ctx: makeCtx(), $boardFrame: null,
+    data: { datasets: [{ label: 'A', hidden: false, data: [0, 0.1], borderColor: '#F97316' }] },
+    getDatasetMeta() { return { hidden: false, data: [{ x: 10, y: 20 }, { x: 530, y: anchorY }] }; },
+    isDatasetVisible() { return true; },
+    chartArea: { left: 0, top: 0, right: 540, bottom: 150 },
+  };
+}
+const plugin = createEndpointLabelPlugin();
+function nameX(anchorY) {
+  const chart = chartAt(anchorY);
+  plugin.beforeLayout(chart);
+  chart.ctx = makeCtx();
+  plugin.afterDatasetsDraw(chart);
+  return chart.ctx.fillTextCalls[0].x;
+}
+console.log(JSON.stringify({
+  inside: nameX(60),      // well above chartArea.bottom
+  descending: nameX(190), // pill spans 182.5-197.5, past bottom (150)
+  clearance: BOARD_TICK_CLEARANCE,
+}));
+"""
+    )
+    assert out["descending"] - out["inside"] == out["clearance"], (
+        "a label hanging into the x-axis strip must be indented past the last "
+        "tick's overhang; one inside the plot must not move"
+    )
+
+
+def test_a_non_finite_anchor_x_drops_its_label_too():
+    """`anchorY` was finite-checked and `anchorX` was not, though the draw hook
+    uses `anchorX` for the endpoint dot, the dotted stub and the leader line.
+
+    The canvas spec silently DISCARDS an `arc`/`moveTo`/`lineTo` containing
+    `NaN` -- no throw, no warning -- so a point with a finite y and a NaN x drew
+    a name and a value pill with no dot and no stub beside them. An
+    inconsistent row, and one no existing test could see: they all stub
+    `anchorY` alone."""
+    out = _run_plugin_node(
+        """
+const chart = {
+  width: 900, height: 420, options: {}, ctx: makeCtx(), $boardFrame: null,
+  data: { datasets: [
+    { label: 'Alpha', hidden: false, data: [0, 0.05], borderColor: '#F97316' },
+    { label: 'Bravo', hidden: false, data: [0, 0.02], borderColor: '#38BDF8' },
+  ] },
+  getDatasetMeta(i) {
+    // Bravo's last point has a finite y and a NaN x.
+    return { hidden: false, data: [{ x: 10, y: 10 }, { x: [530, NaN][i], y: [50, 90][i] }] };
+  },
+  isDatasetVisible() { return true; },
+  chartArea: { left: 0, top: 0, right: 540, bottom: 386 },
+};
+const plugin = createEndpointLabelPlugin();
+plugin.beforeLayout(chart);
+chart.ctx = makeCtx();
+plugin.afterDatasetsDraw(chart);
+console.log(JSON.stringify({ texts: chart.ctx.fillTextCalls.map((c) => c.text) }));
+"""
+    )
+    assert "Alpha" in out["texts"], "the well-formed series must still draw"
+    assert "Bravo" not in out["texts"], (
+        "a NaN anchorX draws a name and a pill with no dot and no stub -- drop "
+        "the row instead of rendering half of it"
+    )
+
+
+def test_the_draw_hook_reuses_the_set_beforelayout_measured():
+    """`formatValue` per series plus 2N `measureText` is the whole cost of a
+    layout, and the draw hook used to rebuild all of it.
+
+    That put the entire measurement on the mousemove path: `applyHoverTarget`
+    calls `chart.update('none')` on every change of hovered curve, and a bare
+    `chart.render()` on the frames between re-ran the draw hook's own copy --
+    ~24 `measureText` calls and N format passes per hover frame, all producing
+    values that cannot have changed. Reuse is safe precisely because nothing
+    changes a label's text without an update, and an update re-runs
+    `beforeLayout`.
+
+    Asserted by mutating the data BETWEEN the two hooks: the drawn text must be
+    what `beforeLayout` measured, not what a re-derivation would produce."""
+    out = _run_plugin_node(
+        """
+const chart = {
+  width: 900, height: 420, options: {}, ctx: makeCtx(), $boardFrame: null,
+  data: { datasets: [{ label: 'Alpha', hidden: false, data: [0, 0.05], borderColor: '#F97316' }] },
+  getDatasetMeta() { return { hidden: false, data: [{ x: 10, y: 10 }, { x: 530, y: 50 }] }; },
+  isDatasetVisible() { return true; },
+  chartArea: { left: 0, top: 0, right: 540, bottom: 386 },
+};
+const plugin = createEndpointLabelPlugin();
+plugin.beforeLayout(chart);
+chart.data.datasets[0].data[1] = 0.99; // no update() -- the draw hook must not see this
+chart.ctx = makeCtx();
+plugin.afterDatasetsDraw(chart);
+console.log(JSON.stringify({
+  stashed: chart.$boardFrame.labels.map((l) => l.value),
+  drawn: chart.ctx.fillTextCalls.map((c) => c.text),
+}));
+"""
+    )
+    assert out["stashed"] == ["+5.00%"], "beforeLayout stashes the measured texts"
+    assert out["drawn"] == ["Alpha", "+5.00%"], (
+        "the draw hook re-derived the value instead of reusing the measured set"
+    )

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -204,3 +204,98 @@ console.log(JSON.stringify({
     assert result["amber"] == "#0b1220"
     assert result["slate"] == "#0b1220"
     assert result["deep"] == "#f8fafc"
+
+
+def test_the_frame_is_built_by_factories_not_a_singleton():
+    """Screen 0 draws the same frame over datasets that carry none of this tab's
+    private fields (`_raw`, `_entry`, `_style`) and has no hover gate. A shared
+    singleton would have to close over this module's `hoveredDatasetIndex` and
+    `currentChartView`, so the only way to share it is to parameterise it."""
+    assert "function createEndpointLabelPlugin(options)" in _SRC
+    assert "function createAxisArrowPlugin(" in _SRC
+    assert "const endpointLabelPlugin = {" not in _SRC, (
+        "the singleton is replaced by a factory call, not kept beside it"
+    )
+
+
+def test_the_gutter_is_reserved_in_beforelayout_and_never_in_the_domain():
+    """`layout.padding`, not scale domain. `resolveHoverTarget` rejects
+    `x > chartArea.right` outright, so padding leaves the hover gate's whole
+    premise true; a domain padded with future slots would move empty territory
+    inside the plot and make the gutter hoverable.
+
+    beforeLayout because the width is a FRACTION of the rendered width, which is
+    not known at config time -- and beforeLayout is the last hook that can still
+    move chartArea."""
+    factory = _extract_function("createEndpointLabelPlugin")
+    assert "beforeLayout(chart)" in factory
+    assert "padding.right = frame.gutter" in factory
+    assert "data.labels" not in factory, (
+        "reserving space by appending empty category labels is the design that "
+        "was dropped -- it puts the gutter INSIDE chartArea"
+    )
+
+
+def test_the_tab_lets_the_plugin_own_the_right_padding():
+    """A literal `right: 120` left in the config is dead but not inert: it is
+    what renders on the first frame before beforeLayout runs, and it is what a
+    reader will believe."""
+    layout = re.search(r"layout:\s*\{\s*padding:\s*\{[^}]*\}", _SRC)
+    assert layout, "the tab's layout.padding block moved or was deleted"
+    assert "right:" not in layout.group(0), (
+        "the gutter is the frame's to compute; leaving a literal here renders it "
+        "for one frame and misinforms every reader after that"
+    )
+    assert "top: 8" in layout.group(0), "the top padding is unrelated and stays"
+
+
+def test_the_tab_pill_follows_the_axis_unit():
+    """Spec §4.5: no surface invents a unit its axis does not show. This tab
+    defaults to `$` (`currentChartView = 'absolute'`) and the endpoint label
+    printed `+7.49%` in that view -- a percent beside a dollar axis."""
+    call = _SRC[_SRC.index("createEndpointLabelPlugin({") :][:800]
+    assert "currentChartView === 'absolute'" in call
+    assert "formatLeaderboardNumber" in call, "the money branch reuses the axis formatter"
+    assert "cumulative_return" in call, (
+        "the percent branch keeps preferring the entry's stored return over the "
+        "last plotted point"
+    )
+
+
+def test_the_hover_fade_stays_this_tabs_business():
+    """`hoveredDatasetIndex` is this module's pointer-gate state. Screen 0 has no
+    hover gate at all, so it must reach the factory as an injected predicate
+    rather than a closed-over global."""
+    factory = _extract_function("createEndpointLabelPlugin")
+    assert "hoveredDatasetIndex" not in factory, (
+        "the factory must not close over this tab's hover state"
+    )
+    assert "isFaded" in factory
+    # 1000, not the 800 used above: `isFaded` is the last option in the call,
+    # after the longer `formatValue` body, so it needs the wider window to
+    # stay inside the same call site rather than spilling into whatever
+    # follows it.
+    call = _SRC[_SRC.index("createEndpointLabelPlugin({") :][:1000]
+    assert "hoveredDatasetIndex" in call, "the tab injects it at the call site"
+
+
+def test_each_curve_ends_in_a_dot_and_a_dotted_stub():
+    """The handwritten note's `•⋯` mark: the curve carries on, and the stub
+    asserts no value for where it goes."""
+    factory = _extract_function("createEndpointLabelPlugin")
+    assert "BOARD_DOT_RADIUS" in factory
+    assert "BOARD_STUB_LENGTH" in factory
+    assert factory.count("setLineDash([1, 3])") == 2, "the stub and the leader line"
+
+
+def test_the_arrow_is_drawn_past_the_plot_and_not_as_an_axis_tick():
+    """Chart.js can draw anywhere on the canvas, not only inside chartArea, so
+    the forward affordance costs no scale configuration at all -- which is the
+    whole reason the future-tick design was dropped."""
+    arrow = _extract_function("createAxisArrowPlugin")
+    assert "chart.width" in arrow, "the arrow tip is on the canvas edge, not chartArea"
+    assert "BOARD_ARROW_HEAD_LENGTH" in arrow and "BOARD_ARROW_HEAD_HALF" in arrow
+    assert "afterDraw(chart)" in arrow, (
+        "chrome above the data: afterDatasetsDraw would let a curve running along "
+        "the floor sit on top of the baseline"
+    )

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -98,6 +98,38 @@ function makeLabels(n, name, value) {
     return json.loads(proc.stdout)
 
 
+def _run_endpoints_node(script: str):
+    """Same node-subprocess shape as ``_run_node``, built for
+    ``boardVisibleEndpoints`` instead: a fake ``chart.data.datasets`` +
+    ``chart.getDatasetMeta(i)`` pair rather than the width/height canvas stub
+    the layout tests above use, since this function never touches a canvas.
+    """
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available")
+    harness = "\n".join(
+        [
+            _extract_function("shortName"),
+            _extract_function("boardSeriesColor"),
+            _extract_function("boardVisibleEndpoints"),
+            """
+function makeChart(datasets, metas) {
+  return {
+    data: { datasets },
+    getDatasetMeta(i) { return (metas && metas[i]) || { data: [] }; },
+  };
+}
+""",
+            script,
+        ]
+    )
+    proc = subprocess.run(
+        [node, "-e", harness], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
 def test_the_gutter_is_two_fifths_of_a_wide_chart():
     """Spec §4.1: plot 60%, gutter 40%, as a FRACTION of measured width so the
     ratio survives every breakpoint rather than holding at one design size."""
@@ -299,3 +331,114 @@ def test_the_arrow_is_drawn_past_the_plot_and_not_as_an_axis_tick():
         "chrome above the data: afterDatasetsDraw would let a curve running along "
         "the floor sit on top of the baseline"
     )
+
+
+def test_a_hidden_dataset_contributes_no_endpoint():
+    """`hiddenSeries` toggling (the tab's legend) sets `ds.hidden` on the
+    dataset the tab builds -- a hidden curve must not get a label in the
+    gutter either."""
+    result = _run_endpoints_node(
+        """
+const chart = makeChart(
+  [{ label: 'A', data: [1, 2, 3], hidden: true }],
+  [{ data: [{ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }] }],
+);
+const out = boardVisibleEndpoints(chart, (ds, idx) => String(ds.data[idx]));
+console.log(JSON.stringify(out));
+"""
+    )
+    assert result == []
+
+
+def test_an_empty_dataset_contributes_no_endpoint():
+    """Series use different hour grids (spanGaps' own justification); a curve
+    that has no data at all yet must be dropped, not throw on an empty
+    backward scan."""
+    result = _run_endpoints_node(
+        """
+const chart = makeChart(
+  [{ label: 'A', data: [] }],
+  [{ data: [] }],
+);
+const out = boardVisibleEndpoints(chart, (ds, idx) => String(ds.data[idx]));
+console.log(JSON.stringify(out));
+"""
+    )
+    assert result == []
+
+
+def test_an_all_null_dataset_contributes_no_endpoint():
+    """A curve that is entirely gaps (no real value has arrived yet) must
+    terminate the backward scan at lastIdx = -1 and drop out, not anchor on a
+    null point or throw."""
+    result = _run_endpoints_node(
+        """
+const chart = makeChart(
+  [{ label: 'A', data: [null, null, null] }],
+  [{ data: [{ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }] }],
+);
+const out = boardVisibleEndpoints(chart, (ds, idx) => String(ds.data[idx]));
+console.log(JSON.stringify(out));
+"""
+    )
+    assert result == []
+
+
+def test_trailing_nulls_anchor_on_the_last_real_point():
+    """Series use different hour grids (e.g. SPY :30 vs an LLM's :00), so a
+    curve that stopped early still trails nulls out to the end of the shared
+    axis. The endpoint must anchor on the last REAL value -- both the index
+    and the x/y read off it -- not the last array slot."""
+    result = _run_endpoints_node(
+        """
+const chart = makeChart(
+  [{ label: 'A', data: [100, 110, 105, null, null] }],
+  [{ data: [
+    { x: 0, y: 50 }, { x: 1, y: 40 }, { x: 2, y: 45 }, { x: 3, y: 0 }, { x: 4, y: 0 },
+  ] }],
+);
+const out = boardVisibleEndpoints(chart, (ds, idx) => String(ds.data[idx]));
+console.log(JSON.stringify(out));
+"""
+    )
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["lastIdx"] == 2, "must land on the last non-null slot, index 2"
+    assert entry["anchorX"] == 2 and entry["anchorY"] == 45, (
+        "anchor must read meta.data[2], not the trailing null slots at 3/4"
+    )
+    assert entry["value"] == "105", "formatValue must be called with lastIdx, not data.length - 1"
+
+
+def test_the_happy_path_returns_one_entry_per_visible_dataset():
+    """A normal multi-dataset chart: each visible curve gets one endpoint,
+    carrying the index, name, color and formatted value a caller (the layout
+    pass, the draw hook) actually reads -- and in dataset order."""
+    result = _run_endpoints_node(
+        """
+const chart = makeChart(
+  [
+    { label: 'DeepSeek V4 Pro', data: [1, 2, 3], _style: { color: '#ff0000' } },
+    { label: 'SPY', data: [4, 5], borderColor: '#00ff00' },
+  ],
+  [
+    { data: [{ x: 0, y: 9 }, { x: 1, y: 8 }, { x: 2, y: 7 }] },
+    { data: [{ x: 0, y: 6 }, { x: 1, y: 5 }] },
+  ],
+);
+const out = boardVisibleEndpoints(chart, (ds, idx) => 'V' + ds.data[idx]);
+console.log(JSON.stringify(out));
+"""
+    )
+    assert len(result) == 2
+    first, second = result
+    assert first["i"] == 0
+    assert first["lastIdx"] == 2
+    assert first["name"] == "DeepSeek V4 Pro"
+    assert first["value"] == "V3"
+    assert first["color"] == "#ff0000"
+    assert second["i"] == 1
+    assert second["lastIdx"] == 1
+    assert second["name"] == "SPY"
+    assert second["value"] == "V5"
+    assert second["color"] == "#00ff00", "no _style on this dataset -- falls back to borderColor"

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -505,3 +505,109 @@ def test_the_shared_fraction_is_the_default_and_any_override_says_why():
     assert "BOARD_GUTTER_FRACTION" not in _HOME_SRC, (
         "the fraction is the frame's; screen 0 either takes it or passes an option"
     )
+
+
+# ---------------------------------------------------------------------------
+# The label stack's vertical layout. Behavioural, not source-shape: the defect
+# these pin rendered clipped labels on BOTH surfaces at 1280/1440/1920 while
+# every source-shape guard in this module stayed green.
+# ---------------------------------------------------------------------------
+
+def _run_stack_node(script: str):
+    """``boardStackLabels`` under node. It is pure in (labels, gap, top, bottom)
+    and touches no canvas, so it needs only the BOARD_* constants -- not the
+    width/height chart stub the layout tests use."""
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available")
+    harness = "\n".join(
+        [_board_constants(), _extract_function("boardStackLabels"), script]
+    )
+    proc = subprocess.run(
+        [node, "-e", harness], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _stack(anchors, gap, canvas_height):
+    """Lay `anchors` out in the band the plugin uses: the CANVAS, inset by half
+    a pill at each edge, which is what makes a pill's own edges land on canvas."""
+    script = """
+const half = BOARD_PILL_HEIGHT / 2;
+const labels = %s.map((y, i) => ({ i, y }));
+const fits = boardStackLabels(labels, %r, half, %r - half);
+const ys = labels.map((l) => l.y);
+console.log(JSON.stringify({
+  fits,
+  top: +(ys[0] - half).toFixed(2),
+  bottom: +(ys[ys.length - 1] + half).toFixed(2),
+  minGap: +Math.min(...ys.slice(1).map((y, i) => y - ys[i])).toFixed(2),
+}));
+""" % (json.dumps(anchors), gap, canvas_height)
+    return _run_stack_node(script)
+
+
+# Endpoint y positions RECORDED from the live render at 1440px, not invented:
+# a fixture built from the plugin's own arithmetic would drift with the code and
+# stay green through exactly the kind of regression these exist to catch.
+_HOME_1440 = ([36.82, 81.13, 121.29, 124.1, 125.51, 138.83, 161.39, 162.81, 167.03], 19.67, 211)
+_TAB_1440 = (
+    [45.95, 82.5, 104.17, 108.27, 164.75, 166.1, 168.71, 170.68, 189.42, 221.15, 223.14, 229.08],
+    19.5,
+    268,
+)
+
+
+@pytest.mark.parametrize(
+    "anchors,gap,height,surface",
+    [_HOME_1440 + ("screen 0",), _TAB_1440 + ("Leaderboard tab",)],
+)
+def test_no_label_is_laid_out_past_either_canvas_edge(anchors, gap, height, surface):
+    """THE REGRESSION. Both surfaces' endpoints cluster low, so the staggered
+    stack is taller than the PLOT -- 202.5px against 168.8px on screen 0, 255.3px
+    against 237.4px on the tab. The version this replaces clamped to `chartArea`
+    with two whole-stack shifts that cancelled exactly, and drew the last label
+    10.4px past the canvas bottom on screen 0 and 5px past it on the tab.
+
+    The bound is the CANVAS: a gutter label sits right of the plot, where the
+    x-axis tick strip is empty, so hanging below `chartArea.bottom` is fine and
+    only the canvas edge clips."""
+    out = _stack(anchors, gap, height)
+    assert out["fits"] is True, f"{surface}: the stack should fit this canvas"
+    assert out["top"] >= 0, f"{surface}: top label {out['top']}px above the canvas"
+    assert out["bottom"] <= height, (
+        f"{surface}: bottom label ends at {out['bottom']} on a {height}px canvas"
+    )
+    assert out["minGap"] >= gap - 0.01, (
+        f"{surface}: gap compressed to {out['minGap']} -- nothing may be squeezed "
+        "to buy the room; the frame drops labels instead"
+    )
+
+
+def test_a_band_too_small_for_the_stack_is_refused_rather_than_clipped():
+    """The degradation, at the helper. Nine pills at a 19.67px pitch need
+    8*19.67 + 15 = 172.4px; offered 120, the stack cannot fit, and the contract
+    is to SAY SO so the plugin draws nothing -- not to return a stack whose tail
+    hangs off the canvas. An earlier draft of this guard asserted the overhang
+    was 'only as large as the real shortfall', which would have certified that
+    clipping the top edge is acceptable once the bottom edge was fixed."""
+    out = _stack([20, 24, 28, 33, 39, 44, 50, 56, 61], 19.67, 120)
+    assert out["fits"] is False, "a stack that cannot fit must report it"
+
+
+def test_a_panel_too_short_for_its_labels_reserves_the_arrow_and_nothing_else():
+    """The degradation, at the layout hook -- and the reachable one. Screen 0's
+    chart is 132px tall at any viewport <= 700px high (measured), where nine
+    labels want a 10.9px pitch against a 13px legibility floor. The frame gives
+    the gutter back rather than stacking unreadable text, which is what a
+    rendered check at 390px and at 1440x600 showed it doing."""
+    out = _run_node(
+        """
+const chart = makeChart(550, 132);
+const frame = boardFrameLayout(chart, makeLabels(9), 0.4);
+console.log(JSON.stringify(frame));
+"""
+    )
+    assert out["drawLabels"] is False
+    assert out["gutter"] == 18, "arrow-only reserves BOARD_ARROW_PAD, not a gutter"

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -1226,3 +1226,63 @@ console.log(JSON.stringify({
     assert out["drawn"] == ["Alpha", "+5.00%"], (
         "the draw hook re-derived the value instead of reusing the measured set"
     )
+
+
+def test_both_colour_readers_share_one_hex_parse():
+    """`boardPillTextColor` carried a verbatim copy of `hexToRgba`'s four-line
+    parse, and neither handled the 3-digit `#rgb` form: `#fff` read as
+    r=255 g=15 b=0, which is a light-ink verdict on a near-white pill in one and
+    an orange-red stroke in the other.
+
+    Latent -- every palette entry in this file is 6-digit -- but the defect is
+    the duplication, not the arithmetic: a fix to one copy would not have
+    reached the other. Asserted through both consumers, not through `hexToRgb`
+    alone, since sharing the parse is the actual property."""
+    result = _run_node(
+        """
+console.log(JSON.stringify({
+  short: hexToRgb('#fff'),
+  long: hexToRgb('#ffffff'),
+  inkShort: boardPillTextColor('#fff'),
+  inkLong: boardPillTextColor('#ffffff'),
+  inkDark: boardPillTextColor('#000'),
+  empty: hexToRgb(''),
+  junk: hexToRgb('nonsense'),
+}));
+"""
+    )
+    assert result["short"] == result["long"], "`#fff` must read as white, not r=255 g=15 b=0"
+    assert result["inkShort"] == result["inkLong"] == "#0b1220", "dark ink on a white pill"
+    assert result["inkDark"] == "#f8fafc", "light ink on a black pill"
+    assert result["empty"] == {"r": 0, "g": 0, "b": 0}, "no colour at all reads as black"
+    # Not an exact triple: `parseInt` stops at the first bad digit, so a junk
+    # string yields whatever prefix happened to be hex. The property that
+    # matters is that no channel is NaN -- a NaN would poison the luminance
+    # comparison into always choosing light ink. Unchanged from `hexToRgba`.
+    assert all(isinstance(v, int) for v in result["junk"].values()), (
+        "an unparseable colour must degrade to numbers, never NaN"
+    )
+
+
+def test_visibility_is_asked_of_chart_js_not_re_implemented():
+    """`resolveHoverTarget` calls `chart.isDatasetVisible(i)`; the label rail
+    hand-rolled `meta.hidden || ds.hidden` for the identical question.
+
+    Two predicates for one chart is how the hover gate and the rail end up
+    disagreeing about which curves are on screen -- a pill drawn for a series
+    that is not there. Chart.js also resolves the pair properly (`meta.hidden`
+    wins only when it is an actual boolean) where `||` reads an explicit
+    `meta.hidden === false` as "fall through to `ds.hidden`". Behavioural
+    coverage lives in the hidden/empty/all-null cases above; this pins the
+    delegation itself, which those cannot see."""
+    body = _extract_function("boardVisibleEndpoints")
+    # STRIPPED, because the negative assertion below is otherwise satisfied by
+    # the comment that explains the fix -- which is how a guard in this repo
+    # has passed on prose before.
+    code = "\n".join(
+        ln for ln in body.splitlines() if not ln.strip().startswith(("//", "*", "/*"))
+    )
+    assert "chart.isDatasetVisible(i)" in code, (
+        "ask Chart.js, so the rail and the hover gate cannot diverge"
+    )
+    assert "meta.hidden ||" not in code, "the hand-rolled predicate is back"

--- a/dashboard/backend/tests/test_frontend_board_frame.py
+++ b/dashboard/backend/tests/test_frontend_board_frame.py
@@ -130,6 +130,61 @@ function makeChart(datasets, metas) {
     return json.loads(proc.stdout)
 
 
+def _run_plugin_node(script: str):
+    """Runs `createEndpointLabelPlugin`'s own hooks end to end -- `beforeLayout`
+    reserves the gutter via `boardFrameLayout`, then `afterDatasetsDraw` walks
+    it -- through a recording ctx stub, rather than re-deriving what the draw
+    hook does by hand. Pulls in every helper the draw hook calls by name
+    (`boardRoundRect`, `boardStackLabels`, `boardSignedPercent`, ...) so a
+    rename or a signature change reddens this instead of a hand-copied
+    stand-in quietly drifting from the shipping code.
+    """
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available")
+    harness = "\n".join(
+        [
+            _board_constants(),
+            _extract_function("hexToRgba"),
+            _extract_function("shortName"),
+            _extract_function("boardSeriesColor"),
+            _extract_function("boardPillTextColor"),
+            _extract_function("boardLabelBlockWidth"),
+            _extract_function("boardFrameLayout"),
+            _extract_function("boardVisibleEndpoints"),
+            _extract_function("boardSignedPercent"),
+            _extract_function("boardDefaultValueText"),
+            _extract_function("boardRoundRect"),
+            _extract_function("boardStackLabels"),
+            _extract_function("createEndpointLabelPlugin"),
+            """
+// A ctx stub that also RECORDS every fillText call -- (text, x, y) -- since
+// that is the only place the draw hook's accumulated x-offset becomes
+// observable from outside. Same 6px/char rule as the layout tests' stub.
+function makeCtx() {
+  const fillTextCalls = [];
+  return {
+    fillTextCalls,
+    save() {}, restore() {}, beginPath() {}, closePath() {},
+    arc() {}, fill() {}, stroke() {}, moveTo() {}, lineTo() {},
+    quadraticCurveTo() {}, setLineDash() {},
+    font: '', textBaseline: '', textAlign: '',
+    fillStyle: '', strokeStyle: '', lineWidth: 0,
+    measureText(text) { return { width: String(text).length * 6 }; },
+    fillText(text, x, y) { fillTextCalls.push({ text, x, y }); },
+  };
+}
+""",
+            script,
+        ]
+    )
+    proc = subprocess.run(
+        [node, "-e", harness], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
 def test_the_gutter_is_two_fifths_of_a_wide_chart():
     """Spec §4.1: plot 60%, gutter 40%, as a FRACTION of measured width so the
     ratio survives every breakpoint rather than holding at one design size."""
@@ -611,3 +666,214 @@ console.log(JSON.stringify(frame));
     )
     assert out["drawLabels"] is False
     assert out["gutter"] == 18, "arrow-only reserves BOARD_ARROW_PAD, not a gutter"
+
+
+# ---------------------------------------------------------------------------
+# boardStackLabels, five more edge cases the forward/backward/forward passes
+# were hand-traced against but never run: a single label (both loops that
+# assume >= 2 elements skip entirely), two labels, unsorted input, and the two
+# band-size extremes. All five are traced correct in the review that asked for
+# them; a failure here is a real defect in boardStackLabels, not in the test.
+# ---------------------------------------------------------------------------
+
+def test_a_single_label_is_left_alone_when_it_already_fits():
+    """`last = labels.length - 1` is 0 here, so every `for (k = 1; k <= last; …)`
+    loop -- both stagger passes -- never executes, and the only code that can
+    still run is the two clamp checks. A label already inside the band must
+    come out exactly where it went in."""
+    out = _stack([100], 20, 200)
+    assert out["fits"] is True
+    assert out["top"] == pytest.approx(92.5)
+    assert out["bottom"] == pytest.approx(107.5)
+
+
+def test_a_single_label_still_clamps_to_the_top_edge():
+    """The clamp checks are reachable even with nothing to stagger against --
+    an anchor above the band must still land on the band's top edge, not sail
+    past it."""
+    out = _stack([5], 20, 200)
+    assert out["fits"] is True
+    assert out["top"] == pytest.approx(0.0)
+
+
+def test_two_labels_open_up_to_the_gap_and_no_further():
+    """The simplest real collision: two endpoints 5px apart must separate to
+    exactly `gap`, not more (nothing here should trigger the reverse or
+    third-pass rework two labels are too few to need)."""
+    out = _stack([100, 105], 20, 300)
+    assert out["fits"] is True
+    assert out["minGap"] == pytest.approx(20.0)
+
+
+def test_unsorted_input_is_sorted_before_it_is_staggered():
+    """The function's first line is `labels.sort((a, b) => a.y - b.y)`. Feed it
+    labels tagged with a stable index but out of y order, and read the index
+    order back afterward: it must come back y-ascending, not in call order.
+
+    `_stack`'s fits/minGap summary (used everywhere else in this file) cannot
+    tell this apart from a bug: the forward stagger pass enforces `gap` between
+    consecutive ARRAY entries regardless of whether the array is y-sorted, so a
+    missing sort would still report a healthy minGap -- just with labels
+    stacked in the wrong order, which only the `i` order below exposes."""
+    out = _run_stack_node(
+        """
+const labels = [{ i: 0, y: 100 }, { i: 1, y: 80 }, { i: 2, y: 90 }];
+const fits = boardStackLabels(labels, 20, 0, 300);
+console.log(JSON.stringify({ fits, order: labels.map((l) => l.i) }));
+"""
+    )
+    assert out["fits"] is True
+    assert out["order"] == [1, 2, 0], (
+        "labels must come back y-ascending (80, 90, 100 -> i 1, 2, 0), not call "
+        "order -- the function's own sort is what guarantees this"
+    )
+
+
+def test_a_band_exactly_one_pill_tall_still_fits_flush_to_the_edge():
+    """`bottom - top == BOARD_PILL_HEIGHT` exactly -- the boundary a `>` instead
+    of `>=` off-by-one would miss. One label, anchored above the band, must
+    still clamp to the top edge and be reported as fitting rather than
+    refused."""
+    out = _stack([0], 20, 30)  # canvas_height = 2 * BOARD_PILL_HEIGHT
+    assert out["fits"] is True
+    assert out["top"] == pytest.approx(0.0)
+
+
+def test_a_band_smaller_than_one_pill_is_refused_rather_than_clipped():
+    """Shrink the canvas below one pill's own height and the half-pill insets
+    `_stack` uses (matching the real caller) cross over: `top > bottom`. The
+    contract this pins is the same as the multi-label case above -- refuse the
+    layout rather than hand back a position squeezed into a band that cannot
+    hold it -- but reached here through the single-label path, which has no
+    stagger pass to catch it and must rely on the clamp checks alone."""
+    out = _stack([5], 20, 10)  # canvas_height < BOARD_PILL_HEIGHT
+    assert out["fits"] is False
+
+
+# ---------------------------------------------------------------------------
+# The measured floor (`boardLabelBlockWidth`) and the draw hook inside
+# `createEndpointLabelPlugin` each total the "dot name pill" block from
+# scratch, ~1400 lines apart, sharing only `BOARD_DOT_GAP`/`BOARD_NAME_GAP` by
+# promise. They agree today -- the point of this guard is to keep it that way
+# numerically, by running the REAL draw hook and reading back where it put the
+# pixels, rather than trusting that a future edit to either copy remembers the
+# other.
+# ---------------------------------------------------------------------------
+
+def test_the_draw_hooks_block_matches_the_measured_floor():
+    """The measured block is the FLOOR under the gutter -- what stops the
+    frame from clipping at narrow widths. The Leaderboard tab has 280-536px of
+    slack under it, so an under-measure would stay invisible there
+    indefinitely; the home panel binds to within 16-52px (measured in a
+    browser), so the same drift clips text on the very next redeploy with
+    every source-shape guard in this file still green.
+
+    Runs `createEndpointLabelPlugin()` for real against one label, then
+    recomputes the block width two ways: once from `boardLabelBlockWidth` (the
+    floor `beforeLayout` reserved room for), and once from where
+    `afterDatasetsDraw` actually put the second `fillText` call (the value
+    pill) plus the pill's own width. If the two literals drift apart, this
+    numeric comparison fails; the source-shape checks elsewhere in this file
+    (`BOARD_DOT_GAP` / `BOARD_NAME_GAP` appearing in both places) cannot."""
+    out = _run_plugin_node(
+        """
+const NAME = 'DeepSeek V4 Pro';
+const chart = {
+  width: 900, height: 420,
+  options: {},
+  ctx: makeCtx(),
+  $boardFrame: null,
+  data: { datasets: [
+    { label: NAME, hidden: false, data: [0, 0.1, -0.1234], borderColor: '#F97316' },
+  ] },
+  getDatasetMeta(i) {
+    if (i !== 0) return { hidden: true, data: [] };
+    return { hidden: false, data: [{ x: 10, y: 50 }, { x: 20, y: 40 }, { x: 30, y: 60 }] };
+  },
+  chartArea: { left: 0, top: 0, right: 540, bottom: 386 },
+};
+
+const plugin = createEndpointLabelPlugin();
+plugin.beforeLayout(chart);
+if (!chart.$boardFrame.drawLabels) throw new Error('frame declined to draw labels');
+chart.ctx = makeCtx();
+plugin.afterDatasetsDraw(chart);
+
+const calls = chart.ctx.fillTextCalls;
+if (calls.length !== 2) throw new Error('expected exactly 2 fillText calls, got ' + calls.length);
+const [nameCall, valueCall] = calls;
+const labelX = chart.chartArea.right + BOARD_GUTTER_TEXT_INSET;
+const pillWidth = valueCall.text.length * 6 + BOARD_PILL_PAD_X * 2;
+const drawBlockWidth = (valueCall.x - BOARD_PILL_PAD_X + pillWidth) - labelX;
+
+const measuredBlock =
+  boardLabelBlockWidth(chart, [{ name: nameCall.text, value: valueCall.text }]) -
+  BOARD_GUTTER_TEXT_INSET - BOARD_GUTTER_TRAILING_PAD;
+
+console.log(JSON.stringify({
+  nameText: nameCall.text, valueText: valueCall.text, drawBlockWidth, measuredBlock,
+}));
+"""
+    )
+    assert out["nameText"] == "DeepSeek V4 Pro"
+    assert out["valueText"] == "-12.34%"
+    assert out["drawBlockWidth"] == pytest.approx(out["measuredBlock"]), (
+        "the draw hook painted a different width than boardLabelBlockWidth "
+        "measured -- the floor no longer matches what actually renders"
+    )
+
+
+def test_one_nan_endpoint_does_not_blank_the_whole_rail():
+    """`anchorY` comes from `meta.data[lastIdx].y` (leaderboard.js), which can
+    be `NaN` for a malformed point -- and `NaN != null` is `false`, so the old
+    `!= null` filter let it through where `Number.isFinite` rejects it.
+
+    A `NaN` anchor left in the array does not merely draw one garbage label:
+    `Array.prototype.sort` treats a `NaN` comparator result as "equal" (V8
+    verified directly -- a `NaN`-valued entry keeps its ORIGINAL array
+    position rather than sorting by value), so a `NaN` that starts out last
+    stays last. From there every `boardStackLabels` comparison against it is
+    `false` (`NaN > x` and `NaN <= x` both are), including the final
+    `labels[last].y <= bottom` the function reports its verdict with -- so
+    `fits` comes back `false` and `afterDatasetsDraw`'s `if (!boardStackLabels
+    (...)) return;` bails before drawing ANYTHING. One bad series, with the old
+    filter, silently deleted every other curve's label -- confirmed below: the
+    unfixed filter on this exact fixture draws zero labels, not merely one.
+
+    Three datasets, the NaN one last (the ordering that reaches the failing
+    branch): the other two must still get their dot, name and value pill."""
+    out = _run_plugin_node(
+        """
+const chart = {
+  width: 900, height: 420,
+  options: {},
+  ctx: makeCtx(),
+  $boardFrame: null,
+  data: { datasets: [
+    { label: 'Alpha', hidden: false, data: [0, 0.05, 0.10], borderColor: '#F97316' },
+    { label: 'Charlie', hidden: false, data: [0, -0.01, 0.07], borderColor: '#4ADE80' },
+    { label: 'Bravo', hidden: false, data: [0, 0.02, -0.03], borderColor: '#38BDF8' },
+  ] },
+  getDatasetMeta(i) {
+    const y = [50, 90, NaN][i]; // Bravo (index 2, last) is the malformed point
+    return { hidden: false, data: [{ x: 10, y: 10 }, { x: 20, y: 20 }, { x: 30, y }] };
+  },
+  chartArea: { left: 0, top: 0, right: 540, bottom: 386 },
+};
+
+const plugin = createEndpointLabelPlugin();
+plugin.beforeLayout(chart);
+chart.ctx = makeCtx();
+plugin.afterDatasetsDraw(chart);
+
+const texts = chart.ctx.fillTextCalls.map((c) => c.text);
+console.log(JSON.stringify({ drawLabels: chart.$boardFrame.drawLabels, texts }));
+"""
+    )
+    assert out["drawLabels"] is True, "the gutter is still reserved -- 3 valid label texts"
+    assert "Alpha" in out["texts"], "the good series before the NaN one must still draw"
+    assert "Charlie" in out["texts"], "the good series after the NaN one must still draw"
+    assert not any("Bravo" in t for t in out["texts"]), (
+        "the NaN series itself must not draw a label at a garbage position"
+    )
+    assert len(out["texts"]) == 4, "exactly 2 surviving labels x (name, value)"

--- a/dashboard/backend/tests/test_frontend_chart_first_home.py
+++ b/dashboard/backend/tests/test_frontend_chart_first_home.py
@@ -576,13 +576,18 @@ def test_the_tooltip_signs_zero_the_way_the_rank_row_does():
     `homeFormatReturnPct` is `> 0`, which renders `0.00%`. A `>= 0` test in the
     tooltip rendered `+0.00%` for the identical value. The precision guard above
     compares decimals and is structurally blind to this.
+
+    The two can no longer disagree by construction -- the tooltip calls the rank
+    row's formatter, which calls the board frame's `boardSignedPercent` -- so
+    what is asserted here is the sign rule at the ONE place that now renders it,
+    plus the local fallback that stands in when leaderboard.js has not landed.
     """
-    assert "pct > 0 ? '+' : ''" in _extract(_HOME_JS, "homeFormatReturnPct"), (
-        "the rank list's sign rule changed -- re-check the tooltip's"
+    assert "v > 0 ? '+' : ''" in _extract(_LEADERBOARD_JS, "boardSignedPercent"), (
+        "the shared formatter's sign rule changed -- it renders the pill, the "
+        "rank row and the tooltip at once now"
     )
-    body = _extract(_HOME_JS, "renderHomeLeaderboardChart")
-    assert "c.parsed.y > 0 ? '+' : ''" in body, (
-        "zero must not read as a gain in one place and flat in the other"
+    assert "pct > 0 ? '+' : ''" in _extract(_HOME_JS, "homeFormatReturnPct"), (
+        "the rank list's leaderboard.js-is-absent fallback must keep the rule too"
     )
 
 
@@ -679,13 +684,27 @@ def test_the_chart_readout_matches_the_rank_lists_own_precision():
     unrelated reason in its own comment: tick labels over a narrow domain
     collapse into duplicates at zero decimals and turn noisy at two. Different
     jobs, different precision; only the tooltip has a neighbour to match.
+
+    MATCHING IS NOW DELEGATION, not two expressions that agree. The tooltip
+    inlined its own `(y * 100).toFixed(2)`, which is a fourth copy of a rule
+    that also lives in `homeFormatReturnPct` and (twice) in leaderboard.js --
+    so this guard asserted that two literals were equal rather than that one
+    number had one source. It now asserts the call, and that the tooltip does
+    NOT re-derive; the precision itself is pinned where it is implemented.
     """
     assert "toFixed(2)" in _extract(_HOME_JS, "homeFormatReturnPct"), (
         "the rank list's formatter changed -- re-check the tooltip's precision"
     )
     body = _extract(_HOME_JS, "renderHomeLeaderboardChart")
-    assert "(c.parsed.y * 100).toFixed(2)" in body, (
-        "the tooltip must read in the same precision as the row beside it"
+    assert "homeFormatReturnPct(c.parsed.y)" in body, (
+        "the tooltip must render through the row's own formatter"
+    )
+    # Scoped to the tooltip's OWN expression, not to `toFixed` anywhere in the
+    # function: the axis tick callback legitimately carries `(v * 100)
+    # .toFixed(1)`, which is the one-decimal rule this docstring separates out.
+    assert "c.parsed.y * 100" not in body, (
+        "the tooltip re-derived the percent instead of delegating -- that is "
+        "exactly the drift this guard exists to prevent"
     )
 
 

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -192,6 +192,6 @@ def test_cache_busters_bumped():
     # round of follow-ups (#347/#348).
     assert "app.js?v=115" in APP_HTML
     assert "styles.css?v=116" in APP_HTML
-    assert "js/leaderboard.js?v=30" in APP_HTML
+    assert "js/leaderboard.js?v=31" in APP_HTML
     assert "home-page.js?v=49" in APP_HTML
     assert "js/credits.js?v=2" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -192,6 +192,6 @@ def test_cache_busters_bumped():
     # round of follow-ups (#347/#348).
     assert "app.js?v=115" in APP_HTML
     assert "styles.css?v=116" in APP_HTML
-    assert "js/leaderboard.js?v=29" in APP_HTML
-    assert "home-page.js?v=48" in APP_HTML
+    assert "js/leaderboard.js?v=30" in APP_HTML
+    assert "home-page.js?v=49" in APP_HTML
     assert "js/credits.js?v=2" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -192,6 +192,6 @@ def test_cache_busters_bumped():
     # round of follow-ups (#347/#348).
     assert "app.js?v=115" in APP_HTML
     assert "styles.css?v=116" in APP_HTML
-    assert "js/leaderboard.js?v=31" in APP_HTML
-    assert "home-page.js?v=49" in APP_HTML
+    assert "js/leaderboard.js?v=32" in APP_HTML
+    assert "home-page.js?v=50" in APP_HTML
     assert "js/credits.js?v=2" in APP_HTML

--- a/dashboard/backend/tests/test_frontend_leaderboard_hover.py
+++ b/dashboard/backend/tests/test_frontend_leaderboard_hover.py
@@ -11,7 +11,11 @@ of the ways to get it wrong are not obvious from reading the code:
   therefore exercised below at Daily-board spacing.
 * Chart.js only fires `onHover` inside `chartArea`, and `chart.update()` replays
   the last in-plot event. Emphasis driven from `onHover` consequently sticks in
-  the 120px endpoint-label gutter *and* re-arms itself when cleared. The fix is
+  the endpoint-label gutter *and* re-arms itself when cleared. (That gutter is
+  measured per layout by `boardFrameLayout`, not a literal: 18px when the frame
+  draws no labels, up to the measured block plus slack otherwise. It read
+  "120px" here until 2026-08-19, which was the pre-frame `layout.padding.right`
+  and is wrong in both directions now.) The fix is
   to take Chart.js out of event handling entirely (`events: []`) and drive hover
   from a canvas pointer listener; the source guards below hold that in place,
   since restoring either default would silently bring the bug back.

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2004,8 +2004,8 @@
     <script src="js/agent-editor.js?v=27" defer></script>
     <script src="app.js?v=115" defer></script>
     <script src="js/credits.js?v=2" defer></script>
-    <script src="js/leaderboard.js?v=29" defer></script>
-    <script src="home-page.js?v=48" defer></script>
+    <script src="js/leaderboard.js?v=30" defer></script>
+    <script src="home-page.js?v=49" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),
          both loaded above — not beside the market-events/* block, which loads

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2004,8 +2004,8 @@
     <script src="js/agent-editor.js?v=27" defer></script>
     <script src="app.js?v=115" defer></script>
     <script src="js/credits.js?v=2" defer></script>
-    <script src="js/leaderboard.js?v=31" defer></script>
-    <script src="home-page.js?v=49" defer></script>
+    <script src="js/leaderboard.js?v=32" defer></script>
+    <script src="home-page.js?v=50" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),
          both loaded above — not beside the market-events/* block, which loads

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2004,7 +2004,7 @@
     <script src="js/agent-editor.js?v=27" defer></script>
     <script src="app.js?v=115" defer></script>
     <script src="js/credits.js?v=2" defer></script>
-    <script src="js/leaderboard.js?v=30" defer></script>
+    <script src="js/leaderboard.js?v=31" defer></script>
     <script src="home-page.js?v=49" defer></script>
     <!-- Load order: must come after app.js (API/API_BASE/escapeHtml) and
          market-events/marketEventRelativeTime.js (formatMarketEventRelativeTime),

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -1546,6 +1546,29 @@ function clearHomeLeaderboardChart() {
     if (wrap && wrap.parentNode) wrap.parentNode.removeChild(wrap);
 }
 
+/** The shared board frame's plugins, or none if js/leaderboard.js has not
+ *  landed yet.
+ *
+ *  Screen 0 takes every default: the pill formatter is percent to two decimals,
+ *  which is exactly what the rank row beside each curve renders
+ *  (`homeFormatReturnPct`), and there is no hover gate here to fade against.
+ *  Passing a formatter would be a second chance to render the same number two
+ *  ways -- the same reason this module borrows both axis formatters rather than
+ *  writing its own.
+ *
+ *  Warns on absence. A frameless chart is a plausible design rather than a
+ *  visible break, so unlike the axis formatters (which degrade to an ugly label
+ *  that is on screen and self-reporting) this one needs a signal. */
+function homeBoardFramePlugins() {
+    const labels = window.createEndpointLabelPlugin;
+    const arrow = window.createAxisArrowPlugin;
+    if (typeof labels !== 'function' || typeof arrow !== 'function') {
+        console.warn('[home] board frame factories missing — drawing an unframed chart');
+        return [];
+    }
+    return [arrow(), labels()];
+}
+
 /** Draw screen 0's equity chart, or nothing at all.
  *
  *  Returns null -- and leaves no element behind -- when there are no series or
@@ -1594,6 +1617,7 @@ function renderHomeLeaderboardChart(series, times) {
     const axis = { color: 'rgba(148, 163, 184, 0.85)', font: { size: 14 } };
     homeRankChart = new window.Chart(wrap.querySelector('canvas'), {
         type: 'line',
+        plugins: homeBoardFramePlugins(),
         data: {
             labels: times,
             datasets: series.map((s) => ({

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -1566,6 +1566,10 @@ function homeBoardFramePlugins() {
         console.warn('[home] board frame factories missing — drawing an unframed chart');
         return [];
     }
+    // Taking the default pill formatter is only correct because `s.values`
+    // (the dataset below) are fractional returns -- the default multiplies by
+    // 100 to print a percent. A dollar-equity series here would need its own
+    // override, or the pill prints something like `+1030000.00%`.
     return [arrow(), labels()];
 }
 

--- a/dashboard/frontend/home-page.js
+++ b/dashboard/frontend/home-page.js
@@ -716,7 +716,25 @@ function homeFormatMoney(value, digits = 0) {
     })}`;
 }
 
+/** The signed percent this module renders everywhere: rank rows, chart tooltip.
+ *
+ *  DELEGATES to the board frame's own formatter. The endpoint pill beside each
+ *  curve is drawn by `createEndpointLabelPlugin`, which prints
+ *  `boardSignedPercent` -- so the pill and the rank row directly beneath it
+ *  were two independent expressions rendering one number, which is how the
+ *  sign rule (`> 0`, not `>= 0`) or the precision drifts apart unnoticed.
+ *  `homeBoardFramePlugins` takes the default pill formatter for exactly this
+ *  reason; delegating here is the other half of that.
+ *
+ *  The local arithmetic survives only as the fallback for leaderboard.js not
+ *  having landed -- the same absence `homeBoardFramePlugins` warns about, where
+ *  there is no pill on screen to match anyway. The `'—'` for a non-finite
+ *  input is this module's own: `boardSignedPercent` returns `''`, which would
+ *  render a rank cell as blank rather than as visibly missing. */
 function homeFormatReturnPct(value) {
+    if (typeof window.boardSignedPercent === 'function') {
+        return window.boardSignedPercent(value) || '—';
+    }
     const n = Number(value);
     if (!Number.isFinite(n)) return '—';
     const pct = n * 100;
@@ -1671,20 +1689,21 @@ function renderHomeLeaderboardChart(series, times) {
                         title: (items) =>
                             (items.length ? homeFormatChartStamp(items[0].label, true) : ''),
                         // Without this the tooltip prints the raw fraction
-                        // (0.0749). Two decimals, not the axis's one: this
-                        // readout sits beside the rank row for the same model,
-                        // and that row renders `homeFormatReturnPct` -- which
-                        // is toFixed(2), so `+7.49%`. Pinned by
+                        // (0.0749). It renders through `homeFormatReturnPct`
+                        // rather than re-deriving the percent, because this
+                        // readout sits beside the rank row for the same model
+                        // and that row renders the same function. Two decimals,
+                        // not the axis's one, follows from that. Pinned by
                         // `test_the_chart_readout_matches_the_rank_lists_own_precision`.
                         //
-                        // `> 0`, not `>= 0`, for the same reason: the FIRST
-                        // point of every series is exactly zero (`values[0]` is
-                        // `(base-base)/base`), so at the leftmost tick a `>=`
-                        // test printed `+0.00%` beside a rank row rendering
-                        // `0.00%` for the identical number. The precision test
-                        // compares decimals and cannot see a sign.
-                        label: (c) =>
-                            `${c.dataset.label}: ${c.parsed.y > 0 ? '+' : ''}${(c.parsed.y * 100).toFixed(2)}%`,
+                        // The sign rule travels with it, and it is `> 0` rather
+                        // than `>= 0`: the FIRST point of every series is
+                        // exactly zero (`values[0]` is `(base-base)/base`), so
+                        // at the leftmost tick a `>=` test printed `+0.00%`
+                        // beside a rank row rendering `0.00%` for the identical
+                        // number. It was an inlined copy of that rule here that
+                        // made the divergence possible at all.
+                        label: (c) => `${c.dataset.label}: ${homeFormatReturnPct(c.parsed.y)}`,
                     },
                 },
             },

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -146,6 +146,13 @@ const BOARD_LABEL_GAP_MIN = 13;
 // Only draw a leader line once collision-avoidance has displaced a label far
 // enough that the connection is genuinely ambiguous; below this it is a stub.
 const BOARD_LEADER_MIN_DISPLACEMENT = 7;
+// The two gaps inside the "dot name pill" block: after the leading dot, and
+// after the name. `boardLabelBlockWidth` (the measure) and the draw hook
+// inside `createEndpointLabelPlugin` (~1400 lines apart) each total this block
+// from scratch -- named constants are what keeps the two arithmetic copies
+// from drifting the way two bare literals silently could.
+const BOARD_DOT_GAP = 4;
+const BOARD_NAME_GAP = 6;
 const BOARD_PILL_PAD_X = 5;
 const BOARD_PILL_HEIGHT = 15;
 const BOARD_DOT_RADIUS = 3;
@@ -197,9 +204,9 @@ function boardLabelBlockWidth(chart, labels) {
   labels.forEach((lab) => {
     const block =
       BOARD_DOT_RADIUS * 2 +
-      4 +
+      BOARD_DOT_GAP +
       ctx.measureText(lab.name).width +
-      6 +
+      BOARD_NAME_GAP +
       ctx.measureText(lab.value).width +
       BOARD_PILL_PAD_X * 2;
     if (block > widest) widest = block;
@@ -1437,12 +1444,20 @@ function boardVisibleEndpoints(chart, formatValue) {
   return out;
 }
 
+/** Percent, two decimals, signed -- `+7.49%` / `-3.20%` / `''` for non-finite.
+ *  Shared so the sign and precision cannot drift between this tab's money-view
+ *  percent branch (Spec §4.5) and `boardDefaultValueText` below, the default
+ *  every other pill on this frame takes. */
+function boardSignedPercent(fraction) {
+  const v = Number(fraction);
+  if (!Number.isFinite(v)) return '';
+  return `${v > 0 ? '+' : ''}${(v * 100).toFixed(2)}%`;
+}
+
 /** Percent, two decimals, signed. The default for every surface whose axis is
  *  percent -- which is both of them except this tab in its money view. */
 function boardDefaultValueText(ds, lastIdx) {
-  const v = Number(ds.data[lastIdx]);
-  if (!Number.isFinite(v)) return '';
-  return `${v > 0 ? '+' : ''}${(v * 100).toFixed(2)}%`;
+  return boardSignedPercent(ds.data[lastIdx]);
 }
 
 /** Path a rounded rect. Caller fills. `ctx.roundRect` is not in every browser
@@ -1554,8 +1569,13 @@ function createEndpointLabelPlugin(options) {
       const { ctx, chartArea } = chart;
       const frame = chart.$boardFrame;
       if (!frame || !frame.drawLabels || !chartArea) return;
+      // Number.isFinite, not `!= null`: a NaN anchorY (a malformed point) would
+      // pass a null check, then poison every comparison inside boardStackLabels,
+      // which returns false and drops the WHOLE stack rather than the one bad
+      // series -- a single corrupt endpoint should not blank every other curve's
+      // label.
       const labels = boardVisibleEndpoints(chart, formatValue).filter(
-        (lab) => lab.anchorY != null,
+        (lab) => Number.isFinite(lab.anchorY),
       );
       if (!labels.length) return;
 
@@ -1616,11 +1636,11 @@ function createEndpointLabelPlugin(options) {
         ctx.beginPath();
         ctx.arc(x + BOARD_DOT_RADIUS, lab.y, BOARD_DOT_RADIUS, 0, Math.PI * 2);
         ctx.fill();
-        x += BOARD_DOT_RADIUS * 2 + 4;
+        x += BOARD_DOT_RADIUS * 2 + BOARD_DOT_GAP;
 
         ctx.fillStyle = hexToRgba(lab.color, alpha);
         ctx.fillText(lab.name, x, lab.y);
-        x += ctx.measureText(lab.name).width + 6;
+        x += ctx.measureText(lab.name).width + BOARD_NAME_GAP;
 
         const pillWidth = ctx.measureText(lab.value).width + BOARD_PILL_PAD_X * 2;
         ctx.fillStyle = hexToRgba(lab.color, faded ? 0.25 : 1);
@@ -1793,8 +1813,7 @@ async function renderEquityCurvesChart() {
             ds._entry && ds._entry.cumulative_return != null
               ? Number(ds._entry.cumulative_return)
               : Number(ds.data[idx]);
-          if (!Number.isFinite(ret)) return '';
-          return `${ret > 0 ? '+' : ''}${(ret * 100).toFixed(2)}%`;
+          return boardSignedPercent(ret);
         },
         isFaded: (i) => hoveredDatasetIndex != null && i !== hoveredDatasetIndex,
       }),

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -130,15 +130,27 @@ function hexToRgba(hex, alpha) {
 // with null future slots would put empty territory INSIDE the plot, and the
 // gutter would silently become hoverable.
 const BOARD_GUTTER_FRACTION = 0.4;
-// The 40% is a target with a measured floor under it; this is the ceiling that
-// stops the floor from eating the plot on a narrow card. Past it the frame
-// gives the space back and draws no labels at all -- see boardFrameLayout.
+// The 40% is a CEILING on the measured floor, not the width the rail always
+// takes -- see boardFrameLayout. Past BOARD_GUTTER_MAX_FRACTION (below) the
+// frame gives up on the ceiling entirely and gives the space back, drawing no
+// labels at all.
 const BOARD_GUTTER_MAX_FRACTION = 0.5;
 const BOARD_GUTTER_FONT = '600 11px Inter, system-ui, sans-serif';
 // Where the label block starts relative to chartArea.right, and the clear
 // canvas left to the right of the widest one so the arrowhead has room.
 const BOARD_GUTTER_TEXT_INSET = 12;
 const BOARD_GUTTER_TRAILING_PAD = 16;
+// Breathing room ABOVE the measured floor, once the floor is smaller than the
+// fraction would reserve. A 1600px Leaderboard tab at BOARD_GUTTER_FRACTION
+// reserved 640px for a ~200px label block -- 440px of dead plot -- while the
+// home panel's browser-checked floor (Task 4, 2026-08-19) came out within
+// 0-36.2px of its own fraction-driven gutter at every desktop width measured
+// (1280: 0px over the floor: it already bound; 1440: 9px; 1920: 36.2px). 36
+// sits just under that observed ceiling, so every one of those three widths
+// still lands within a fraction of a px of what a browser already confirmed
+// looked right, while the tab's floor+slack (~240px) still gives back most of
+// the 440px it used to waste. See boardFrameLayout.
+const BOARD_GUTTER_SLACK = 36;
 // Comfortable vertical spacing between stacked labels, and the floor below
 // which 11px text stops being separable.
 const BOARD_LABEL_GAP_MAX = 20;
@@ -245,7 +257,18 @@ function boardFrameLayout(chart, labels, fraction) {
   if ((labels.length - 1) * gap + BOARD_PILL_HEIGHT > chart.height) return none;
   const floor = boardLabelBlockWidth(chart, labels);
   if (floor > chart.width * BOARD_GUTTER_MAX_FRACTION) return none;
-  return { gutter: Math.max(chart.width * fraction, floor), drawLabels: true, gap };
+  // `fraction` is a CEILING on the floor, not the gutter's width. A wide board
+  // (the 1600px Leaderboard tab) has `width * fraction` far above what the
+  // labels measure, and reserving that much left ~440px of the plot rendering
+  // as an empty column; a narrow one (the ~400px home panel) has the floor
+  // already at or past the fraction, where it was binding correctly all
+  // along. `Math.max(floor, ...)` is therefore LOAD-BEARING, not defensive:
+  // `floor` is the hard lower bound clipped label text would otherwise
+  // require, and it must survive the min() clamp below untouched. The
+  // genuinely-impossible case -- floor itself past BOARD_GUTTER_MAX_FRACTION
+  // -- is the `return none` above; this line never has to refuse on its own.
+  const room = Math.max(floor, Math.min(chart.width * fraction, floor + BOARD_GUTTER_SLACK));
+  return { gutter: room, drawLabels: true, gap };
 }
 
 function getTeamColor(stableId) {

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -117,6 +117,121 @@ function hexToRgba(hex, alpha) {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+// ── The shared board frame (2026-08-19 spec §4) ──────────────────────────────
+//
+// One visual contract across three charts: curves stop short of the right edge,
+// the reserved gutter carries each curve's owner and value, and the x-axis runs
+// on through it to an arrowhead.
+//
+// The gutter is `layout.padding`, NOT extra scale domain, and that distinction
+// is load-bearing rather than stylistic. Everything in this tab's hover gate
+// reads `chartArea.right` as "the end of real data" -- `resolveHoverTarget`
+// rejects `x > area.right` outright. Padding leaves that true. A domain padded
+// with null future slots would put empty territory INSIDE the plot, and the
+// gutter would silently become hoverable.
+const BOARD_GUTTER_FRACTION = 0.4;
+// The 40% is a target with a measured floor under it; this is the ceiling that
+// stops the floor from eating the plot on a narrow card. Past it the frame
+// gives the space back and draws no labels at all -- see boardFrameLayout.
+const BOARD_GUTTER_MAX_FRACTION = 0.5;
+const BOARD_GUTTER_FONT = '600 11px Inter, system-ui, sans-serif';
+// Where the label block starts relative to chartArea.right, and the clear
+// canvas left to the right of the widest one so the arrowhead has room.
+const BOARD_GUTTER_TEXT_INSET = 12;
+const BOARD_GUTTER_TRAILING_PAD = 16;
+// Comfortable vertical spacing between stacked labels, and the floor below
+// which 11px text stops being separable.
+const BOARD_LABEL_GAP_MAX = 20;
+const BOARD_LABEL_GAP_MIN = 13;
+// Only draw a leader line once collision-avoidance has displaced a label far
+// enough that the connection is genuinely ambiguous; below this it is a stub.
+const BOARD_LEADER_MIN_DISPLACEMENT = 7;
+const BOARD_PILL_PAD_X = 5;
+const BOARD_PILL_HEIGHT = 15;
+const BOARD_DOT_RADIUS = 3;
+const BOARD_STUB_LENGTH = 7;
+// Reserved right padding when the frame declines to draw labels: enough for the
+// arrowhead and nothing else.
+const BOARD_ARROW_PAD = 18;
+const BOARD_ARROW_HEAD_LENGTH = 8;
+const BOARD_ARROW_HEAD_HALF = 4;
+// Conservative allowance for the x-axis, subtracted from canvas height to
+// estimate plot height. Needed in `beforeLayout`, where chartArea is exactly
+// what has not been computed yet -- and both the layout hook and the draw hook
+// must reach the same drawLabels verdict or the gutter is reserved and empty.
+const BOARD_XAXIS_ALLOWANCE = 34;
+const BOARD_AXIS_COLOR = 'rgba(148, 163, 184, 0.45)';
+
+/** The curve's own colour, from whichever field this surface carries it in.
+ *
+ *  This tab decorates datasets with `_style`; screen 0 sets a plain hex on
+ *  `borderColor`. Reading both is what lets one factory serve both without
+ *  either surface having to adopt the other's dataset shape. `borderColor` is
+ *  second because `styleDatasets` rewrites it to an rgba with a hover alpha,
+ *  and a faded swatch is not the series colour. */
+function boardSeriesColor(ds) {
+  return (ds && ds._style && ds._style.color) || (ds && ds.borderColor) || '#e5e7eb';
+}
+
+/** Dark or light pill ink, by the swatch's relative luminance. */
+function boardPillTextColor(hex) {
+  const h = String(hex || '').replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16) || 0;
+  const g = parseInt(h.slice(2, 4), 16) || 0;
+  const b = parseInt(h.slice(4, 6), 16) || 0;
+  return 0.299 * r + 0.587 * g + 0.114 * b > 150 ? '#0b1220' : '#f8fafc';
+}
+
+/** Width of the widest `dot name pill` block, measured in the gutter's own font.
+ *
+ *  MEASURED, not a recorded constant. The spec allowed either; this is the one
+ *  that cannot go stale. `BoardPreview.tsx`'s `width={56}` is the cautionary
+ *  case in this repo: measured correctly against `$1030` at 11px, then the tick
+ *  font moved to 14px and four of five labels lost their leading `$` with
+ *  nothing failing. A measurement taken at layout time re-takes itself. */
+function boardLabelBlockWidth(chart, labels) {
+  const ctx = chart.ctx;
+  let widest = 0;
+  ctx.save();
+  ctx.font = BOARD_GUTTER_FONT;
+  labels.forEach((lab) => {
+    const block =
+      BOARD_DOT_RADIUS * 2 +
+      4 +
+      ctx.measureText(lab.name).width +
+      6 +
+      ctx.measureText(lab.value).width +
+      BOARD_PILL_PAD_X * 2;
+    if (block > widest) widest = block;
+  });
+  ctx.restore();
+  return BOARD_GUTTER_TEXT_INSET + widest + BOARD_GUTTER_TRAILING_PAD;
+}
+
+/** How much right padding to reserve, whether to draw labels, and how far apart.
+ *
+ *  Pure in (chart.width, chart.height, label texts, fraction) so it can be
+ *  exercised under node without a canvas -- which, in this repo, is the only
+ *  kind of chart test that exists.
+ *
+ *  TWO DEGRADATIONS, BOTH TO "ARROW ONLY". Too narrow for the widest label, or
+ *  too short to stack N of them, and the frame gives the space back rather than
+ *  clipping text or piling labels on each other. Clipping is the failure this
+ *  codebase keeps re-learning: the chip strip on / silently cut four of five
+ *  model names at 390px with no scrollbar, no ellipsis and nothing failing.
+ *  Both surfaces keep a complete key elsewhere (this tab's custom legend,
+ *  screen 0's rank list), so dropping the labels loses no information. */
+function boardFrameLayout(chart, labels, fraction) {
+  const none = { gutter: BOARD_ARROW_PAD, drawLabels: false, gap: 0 };
+  if (!labels || !labels.length) return none;
+  const usableHeight = chart.height - BOARD_XAXIS_ALLOWANCE;
+  const gap = Math.min(BOARD_LABEL_GAP_MAX, usableHeight / labels.length);
+  if (gap < BOARD_LABEL_GAP_MIN) return none;
+  const floor = boardLabelBlockWidth(chart, labels);
+  if (floor > chart.width * BOARD_GUTTER_MAX_FRACTION) return none;
+  return { gutter: Math.max(chart.width * fraction, floor), drawLabels: true, gap };
+}
+
 function getTeamColor(stableId) {
   const key = String(stableId);
   if (!teamColorMap[key]) {

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -109,11 +109,27 @@ function shortName(label) {
   return label && label.length > 18 ? `${label.slice(0, 17)}…` : (label || '');
 }
 
+/** `#rgb` / `#rrggbb` -> `{ r, g, b }`, black on anything unparseable.
+ *
+ *  ONE parse, TWO callers. `hexToRgba` (curve strokes, leader lines) and
+ *  `boardPillTextColor` (pill ink) both need the channels, and carrying the
+ *  same four lines twice meant the 3-digit form was wrong in both at once:
+ *  `#fff` read as r=255 g=15 b=0, which is a light-ink verdict on a near-white
+ *  pill in one and an orange-red stroke in the other. Every palette entry in
+ *  this file is 6-digit, so neither ever fired -- but a fix applied to one copy
+ *  would not have reached the other, which is the actual defect. */
+function hexToRgb(hex) {
+  let h = String(hex || '').replace('#', '');
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  return {
+    r: parseInt(h.slice(0, 2), 16) || 0,
+    g: parseInt(h.slice(2, 4), 16) || 0,
+    b: parseInt(h.slice(4, 6), 16) || 0,
+  };
+}
+
 function hexToRgba(hex, alpha) {
-  const h = String(hex || '').replace('#', '');
-  const r = parseInt(h.slice(0, 2), 16) || 0;
-  const g = parseInt(h.slice(2, 4), 16) || 0;
-  const b = parseInt(h.slice(4, 6), 16) || 0;
+  const { r, g, b } = hexToRgb(hex);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
@@ -131,15 +147,40 @@ function hexToRgba(hex, alpha) {
 // gutter would silently become hoverable.
 const BOARD_GUTTER_FRACTION = 0.4;
 // The 40% is a CEILING on the measured floor, not the width the rail always
-// takes -- see boardFrameLayout. Past BOARD_GUTTER_MAX_FRACTION (below) the
-// frame gives up on the ceiling entirely and gives the space back, drawing no
-// labels at all.
+// takes -- see boardFrameLayout.
+//
+// WHERE IT ACTUALLY BINDS, since "caps how much of the board the rail may
+// take" overstates it: the gutter is `max(floor, min(width * 0.4, floor +
+// SLACK))`, so the fraction only wins while `width * 0.4 < floor + SLACK` --
+// i.e. below `2.5 * floor + 90` px of canvas, about 613px at today's ~209px
+// measured floor. Every desktop width this dashboard renders at is above that,
+// so on a 1440 or 1600px tab the gutter is floor + SLACK and the fraction is
+// inert; it binds on the narrow home panel and on mobile, which is exactly
+// where an unbounded rail would eat the plot. BOARD_GUTTER_MAX_FRACTION
+// (below) is the one width-relative guard that fires at any size: past it the
+// frame gives up entirely and gives the space back, drawing no labels at all.
 const BOARD_GUTTER_MAX_FRACTION = 0.5;
 const BOARD_GUTTER_FONT = '600 11px Inter, system-ui, sans-serif';
 // Where the label block starts relative to chartArea.right, and the clear
 // canvas left to the right of the widest one so the arrowhead has room.
 const BOARD_GUTTER_TEXT_INSET = 12;
 const BOARD_GUTTER_TRAILING_PAD = 16;
+// Extra indent for a label that hangs into the x-axis strip -- see the band
+// note on boardStackLabels for why the strip is not the empty canvas it looks
+// like. Chart.js centres the LAST x tick on chartArea.right, so roughly half
+// its width overhangs into our gutter: ~18px for this tab's 12px `May 15`,
+// ~21px for screen 0's 14px ticks. Only the 6px leading dot reaches that far
+// (the name starts at inset + 10), and labels draw after the scales so they
+// win the pixels -- but a colour dot sitting on the tail of a tick label is
+// still a collision, and it is the bottom-most labels, the ones the taller-
+// than-the-plot stack routinely produces, that hit it.
+//
+// A LITERAL IS DEFENSIBLE HERE, unlike BOARD_XAXIS_ALLOWANCE below. This one
+// is RESERVED unconditionally in boardLabelBlockWidth and spent only by the
+// labels that descend, so getting it wrong costs a few px of residual overlap
+// -- never clipped text, and never a wrong verdict. 12 clears both measured
+// overhangs from the inset with margin.
+const BOARD_TICK_CLEARANCE = 12;
 // Breathing room ABOVE the measured floor, once the floor is smaller than the
 // fraction would reserve. A 1600px Leaderboard tab at BOARD_GUTTER_FRACTION
 // reserved 640px for a ~200px label block -- 440px of dead plot -- while the
@@ -151,13 +192,6 @@ const BOARD_GUTTER_TRAILING_PAD = 16;
 // looked right, while the tab's floor+slack (~240px) still gives back most of
 // the 440px it used to waste. See boardFrameLayout.
 const BOARD_GUTTER_SLACK = 36;
-// Comfortable vertical spacing between stacked labels, and the floor below
-// which 11px text stops being separable.
-const BOARD_LABEL_GAP_MAX = 20;
-const BOARD_LABEL_GAP_MIN = 13;
-// Only draw a leader line once collision-avoidance has displaced a label far
-// enough that the connection is genuinely ambiguous; below this it is a stub.
-const BOARD_LEADER_MIN_DISPLACEMENT = 7;
 // The two gaps inside the "dot name pill" block: after the leading dot, and
 // after the name. `boardLabelBlockWidth` (the measure) and the draw hook
 // inside `createEndpointLabelPlugin` (~1400 lines apart) each total this block
@@ -169,17 +203,53 @@ const BOARD_PILL_PAD_X = 5;
 const BOARD_PILL_HEIGHT = 15;
 const BOARD_DOT_RADIUS = 3;
 const BOARD_STUB_LENGTH = 7;
+// Comfortable vertical spacing between stacked labels, and the floor below
+// which the frame gives up and reserves the arrow alone.
+//
+// THE FLOOR IS GEOMETRIC, NOT TYPOGRAPHIC, and it is DERIVED for that reason.
+// It was 13 against a 15px pill, so at any pitch in [13, 15) the guard passed
+// -- it was reading "is 11px text still separable?" -- while consecutive
+// FILLED colour pills overlapped by up to 2px. That is not a legibility
+// judgement anyone can tune: two opaque rounded rects at a pitch below their
+// own height intersect, and no font size changes it. Screen 0 reached it for
+// real (9 series into `clamp(140px, 26vh, 280px)` is a 152-168px canvas at a
+// 585-645px viewport), as does this tab once the curated roster hits 14 at the
+// mobile height. Deriving it from BOARD_PILL_HEIGHT is what stops the two
+// numbers being edited apart again; the +1 is a hairline so pills never touch.
+const BOARD_LABEL_GAP_MAX = 20;
+const BOARD_LABEL_GAP_MIN = BOARD_PILL_HEIGHT + 1;
+// Only draw a leader line once collision-avoidance has displaced a label far
+// enough that the connection is genuinely ambiguous; below this it is a stub.
+const BOARD_LEADER_MIN_DISPLACEMENT = 7;
 // Reserved right padding when the frame declines to draw labels: enough for the
 // arrowhead and nothing else.
 const BOARD_ARROW_PAD = 18;
 const BOARD_ARROW_HEAD_LENGTH = 8;
 const BOARD_ARROW_HEAD_HALF = 4;
-// Conservative allowance for the x-axis, subtracted from canvas height to
+// FIRST-FRAME allowance for the x-axis, subtracted from canvas height to
 // estimate plot height. Needed in `beforeLayout`, where chartArea is exactly
-// what has not been computed yet -- and both the layout hook and the draw hook
-// must reach the same drawLabels verdict or the gutter is reserved and empty.
+// what has not been computed yet. See boardXAxisHeight: from the second update
+// onwards the real number is read off the scale, and this is only the estimate
+// that stands in before any layout has happened.
 const BOARD_XAXIS_ALLOWANCE = 34;
 const BOARD_AXIS_COLOR = 'rgba(148, 163, 184, 0.45)';
+
+/** The x-axis strip's real height, or a conservative stand-in before layout.
+ *
+ *  `beforeLayout` runs at the one moment chartArea does not exist yet, which
+ *  is why this began as a bare literal. But 34 was a guess and the tab's axis
+ *  renders at 20.4px, so it threw away 14px of stacking room on every frame --
+ *  and that is the height the gap divisor and the fits-the-canvas guard both
+ *  spend, so the frame gave up on labels earlier than its own geometry
+ *  required. Chart.js leaves the previous layout's scale on the chart, so from
+ *  the second update onwards the true value is right here; the constant is the
+ *  first frame's estimate and nothing more. Reading it also means a change to
+ *  the tick font moves this number by itself, rather than leaving a literal
+ *  quietly wrong the way `BoardPreview.tsx`'s `width={56}` was. */
+function boardXAxisHeight(chart) {
+  const h = chart && chart.scales && chart.scales.x && chart.scales.x.height;
+  return Number.isFinite(h) ? h : BOARD_XAXIS_ALLOWANCE;
+}
 
 /** The curve's own colour, from whichever field this surface carries it in.
  *
@@ -194,10 +264,7 @@ function boardSeriesColor(ds) {
 
 /** Dark or light pill ink, by the swatch's relative luminance. */
 function boardPillTextColor(hex) {
-  const h = String(hex || '').replace('#', '');
-  const r = parseInt(h.slice(0, 2), 16) || 0;
-  const g = parseInt(h.slice(2, 4), 16) || 0;
-  const b = parseInt(h.slice(4, 6), 16) || 0;
+  const { r, g, b } = hexToRgb(hex);
   return 0.299 * r + 0.587 * g + 0.114 * b > 150 ? '#0b1220' : '#f8fafc';
 }
 
@@ -224,7 +291,9 @@ function boardLabelBlockWidth(chart, labels) {
     if (block > widest) widest = block;
   });
   ctx.restore();
-  return BOARD_GUTTER_TEXT_INSET + widest + BOARD_GUTTER_TRAILING_PAD;
+  return (
+    BOARD_GUTTER_TEXT_INSET + widest + BOARD_TICK_CLEARANCE + BOARD_GUTTER_TRAILING_PAD
+  );
 }
 
 /** How much right padding to reserve, whether to draw labels, and how far apart.
@@ -243,14 +312,17 @@ function boardLabelBlockWidth(chart, labels) {
 function boardFrameLayout(chart, labels, fraction) {
   const none = { gutter: BOARD_ARROW_PAD, drawLabels: false, gap: 0 };
   if (!labels || !labels.length) return none;
-  const usableHeight = chart.height - BOARD_XAXIS_ALLOWANCE;
+  const usableHeight = chart.height - boardXAxisHeight(chart);
   const gap = Math.min(BOARD_LABEL_GAP_MAX, usableHeight / labels.length);
   if (gap < BOARD_LABEL_GAP_MIN) return none;
   // ...and the stack that pitch produces must FIT THE CANVAS. The line above
   // sizes a gap; this is the extent of n pills at it -- (n-1) gaps plus one
-  // pill's height -- against the band boardStackLabels is given. Checking it
-  // here is what makes this hook's verdict and the draw hook's identical rather
-  // than merely usually-equal, so the gutter is never reserved and left empty.
+  // pill's height -- against the band boardStackLabels is given. Checked here
+  // so the layout hook refuses on the same geometry the draw hook would, on a
+  // set that is a SUPERSET of what the draw hook will lay out (see
+  // boardLayoutLabels) -- which makes this verdict conservative rather than
+  // identical: the frame can reserve a gutter and draw fewer labels in it, but
+  // it can never reserve too little and clip one.
   // With today's constants it cannot fire; it is here so that raising
   // BOARD_LABEL_GAP_MAX or shrinking BOARD_XAXIS_ALLOWANCE degrades to
   // arrow-only instead of silently reintroducing a clipped label.
@@ -1349,9 +1421,12 @@ function clearChartHoverEmphasis() {
  *
  * Chart.js' own `onHover` cannot do this job. It only fires while the pointer
  * is inside `chartArea` (plus `_minPadding`, a couple of px of dataset
- * overflow), so the 120px endpoint-label gutter reserved by
- * `layout.padding.right` never reaches the proximity gate — emphasis would
- * stick on whichever curve was hovered last. Worse, `chart.update()` replays
+ * overflow), so the endpoint-label gutter reserved by `layout.padding.right`
+ * never reaches the proximity gate — emphasis would stick on whichever curve
+ * was hovered last. (That gutter is no longer a literal: it is measured per
+ * layout by `boardFrameLayout`, from 18px when the frame draws no labels up to
+ * the measured block plus slack, ~245px on this tab. Do not re-introduce a
+ * number here — the previous one said 120 and was wrong in both directions.) Worse, `chart.update()` replays
  * the last in-plot event, so clearing from `onHover` re-emphasized the curve
  * the clear had just dropped. Handling the DOM event directly sidesteps both.
  */
@@ -1446,8 +1521,15 @@ const hoverMarkerPlugin = {
 function boardVisibleEndpoints(chart, formatValue) {
   const out = [];
   chart.data.datasets.forEach((ds, i) => {
+    // `chart.isDatasetVisible(i)`, not a hand-rolled `meta.hidden || ds.hidden`:
+    // `resolveHoverTarget` in this same file already asks Chart.js the question
+    // this way, and two predicates for one chart is how the hover gate and the
+    // label rail end up disagreeing about which curves are on screen. Chart.js
+    // also resolves the pair properly -- meta.hidden wins only when it is an
+    // actual boolean -- where `||` reads an explicit `meta.hidden === false`
+    // as "fall through to ds.hidden".
+    if (!chart.isDatasetVisible(i) || !ds.data || !ds.data.length) return;
     const meta = chart.getDatasetMeta(i);
-    if (meta.hidden || ds.hidden || !ds.data || !ds.data.length) return;
     let lastIdx = -1;
     for (let k = ds.data.length - 1; k >= 0; k -= 1) {
       if (ds.data[k] != null) { lastIdx = k; break; }
@@ -1465,6 +1547,53 @@ function boardVisibleEndpoints(chart, formatValue) {
     });
   });
   return out;
+}
+
+/** The label set `beforeLayout` sizes the gutter from.
+ *
+ *  THE TWO HOOKS DO NOT SHARE A PREDICATE, and pretending otherwise was the
+ *  bug. `beforeLayout` runs before any point has a position, so it cannot
+ *  filter on `Number.isFinite(anchorY)` the way the draw hook does -- on the
+ *  very first layout that would reject every series and reserve no gutter at
+ *  all. It therefore counts every CANDIDATE, which keeps the reserve
+ *  conservative in both directions (a wider measured floor, a larger gap) and
+ *  means the draw set is always a subset: the frame can waste gutter, never
+ *  clip a label.
+ *
+ *  What it CAN do is stop wasting it after the first frame. Once any anchor is
+ *  positioned the unpositioned ones are genuinely absent rather than merely
+ *  not-yet-laid-out, so from the second update onwards the two hooks see the
+ *  same set and "gutter reserved and empty" stops being reachable at all. */
+function boardLayoutLabels(chart, formatValue) {
+  const all = boardVisibleEndpoints(chart, formatValue);
+  const positioned = all.filter((lab) => Number.isFinite(lab.anchorY));
+  return positioned.length ? positioned : all;
+}
+
+/** Re-lay-out once the gutter's webfont has actually landed.
+ *
+ *  `boardLabelBlockWidth` measures in `600 11px Inter`, and app.html loads
+ *  Inter with `display=swap`. A chart laid out before the face arrives sizes
+ *  its gutter against system-ui and then never re-measures: the next repaint
+ *  is a bare `chart.render()` (the hover path), which does not re-run
+ *  `beforeLayout`. The labels paint in Inter into a gutter measured for the
+ *  fallback, and where Inter is the wider face the value pill runs off the
+ *  canvas -- precisely the clipping a runtime measurement is supposed to be
+ *  immune to, which is the claim `boardLabelBlockWidth`'s docstring makes.
+ *
+ *  One shot per chart. A no-op wherever `document.fonts` does not exist (node,
+ *  older browsers), where nothing swapped under the measurement anyway. */
+function boardWatchGutterFont(chart) {
+  if (chart.$boardFontWatched) return;
+  chart.$boardFontWatched = true;
+  if (typeof document === 'undefined' || !document.fonts || !document.fonts.ready) return;
+  document.fonts.ready
+    .then(() => {
+      // This tab destroys and rebuilds its chart on every render; Chart.js
+      // nulls both of these on destroy.
+      if (chart.canvas && chart.ctx) chart.update('none');
+    })
+    .catch(() => {});
 }
 
 /** Percent, two decimals, signed -- `+7.49%` / `-3.20%` / `''` for non-finite.
@@ -1513,8 +1642,14 @@ function boardRoundRect(ctx, x, y, w, h, r) {
  *
  *  THE BAND IS THE CANVAS, NOT THE PLOT -- that distinction IS the bug this
  *  fixes. These labels live in the gutter, to the right of `chartArea.right`,
- *  so the x-axis tick strip below the plot is empty at their x and they may
- *  legitimately hang past `chartArea.bottom`. The version this replaces clamped
+ *  so they may legitimately hang past `chartArea.bottom` into the x-axis strip.
+ *  That strip is NEARLY empty at their x, not actually empty: Chart.js centres
+ *  the last x tick on `chartArea.right` and reserves its right-half overhang
+ *  inside our own `layout.padding.right`, which reaches about 18px into the
+ *  gutter here and 21px on screen 0's larger ticks. Scales draw before
+ *  `afterDatasetsDraw`, so a label always wins those pixels rather than being
+ *  occluded by one; BOARD_TICK_CLEARANCE is what keeps it from landing on top
+ *  of a tick in the first place. The version this replaces clamped
  *  them to `chartArea` instead, and since the forward pass enforces a MINIMUM
  *  gap the staggered stack is routinely taller than the plot: 255.3px against a
  *  237.4px plot on the Leaderboard tab at 1440, 202.5px against 168.8px on
@@ -1578,28 +1713,59 @@ function createEndpointLabelPlugin(options) {
     // config time; beforeLayout is the last hook that can still move chartArea,
     // and `chart.width`/`chart.height` are already current there.
     beforeLayout(chart) {
-      const labels = boardVisibleEndpoints(chart, formatValue);
+      boardWatchGutterFont(chart);
+      const labels = boardLayoutLabels(chart, formatValue);
       const frame = boardFrameLayout(chart, labels, fraction);
+      // The measured texts ride along so the draw hook does not rebuild them.
+      // `formatValue` per series plus 2N `measureText` is the whole cost of a
+      // layout, and `applyHoverTarget` calls `chart.update('none')` on every
+      // change of hovered curve -- so recomputing it in the draw hook ran the
+      // entire measurement again on the mousemove path, for values that cannot
+      // have changed without an update. Anchors are deliberately NOT carried:
+      // they are last frame's here, and the draw hook re-reads them.
+      frame.labels = labels;
       chart.$boardFrame = frame;
       const layout = chart.options.layout || (chart.options.layout = {});
+      // `padding` may legally be a NUMBER -- Chart.js shorthand for uniform
+      // padding. Replacing it with `{}` and setting only `.right` silently
+      // dropped the other three sides. Neither caller in this repo passes one,
+      // but this factory is exported on `window` precisely so other surfaces
+      // can adopt the frame, and losing top/left/bottom padding renders their
+      // curves flush to the canvas edges.
+      const current = layout.padding;
       const padding =
-        layout.padding && typeof layout.padding === 'object'
-          ? layout.padding
-          : (layout.padding = {});
+        current && typeof current === 'object'
+          ? current
+          : (layout.padding = Number.isFinite(current)
+            ? { top: current, right: current, bottom: current, left: current }
+            : {});
       padding.right = frame.gutter;
     },
     afterDatasetsDraw(chart) {
       const { ctx, chartArea } = chart;
       const frame = chart.$boardFrame;
-      if (!frame || !frame.drawLabels || !chartArea) return;
-      // Number.isFinite, not `!= null`: a NaN anchorY (a malformed point) would
-      // pass a null check, then poison every comparison inside boardStackLabels,
-      // which returns false and drops the WHOLE stack rather than the one bad
-      // series -- a single corrupt endpoint should not blank every other curve's
-      // label.
-      const labels = boardVisibleEndpoints(chart, formatValue).filter(
-        (lab) => Number.isFinite(lab.anchorY),
-      );
+      if (!frame || !frame.drawLabels || !chartArea || !frame.labels) return;
+      // Re-anchor the set `beforeLayout` measured, rather than rebuilding it:
+      // the names and values are already current (nothing changes them without
+      // an update, and an update re-runs beforeLayout), so only the positions
+      // have to be re-read.
+      //
+      // Number.isFinite on BOTH axes, not `!= null`: a NaN anchorY (a malformed
+      // point) would pass a null check, then poison every comparison inside
+      // boardStackLabels, which returns false and drops the WHOLE stack rather
+      // than the one bad series. anchorX is checked for a quieter reason -- the
+      // canvas spec silently discards an arc/moveTo/lineTo containing NaN, so a
+      // point with a finite y and a NaN x used to draw a name and a pill with
+      // no endpoint dot and no stub, an inconsistent row nothing would report.
+      const labels = [];
+      frame.labels.forEach((lab) => {
+        const meta = chart.getDatasetMeta(lab.i);
+        const point = meta && meta.data && meta.data[lab.lastIdx];
+        const anchorX = point ? point.x : null;
+        const anchorY = point ? point.y : null;
+        if (!Number.isFinite(anchorX) || !Number.isFinite(anchorY)) return;
+        labels.push({ ...lab, anchorX, anchorY, y: anchorY });
+      });
       if (!labels.length) return;
 
       // Stagger overlapping labels, keeping >= gap px spacing and staying on
@@ -1607,12 +1773,13 @@ function createEndpointLabelPlugin(options) {
       // later whether collision-avoidance actually moved it.
       //
       // The band is the CANVAS, not chartArea: a gutter label sits to the right
-      // of the plot, where the x-axis tick strip is empty, so hanging below
-      // chartArea.bottom costs nothing and clamping to it clipped the stack.
+      // of the plot, so hanging below chartArea.bottom into the axis strip is
+      // legitimate where clamping to it clipped the stack. The strip is not
+      // quite empty there -- the last x tick overhangs into the gutter -- which
+      // is what BOARD_TICK_CLEARANCE indents the descending labels past.
       // See boardStackLabels. A false return means the band cannot hold the
       // stack -- draw nothing rather than something cut off, which is the same
       // degradation boardFrameLayout takes at the narrow and short extremes.
-      labels.forEach((lab) => { lab.y = lab.anchorY; });
       const half = BOARD_PILL_HEIGHT / 2;
       if (!boardStackLabels(labels, frame.gap, half, chart.height - half)) return;
 
@@ -1627,6 +1794,11 @@ function createEndpointLabelPlugin(options) {
       labels.forEach((lab) => {
         const faded = isFaded(lab.i);
         const alpha = faded ? 0.3 : 1;
+        // Past the last x tick's overhang, but only for the labels that
+        // actually hang into the axis strip -- see BOARD_TICK_CLEARANCE. The
+        // clearance is reserved unconditionally by boardLabelBlockWidth, so
+        // spending it here can never push a block out of the gutter.
+        const lx = labelX + (lab.y + half > chartArea.bottom ? BOARD_TICK_CLEARANCE : 0);
 
         // The note's `•⋯`: a filled endpoint dot and a short dotted stub. It
         // says the curve continues; it asserts no value for where it goes.
@@ -1649,12 +1821,12 @@ function createEndpointLabelPlugin(options) {
           ctx.lineWidth = 1;
           ctx.beginPath();
           ctx.moveTo(gutterStart, lab.anchorY);
-          ctx.lineTo(labelX - 3, lab.y);
+          ctx.lineTo(lx - 3, lab.y);
           ctx.stroke();
           ctx.setLineDash([]);
         }
 
-        let x = labelX;
+        let x = lx;
         ctx.fillStyle = hexToRgba(lab.color, alpha);
         ctx.beginPath();
         ctx.arc(x + BOARD_DOT_RADIUS, lab.y, BOARD_DOT_RADIUS, 0, Math.PI * 2);
@@ -1693,9 +1865,17 @@ function createEndpointLabelPlugin(options) {
 function createAxisArrowPlugin() {
   return {
     id: 'boardAxisArrow',
-    // afterDraw, not afterDatasetsDraw: this is chrome, and a curve running
-    // along the floor would otherwise sit on top of the baseline.
-    afterDraw(chart) {
+    // afterDatasetsDraw, and registered BEFORE createEndpointLabelPlugin at
+    // both call sites. Chart.js has already drawn the datasets by this hook,
+    // so the original reason for afterDraw -- chrome above a curve running
+    // along the floor -- still holds exactly. What afterDraw could NOT do is
+    // let the labels sit above the chrome: this baseline runs the full canvas
+    // width, straight through the reserved gutter, so it painted a line
+    // through every label the stack pushes below chartArea.bottom. Measured on
+    // a 1440x268 tab with 12 low-clustered curves: chartArea.bottom 247.6, a
+    // label at y=241 whose pill spans 233.5-248.5, struck through at 247.6.
+    // Plugins run a hook in array order, so the labels now paint last.
+    afterDatasetsDraw(chart) {
       const { ctx, chartArea } = chart;
       if (!chartArea) return;
       const y = Math.round(chartArea.bottom) + 0.5;
@@ -2014,5 +2194,9 @@ window.formatChartTooltipLabel = formatChartTooltipLabel;
 // degrades on rename to a chart with no frame, and a frame that silently stops
 // drawing is indistinguishable from a frame nobody asked for. Pinned from both
 // sides by test_frontend_board_frame.py.
+// Exported for home-page.js's rank rows: the pill beside a curve and the row
+// beneath it render the same number, and two independent expressions producing
+// it is how they drift.
+window.boardSignedPercent = boardSignedPercent;
 window.createEndpointLabelPlugin = createEndpointLabelPlugin;
 window.createAxisArrowPlugin = createAxisArrowPlugin;

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -227,6 +227,15 @@ function boardFrameLayout(chart, labels, fraction) {
   const usableHeight = chart.height - BOARD_XAXIS_ALLOWANCE;
   const gap = Math.min(BOARD_LABEL_GAP_MAX, usableHeight / labels.length);
   if (gap < BOARD_LABEL_GAP_MIN) return none;
+  // ...and the stack that pitch produces must FIT THE CANVAS. The line above
+  // sizes a gap; this is the extent of n pills at it -- (n-1) gaps plus one
+  // pill's height -- against the band boardStackLabels is given. Checking it
+  // here is what makes this hook's verdict and the draw hook's identical rather
+  // than merely usually-equal, so the gutter is never reserved and left empty.
+  // With today's constants it cannot fire; it is here so that raising
+  // BOARD_LABEL_GAP_MAX or shrinking BOARD_XAXIS_ALLOWANCE degrades to
+  // arrow-only instead of silently reintroducing a clipped label.
+  if ((labels.length - 1) * gap + BOARD_PILL_HEIGHT > chart.height) return none;
   const floor = boardLabelBlockWidth(chart, labels);
   if (floor > chart.width * BOARD_GUTTER_MAX_FRACTION) return none;
   return { gutter: Math.max(chart.width * fraction, floor), drawLabels: true, gap };
@@ -1454,6 +1463,55 @@ function boardRoundRect(ctx, x, y, w, h, r) {
   ctx.closePath();
 }
 
+/** Lay the endpoint labels out vertically: sorted by endpoint, never closer
+ *  together than `gap`, and never outside the band `[top, bottom]`. Mutates
+ *  `lab.y`; returns whether the stack fits, so a caller that cannot honour the
+ *  band draws nothing rather than something clipped.
+ *
+ *  Pure in (labels, gap, top, bottom) for the same reason `boardFrameLayout`
+ *  is: node without a canvas is the only kind of chart test this repo has, and
+ *  the defect this replaces was invisible to every source-shape guard that
+ *  already existed.
+ *
+ *  THE BAND IS THE CANVAS, NOT THE PLOT -- that distinction IS the bug this
+ *  fixes. These labels live in the gutter, to the right of `chartArea.right`,
+ *  so the x-axis tick strip below the plot is empty at their x and they may
+ *  legitimately hang past `chartArea.bottom`. The version this replaces clamped
+ *  them to `chartArea` instead, and since the forward pass enforces a MINIMUM
+ *  gap the staggered stack is routinely taller than the plot: 255.3px against a
+ *  237.4px plot on the Leaderboard tab at 1440, 202.5px against 168.8px on
+ *  screen 0. Two whole-stack shifts then cancelled each other exactly -- lift
+ *  the tail inside, put it straight back -- and a rendered check found the last
+ *  label drawn 5px past the canvas bottom on the tab and 10.4px past it on
+ *  screen 0, sliced through the middle.
+ *
+ *  THREE PASSES. Down to open the gaps, up to pull the tail inside `bottom`,
+ *  down again to push the head inside `top`. The third is not redundant with
+ *  the first: the second pass is what can drive the head out, and re-running
+ *  the first is what puts it back without compressing anything. Walking a bound
+ *  rather than shifting the whole stack is what keeps every gap at or above
+ *  `gap` -- nothing is squeezed to buy the room. */
+function boardStackLabels(labels, gap, top, bottom) {
+  if (!labels || !labels.length) return false;
+  labels.sort((a, b) => a.y - b.y);
+  const last = labels.length - 1;
+  for (let k = 1; k <= last; k += 1) {
+    if (labels[k].y - labels[k - 1].y < gap) labels[k].y = labels[k - 1].y + gap;
+  }
+  if (labels[last].y > bottom) labels[last].y = bottom;
+  for (let k = last - 1; k >= 0; k -= 1) {
+    if (labels[k].y > labels[k + 1].y - gap) labels[k].y = labels[k + 1].y - gap;
+  }
+  if (labels[0].y < top) labels[0].y = top;
+  for (let k = 1; k <= last; k += 1) {
+    if (labels[k].y - labels[k - 1].y < gap) labels[k].y = labels[k - 1].y + gap;
+  }
+  // False only when the band cannot hold n pills at this pitch, which
+  // boardFrameLayout now excludes before reserving the gutter. Reported rather
+  // than asserted so the two hooks cannot drift into disagreeing again.
+  return labels[last].y <= bottom;
+}
+
 /** Right-endpoint labels: a colour-matched dot, the owner's name, and a value
  *  pill, laid out in the reserved gutter with vertical collision avoidance and
  *  dotted leaders to displaced labels.
@@ -1501,24 +1559,19 @@ function createEndpointLabelPlugin(options) {
       );
       if (!labels.length) return;
 
-      // Stagger overlapping labels downward, keeping >= gap px spacing. Each
-      // keeps its original endpoint y (anchorY) so we can tell later whether
-      // collision-avoidance actually moved it.
+      // Stagger overlapping labels, keeping >= gap px spacing and staying on
+      // canvas. Each keeps its original endpoint y (anchorY) so we can tell
+      // later whether collision-avoidance actually moved it.
+      //
+      // The band is the CANVAS, not chartArea: a gutter label sits to the right
+      // of the plot, where the x-axis tick strip is empty, so hanging below
+      // chartArea.bottom costs nothing and clamping to it clipped the stack.
+      // See boardStackLabels. A false return means the band cannot hold the
+      // stack -- draw nothing rather than something cut off, which is the same
+      // degradation boardFrameLayout takes at the narrow and short extremes.
       labels.forEach((lab) => { lab.y = lab.anchorY; });
-      labels.sort((a, b) => a.y - b.y);
-      for (let k = 1; k < labels.length; k += 1) {
-        if (labels[k].y - labels[k - 1].y < frame.gap) {
-          labels[k].y = labels[k - 1].y + frame.gap;
-        }
-      }
-      // Shift the whole stack back inside the plot. Both clamps, not just the
-      // bottom one: pushing an overflowing stack up can drive its head above
-      // chartArea.top. It cannot exceed both bounds at once -- boardFrameLayout
-      // only returns drawLabels when the stack fits in the plot height.
-      const overflow = labels[labels.length - 1].y - chartArea.bottom;
-      if (overflow > 0) labels.forEach((lab) => { lab.y -= overflow; });
-      const underflow = chartArea.top - labels[0].y;
-      if (underflow > 0) labels.forEach((lab) => { lab.y += underflow; });
+      const half = BOARD_PILL_HEIGHT / 2;
+      if (!boardStackLabels(labels, frame.gap, half, chart.height - half)) return;
 
       // Labels live entirely inside the reserved gutter so the plotted line
       // paths (which end at chartArea.right) never leave stubs under them.

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -1914,3 +1914,10 @@ window.getSeriesStyle = getSeriesStyle;
 // gets to invent; it is a rendering of the other's data.
 window.formatShortDate = formatShortDate;
 window.formatChartTooltipLabel = formatChartTooltipLabel;
+// The shared board frame, consumed by home-page.js for screen 0's chart.
+// Explicit for the same reason the four exports above are: the implicit global
+// degrades on rename to a chart with no frame, and a frame that silently stops
+// drawing is indistinguishable from a frame nobody asked for. Pinned from both
+// sides by test_frontend_board_frame.py.
+window.createEndpointLabelPlugin = createEndpointLabelPlugin;
+window.createAxisArrowPlugin = createAxisArrowPlugin;

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -1395,82 +1395,234 @@ const hoverMarkerPlugin = {
   },
 };
 
-// Right-endpoint labels: name + latest return for each visible curve, with
-// vertical collision avoidance and subtle leader lines to displaced labels.
-const endpointLabelPlugin = {
-  id: 'endpointLabels',
-  afterDatasetsDraw(chart) {
-    const { ctx, chartArea } = chart;
-    const labels = [];
-
-    chart.data.datasets.forEach((ds, i) => {
-      const meta = chart.getDatasetMeta(i);
-      if (meta.hidden || ds.hidden || !ds._raw || !meta.data || !meta.data.length) return;
-      let lastIdx = -1;
-      for (let k = ds._raw.length - 1; k >= 0; k -= 1) {
-        if (ds._raw[k] != null) { lastIdx = k; break; }
-      }
-      if (lastIdx < 0 || !meta.data[lastIdx]) return;
-
-      const ret = (ds._entry && ds._entry.cumulative_return != null)
-        ? Number(ds._entry.cumulative_return)
-        : (ds._raw[lastIdx] - ds._initial) / (ds._initial || 1);
-
-      labels.push({
-        i,
-        anchorX: meta.data[lastIdx].x,
-        anchorY: meta.data[lastIdx].y,
-        y: meta.data[lastIdx].y,
-        color: (ds._style && ds._style.color) || '#e5e7eb',
-        text: `${shortName(ds.label)}  ${(ret * 100).toFixed(2)}%`,
-      });
-    });
-    if (!labels.length) return;
-
-    // Stagger overlapping labels downward, keeping >= GAP px spacing. Each
-    // label keeps its original endpoint y (anchorY) so we can tell later
-    // whether collision-avoidance actually moved it.
-    const GAP = 20;
-    // Only draw a leader line once a label has been displaced enough that the
-    // connection is genuinely ambiguous; otherwise it just leaves a tiny stub.
-    const LEADER_MIN_DISPLACEMENT = 7;
-    labels.sort((a, b) => a.y - b.y);
-    for (let k = 1; k < labels.length; k += 1) {
-      if (labels[k].y - labels[k - 1].y < GAP) labels[k].y = labels[k - 1].y + GAP;
+/** The endpoint of each visible curve, and the two strings that label it.
+ *
+ *  Reads `ds.data` -- the PLOTTED values, already in whatever unit this chart's
+ *  axis shows -- rather than any surface's private raw-curve field, which is
+ *  what lets one factory serve two dataset shapes.
+ *
+ *  Called from `beforeLayout` as well as from the draw hook. In the layout pass
+ *  `meta.data[i].x/y` are last frame's positions or undefined, which is fine:
+ *  that pass only needs the label TEXT, to measure it. */
+function boardVisibleEndpoints(chart, formatValue) {
+  const out = [];
+  chart.data.datasets.forEach((ds, i) => {
+    const meta = chart.getDatasetMeta(i);
+    if (meta.hidden || ds.hidden || !ds.data || !ds.data.length) return;
+    let lastIdx = -1;
+    for (let k = ds.data.length - 1; k >= 0; k -= 1) {
+      if (ds.data[k] != null) { lastIdx = k; break; }
     }
-    // If the stack overflows the plot bottom, shift the whole stack up.
-    const overflow = labels[labels.length - 1].y - chartArea.bottom;
-    if (overflow > 0) labels.forEach((lab) => { lab.y -= overflow; });
+    if (lastIdx < 0) return;
+    const point = meta.data && meta.data[lastIdx];
+    out.push({
+      i,
+      lastIdx,
+      anchorX: point ? point.x : null,
+      anchorY: point ? point.y : null,
+      color: boardSeriesColor(ds),
+      name: shortName(ds.label),
+      value: formatValue(ds, lastIdx),
+    });
+  });
+  return out;
+}
 
-    // Labels live entirely inside the reserved right gutter so the plotted
-    // line paths (which end at chartArea.right) never leave stubs under them.
-    const gutterStart = chartArea.right + 6;
-    const labelX = chartArea.right + 12;
-    ctx.save();
-    ctx.font = '600 11px Inter, system-ui, sans-serif';
-    ctx.textBaseline = 'middle';
-    ctx.textAlign = 'left';
-    labels.forEach((lab) => {
-      const faded = hoveredDatasetIndex != null && lab.i !== hoveredDatasetIndex;
-      const displaced = Math.abs(lab.y - lab.anchorY) > LEADER_MIN_DISPLACEMENT;
-      if (displaced) {
-        // Subtle dotted leader, drawn only within the gutter (never over the
-        // data line endpoint), connecting the displaced label to its curve.
-        ctx.setLineDash([1, 3]);
-        ctx.strokeStyle = hexToRgba(lab.color, faded ? 0.12 : 0.35);
-        ctx.lineWidth = 1;
+/** Percent, two decimals, signed. The default for every surface whose axis is
+ *  percent -- which is both of them except this tab in its money view. */
+function boardDefaultValueText(ds, lastIdx) {
+  const v = Number(ds.data[lastIdx]);
+  if (!Number.isFinite(v)) return '';
+  return `${v > 0 ? '+' : ''}${(v * 100).toFixed(2)}%`;
+}
+
+/** Path a rounded rect. Caller fills. `ctx.roundRect` is not in every browser
+ *  this dashboard is opened in, and a missing method here would throw inside a
+ *  draw hook -- which takes the whole chart down, not just the pill. */
+function boardRoundRect(ctx, x, y, w, h, r) {
+  const radius = Math.min(r, h / 2, w / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + w - radius, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+  ctx.lineTo(x + w, y + h - radius);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+  ctx.lineTo(x + radius, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+}
+
+/** Right-endpoint labels: a colour-matched dot, the owner's name, and a value
+ *  pill, laid out in the reserved gutter with vertical collision avoidance and
+ *  dotted leaders to displaced labels.
+ *
+ *  A FACTORY. Screen 0 (home-page.js) draws this same frame over datasets that
+ *  carry none of this tab's private fields and has no hover gate, so the two
+ *  things that differ -- the value's unit and whether a series is faded -- are
+ *  injected. The defaults reproduce this tab in its percent view.
+ *
+ *  The stagger, `BOARD_LEADER_MIN_DISPLACEMENT` and the `gutterStart`/`labelX`
+ *  split are carried over unchanged from the plugin this replaces: labels drawn
+ *  over the line endpoints left visible stubs, and a leader shorter than the
+ *  displacement threshold is just a tick that connects nothing. */
+function createEndpointLabelPlugin(options) {
+  const opts = options || {};
+  const formatValue =
+    typeof opts.formatValue === 'function' ? opts.formatValue : boardDefaultValueText;
+  const isFaded = typeof opts.isFaded === 'function' ? opts.isFaded : () => false;
+  const fraction = Number.isFinite(opts.gutterFraction)
+    ? opts.gutterFraction
+    : BOARD_GUTTER_FRACTION;
+
+  return {
+    id: 'endpointLabels',
+    // The gutter is a fraction of the RENDERED width, which is not known at
+    // config time; beforeLayout is the last hook that can still move chartArea,
+    // and `chart.width`/`chart.height` are already current there.
+    beforeLayout(chart) {
+      const labels = boardVisibleEndpoints(chart, formatValue);
+      const frame = boardFrameLayout(chart, labels, fraction);
+      chart.$boardFrame = frame;
+      const layout = chart.options.layout || (chart.options.layout = {});
+      const padding =
+        layout.padding && typeof layout.padding === 'object'
+          ? layout.padding
+          : (layout.padding = {});
+      padding.right = frame.gutter;
+    },
+    afterDatasetsDraw(chart) {
+      const { ctx, chartArea } = chart;
+      const frame = chart.$boardFrame;
+      if (!frame || !frame.drawLabels || !chartArea) return;
+      const labels = boardVisibleEndpoints(chart, formatValue).filter(
+        (lab) => lab.anchorY != null,
+      );
+      if (!labels.length) return;
+
+      // Stagger overlapping labels downward, keeping >= gap px spacing. Each
+      // keeps its original endpoint y (anchorY) so we can tell later whether
+      // collision-avoidance actually moved it.
+      labels.forEach((lab) => { lab.y = lab.anchorY; });
+      labels.sort((a, b) => a.y - b.y);
+      for (let k = 1; k < labels.length; k += 1) {
+        if (labels[k].y - labels[k - 1].y < frame.gap) {
+          labels[k].y = labels[k - 1].y + frame.gap;
+        }
+      }
+      // Shift the whole stack back inside the plot. Both clamps, not just the
+      // bottom one: pushing an overflowing stack up can drive its head above
+      // chartArea.top. It cannot exceed both bounds at once -- boardFrameLayout
+      // only returns drawLabels when the stack fits in the plot height.
+      const overflow = labels[labels.length - 1].y - chartArea.bottom;
+      if (overflow > 0) labels.forEach((lab) => { lab.y -= overflow; });
+      const underflow = chartArea.top - labels[0].y;
+      if (underflow > 0) labels.forEach((lab) => { lab.y += underflow; });
+
+      // Labels live entirely inside the reserved gutter so the plotted line
+      // paths (which end at chartArea.right) never leave stubs under them.
+      const gutterStart = chartArea.right + 6;
+      const labelX = chartArea.right + BOARD_GUTTER_TEXT_INSET;
+      ctx.save();
+      ctx.font = BOARD_GUTTER_FONT;
+      ctx.textBaseline = 'middle';
+      ctx.textAlign = 'left';
+      labels.forEach((lab) => {
+        const faded = isFaded(lab.i);
+        const alpha = faded ? 0.3 : 1;
+
+        // The note's `•⋯`: a filled endpoint dot and a short dotted stub. It
+        // says the curve continues; it asserts no value for where it goes.
+        ctx.fillStyle = hexToRgba(lab.color, alpha);
         ctx.beginPath();
-        ctx.moveTo(gutterStart, lab.anchorY);
-        ctx.lineTo(labelX - 3, lab.y);
+        ctx.arc(lab.anchorX, lab.anchorY, BOARD_DOT_RADIUS, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.setLineDash([1, 3]);
+        ctx.strokeStyle = hexToRgba(lab.color, faded ? 0.2 : 0.6);
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.moveTo(lab.anchorX + BOARD_DOT_RADIUS + 1, lab.anchorY);
+        ctx.lineTo(lab.anchorX + BOARD_DOT_RADIUS + 1 + BOARD_STUB_LENGTH, lab.anchorY);
         ctx.stroke();
         ctx.setLineDash([]);
-      }
-      ctx.fillStyle = hexToRgba(lab.color, faded ? 0.3 : 1);
-      ctx.fillText(lab.text, labelX, lab.y);
-    });
-    ctx.restore();
-  },
-};
+
+        if (Math.abs(lab.y - lab.anchorY) > BOARD_LEADER_MIN_DISPLACEMENT) {
+          ctx.setLineDash([1, 3]);
+          ctx.strokeStyle = hexToRgba(lab.color, faded ? 0.12 : 0.35);
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(gutterStart, lab.anchorY);
+          ctx.lineTo(labelX - 3, lab.y);
+          ctx.stroke();
+          ctx.setLineDash([]);
+        }
+
+        let x = labelX;
+        ctx.fillStyle = hexToRgba(lab.color, alpha);
+        ctx.beginPath();
+        ctx.arc(x + BOARD_DOT_RADIUS, lab.y, BOARD_DOT_RADIUS, 0, Math.PI * 2);
+        ctx.fill();
+        x += BOARD_DOT_RADIUS * 2 + 4;
+
+        ctx.fillStyle = hexToRgba(lab.color, alpha);
+        ctx.fillText(lab.name, x, lab.y);
+        x += ctx.measureText(lab.name).width + 6;
+
+        const pillWidth = ctx.measureText(lab.value).width + BOARD_PILL_PAD_X * 2;
+        ctx.fillStyle = hexToRgba(lab.color, faded ? 0.25 : 1);
+        boardRoundRect(ctx, x, lab.y - BOARD_PILL_HEIGHT / 2, pillWidth, BOARD_PILL_HEIGHT, 4);
+        ctx.fill();
+        const ink = boardPillTextColor(lab.color);
+        ctx.fillStyle = faded ? hexToRgba(ink, 0.5) : ink;
+        ctx.fillText(lab.value, x + BOARD_PILL_PAD_X, lab.y);
+      });
+      ctx.restore();
+    },
+  };
+}
+
+/** The x-axis line, running the full width and terminating in a right-pointing
+ *  arrowhead out in the gutter.
+ *
+ *  The forward affordance, and the whole of it: the future-date-tick design was
+ *  dropped precisely because Chart.js can draw anywhere on the canvas, so this
+ *  costs no scale configuration and cannot touch the hover gate.
+ *
+ *  ACCEPTED IMPRECISION, STATED. On the Competition board the arrow implies an
+ *  advancement a closed window does not perform -- that window ran 2026-04-15 →
+ *  2026-05-15 and is finished. The mitigation is that the window label sits
+ *  directly above the chart on every surface that draws this. It is a soft
+ *  visual affordance rather than a data claim, and it was accepted knowingly. */
+function createAxisArrowPlugin() {
+  return {
+    id: 'boardAxisArrow',
+    // afterDraw, not afterDatasetsDraw: this is chrome, and a curve running
+    // along the floor would otherwise sit on top of the baseline.
+    afterDraw(chart) {
+      const { ctx, chartArea } = chart;
+      if (!chartArea) return;
+      const y = Math.round(chartArea.bottom) + 0.5;
+      const tipX = chart.width - 4;
+      if (tipX <= chartArea.left + BOARD_ARROW_HEAD_LENGTH) return;
+      ctx.save();
+      ctx.strokeStyle = BOARD_AXIS_COLOR;
+      ctx.fillStyle = BOARD_AXIS_COLOR;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(chartArea.left, y);
+      ctx.lineTo(tipX - BOARD_ARROW_HEAD_LENGTH, y);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(tipX, y);
+      ctx.lineTo(tipX - BOARD_ARROW_HEAD_LENGTH, y - BOARD_ARROW_HEAD_HALF);
+      ctx.lineTo(tipX - BOARD_ARROW_HEAD_LENGTH, y + BOARD_ARROW_HEAD_HALF);
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+    },
+  };
+}
 
 function buildCustomLegend(chart) {
   const container = document.getElementById('equityCurvesLegend');
@@ -1570,11 +1722,37 @@ async function renderEquityCurvesChart() {
   equityCurvesChartInstance = new Chart(ctx, {
     type: 'line',
     data: { labels: axisLabels, datasets },
-    plugins: [selectedGlowPlugin, hoverMarkerPlugin, endpointLabelPlugin],
+    plugins: [
+      selectedGlowPlugin,
+      hoverMarkerPlugin,
+      createAxisArrowPlugin(),
+      createEndpointLabelPlugin({
+        // Spec §4.5: the pill renders THIS chart's axis unit. This tab defaults
+        // to money, and the label printed `+7.49%` beside a `$` axis.
+        formatValue(ds, idx) {
+          if (currentChartView === 'absolute') {
+            return `$${formatLeaderboardNumber(ds.data[idx])}`;
+          }
+          // The entry's stored return in preference to the last plotted point:
+          // the point is the curve's own arithmetic, the field is what the run
+          // recorded, and the rank column beside it renders the field.
+          const ret =
+            ds._entry && ds._entry.cumulative_return != null
+              ? Number(ds._entry.cumulative_return)
+              : Number(ds.data[idx]);
+          if (!Number.isFinite(ret)) return '';
+          return `${ret > 0 ? '+' : ''}${(ret * 100).toFixed(2)}%`;
+        },
+        isFaded: (i) => hoveredDatasetIndex != null && i !== hoveredDatasetIndex,
+      }),
+    ],
     options: {
       responsive: true,
       maintainAspectRatio: false,
-      layout: { padding: { right: 120, top: 8 } },
+      // `right` is the frame's, computed per layout from the rendered width.
+      // A literal here is not merely dead: it is what renders on the first
+      // frame, and what every later reader believes.
+      layout: { padding: { top: 8 } },
       // Chart.js does no interaction resolution of its own: hover, the marker
       // and the tooltip are all driven from handleCanvasPointerMove, which is
       // the only path that sees the endpoint-label gutter. Leaving the built-in

--- a/docs/superpowers/specs/2026-08-19-nof1-leaderboard-frame-design.md
+++ b/docs/superpowers/specs/2026-08-19-nof1-leaderboard-frame-design.md
@@ -107,6 +107,21 @@ reads as room for the board to grow into. Revisit only after seeing it rendered.
 too little for `⬤ DeepSeek V4 Pro +7.49%`, and the labels clip. The gutter is
 therefore `max(40% of chart width, GUTTER_MIN_PX)`.
 
+> **As implemented (PR #382).** The 40% shipped as a *ceiling* on the measured
+> floor rather than as the gutter's width: rendered, a fixed 40% reserved 640px
+> on a 1600px canvas to hold ~200px of labels, leaving ~440px of the plot as an
+> empty column. `boardFrameLayout` computes
+> `max(floor, min(width * 0.4, floor + BOARD_GUTTER_SLACK))`.
+>
+> **Where the fraction actually binds**, since "the gutter takes 40%" now
+> overstates it: only while `width * 0.4 < floor + slack`, i.e. below
+> `2.5 * floor + 90` px of canvas — about 613px at today's ~209px measured
+> floor. Every desktop width this dashboard renders at is above that, so on a
+> 1440 or 1600px tab the slack binds and the fraction is inert; it does its job
+> on the home panel and on mobile, which is where an unbounded rail would eat
+> the plot. `BOARD_GUTTER_MAX_FRACTION` (0.5) is the one width-relative guard
+> that fires at any size: past it the frame draws no labels at all.
+
 `GUTTER_MIN_PX` is **derived at implementation time, not guessed**: render the
 longest label the roster can produce — `shortName()` truncates at 18 characters,
 so the worst case is 18 chars plus the dot, the gap and a `-12.34%` pill — in the
@@ -148,7 +163,21 @@ The x-axis line extends through the gutter and terminates in a right-pointing
 arrowhead. Drawn in a plugin (Chart.js can draw anywhere on the canvas, not only
 inside `chartArea`) / as an SVG overlay (Recharts).
 
-No tick labels appear in the gutter.
+No tick labels are *placed* in the gutter — but the strip below the plot is not
+empty at the labels' x, and the implementation must not assume it is.
+
+> **Correction (PR #382).** Chart.js centres the **last** x tick on
+> `chartArea.right` and reserves its right-half overhang inside the same
+> `layout.padding.right` this design uses for the gutter: roughly 18px at the
+> Leaderboard tab's 12px ticks, ~21px at screen 0's 14px ones. That matters
+> because endpoint labels legitimately hang *below* `chartArea.bottom` into the
+> axis strip — the stagger is routinely taller than the plot — so a descending
+> label and the final tick occupy overlapping pixels. Scales draw before
+> `afterDatasetsDraw`, so the label always wins them rather than being
+> occluded; `BOARD_TICK_CLEARANCE` indents descending labels past the overhang
+> so the collision does not arise. The gutter is *reserved* space, not *empty
+> canvas*, and the axis arrow's own baseline crosses it too (§4.4) — which is
+> why that plugin draws under the labels rather than after them.
 
 **Accepted imprecision, stated:** on the Competition board the arrow implies
 advancement that a closed window does not do — that window ran


### PR DESCRIPTION
Shared visual frame on the Leaderboard tab and Home screen 0, per
`docs/superpowers/specs/2026-08-19-nof1-leaderboard-frame-design.md` §4.

- Reserved right gutter holding an endpoint dot, a dotted stub, the owner name
  and a colour-matched value pill.
- x-axis continues through the gutter to a forward arrowhead.
- The tab's pill now follows `currentChartView` instead of always printing a
  percent beside a dollar axis.

Two things worth knowing before reading the diff:

**The gutter is `layout.padding`, never scale domain.** `resolveHoverTarget`
rejects `x > chartArea.right`, so widening the domain would have made the empty
rail hoverable. Reserving padding keeps `chartArea.right` meaning "end of real
data" and leaves the hover gate untouched.

**§4.1's 3:2 split ships as a ceiling, not as the gutter width.** Rendered, a
fixed 40% reserved 640px on a 1600px canvas to hold ~200px of labels. The gutter
is now `max(measuredBlock, min(width * 0.4, measuredBlock + slack))`: the
measured block is a hard floor so text can never be clipped, and the fraction
caps the rail on narrow canvases. It only binds below `2.5 * floor + 90` px --
about 613px -- so on a 1440 or 1600px tab the slack is what binds and the
fraction is inert; it earns its keep on the home panel and on mobile. Both
arrow-only degradations (too narrow for the widest label, too short to stack
them) are unchanged.

A review pass landed on top of this (`afa1bd6`): the axis arrow was painting
its baseline through descended endpoint labels, the minimum label pitch was
shorter than the pill it has to clear, and the reserved gutter is not the empty
canvas the band note claimed -- the last x tick overhangs into it. Six further
fixes and eight new guards; see the commit body.

Landing hero (PR B) and the backend season block (PR C) follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6tsRGnDnjAm6L1fen4ERi

