### PR TITLE
feat(leaderboard): live becomes a real period

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Pipeline is **backtest → SQLite → API → dashboard**. The backend is layere
 
 **H6 leaderboard integrity guard.** An LLM-backed entry can only publish if the model actually drove ≥95% of its steps (`MIN_LLM_DECISION_COVERAGE = 0.95`). The guard (`domain/leaderboard/service.py`) keys on `PortfolioManager.llm_decisions` — steps the model genuinely drove, incremented only at the *success exit* of the decision path — **not** `llm_calls` (a pure billing counter that also ticks on truncated/unparseable responses that then silently fall back to rule-based). This stops a rule-based fallback curve from being published under an LLM's name. See the memory note `leaderboard-h6-integrity-model` for the full rationale. All 7 LLM entries currently on the board (Claude Haiku 4.5, Sonnet 4.6, GPT-5.5, Gemini 3.1 Pro, Qwen3.7 Plus, DeepSeek V4 Pro, Nemotron 3 Nano 30B) cleared it; only DeepSeek beat the passive baselines.
 
-### Two leaderboards, and why `live` is frontend-only vocabulary
+### Two leaderboards, and what `live` does *not* mean
 
 Since PR #352 the dashboard serves **two** boards: the **Competition Leaderboard** (one fixed
 historical window, the acquisition hook) and the **Live Trading Leaderboard**, which is meant to
@@ -99,24 +99,63 @@ Neither board takes user entries — `get_leaderboard` builds every row from the
 `strategies` roster in `dashboard/config/leaderboard.json`, and `api/routers/leaderboard.py`
 exposes no submission route. Don't write copy that implies otherwise.
 
-**The season engine does not exist yet.** `VALID_PERIODS = ("contest", "daily")`
-(`domain/leaderboard/service.py:50`) — `live` and `season` are *frontend* vocabulary only
-(`normalizeBoardPeriod()`, `dashboard/frontend/js/leaderboard.js:636`). `_normalize_period`
-(`:91-93`) coerces any unrecognised period back to `contest` rather than 4xx-ing it, so
-`GET /api/v1/leaderboard?period=live` returns a perfectly successful **HTTP 200 carrying the
-Competition board**. The tab therefore renders in a deliberate **Season 0 preview**: real
-Competition curves under season chrome, plus a banner saying nothing here has advanced.
+**`live` is a real period; the season engine still does not exist.** As of PR #386
+`VALID_PERIODS = ("contest", "daily", "live")` (`domain/leaderboard/service.py:50`) and
+`GET /api/v1/leaderboard?period=live` answers with `period: "live"`, its own
+`window.description`, and a `season` block (`build_season_payload`, `:621`). `_normalize_period`
+(`:91-93`) still coerces genuinely unrecognised periods back to `contest` rather than 4xx-ing
+them. **Nothing advances anything** — the block is hardcoded to the not-yet-advanced state — so
+the tab renders a deliberate **Season 0 preview**: real Competition curves under season chrome,
+plus a banner saying nothing here has advanced. `season` remains vocabulary the *engine* has yet
+to earn.
+
+**The live board reuses the contest session and window byte-for-byte, and that is a spend
+control.** `resolve_leaderboard_config("live")` spreads the contest base so `_find_cached_run`
+hits cache on all twelve entries; inventing a window would miss on every one and start
+recomputing baselines — and, with `LEADERBOARD_DAILY_AUTO_DEPLOY` armed, billable LLM deploys —
+from a public unauthenticated GET. The independent second lock is
+`maybe_schedule_daily_leaderboard_refresh()` being gated on `period == "daily"`. Neither was
+written as a backstop for the other.
 
 ⚠ **The preview banner is anchored on evidence of an advance, not on the period — keep it that
 way.** `isLivePreview()` is `isLiveBoard() && !seasonHasAdvanced(payload)`, and
-`seasonHasAdvanced()` tests `season.last_advanced_date` / `trading_days_elapsed > 0`: fields only
-a real nightly advance can write. It was originally `payload.period !== 'live'`, which meant the
-season engine's most natural first commit — adding `"live"` to `VALID_PERIODS`, needing no season
-payload at all — would have silently cleared every banner while nothing had run. Do not
-"simplify" it back to a period check. Relatedly, **Season 0 is falsy**: every read of the number
-goes through `displayedSeasonNumber()` + `Number.isFinite`, because `season?.number ? … : '—'`
-renders the shakedown season as no season at all. Both are pinned by source-shape tests, which is
-the only kind that can catch either (a test passing period `"live"` or season `3` passes anyway).
+`seasonHasAdvanced()` (`js/leaderboard.js:312`) tests `season.last_advanced_date` /
+`trading_days_elapsed > 0`: fields only a real nightly advance can write. It was originally
+`payload.period !== 'live'`, which meant the season engine's most natural first commit — adding
+`"live"` to `VALID_PERIODS`, needing no season payload at all — would have silently cleared every
+banner while nothing had run. **That commit has now landed and changed nothing here, which was
+the point.** Do not now "simplify" it to a period check on the grounds that the period is finally
+real; it is real and still says nothing about an advance.
+
+⚠ **Season 0 is falsy, and the number has exactly one owner.** Every read goes through
+`displayedSeasonNumber()` + `Number.isFinite` (`:341`), because `season?.number ? … : '—'`
+renders the shakedown season as no season at all; every *rendered* mention goes through
+`displayedSeasonLabel()` (`:359`). `PREVIEW_SEASON_NUMBER` exists on both sides, but the JS copy
+is only the fallback inside `displayedSeasonNumber` — the payload's `season.number` decides.
+Interpolating the JS constant into copy gave the badge and the banner separate owners that
+disagreed the moment the server's constant moved. `phase_label` is `f"Season {…}"` for the same
+reason.
+
+⚠ **The preview season's window expires by itself, on purpose.** Nothing advances Season 0, so
+`season_zero_start` + `length_trading_days` describes a fortnight that becomes a *past* fortnight
+with no code noticing. `_preview_season_dates` (`:566`) therefore returns `(None, None)` once the
+window has elapsed — and also when `season_zero_start` is absent or unparseable — which lands on
+copy the client already ships ("Dates set when the first season opens") and prints a one-time
+operator log line. Do **not** restore the old `or config["start_date"]` fallback: it published
+the *contest* window (2026-04-15 → 2026-04-28) as a season, so "nobody configured a season" and
+"the season is the April contest window" came back byte-identical, `status: preview`, HTTP 200 —
+the exact shape the fail-closed-is-not-fail-visible section below is about.
+
+The season length is untrusted config on a public GET: `_season_trading_days` (`:494`) parses and
+clamps it **once** to `1..MAX_SEASON_TRADING_DAYS`, and the payload reports the clamped value.
+Clamping inside `season_window` while publishing the raw number let a negative length render a
+**100%-full** progress bar (`elapsed / total`, both negative) directly under the banner denying
+that anything advanced.
+
+All of the above is pinned by tests: `tests/test_leaderboard_season.py` (the server contract),
+`tests/test_leaderboard_api.py` (the route), and `tests/test_frontend_live_trading_board.py`
+(source-shape guards — the only kind that can catch the falsy-season and two-owners bugs, since a
+test passing period `"live"` or season `3` passes anyway).
 
 ### LLM safety boundary
 

--- a/dashboard/backend/api/routers/leaderboard.py
+++ b/dashboard/backend/api/routers/leaderboard.py
@@ -32,15 +32,24 @@ def api_get_leaderboard(
     refresh: bool = Query(default=False),
     period: str = Query(
         default="contest",
-        description="Leaderboard period: 'contest' (fixed preseason window) or 'daily' (last completed weekday).",
+        description=(
+            "Leaderboard period: 'contest' (fixed preseason window), "
+            "'daily' (last completed weekday), or 'live' (Season 0 preview — "
+            "the contest curves under season chrome; no season has advanced)."
+        ),
     ),
 ):
     """
-    Official competition / daily leaderboard for the requested period.
+    Official competition / daily / live leaderboard for the requested period.
 
     Baselines are computed from Alpaca hourly backtest data and cached in SQLite.
     Pass ?refresh=true to recompute (e.g. after config change).
     Pass ?period=daily for the rolling one-day board (weekends show Friday).
+    Pass ?period=live for the Live Trading Leaderboard: the contest window and
+    curves, plus a ``season`` block describing Season 0. No advance engine
+    exists yet, so the response always carries a preview season (no
+    last_advanced_date, zero trading_days_elapsed) — see
+    ``domain/leaderboard/service.py::build_season_payload``.
     """
     # Public, unauthenticated endpoint: no exception text reaches the caller.
     # A raw exception string can embed internal infrastructure details — the

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -479,6 +479,50 @@ def verify_daily_refresh_secret(provided: Optional[str]) -> None:
 # PREVIEW_SEASON_NUMBER in dashboard/frontend/js/leaderboard.js.
 PREVIEW_SEASON_NUMBER = 0
 DEFAULT_SEASON_TRADING_DAYS = 10
+# One calendar year of weekday sessions. An upper bound rather than a sanity
+# check: `season_window` walks the calendar one day at a time and runs inside a
+# public, unauthenticated GET, so the config number is the loop bound. See
+# `_season_trading_days`.
+MAX_SEASON_TRADING_DAYS = 260
+
+# Preview-season windows already reported as elapsed — see `_preview_season_dates`.
+# Warned once per (start, end) rather than per request, because the request is a
+# public GET and the condition, once true, is true forever.
+_warned_elapsed_seasons: set[Tuple[str, str]] = set()
+
+
+def _season_trading_days(season_cfg: Dict[str, Any]) -> int:
+    """The configured season length, clamped to a length a season can have.
+
+    Parsed and clamped **once**, here, so the ``trading_days_total`` the payload
+    reports is the number the window was actually built from. Reporting the raw
+    config value instead was not cosmetic: the client computes
+    ``elapsed / total``, so a negative length rendered a **100%-full** progress
+    bar directly underneath the banner whose entire job is denying that anything
+    advanced.
+
+    The parse is guarded for the same reason the clamp is. A bare ``int()`` on a
+    config string raises ``ValueError`` out of a public, unauthenticated GET, and
+    a large value spins the ``season_window`` calendar walk on every request.
+    """
+    raw = season_cfg.get("length_trading_days")
+    if raw is None or raw == "":
+        return DEFAULT_SEASON_TRADING_DAYS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        print(
+            "[leaderboard] season.length_trading_days is not an integer "
+            f"({raw!r}); using {DEFAULT_SEASON_TRADING_DAYS}"
+        )
+        return DEFAULT_SEASON_TRADING_DAYS
+    clamped = max(1, min(value, MAX_SEASON_TRADING_DAYS))
+    if clamped != value:
+        print(
+            f"[leaderboard] season.length_trading_days={value} is outside "
+            f"1..{MAX_SEASON_TRADING_DAYS}; using {clamped}"
+        )
+    return clamped
 
 
 def season_window(start_date: str, trading_days: int) -> Tuple[str, str]:
@@ -494,12 +538,24 @@ def season_window(start_date: str, trading_days: int) -> Tuple[str, str]:
     calendar. It is stated here rather than left for that engine to discover:
     the failure would be a season that ends one session short with nothing
     reporting it.
+
+    A **weekend ``start_date`` rolls forward** to the following Monday instead of
+    being echoed back. The returned start is the season's first *session*, and
+    the client prints it as the window's first day; a Saturday there is a date on
+    which, by this function's own weekday rule, nothing traded.
+
+    ``trading_days`` is clamped to ``1..MAX_SEASON_TRADING_DAYS`` **in here**, not
+    only in the caller: this is a module-level function reached from a public GET
+    and the argument is the bound on a day-at-a-time calendar walk.
     """
-    start = date.fromisoformat(start_date)
-    cursor = start
+    cursor = date.fromisoformat(start_date)
+    while cursor.weekday() >= 5:
+        cursor += timedelta(days=1)
+    start = cursor
+    target = max(1, min(int(trading_days), MAX_SEASON_TRADING_DAYS))
     counted = 0
     last = start
-    while counted < max(int(trading_days), 1):
+    while counted < target:
         if cursor.weekday() < 5:
             counted += 1
             last = cursor
@@ -507,7 +563,65 @@ def season_window(start_date: str, trading_days: int) -> Tuple[str, str]:
     return start.isoformat(), last.isoformat()
 
 
-def build_season_payload(config: Dict[str, Any]) -> Dict[str, Any]:
+def _preview_season_dates(
+    season_cfg: Dict[str, Any],
+    trading_days: int,
+    as_of: Optional[Union[date, datetime]] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """The preview season's window, or ``(None, None)`` when it cannot be stated.
+
+    Two ways it cannot be, and both used to answer with a confident wrong window:
+
+    - **No ``season_zero_start``.** This fell back to ``config["start_date"]`` --
+      the *contest* window -- and published 2026-04-15 → 2026-04-28 as a season.
+      "Nobody configured a season" and "the season is the April contest window"
+      came back byte-identical, both ``status: preview``, HTTP 200. That is the
+      exact shape of CLAUDE.md's fail-closed-is-not-fail-visible section.
+    - **The configured window has already elapsed.** *Nothing advances Season 0* --
+      there is no engine -- so a fixed fortnight becomes a fixed **past** fortnight
+      the day after it ends, and the strip renders "Aug 12 – Aug 25 · Day 0 of 10"
+      for as long as the preview ships. No operator error is required, only time,
+      which is why it is handled here rather than left to a config bump.
+
+    ``(None, None)`` lands on copy the client already carries for this exact
+    state: "Dates set when the first season opens", and a subtitle with the date
+    clause dropped. A season that has not opened has no window -- that is the
+    true thing to say, and the only one that does not rot.
+
+    The elapsed case prints once per window. Silently swapping a stale window for
+    no window is still a silent swap; the operator signal is a log line because
+    the caller is an anonymous GET (same convention as `_warn_on_feed_drift`).
+    """
+    raw = season_cfg.get("season_zero_start")
+    raw_start = raw.strip() if isinstance(raw, str) else ""
+    if not raw_start:
+        return None, None
+    try:
+        start, end = season_window(raw_start, trading_days)
+    except ValueError:
+        print(
+            "[leaderboard] season.season_zero_start is not an ISO date "
+            f"({raw!r}); the preview season reports no window"
+        )
+        return None, None
+    if date.fromisoformat(end) < _coerce_as_of_eastern(as_of).date():
+        key = (start, end)
+        if key not in _warned_elapsed_seasons:
+            _warned_elapsed_seasons.add(key)
+            print(
+                f"[leaderboard] preview season window {start} → {end} has fully "
+                "elapsed and no advance engine exists; the season block now "
+                "reports no dates. Move season.season_zero_start forward in "
+                "dashboard/config/leaderboard.json, or ship the advance engine."
+            )
+        return None, None
+    return start, end
+
+
+def build_season_payload(
+    config: Dict[str, Any],
+    as_of: Optional[Union[date, datetime]] = None,
+) -> Dict[str, Any]:
     """The season block the Live Trading tab renders.
 
     NOTHING HERE MAY CLAIM AN ADVANCE. ``last_advanced_date`` stays None and
@@ -521,12 +635,14 @@ def build_season_payload(config: Dict[str, Any]) -> Dict[str, Any]:
     Every key the client reads is present. A missing one is not a crash there --
     the render path uses optional chaining throughout -- it is a silently blank
     season strip, which is worse.
+
+    ``start_date``/``end_date`` are the two that may legitimately be ``None``;
+    see `_preview_season_dates` for the two states that produce it. Present-but-
+    null, never absent.
     """
     season_cfg = config.get("season") or {}
-    trading_days = int(season_cfg.get("length_trading_days") or DEFAULT_SEASON_TRADING_DAYS)
-    start, end = season_window(
-        season_cfg.get("season_zero_start") or config["start_date"], trading_days
-    )
+    trading_days = _season_trading_days(season_cfg)
+    start, end = _preview_season_dates(season_cfg, trading_days, as_of)
     return {
         "number": PREVIEW_SEASON_NUMBER,
         "status": "preview",
@@ -585,9 +701,25 @@ def resolve_leaderboard_config(period: Optional[str] = "contest") -> Dict[str, A
         # LLM deploys -- from a public, unauthenticated GET.
         return {
             **base,
+            # Overridden, not inherited. The contest description ("One-month
+            # contest window; stock baselines use prior-month data only as
+            # reference…") describes the *rules of the Competition board*, and
+            # inheriting it shipped those rules to `window.description` on a tab
+            # that does not run under them -- to every non-browser consumer of
+            # this payload, since /app never renders the field and so never
+            # showed the mismatch.
+            "description": (
+                f"Season {PREVIEW_SEASON_NUMBER} preview. The curves are the "
+                "Competition board's fixed window, shown under season chrome so "
+                "the layout can be reviewed: no season has advanced, and no "
+                "ranking on this board counts. There is no advance engine yet."
+            ),
             "period": "live",
             "board_title": "Live Trading Leaderboard",
-            "phase_label": "Season 0",
+            # Derived, never spelled out: a literal "Season 0" here is a second
+            # owner of the season number, and the first thing the advance engine
+            # does is bump PREVIEW_SEASON_NUMBER.
+            "phase_label": f"Season {PREVIEW_SEASON_NUMBER}",
             "standings_label": "Ranking",
         }
     return {

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -47,7 +47,7 @@ downsample_daily = _baselines.downsample_daily
 fetch_hourly_bars = _baselines.fetch_hourly_bars
 
 LEADERBOARD_MODE = "leaderboard"
-VALID_PERIODS = ("contest", "daily")
+VALID_PERIODS = ("contest", "daily", "live")
 _SKIP_CACHE_PATH = DATA_DIR / "leaderboard_skip_cache.json"
 _DAILY_REFRESH_STATE_PATH = DATA_DIR / "leaderboard_daily_refresh.json"
 _daily_refresh_lock = threading.Lock()
@@ -473,6 +473,76 @@ def verify_daily_refresh_secret(provided: Optional[str]) -> None:
         raise PermissionError("Invalid daily leaderboard refresh secret")
 
 
+# Season 0 is the shakedown season by convention: numbered, so the board has a
+# real identity to show and so Season 1 means "the first one that counted", but
+# explicitly the one whose results nobody should read as a standing. Mirrors
+# PREVIEW_SEASON_NUMBER in dashboard/frontend/js/leaderboard.js.
+PREVIEW_SEASON_NUMBER = 0
+DEFAULT_SEASON_TRADING_DAYS = 10
+
+
+def season_window(start_date: str, trading_days: int) -> Tuple[str, str]:
+    """The (start, end) dates of a season ``trading_days`` sessions long.
+
+    Ten sessions is two calendar weeks of US cash trading, Monday through
+    Friday. Not a new number: ``js/leaderboard.js`` already declares
+    ``const SEASON_TRADING_DAYS = 10;`` with exactly that comment.
+
+    Weekdays only -- market holidays are NOT modelled. That is correct for
+    Season 0, whose window (2026-08-12 → 2026-08-25) contains none, and it is
+    knowingly insufficient for the advance engine, which will need a real
+    calendar. It is stated here rather than left for that engine to discover:
+    the failure would be a season that ends one session short with nothing
+    reporting it.
+    """
+    start = date.fromisoformat(start_date)
+    cursor = start
+    counted = 0
+    last = start
+    while counted < max(int(trading_days), 1):
+        if cursor.weekday() < 5:
+            counted += 1
+            last = cursor
+        cursor += timedelta(days=1)
+    return start.isoformat(), last.isoformat()
+
+
+def build_season_payload(config: Dict[str, Any]) -> Dict[str, Any]:
+    """The season block the Live Trading tab renders.
+
+    NOTHING HERE MAY CLAIM AN ADVANCE. ``last_advanced_date`` stays None and
+    ``trading_days_elapsed`` stays 0 because no season has advanced -- there is
+    no advance engine. ``seasonHasAdvanced()`` on the client tests exactly those
+    two fields, deliberately rather than the period string, precisely so that
+    teaching the server the word "live" cannot clear the preview banner. A date
+    here flips the badge to "Running" and prints "Next advance: nightly after
+    the 16:00 ET close" under a board nothing updates.
+
+    Every key the client reads is present. A missing one is not a crash there --
+    the render path uses optional chaining throughout -- it is a silently blank
+    season strip, which is worse.
+    """
+    season_cfg = config.get("season") or {}
+    trading_days = int(season_cfg.get("length_trading_days") or DEFAULT_SEASON_TRADING_DAYS)
+    start, end = season_window(
+        season_cfg.get("season_zero_start") or config["start_date"], trading_days
+    )
+    return {
+        "number": PREVIEW_SEASON_NUMBER,
+        "status": "preview",
+        "start_date": start,
+        "end_date": end,
+        "last_advanced_date": None,
+        "trading_days_elapsed": 0,
+        "trading_days_total": trading_days,
+        "entries_open": False,
+        "entry_closes_at": None,
+        "entry_count": 0,
+        "next_advance_at": None,
+        "gaps": [],
+    }
+
+
 def resolve_leaderboard_config(period: Optional[str] = "contest") -> Dict[str, Any]:
     """Return the effective leaderboard config for ``contest`` or ``daily``.
 
@@ -501,6 +571,20 @@ def resolve_leaderboard_config(period: Optional[str] = "contest") -> Dict[str, A
             "period": "daily",
             "board_title": "Daily Leaderboard",
             "phase_label": "Daily",
+            "standings_label": "Ranking",
+        }
+    if period_key == "live":
+        # The contest session and the contest window, deliberately. This board
+        # is a Season 0 PREVIEW: real Competition curves under season chrome,
+        # with a banner saying nothing here has advanced. Inventing a window
+        # would make `_find_cached_run` miss on all twelve entries and start
+        # recomputing baselines -- and with LEADERBOARD_DAILY_AUTO_DEPLOY armed,
+        # LLM deploys -- from a public, unauthenticated GET.
+        return {
+            **base,
+            "period": "live",
+            "board_title": "Live Trading Leaderboard",
+            "phase_label": "Season 0",
             "standings_label": "Ranking",
         }
     return {
@@ -1312,4 +1396,6 @@ def get_leaderboard(
     }
     if daily_status is not None:
         payload["daily_status"] = daily_status
+    if config.get("period") == "live":
+        payload["season"] = build_season_payload(config)
     return payload

--- a/dashboard/backend/domain/leaderboard/service.py
+++ b/dashboard/backend/domain/leaderboard/service.py
@@ -544,10 +544,13 @@ def build_season_payload(config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def resolve_leaderboard_config(period: Optional[str] = "contest") -> Dict[str, Any]:
-    """Return the effective leaderboard config for ``contest`` or ``daily``.
+    """Return the effective leaderboard config for ``contest``, ``daily``, or ``live``.
 
     Daily reuses the same strategy roster as the contest board, but caches under
     a separate session and a rolling 1-day (last completed weekday) window.
+    Live reuses the contest session and window verbatim — it is a Season 0
+    preview of the Competition board under season chrome, not a distinct
+    computed window — so every entry still hits the same cache.
     """
     base = load_leaderboard_config()
     period_key = _normalize_period(period)

--- a/dashboard/backend/tests/test_frontend_live_trading_board.py
+++ b/dashboard/backend/tests/test_frontend_live_trading_board.py
@@ -662,3 +662,42 @@ def test_manual_refresh_does_not_default_to_billable_deploys():
     assert re.search(r"default:\s*false", block.group(1)), (
         "deploy_models must default to false while no board can show the result"
     )
+
+
+def test_the_live_route_answers_with_a_season_and_still_reads_as_preview(monkeypatch):
+    """End to end, not source shape: the payload the route actually serves must
+    fail `seasonHasAdvanced()`'s test.
+
+    That function is `last_advanced_date || trading_days_elapsed > 0`, and it is
+    the anchor under every disclaimer on this tab. Adding "live" to VALID_PERIODS
+    was named in its docstring as the change most likely to break it silently --
+    a one-line commit that needs no season payload at all -- so this is the case
+    that closes that loop from the other side.
+    """
+    from dashboard.backend.domain.leaderboard import service
+
+    # `ensure_leaderboard_runs` fetches bars; this module is about the payload
+    # shape, not run production. Same stub tests/domain/leaderboard/
+    # test_service_move.py uses.
+    monkeypatch.setattr(
+        service,
+        "ensure_leaderboard_runs",
+        lambda force_refresh=False, period="contest", config=None: {
+            "session_id": "leaderboard-contest",
+            "created": 0,
+            "refreshed_at": "2026-08-19T00:00:00+00:00",
+        },
+    )
+    payload = service.get_leaderboard(period="live")
+    season = payload["season"]
+    assert payload["period"] == "live"
+    assert not season["last_advanced_date"]
+    assert not (season["trading_days_elapsed"] > 0)
+
+
+def test_the_route_documents_the_third_period():
+    """The description is what /docs shows and what the next reader believes."""
+    router = (
+        Path(__file__).resolve().parents[1] / "api" / "routers" / "leaderboard.py"
+    ).read_text(encoding="utf-8")
+    assert "'live'" in router or '"live"' in router

--- a/dashboard/backend/tests/test_frontend_live_trading_board.py
+++ b/dashboard/backend/tests/test_frontend_live_trading_board.py
@@ -16,16 +16,18 @@ re-check inside the timeout callback, a refresh that is in progress keeps the
 30s poll re-fetching and re-rendering a hidden Chart.js canvas for the whole
 (possibly multi-hour) model deploy.
 
-**The preview banner.** The season engine is not deployed, and the server
-coerces an unknown ``period`` back to 'contest' rather than 4xx-ing it, so
-asking for the live board returns HTTP 200 carrying the Competition board.
-Every other element on the tab -- chart, table, curve picker, rankings --
-renders identically either way, because those shapes are shared between the two
-boards. The banner is the *only* thing on screen that distinguishes "no season
-has ever run" from "these are the live standings", and it can only do that by
-comparing what was requested against what came back. See the
+**The preview banner.** The season engine is not deployed. The server now
+answers ``?period=live`` with ``period: 'live'`` and a real ``season`` block --
+it no longer coerces the period back to 'contest' -- but that block is
+hardcoded to the not-yet-advanced state, so the hazard is unchanged: every
+other element on the tab (chart, table, curve picker, rankings) renders
+identically whether or not a season ran, because those shapes are shared
+between the two boards. The banner is the *only* thing on screen that
+distinguishes "no season has ever run" from "these are the live standings", and
+it can only do that by testing a field an advance had to write. See the
 fail-closed-is-not-fail-visible section of CLAUDE.md, and the FinSearch news
-adapter it was written about.
+adapter it was written about. The server half of this contract is pinned in
+tests/test_leaderboard_season.py.
 
 **Season 0.** The current season is numbered zero, which is falsy. Every
 ``season.number ? ... : '-'`` in this file's subject matter renders the live
@@ -86,11 +88,11 @@ def test_no_daily_status_machinery_survives():
     """``daily_status`` was the Daily board's notice/poll contract.
 
     The server attaches it only for ``period == 'daily'`` (service.py), a period
-    this UI can no longer request -- it asks for 'live', which `_normalize_period`
-    coerces to 'contest'. So every branch keyed on that field became unreachable
-    the moment the tab was renamed, and the season payload contract this PR ships
-    defines `season.*` with no `daily_status` at all, so it stays unreachable
-    after the engine lands.
+    this UI can no longer request -- it asks for 'live', which is now its own
+    period and carries a `season` block instead. So every branch keyed on that
+    field became unreachable the moment the tab was renamed, and the season
+    payload contract defines `season.*` with no `daily_status` at all, so it
+    stays unreachable after the engine lands.
 
     Carried-over code that can never run is worse than absent code once tests
     guard it: three cases in this file used to exercise the notice and the poll,
@@ -445,15 +447,82 @@ def test_preview_season_is_zero():
 
 
 def test_every_rendered_season_number_goes_through_the_resolver():
-    """Two places print the number: the strip badge and the Phase stat."""
-    for fn in ("renderSeasonStrip", "updateLeaderboardHeader"):
+    """Four places print the number: strip badge, Phase stat, banner, subtitle."""
+    for fn in (
+        "renderSeasonStrip",
+        "updateLeaderboardHeader",
+        "renderLivePreviewBanner",
+        "formatLiveBoardSubtitle",
+    ):
         body = _fn_body(fn)
         if "Season $" not in body and "Season ${" not in body:
             continue
-        assert "displayedSeasonNumber(" in body, (
+        assert "displayedSeasonNumber(" in body or "displayedSeasonLabel(" in body, (
             f"{fn} formats a season number without the resolver, so it can "
             "reintroduce the season-0-is-falsy bug independently"
         )
+
+
+def test_the_season_number_has_exactly_one_owner_on_screen():
+    """The payload's `season.number` decides; this file's constant only fills in.
+
+    The banner and the subtitle used to interpolate PREVIEW_SEASON_NUMBER
+    directly while the badge read the payload, which meant the number had two
+    owners that could disagree. The disagreement is not hypothetical: the first
+    act of the advance engine is bumping the *server's* PREVIEW_SEASON_NUMBER,
+    at which point the badge reads "Season 1" and the banner underneath it reads
+    "Season 0 has not been run".
+
+    Guarding the resolver alone cannot catch this -- the offending lines never
+    called it -- so the guard is on where the constant may appear at all.
+    """
+    remainder = _SOURCE.replace(_fn_body("displayedSeasonNumber"), "")
+    remainder = re.sub(r"const PREVIEW_SEASON_NUMBER\s*=\s*\d+\s*;", "", remainder)
+    assert "PREVIEW_SEASON_NUMBER" not in remainder, (
+        "PREVIEW_SEASON_NUMBER is read outside displayedSeasonNumber(); it is a "
+        "fallback for a missing payload, not a second source of the season "
+        "number. Render it through displayedSeasonLabel()/displayedSeasonNumber()."
+    )
+
+
+def test_the_season_label_never_prints_a_null_number():
+    """`displayedSeasonNumber` returns null for "no season at all"."""
+    body = _fn_body("displayedSeasonLabel")
+    assert "=== null" in body or "== null" in body, (
+        "displayedSeasonLabel must handle the null the resolver can return, or "
+        "the banner renders the words 'Season null'"
+    )
+
+
+def test_the_season_constants_are_the_same_number_in_all_three_places():
+    """10 and 0 are declared in Python, in JS, and in leaderboard.json.
+
+    Nothing but a comment tied them together, and the comment is in the file a
+    reader is already looking at -- so the drift it warns about is invisible
+    from either of the other two. Season length in particular is the divisor
+    behind the progress bar on one side and the window builder on the other.
+    """
+    import json
+
+    from dashboard.backend.domain.leaderboard import service
+
+    config = json.loads(
+        (Path(__file__).resolve().parents[2] / "config" / "leaderboard.json")
+        .read_text(encoding="utf-8")
+    )
+    js_days = re.search(r"const SEASON_TRADING_DAYS\s*=\s*(\d+)", _SOURCE)
+    js_preview = re.search(r"const PREVIEW_SEASON_NUMBER\s*=\s*(\d+)", _SOURCE)
+    assert js_days and js_preview, "the JS season constants moved -- re-point this guard"
+
+    assert int(js_days.group(1)) == service.DEFAULT_SEASON_TRADING_DAYS, (
+        "js/leaderboard.js and service.py disagree on the length of a season"
+    )
+    assert config["season"]["length_trading_days"] == service.DEFAULT_SEASON_TRADING_DAYS, (
+        "leaderboard.json and service.py disagree on the length of a season"
+    )
+    assert int(js_preview.group(1)) == service.PREVIEW_SEASON_NUMBER, (
+        "js/leaderboard.js and service.py disagree on which season is the preview"
+    )
 
 
 # ── Gap markers: a missed night must not read like a flat market ─────────────
@@ -662,42 +731,3 @@ def test_manual_refresh_does_not_default_to_billable_deploys():
     assert re.search(r"default:\s*false", block.group(1)), (
         "deploy_models must default to false while no board can show the result"
     )
-
-
-def test_the_live_route_answers_with_a_season_and_still_reads_as_preview(monkeypatch):
-    """End to end, not source shape: the payload the route actually serves must
-    fail `seasonHasAdvanced()`'s test.
-
-    That function is `last_advanced_date || trading_days_elapsed > 0`, and it is
-    the anchor under every disclaimer on this tab. Adding "live" to VALID_PERIODS
-    was named in its docstring as the change most likely to break it silently --
-    a one-line commit that needs no season payload at all -- so this is the case
-    that closes that loop from the other side.
-    """
-    from dashboard.backend.domain.leaderboard import service
-
-    # `ensure_leaderboard_runs` fetches bars; this module is about the payload
-    # shape, not run production. Same stub tests/domain/leaderboard/
-    # test_service_move.py uses.
-    monkeypatch.setattr(
-        service,
-        "ensure_leaderboard_runs",
-        lambda force_refresh=False, period="contest", config=None: {
-            "session_id": "leaderboard-contest",
-            "created": 0,
-            "refreshed_at": "2026-08-19T00:00:00+00:00",
-        },
-    )
-    payload = service.get_leaderboard(period="live")
-    season = payload["season"]
-    assert payload["period"] == "live"
-    assert not season["last_advanced_date"]
-    assert not (season["trading_days_elapsed"] > 0)
-
-
-def test_the_route_documents_the_third_period():
-    """The description is what /docs shows and what the next reader believes."""
-    router = (
-        Path(__file__).resolve().parents[1] / "api" / "routers" / "leaderboard.py"
-    ).read_text(encoding="utf-8")
-    assert "'live'" in router or '"live"' in router

--- a/dashboard/backend/tests/test_leaderboard_api.py
+++ b/dashboard/backend/tests/test_leaderboard_api.py
@@ -771,3 +771,64 @@ def test_thread_start_failure_releases_the_in_progress_flag(monkeypatch):
     with pytest.raises(RuntimeError):
         lb_service.maybe_schedule_daily_leaderboard_refresh(force_refresh=True)
     assert lb_service._daily_refresh_running is False
+
+
+def test_live_leaderboard_api_serves_the_contest_curves_under_season_chrome(client, monkeypatch):
+    """The route, not the service function. `?period=live` was previously coerced
+    to 'contest' *inside* `_normalize_period`, so every service-level assertion
+    about the live board passed identically before and after the period existed.
+    Only a request through the router proves FastAPI accepts the value, that it
+    survives the `Query` declaration, and that `season` reaches the wire.
+    """
+    _seed_leaderboard_runs(lb_service.db)
+    monkeypatch.setattr(
+        lb_service,
+        "ensure_leaderboard_runs",
+        lambda force_refresh=False, period="contest", config=None: {
+            "session_id": "leaderboard-contest",
+            "start_date": "2026-04-15",
+            "end_date": "2026-05-15",
+            "period": "live",
+            "created": 0,
+            "refreshed_at": "2026-06-18T00:00:00+00:00",
+        },
+    )
+
+    resp = client.get("/api/v1/leaderboard?period=live")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["period"] == "live"
+    assert body["board_title"] == "Live Trading Leaderboard"
+    # Same window as the contest board, deliberately: a distinct window would
+    # miss `_find_cached_run` on every entry and start recomputing baselines --
+    # and, with LEADERBOARD_DAILY_AUTO_DEPLOY armed, billable LLM deploys -- from
+    # a public, unauthenticated GET.
+    assert body["window"]["start_date"] == "2026-04-15"
+    assert body["window"]["end_date"] == "2026-05-15"
+    assert body["total_entries"] == 2
+
+    # The board's own description, not the Competition board's rules.
+    assert "contest window" not in body["window"]["description"]
+    assert "preview" in body["window"]["description"].lower()
+
+    # And it still reads as a preview to `seasonHasAdvanced()`.
+    season = body["season"]
+    assert season["number"] == 0
+    assert season["last_advanced_date"] is None
+    assert season["trading_days_elapsed"] == 0
+
+
+def test_contest_leaderboard_api_carries_no_season(client, monkeypatch):
+    """One fixed historical window is not a season. Attaching one would render
+    the season strip on a board that has none."""
+    _seed_leaderboard_runs(lb_service.db)
+    monkeypatch.setattr(
+        lb_service,
+        "ensure_leaderboard_runs",
+        lambda force_refresh=False, period="contest", config=None: {
+            "session_id": "leaderboard-contest",
+            "created": 0,
+            "refreshed_at": "2026-06-18T00:00:00+00:00",
+        },
+    )
+    assert "season" not in client.get("/api/v1/leaderboard").json()

--- a/dashboard/backend/tests/test_leaderboard_season.py
+++ b/dashboard/backend/tests/test_leaderboard_season.py
@@ -1,0 +1,118 @@
+"""The season contract: `live` is a real period, and Season 0 has not advanced.
+
+The client half of this contract already ships in full and has never had a
+server to talk to -- js/leaderboard.js reads eleven season fields. These pin the
+shape it reads and, more importantly, the one thing that must NOT be true yet.
+"""
+
+import json
+
+import pytest
+
+from dashboard.backend.domain.leaderboard import service
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    """`get_leaderboard` calls `ensure_leaderboard_runs`, which fetches bars.
+
+    Stubbed here for every case in this module, following the pattern in
+    tests/domain/leaderboard/test_service_move.py. Nothing in this file is about
+    run production -- with the suite's temp DATABASE_PATH `_find_cached_run`
+    misses on all twelve entries and `entries` comes back empty, which is
+    exactly the shape these assertions want: the season block must be attached
+    by the PERIOD, not by anything the roster happens to contain.
+    """
+    monkeypatch.setattr(
+        service,
+        "ensure_leaderboard_runs",
+        lambda force_refresh=False, period="contest", config=None: {
+            "session_id": (config or {}).get("session_id", "leaderboard-contest"),
+            "created": 0,
+            "refreshed_at": "2026-08-19T00:00:00+00:00",
+        },
+    )
+
+
+def test_live_is_a_real_period():
+    """`_normalize_period` coerces anything unrecognised back to 'contest', so
+    before this change `?period=live` returned a perfectly successful HTTP 200
+    carrying the Competition board."""
+    assert "live" in service.VALID_PERIODS
+    assert service._normalize_period("live") == "live"
+    assert service._normalize_period("LIVE") == "live"
+    assert service._normalize_period("season") == "contest", (
+        "coercion stays the behaviour for genuinely unknown periods"
+    )
+
+
+def test_the_live_board_reuses_the_contest_runs_and_window():
+    """Nothing in this change may spend money. A live branch with its own window
+    would miss `_find_cached_run` on all twelve entries and start recomputing
+    baselines -- and, with LEADERBOARD_DAILY_AUTO_DEPLOY armed, LLM deploys --
+    from a public, unauthenticated GET."""
+    base = service.load_leaderboard_config()
+    live = service.resolve_leaderboard_config("live")
+    assert live["session_id"] == base["session_id"]
+    assert live["start_date"] == base["start_date"]
+    assert live["end_date"] == base["end_date"]
+    assert live["period"] == "live"
+
+
+def test_a_season_is_ten_trading_days_which_is_two_calendar_weeks():
+    """Ten US cash sessions, Monday through Friday. Not a new number:
+    js/leaderboard.js already declares `const SEASON_TRADING_DAYS = 10;` with
+    exactly that comment."""
+    start, end = service.season_window("2026-08-12", 10)
+    assert start == "2026-08-12"
+    assert end == "2026-08-25", "Wed 12 Aug through Tue 25 Aug is ten sessions"
+
+
+def test_the_season_payload_says_nothing_has_advanced():
+    """THE invariant. `seasonHasAdvanced()` tests `last_advanced_date` and
+    `trading_days_elapsed` -- deliberately, rather than the period string --
+    precisely so that adding "live" to VALID_PERIODS cannot clear the preview
+    banner. A non-null date here flips the badge to "Running" and promises a
+    nightly advance that nothing performs."""
+    season = service.build_season_payload(service.resolve_leaderboard_config("live"))
+    assert season["last_advanced_date"] is None
+    assert season["trading_days_elapsed"] == 0
+    assert season["next_advance_at"] is None
+    assert season["entries_open"] is False
+    assert season["status"] != "running"
+
+
+def test_season_zero_is_numbered_zero_and_survives_json():
+    """Season 0 is the shakedown season by convention: numbered, so the board has
+    a real identity to show, but explicitly the one whose results nobody should
+    read as a standing. It is also FALSY, which is the whole hazard on the client
+    side -- `displayedSeasonNumber()` exists for it."""
+    season = service.build_season_payload(service.resolve_leaderboard_config("live"))
+    assert season["number"] == 0
+    assert json.loads(json.dumps(season))["number"] == 0
+
+
+def test_the_season_payload_carries_every_field_the_client_reads():
+    """The client contract was written before the server existed. A missing key
+    is not a crash there -- the render path uses optional chaining throughout --
+    it is a silently blank strip."""
+    season = service.build_season_payload(service.resolve_leaderboard_config("live"))
+    for field in (
+        "number", "status", "start_date", "end_date", "last_advanced_date",
+        "trading_days_elapsed", "trading_days_total", "entries_open",
+        "entry_closes_at", "entry_count", "next_advance_at", "gaps",
+    ):
+        assert field in season, f"the client reads season.{field}"
+
+
+def test_the_config_declares_the_season_rather_than_the_code():
+    cfg = service.load_leaderboard_config()
+    assert cfg["season"]["length_trading_days"] == 10
+    assert cfg["season"]["season_zero_start"] == "2026-08-12"
+
+
+def test_only_the_live_board_carries_a_season():
+    """The Competition board is one fixed historical window and is not a season;
+    attaching one would make the season strip render on a board that has none."""
+    assert "season" not in service.get_leaderboard(period="contest")
+    assert "season" in service.get_leaderboard(period="live")

--- a/dashboard/backend/tests/test_leaderboard_season.py
+++ b/dashboard/backend/tests/test_leaderboard_season.py
@@ -6,6 +6,7 @@ shape it reads and, more importantly, the one thing that must NOT be true yet.
 """
 
 import json
+from datetime import date
 
 import pytest
 
@@ -116,3 +117,147 @@ def test_only_the_live_board_carries_a_season():
     attaching one would make the season strip render on a board that has none."""
     assert "season" not in service.get_leaderboard(period="contest")
     assert "season" in service.get_leaderboard(period="live")
+
+
+# ── The window is a claim, and a claim that nothing maintains goes stale ─────
+
+
+def test_the_preview_window_disappears_once_it_has_elapsed():
+    """Nothing advances Season 0, so its fortnight becomes a *past* fortnight.
+
+    The config pins 2026-08-12 → 2026-08-25. On 2026-08-26 and every day after,
+    the unfixed code kept publishing that window with `trading_days_elapsed: 0`,
+    so the strip read "Aug 12 – Aug 25 · Day 0 of 10" indefinitely -- a board
+    advertising a schedule it had already missed. No operator error is needed to
+    reach this state, only time, which is why it cannot be left to a config bump.
+
+    `(None, None)` lands on copy the client already ships for exactly this:
+    "Dates set when the first season opens".
+    """
+    live = service.resolve_leaderboard_config("live")
+    inside = service.build_season_payload(live, as_of=date(2026, 8, 20))
+    assert inside["start_date"] == "2026-08-12"
+    assert inside["end_date"] == "2026-08-25"
+
+    after = service.build_season_payload(live, as_of=date(2026, 9, 30))
+    assert after["start_date"] is None
+    assert after["end_date"] is None
+    # Present-but-null, never absent: the client reads these keys unguarded-ish.
+    assert "start_date" in after and "end_date" in after
+    assert after["status"] == "preview"
+    assert after["trading_days_total"] == 10
+
+
+def test_the_last_day_of_the_window_still_counts_as_inside_it():
+    """A season that ends today has not elapsed. `<` not `<=`."""
+    live = service.resolve_leaderboard_config("live")
+    on_the_day = service.build_season_payload(live, as_of=date(2026, 8, 25))
+    assert on_the_day["end_date"] == "2026-08-25"
+
+
+def test_a_missing_season_start_reports_no_window_not_the_contest_one():
+    """This fell back to `config["start_date"]` -- the *contest* window -- and
+    published 2026-04-15 → 2026-04-28 as a season, `status: preview`, HTTP 200.
+
+    "Nobody configured a season" and "the season is the April contest window"
+    were byte-identical responses. That is the failure shape CLAUDE.md's
+    fail-closed-is-not-fail-visible section is about.
+    """
+    season = service.build_season_payload(
+        {"start_date": "2026-04-15", "season": {"length_trading_days": 10}}
+    )
+    assert season["start_date"] is None
+    assert season["end_date"] is None
+
+
+def test_an_unparseable_season_start_reports_no_window_rather_than_raising():
+    """`date.fromisoformat` raises ValueError, on a public unauthenticated GET."""
+    season = service.build_season_payload({"season": {"season_zero_start": "not-a-date"}})
+    assert season["start_date"] is None
+
+
+def test_a_weekend_start_rolls_forward_to_the_first_session():
+    """The returned start is the season's first *session*.
+
+    `season_window` counts weekdays, so a Saturday start was echoed back verbatim
+    as a first day on which, by this function's own rule, nothing traded -- and
+    the client prints it as the window's first day.
+    """
+    start, end = service.season_window("2026-08-15", 10)  # Saturday
+    assert start == "2026-08-17", "Sat 15 Aug rolls forward to Mon 17 Aug"
+    assert end == "2026-08-28"
+
+
+# ── The length is config, so it is untrusted input on a public GET ──────────
+
+
+def test_trading_days_total_is_the_number_the_window_was_built_from():
+    """The clamp used to live inside `season_window` while the payload reported
+    the raw config value, so the two consumers disagreed. The client computes
+    `elapsed / total` for a CSS width: a negative total rendered a **100%-full**
+    progress bar directly under the banner denying that anything had advanced.
+    """
+    season = service.build_season_payload(
+        {"season": {"length_trading_days": -5, "season_zero_start": "2026-08-12"}}
+    )
+    assert season["trading_days_total"] == 1, "clamped, and reported as clamped"
+    assert season["trading_days_total"] >= 1
+
+
+def test_a_junk_season_length_falls_back_instead_of_raising():
+    """A bare `int()` on a config string raised ValueError out of the GET."""
+    season = service.build_season_payload(
+        {"season": {"length_trading_days": "ten", "season_zero_start": "2026-08-12"}}
+    )
+    assert season["trading_days_total"] == service.DEFAULT_SEASON_TRADING_DAYS
+
+
+def test_the_season_length_bounds_the_calendar_walk():
+    """`season_window` steps one day at a time and runs inside a public GET, so
+    the config number is the loop bound. Bounded in the function itself, not only
+    in its caller."""
+    start, end = service.season_window("2026-08-12", 10 ** 9)
+    assert start == "2026-08-12"
+    span = date.fromisoformat(end) - date.fromisoformat(start)
+    assert span.days < 400, "a season length may not become an unbounded loop"
+
+
+# ── The live board describes itself ─────────────────────────────────────────
+
+
+def test_the_live_board_does_not_inherit_the_contest_rules_as_its_description():
+    """`window.description` is served to every non-browser consumer of this
+    payload; /app never renders it, so nothing on screen showed the mismatch.
+    Inherited, it shipped the Competition board's *rules* to a tab that does not
+    run under them."""
+    contest = service.resolve_leaderboard_config("contest")
+    live = service.resolve_leaderboard_config("live")
+    assert live["description"] != contest["description"]
+    assert "look-ahead" not in live["description"]
+    assert "preview" in live["description"].lower()
+
+
+def test_the_live_phase_label_is_derived_from_the_season_number():
+    """A literal "Season 0" here is a second owner of the season number, and
+    bumping PREVIEW_SEASON_NUMBER is the first act of the advance engine."""
+    live = service.resolve_leaderboard_config("live")
+    assert live["phase_label"] == f"Season {service.PREVIEW_SEASON_NUMBER}"
+
+
+def test_the_route_documents_the_third_period():
+    """The description is what /docs shows and what the next reader believes.
+
+    Asserted against the `Query` object FastAPI actually serves, not against the
+    router file as text: a whole-file substring search for "live" passes on the
+    word appearing anywhere -- a comment, an unrelated identifier, the import
+    block -- so it could not tell a documented period from an undocumented one.
+    """
+    import inspect
+
+    from dashboard.backend.api.routers import leaderboard as router
+
+    param = inspect.signature(router.api_get_leaderboard).parameters["period"]
+    described = param.default.description
+    assert "live" in described, "the period the route now accepts must be in its own description"
+    for known in ("contest", "daily"):
+        assert known in described, f"the {known} period lost its documentation"

--- a/dashboard/config/leaderboard.json
+++ b/dashboard/config/leaderboard.json
@@ -6,6 +6,10 @@
   "end_date": "2026-05-15",
   "reference_start_date": "2026-03-15",
   "description": "One-month contest window; stock baselines use prior-month data only as reference (no in-window look-ahead)",
+  "season": {
+    "length_trading_days": 10,
+    "season_zero_start": "2026-08-12"
+  },
   "strategies": [
     {
       "id": "spy_index",

--- a/dashboard/frontend/js/leaderboard.js
+++ b/dashboard/frontend/js/leaderboard.js
@@ -301,6 +301,13 @@ function isLiveBoard() {
  * banner, flip the badge to "Running" and promise a nightly advance while no
  * season had ever run. What the banner claims is that nothing here advanced, so
  * that is what it tests: a date the engine can only write after a real advance.
+ *
+ * That commit has since landed: `VALID_PERIODS` is now
+ * `("contest", "daily", "live")` and the server sends a real `season` block. It
+ * changed nothing here, which was the point — the block hardcodes the
+ * not-yet-advanced state, so this still returns false and the banner still
+ * shows. Do not now "simplify" this to a period check on the grounds that the
+ * period is finally real; it is real and still says nothing about an advance.
  */
 function seasonHasAdvanced(payload) {
   const season = (payload || {}).season;
@@ -311,11 +318,15 @@ function seasonHasAdvanced(payload) {
 
 /** True when the Live Trading tab is rendering something that is not a season.
  *
- * The server coerces an unknown ``period`` back to 'contest' instead of 4xx-ing,
- * so the wrong board arrives as a perfectly successful HTTP 200. Without this,
- * "the season engine is not deployed" and "here are the live standings" render
- * byte-identically — the exact failure shape CLAUDE.md's
- * fail-closed-is-not-fail-visible section is about.
+ * The server now answers `?period=live` with `period: 'live'` and a season
+ * block, so the old reason — an unknown period silently coerced to 'contest',
+ * arriving as a perfectly successful HTTP 200 — no longer applies. The check
+ * outlives it, because the *shape* it guards did not change: the season block
+ * is hardcoded to the not-yet-advanced state and every other element on the tab
+ * (chart, table, curve picker, rankings) renders identically whether or not a
+ * season ran. Without this, "the season engine is not deployed" and "here are
+ * the live standings" still render byte-identically — the exact failure shape
+ * CLAUDE.md's fail-closed-is-not-fail-visible section is about.
  */
 function isLivePreview(payload) {
   return isLiveBoard() && !seasonHasAdvanced(payload);
@@ -331,6 +342,23 @@ function displayedSeasonNumber(payload) {
   const n = Number((payload || {}).season?.number);
   if (Number.isFinite(n)) return n;
   return isLivePreview(payload) ? PREVIEW_SEASON_NUMBER : null;
+}
+
+/** "Season 0" / "Season 3" / "This season" — the number rendered as prose.
+ *
+ * Every sentence on this tab that names the season goes through here, so the
+ * server's `season.number` is the single owner of it. Interpolating
+ * PREVIEW_SEASON_NUMBER directly gave the number two: the badge read the
+ * payload while the banner beneath it read this file's constant, so the first
+ * act of the advance engine — bumping the server's PREVIEW_SEASON_NUMBER —
+ * would have printed "Season 1" above "Season 0 has not been run".
+ *
+ * `null` (no season at all) becomes "This season" rather than "Season null",
+ * and the sentences are written to read correctly either way.
+ */
+function displayedSeasonLabel(payload) {
+  const n = displayedSeasonNumber(payload);
+  return n === null ? 'This season' : `Season ${n}`;
 }
 
 /** A relative phrase, or null when the timestamp is absent or unparseable.
@@ -464,7 +492,7 @@ function formatLiveBoardSubtitle(payload) {
     // Stating the cadence here would promise a nightly advance that no deployed
     // job performs. The banner above carries the full explanation; this is the
     // one-line version that has to survive next to it.
-    return `${dates}Season ${PREVIEW_SEASON_NUMBER} preview — no advance has run`;
+    return `${dates}${displayedSeasonLabel(payload)} preview — no advance has run`;
   }
   // `window.start_date` is the board's display window, NOT a record that an
   // advance ran, and falling back to it printed the Competition window's first
@@ -499,7 +527,7 @@ function renderLivePreviewBanner(payload) {
   lead.textContent = 'Preview — the season engine is not deployed.';
   const body = document.createElement('span');
   const label = payload.window?.label || 'the Competition window';
-  body.textContent = ` Season ${PREVIEW_SEASON_NUMBER} has not been run. The curves below are the Competition board's fixed window (${label}), shown so this layout can be reviewed: nothing here is a live standing, and no ranking on this tab counts.`;
+  body.textContent = ` ${displayedSeasonLabel(payload)} has not been run. The curves below are the Competition board's fixed window (${label}), shown so this layout can be reviewed: nothing here is a live standing, and no ranking on this tab counts.`;
   host.append(lead, body);
 }
 
@@ -514,7 +542,14 @@ function renderSeasonStrip(payload) {
   host.hidden = false;
   host.classList.toggle('is-placeholder', !season);
 
-  const total = Number(season?.trading_days_total) || SEASON_TRADING_DAYS;
+  // Both clamped before either is divided by the other. The server clamps
+  // `trading_days_total` too, and that is the real fix — but this value reaches
+  // `(elapsed / total) * 100` as a CSS width, so a zero or negative one draws a
+  // full or backwards bar under the banner that says nothing has advanced.
+  const rawTotal = Number(season?.trading_days_total);
+  const total = Number.isFinite(rawTotal) && rawTotal >= 1
+    ? Math.floor(rawTotal)
+    : SEASON_TRADING_DAYS;
   const elapsed = Math.min(Math.max(Number(season?.trading_days_elapsed) || 0, 0), total);
 
   const badge = document.getElementById('seasonBadge');
@@ -1007,9 +1042,11 @@ function populateLeaderboardTable() {
 
   const filtered = getFilteredLeaderboardEntries();
   if (!filtered.length) {
-    // Keyed on the board asked for, not the one returned: in preview the
-    // response says 'contest', and the season tab explaining itself as the
-    // contest board is how an empty season stops being legible as one.
+    // Keyed on the board asked for, not the one returned. The server now
+    // echoes `period: 'live'` so the two agree today, but this tab is defined
+    // by what the user clicked: a coerced or fallback response explaining the
+    // season tab as the contest board is how an empty season stops being
+    // legible as one.
     const msg = isLiveBoard()
       ? 'No entries in this season yet. Baselines compute on first load; competition models advance via the nightly job.'
       : 'No leaderboard entries yet. Baselines compute on first load (requires market data).';


### PR DESCRIPTION
`live` becomes a real period. Before this, `VALID_PERIODS` was
`("contest", "daily")` and `_normalize_period` coerced anything else back to
`contest`, so `GET /api/v1/leaderboard?period=live` returned a perfectly
successful **HTTP 200 carrying the Competition board**. It now returns the
Competition curves under season chrome with a real `season` block, which is what
the Live Trading tab has been rendering as a Season 0 preview all along.

**No new spend, by construction.** The live config spreads the *contest* base, so
`session_id` and the window are byte-identical and `_find_cached_run` hits cache
on all twelve entries. Inventing a window here would have missed on every one and
started recomputing baselines — and, with `LEADERBOARD_DAILY_AUTO_DEPLOY` armed,
billable LLM deploys, from a public unauthenticated GET. Second, independent
lock: `maybe_schedule_daily_leaderboard_refresh()` is gated on `period == "daily"`,
so `live` cannot reach the deploy path regardless.

**The preview banner survives this commit, which is the point of the change.**
`seasonHasAdvanced()` tests `season.last_advanced_date` / `trading_days_elapsed`,
not the period string — it was originally `payload.period !== 'live'`, under
which *this very commit* would have silently cleared the banner everywhere while
nothing had run. `build_season_payload` therefore hardcodes the not-yet-advanced
state, and `number: 0` stays falsy for `displayedSeasonNumber()` to handle.

The advance engine still does not exist. Nothing here advances anything, and the
added prose says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6tsRGnDnjAm6L1fen4ERi
