### PR TITLE
fix(home): widen screen 0's leaderboard board

### DIFF
--- a/dashboard/backend/tests/test_frontend_chart_first_home.py
+++ b/dashboard/backend/tests/test_frontend_chart_first_home.py
@@ -860,3 +860,94 @@ def test_the_series_style_helper_is_an_explicit_cross_file_export():
     """
     assert "window.getSeriesStyle = getSeriesStyle;" in _LEADERBOARD_JS
     assert "window.getSeriesStyle" in _HOME_JS
+
+
+_CSS_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+
+
+def _declared_max_width(prelude: str) -> str | None:
+    """The `max-width` this selector declares, read from code and not prose.
+
+    Comments are stripped first because the two rules guarded below now carry
+    long notes that quote their own numbers ("1720 here put the hero rail at
+    x=93", "caps its own rail at 1500") -- exactly the trap this file's
+    `_strip_comments` docstring describes for the JS side. Without the strip,
+    editing one rail to 1720 and leaving the note behind keeps the guard green
+    on the regression it exists to catch.
+
+    Returns the first block that declares one: `css_blocks` also returns the
+    narrow-viewport override of each selector, and only one of the two sets a
+    rail width.
+    """
+    for block in css_blocks(prelude):
+        match = re.search(r"\bmax-width:\s*([^;]+);", _CSS_COMMENT.sub("", block))
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def test_the_two_pager_screens_share_one_content_rail():
+    """Screen 0's rail and screen 1's rail are one number, declared twice.
+
+    `#homeView` is a scroll-snap pager: the two screens are never on-screen
+    together, so a rail mismatch is invisible in any single view and shows up
+    only as the content sliding sideways on every snap. That is precisely the
+    kind of defect nobody files. Measured at 1920 while the hero rail was
+    1720px against screen 1's 1500px: x=93 vs x=203, a 110px jump.
+
+    Kept as an equality between two independently-read declarations rather than
+    a literal, so widening the app later stays a one-line change that this case
+    forces you to make in both places -- pinning `1500px` here would just make
+    the guard the third thing to update.
+    """
+    hero = _declared_max_width(
+        'html[data-nav-page="home"] #homeView .home-landing-hero-inner'
+    )
+    dash = _declared_max_width(
+        'html[data-nav-page="home"] #homeView .home-dashboard-screen-inner'
+    )
+    assert hero and dash, (
+        "one of the two pager rails no longer declares a max-width where this "
+        f"guard reads it (hero={hero!r}, dashboard={dash!r}) -- re-point it at "
+        "however the rail is now expressed, do not delete the case"
+    )
+    assert hero == dash, (
+        f"screen 0's rail is {hero} but screen 1's is {dash}, so the content "
+        "shifts sideways on every pager snap -- move both or neither"
+    )
+
+
+def test_the_scroll_hint_steps_out_of_the_board_column():
+    """The hint is centred on the VIEWPORT, and the hero is two columns.
+
+    Fine while the hero was one column; beside a board card it puts "SEE YOUR
+    DASHBOARD" on top of the card -- measured 165x42px of overlap at 1920, and
+    the hint's own `z-index: 3` means it wins the pixels. The base rule keeps
+    viewport-centring because below 1201px the hero really is one column.
+
+    Both halves are asserted: an override that sets `left` but leaves the base
+    `translateX(-50%)` in place pulls the hint a half-width back toward the
+    card, which is the natural way to half-fix this.
+    """
+    base = [_CSS_COMMENT.sub("", block) for block in css_blocks(".home-scroll-hint")]
+    assert any("left: 50%" in block for block in base), (
+        "the scroll hint no longer viewport-centres by default -- the stacked "
+        "layout below 1201px relies on that; re-point this case if the anchor moved"
+    )
+    override = [
+        _CSS_COMMENT.sub("", block)
+        for block in css_blocks(
+            'html[data-nav-page="home"] #homeView .home-scroll-hint'
+        )
+    ]
+    assert override, (
+        "the two-column override is gone, so the hint is viewport-centred beside "
+        "the board card again -- it overlapped it by 165x42px at 1920 before this"
+    )
+    assert any(
+        "left:" in block and "transform: none" in block for block in override
+    ), (
+        "the override must reset BOTH `left` and the base rule's "
+        "`translateX(-50%)`; resetting only `left` leaves the hint pulled a "
+        f"half-width back over the card (blocks: {override!r})"
+    )

--- a/dashboard/backend/tests/test_frontend_chart_first_home.py
+++ b/dashboard/backend/tests/test_frontend_chart_first_home.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from dashboard.backend.tests._frontend_source import css_blocks
+from dashboard.backend.tests._frontend_source import STYLES, css_blocks
 
 _FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
 _CONFIG = Path(__file__).resolve().parents[2] / "config"
@@ -864,90 +864,287 @@ def test_the_series_style_helper_is_an_explicit_cross_file_export():
 
 _CSS_COMMENT = re.compile(r"/\*.*?\*/", re.S)
 
+# The hint is `position: absolute; bottom: 18px` and stands ~50px tall, so the
+# strip it occupies is ~68px. The <=1200px branch reserves 96px and documents
+# why ("anything less than ~90px of padding lets the panel slide under it");
+# 90 is that stated floor, asserted rather than the exact 96 so tuning the
+# padding does not have to touch this file.
+_HINT_STRIP_FLOOR_PX = 90
 
-def _declared_max_width(prelude: str) -> str | None:
-    """The `max-width` this selector declares, read from code and not prose.
+# Above this the headline's second line wraps. Measured under headless Chromium
+# with Inter loaded: 1.5 wraps at every width >=1201px, 1.4 wraps at 1920/2560,
+# 1.35 clears 1920 by ~2px. See the rule's own comment for the full table.
+_MAX_BOARD_GROW = 1.35
 
-    Comments are stripped first because the two rules guarded below now carry
-    long notes that quote their own numbers ("1720 here put the hero rail at
-    x=93", "caps its own rail at 1500") -- exactly the trap this file's
-    `_strip_comments` docstring describes for the JS side. Without the strip,
-    editing one rail to 1720 and leaving the note behind keeps the guard green
-    on the regression it exists to catch.
 
-    Returns the first block that declares one: `css_blocks` also returns the
-    narrow-viewport override of each selector, and only one of the two sets a
-    rail width.
+def _exact_rule_blocks(prelude: str) -> list[str]:
+    """`css_blocks`, minus blocks where `prelude` is only a selector's TAIL.
+
+    `css_blocks` searches for the prelude followed by `{`, so a *scoped* rule --
+    `html[data-nav-page="home"] #homeView .home-scroll-hint {` -- also matches a
+    bare `.home-scroll-hint` and comes back as a block that begins mid-selector.
+    A guard asking "does the UNSCOPED rule still viewport-centre the hint" was
+    therefore satisfiable by the scoped override: by the very rule it exists to
+    be independent of. Keep only matches that start where a selector may start.
     """
-    for block in css_blocks(prelude):
-        match = re.search(r"\bmax-width:\s*([^;]+);", _CSS_COMMENT.sub("", block))
-        if match:
-            return match.group(1).strip()
-    return None
+    starts = [
+        match.start()
+        for match in re.finditer(re.escape(prelude) + r"\s*\{", STYLES)
+    ]
+    blocks = css_blocks(prelude)
+    assert len(starts) == len(blocks), "css_blocks stopped matching its own regex"
+    kept = []
+    for start, block in zip(starts, blocks):
+        before = STYLES[:start].rstrip()
+        if before == "" or before[-1] in "{}" or before.endswith("*/"):
+            kept.append(block)
+    return kept
+
+
+def _declarations(block: str, prop: str) -> list[str]:
+    """Every value `block` declares for `prop`, read from code and never prose.
+
+    Comments are stripped first because the rules guarded here carry long notes
+    that quote their own numbers ("caps itself at 1500px", "1444 rather than
+    1500") -- exactly the trap this file's `_strip_comments` docstring describes
+    for the JS side. Without the strip, moving a rail and leaving the note
+    behind keeps the guard green on the regression it exists to catch.
+    """
+    body = _CSS_COMMENT.sub("", block)
+    return [
+        match.group(1).strip()
+        for match in re.finditer(rf"(?m)^\s*{re.escape(prop)}:\s*([^;]+);", body)
+    ]
+
+
+def _shorthand_parts(value: str) -> list[str]:
+    """Split a shorthand on TOP-LEVEL whitespace only.
+
+    A plain `.split()` is wrong here and fails open in the worst way: the hero's
+    padding is `clamp(20px, 3vh, 40px) clamp(40px, 5vw, 80px) 96px`, and the
+    spaces inside those `clamp()` calls turn a three-value shorthand into seven
+    tokens. The bottom value then reads as `3vh,` -- not a px length, so a guard
+    that tolerates unparseable values concludes "no fixed reserve declared" over
+    a rule that declares one perfectly well.
+    """
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for char in value:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        if char.isspace() and depth == 0:
+            if current:
+                parts.append(current)
+                current = ""
+            continue
+        current += char
+    if current:
+        parts.append(current)
+    return parts
+
+
+def _px(value: str) -> float:
+    match = re.fullmatch(r"(-?[\d.]+)px", value.strip())
+    assert match, f"expected a plain px length, got {value!r}"
+    return float(match.group(1))
+
+
+def _rail_geometry(prelude: str) -> tuple[float, float]:
+    """(rail width, horizontal inset) for the one rule that declares the rail.
+
+    Both numbers are read from the SAME block rather than from whichever rule
+    happens to come first. The previous helper returned the first block that
+    declared a `max-width`, which silently depended on authoring order: adding a
+    `max-width` to either selector's narrow-viewport override -- or authoring a
+    new override above the base rule -- would have made this compare a stacked
+    rail against a desktop one, and the failure would have read as a real
+    mismatch. Taking the padding from the same block matters for the same
+    reason: screen 1 re-declares its padding inside `@media (max-width: 820px)`.
+    """
+    capped = [
+        block for block in _exact_rule_blocks(prelude) if _declarations(block, "max-width")
+    ]
+    assert len(capped) == 1, (
+        f"{prelude} now declares max-width in {len(capped)} rules; this guard "
+        "cannot tell which one is the desktop rail -- disambiguate it here "
+        "rather than deleting the case"
+    )
+    block = capped[0]
+    assert "box-sizing: border-box" in _CSS_COMMENT.sub("", block), (
+        f"{prelude} is no longer border-box, so its max-width stopped including "
+        "its padding and the arithmetic below is wrong"
+    )
+    (width,) = _declarations(block, "max-width")
+    padding = _declarations(block, "padding")
+    if not padding:
+        return _px(width), 0.0
+    parts = _shorthand_parts(padding[0])
+    # padding: A | A B | A B C | A B C D -- the inline value is [1] whenever
+    # there is more than one part, and [0] when the shorthand has just one.
+    inline = parts[1] if len(parts) > 1 else parts[0]
+    return _px(width), _px(inline)
 
 
 def test_the_two_pager_screens_share_one_content_rail():
-    """Screen 0's rail and screen 1's rail are one number, declared twice.
+    """The two screens put their CONTENT on the same x, not their border boxes.
 
-    `#homeView` is a scroll-snap pager: the two screens are never on-screen
+    `#homeView` is a scroll-snap pager: the screens are never on-screen
     together, so a rail mismatch is invisible in any single view and shows up
-    only as the content sliding sideways on every snap. That is precisely the
-    kind of defect nobody files. Measured at 1920 while the hero rail was
-    1720px against screen 1's 1500px: x=93 vs x=203, a 110px jump.
+    only as the content sliding sideways on every snap -- precisely the kind of
+    defect nobody files.
 
-    Kept as an equality between two independently-read declarations rather than
-    a literal, so widening the app later stays a one-line change that this case
-    forces you to make in both places -- pinning `1500px` here would just make
-    the guard the third thing to update.
+    The quantity is the content rail, and getting that wrong is not theoretical:
+    screen 1 caps itself at 1500px and then insets its content by 28px a side,
+    so equalising the two `max-width` declarations at 1500 lands the border
+    boxes on the same x while moving the content edges 28px APART. Measured at
+    1920 and 2560 that change made the jump 28px, against 2px for the 1440 rail
+    it replaced -- the old rail was very nearly right by accident, its 60px
+    under-size almost exactly screen 1's 56px of padding. A guard on the raw
+    `max-width` values calls that regression a fix.
+
+    Kept as arithmetic over two independently-read declarations rather than a
+    literal, so widening the app stays a change this case forces you to make
+    consistently instead of a third number to update.
     """
-    hero = _declared_max_width(
+    hero_rail, hero_inset = _rail_geometry(
         'html[data-nav-page="home"] #homeView .home-landing-hero-inner'
     )
-    dash = _declared_max_width(
+    dash_rail, dash_inset = _rail_geometry(
         'html[data-nav-page="home"] #homeView .home-dashboard-screen-inner'
     )
-    assert hero and dash, (
-        "one of the two pager rails no longer declares a max-width where this "
-        f"guard reads it (hero={hero!r}, dashboard={dash!r}) -- re-point it at "
-        "however the rail is now expressed, do not delete the case"
+    hero_content = hero_rail - 2 * hero_inset
+    dash_content = dash_rail - 2 * dash_inset
+    assert hero_content == dash_content, (
+        f"screen 0 puts {hero_content}px of content on screen "
+        f"({hero_rail} rail less {hero_inset}px a side) but screen 1 puts "
+        f"{dash_content}px ({dash_rail} less {dash_inset}px a side), so the "
+        f"content shifts {abs(hero_content - dash_content) / 2}px sideways on "
+        "every pager snap -- move the rails together, or absorb the difference "
+        "in the other screen's padding"
     )
-    assert hero == dash, (
-        f"screen 0's rail is {hero} but screen 1's is {dash}, so the content "
-        "shifts sideways on every pager snap -- move both or neither"
-    )
 
 
-def test_the_scroll_hint_steps_out_of_the_board_column():
-    """The hint is centred on the VIEWPORT, and the hero is two columns.
+def test_the_hero_reserves_the_scroll_hints_strip():
+    """The hint gets its own strip; nothing is laid out under it.
 
-    Fine while the hero was one column; beside a board card it puts "SEE YOUR
-    DASHBOARD" on top of the card -- measured 165x42px of overlap at 1920, and
-    the hint's own `z-index: 3` means it wins the pixels. The base rule keeps
-    viewport-centring because below 1201px the hero really is one column.
+    The hint is `position: absolute; bottom: 18px` with `z-index: 3` and live
+    pointer-events, so anything sharing its band is not merely overlapped but
+    UN-CLICKABLE. Measured at 1600x620, 1440x650, 1366x640 and 1280x600 with a
+    hero that reserved nothing, `document.elementFromPoint` at the centre of the
+    "Join our Discord community" CTA returned `homeScrollHint`: the click
+    scrolled to the dashboard instead of opening Discord.
 
-    Both halves are asserted: an override that sets `left` but leaves the base
-    `translateX(-50%)` in place pulls the hint a half-width back toward the
-    card, which is the natural way to half-fix this.
+    Reserving the strip vertically is also what keeps the hint off the board
+    card, which is why the fix is NOT to move the hint sideways. An override
+    that re-anchors it horizontally trades the board overlap for a copy-column
+    overlap and lands it on the CTAs -- and it has to hard-code half the rail
+    to do so, a second constant nothing keeps in step with the rail itself.
     """
-    base = [_CSS_COMMENT.sub("", block) for block in css_blocks(".home-scroll-hint")]
-    assert any("left: 50%" in block for block in base), (
-        "the scroll hint no longer viewport-centres by default -- the stacked "
-        "layout below 1201px relies on that; re-point this case if the anchor moved"
+    hero_blocks = _exact_rule_blocks(
+        'html[data-nav-page="home"] #homeView .home-landing-hero'
     )
-    override = [
+    assert hero_blocks, "the hero rule was renamed or deleted"
+    reserves = []
+    for block in hero_blocks:
+        for prop in ("padding", "padding-block", "padding-bottom"):
+            for value in _declarations(block, prop):
+                parts = _shorthand_parts(value)
+                bottom = {
+                    "padding": {1: 0, 2: 0, 3: 2, 4: 2},
+                    "padding-block": {1: 0, 2: 1},
+                    "padding-bottom": {1: 0},
+                }[prop].get(len(parts))
+                if bottom is None:
+                    continue
+                try:
+                    reserves.append(_px(parts[bottom]))
+                except AssertionError:
+                    continue  # a clamp()/var() bottom is not a fixed reserve
+    assert reserves, (
+        "no hero rule declares a fixed bottom padding any more, so nothing "
+        "reserves the scroll hint's strip -- re-point this case at however the "
+        "reserve is now expressed, do not delete it"
+    )
+    assert min(reserves) >= _HINT_STRIP_FLOOR_PX, (
+        f"the hero reserves only {min(reserves)}px at its shallowest, under the "
+        f"~{_HINT_STRIP_FLOOR_PX}px the hint's own strip needs; the CTA row "
+        "slides under the hint and stops taking clicks"
+    )
+
+    base = _exact_rule_blocks(".home-scroll-hint")
+    assert base, "the unscoped scroll-hint rule was renamed or deleted"
+    assert any("left: 50%" in _CSS_COMMENT.sub("", block) for block in base), (
+        "the scroll hint no longer viewport-centres -- that is the anchor both "
+        "the stacked and the two-column layouts rely on now that the hero "
+        "reserves the hint's strip instead of moving it"
+    )
+    scoped = [
         _CSS_COMMENT.sub("", block)
-        for block in css_blocks(
+        for block in _exact_rule_blocks(
             'html[data-nav-page="home"] #homeView .home-scroll-hint'
         )
     ]
-    assert override, (
-        "the two-column override is gone, so the hint is viewport-centred beside "
-        "the board card again -- it overlapped it by 165x42px at 1920 before this"
+    assert not any("left:" in block for block in scoped), (
+        "something re-anchors the scroll hint horizontally on the home pager. "
+        "That is the fix this case exists to prevent: it moves the hint off the "
+        "board card and onto the copy column's CTAs, and it needs half the rail "
+        f"as a hard-coded constant to do it (blocks: {scoped!r})"
     )
-    assert any(
-        "left:" in block and "transform: none" in block for block in override
-    ), (
-        "the override must reset BOTH `left` and the base rule's "
-        "`translateX(-50%)`; resetting only `left` leaves the hint pulled a "
-        f"half-width back over the card (blocks: {override!r})"
+
+
+def _board_block() -> str:
+    """The desktop (>1200px) rule for the board column."""
+    blocks = _exact_rule_blocks(
+        'html[data-nav-page="home"] #homeView .home-landing-board'
+    )
+    assert blocks, "the board column rule was renamed or deleted"
+    return blocks[0]
+
+
+def test_the_board_ratio_leaves_the_headline_room():
+    """The board may not grow so fast that the headline gains a third line.
+
+    The copy column is whatever the board leaves: (rail - gap) / (1 + grow),
+    less a 24px inset. Measured under headless Chromium with Inter loaded,
+    `.home-headline-line--2` ("AI models finished") needs 396/424/454/478/533/
+    575px at 1201/1280/1366/1440/1600/1920. At `flex: 1.5` the column is under
+    that at EVERY width >=1201px and "See where the / AI models finished"
+    renders as three lines; 1.4 still wraps at 1920 and 2560.
+
+    Asserted as a ceiling rather than the exact value so the ratio stays
+    tunable, but it is a measured ceiling: raising it means re-running the
+    headline measurement, not editing this number.
+    """
+    (flex,) = _declarations(_board_block(), "flex")
+    grow = float(flex.split()[0])
+    assert grow <= _MAX_BOARD_GROW, (
+        f"the board grows at {grow}, above the measured {_MAX_BOARD_GROW} "
+        "ceiling; the hero headline wraps to a third line at desktop widths"
+    )
+
+
+def test_the_board_column_is_not_recapped_by_the_unscoped_rule():
+    """`max-width: none` here is load-bearing, not a leftover.
+
+    The unscoped `.home-landing-board` rule carries `max-width: 42rem`. This
+    scoped rule used to mask it with a cap of its own, so DELETING the cap here
+    -- the obvious tidy-up, since no cap ever binds above 1200px -- does not
+    uncap the column: it hands it to that 42rem and measured pins the board to
+    672px at 1600/1920/2560, silently undoing most of the widening.
+    """
+    (declared,) = _declarations(_board_block(), "max-width")
+    assert declared == "none", (
+        f"the board's desktop rule declares `max-width: {declared}` instead of "
+        "`none`; if that is narrower than the column wants it re-caps the board"
+    )
+    unscoped = [
+        block for block in _exact_rule_blocks(".home-landing-board")
+        if _declarations(block, "max-width")
+    ]
+    assert unscoped, (
+        "the unscoped .home-landing-board no longer declares a max-width, so "
+        "`max-width: none` above may now be removable -- verify and update both"
     )

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -191,7 +191,7 @@ def test_cache_busters_bumped():
     # "fixed" by loosening it. That collision has already cost this repo one
     # round of follow-ups (#347/#348).
     assert "app.js?v=115" in APP_HTML
-    assert "styles.css?v=116" in APP_HTML
+    assert "styles.css?v=117" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML
     assert "js/credits.js?v=2" in APP_HTML

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=116">
+    <link rel="stylesheet" href="styles.css?v=117">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -5286,7 +5286,22 @@ html[data-nav-page="home"] #homeView .home-landing-hero-inner {
     /* Wider page-1 rail so a larger center gap does not crush the two columns.
        Page-2 padding (home-dashboard-screen-inner) stays untouched. */
     width: 100%;
-    max-width: 1440px;
+    /* 1440 left 240px of dead margin EACH SIDE at 1920 (measured: the rail sat
+       at x=232.5 inside 80px of hero padding, so 160px of it was pure centring
+       slack), and the board column is capped, so that slack came straight out
+       of the chart. Measured plot area was 320px at 1920 and 316px at 2560 --
+       NARROWER than the 627px the same board gets at 1100px wide, where the
+       hero stacks and the cap is released. The board being widest on a small
+       laptop and narrowest on a 4K monitor is the defect.
+
+       This number is NOT free: `#homeView` is a scroll-snap pager and
+       `.home-dashboard-screen-inner` (screen 1) caps its own rail at the same
+       value. Measured at 1920, 1720 here put this rail at x=93 against screen
+       1's x=203 -- a 110px sideways jump on every snap, where the pre-existing
+       mismatch was 29.5px. Matching lands both on x=202.5 exactly. Move this
+       only together with that one; pinned by
+       test_the_two_pager_screens_share_one_content_rail. */
+    max-width: 1500px;
     margin-inline: auto;
     justify-content: flex-start;
     align-items: center;
@@ -5309,9 +5324,22 @@ html[data-nav-page="home"] #homeView .home-landing-hero-copy {
    scrollbar and nothing failing. Stretch gives the board the row's definite
    height, which is the only thing that lets the rules below bound the panel. */
 html[data-nav-page="home"] #homeView .home-landing-board {
-    flex: 1 1 0;
+    /* Grows FASTER than the copy column rather than splitting 1:1. The copy is
+       a headline, a one-line lede and two buttons -- it stops improving past
+       ~720px, while the board holds a chart whose plot area is what this whole
+       screen is for. The endpoint rail needs a measured ~220px floor
+       (boardLabelBlockWidth) no matter how wide the card is, so at 660px of
+       card that rail WAS 40% of the canvas; the fix is a bigger denominator,
+       not a smaller rail.
+
+       1.5 rather than 1.25: measured plot area at 1280/1440/1600 was
+       270/319/385px at 1.25 against 302/363/444px at 1.5, while the copy
+       column only falls 490/551/611 -> 444/498/552, which still clears the
+       two-line headline at every one of those widths. At 1920+ the board is at
+       its own max-width, so the ratio stops mattering there. */
+    flex: 1.5 1 0;
     width: 100%;
-    max-width: 42rem;
+    max-width: 56rem;
     min-width: 0;
     flex-shrink: 0;
     display: flex;
@@ -5341,6 +5369,28 @@ html[data-nav-page="home"] #homeView .home-landing-board .home-module {
     height: 100%;
     min-height: 0;
     max-height: none;
+}
+
+/* The scroll hint is `left: 50%` on a containing block the full width of the
+   screen, so it centres on the VIEWPORT while the hero it labels is two
+   asymmetric columns. Already wrong before the board column was widened --
+   measured 28x42px of overlap with the board card at 1920 -- and widening the
+   board turned 28px into 165px, with the hint's own `z-index: 3` painting
+   "SEE YOUR DASHBOARD" across the card's bottom-left corner. Viewport-centre
+   is only the right anchor when the hero is ONE column, so below 1201px the
+   base rule still applies.
+
+   `calc(50% - 750px)` is the rail's left edge whenever the 1500px rail is
+   cap-limited, and the `max()` falls back to the hero's own padding at the
+   widths where it is viewport-limited instead -- the same two-branch geometry
+   the rail itself resolves, rather than a second constant that could drift
+   from it. `transform: none` undoes the base rule's `translateX(-50%)`, which
+   would otherwise pull it a half-width back over the card. */
+@media (min-width: 1201px) {
+    html[data-nav-page="home"] #homeView .home-scroll-hint {
+        left: max(clamp(40px, 5vw, 80px), calc(50% - 750px));
+        transform: none;
+    }
 }
 
 /* Below 1200px the hero stacks to a column (see the unscoped rule further down).

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -5275,8 +5275,22 @@ html[data-nav-page="home"] #homeView #homeScreenLanding {
 html[data-nav-page="home"] #homeView .home-landing-hero {
     height: 100%;
     min-height: 0;
-    /* Match .home-page gutters — pager zeroes page padding, so hero must carry the rail. */
-    padding: clamp(20px, 3vh, 40px) clamp(40px, 5vw, 80px);
+    /* Match .home-page gutters — pager zeroes page padding, so hero must carry
+       the rail. The bottom is the scroll hint's own strip, RESERVED rather than
+       shared: the hint is position:absolute at bottom:18px, stands ~50px tall,
+       and carries `z-index: 3` with live pointer-events, so anything the hero
+       lays out down there is not merely overlapped but un-clickable. Measured
+       at 1600x620, 1440x650, 1366x640 and 1280x600 without this reserve,
+       `document.elementFromPoint` at the centre of the "Join our Discord
+       community" CTA returned `homeScrollHint` -- the click scrolled to the
+       dashboard instead of opening Discord. Reserving the strip is also what
+       keeps the hint off the board card (measured overlap 28x42px before this,
+       and it grows with the card), which is why no rule moves the hint
+       sideways: viewport-centring is correct once nothing is laid out beneath
+       it. The <=1200px branch below reserves the same 96px for the same reason
+       -- this is that rule's desktop half, not a second mechanism.
+       Pinned by test_the_hero_reserves_the_scroll_hints_strip. */
+    padding: clamp(20px, 3vh, 40px) clamp(40px, 5vw, 80px) 96px;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -5294,14 +5308,21 @@ html[data-nav-page="home"] #homeView .home-landing-hero-inner {
        hero stacks and the cap is released. The board being widest on a small
        laptop and narrowest on a 4K monitor is the defect.
 
-       This number is NOT free: `#homeView` is a scroll-snap pager and
-       `.home-dashboard-screen-inner` (screen 1) caps its own rail at the same
-       value. Measured at 1920, 1720 here put this rail at x=93 against screen
-       1's x=203 -- a 110px sideways jump on every snap, where the pre-existing
-       mismatch was 29.5px. Matching lands both on x=202.5 exactly. Move this
-       only together with that one; pinned by
+       1444 rather than 1500, and the 56px is not slack: `#homeView` is a
+       scroll-snap pager, and the number that must match screen 1 is the
+       CONTENT rail, not the border box. `.home-dashboard-screen-inner` caps
+       itself at 1500px but then insets its content by `padding: 16px 28px`,
+       so its content rail is 1500 - 56 = 1444. This screen has no such
+       padding, so 1444 here puts both content edges on the same x.
+
+       Setting this to 1500 to "match" screen 1 is the trap, and it measures
+       WORSE than the 1440 it replaced: matching the border boxes lands both
+       at x=202.5 while the content edges sit 28px apart at 1920 and 2560,
+       against 2px before. 1440 was very nearly right by accident -- its 60px
+       under-size was almost exactly screen 1's 56px of padding. Move this
+       only together with screen 1's rail OR its padding; pinned by
        test_the_two_pager_screens_share_one_content_rail. */
-    max-width: 1500px;
+    max-width: 1444px;
     margin-inline: auto;
     justify-content: flex-start;
     align-items: center;
@@ -5332,16 +5353,35 @@ html[data-nav-page="home"] #homeView .home-landing-board {
        card that rail WAS 40% of the canvas; the fix is a bigger denominator,
        not a smaller rail.
 
-       1.5 rather than 1.25: measured plot area at 1280/1440/1600 was
-       270/319/385px at 1.25 against 302/363/444px at 1.5, while the copy
-       column only falls 490/551/611 -> 444/498/552, which still clears the
-       two-line headline at every one of those widths. At 1920+ the board is at
-       its own max-width, so the ratio stops mattering there. */
-    flex: 1.5 1 0;
+       1.25 is a CEILING the headline sets, not a taste call. Measured under
+       headless Chromium with Inter loaded, `.home-headline-line--2` ("AI models
+       finished") needs 396/424/454/478/533/575px at 1201/1280/1366/1440/1600/
+       1920, against a copy column of (rail - gap) / (1 + ratio) less a 24px
+       inset. At 1.5 that column is too narrow at EVERY width >=1201px and the
+       headline becomes three lines; 1.4 still wraps at 1920 and 2560; 1.35
+       clears 1920 by ~2px, which one font revision would eat. 1.25 leaves ~25px
+       at the tightest width and still takes the board from 690px to 767px at
+       1920 (+11%). Raising it is not free -- re-measure the headline first.
+       Pinned by test_the_board_ratio_leaves_the_headline_room.
+
+       Shrink is 0, written into the shorthand. It used to read `flex: 1.5 1 0`
+       with a `flex-shrink: 0` three lines below silently overriding the `1`,
+       so the source said the two columns were symmetric and the computed style
+       said otherwise.
+
+       `max-width: none` is load-bearing and must not be "tidied" away. The
+       unscoped `.home-landing-board` rule further down carries `max-width:
+       42rem`, which this rule's own cap used to mask. Simply DELETING the cap
+       here does not uncap the column -- it hands it to that 42rem, measured
+       pinning the board to 672px at 1600/1920/2560 and silently undoing most
+       of this fix. The cap is dropped rather than re-tuned because the rail's
+       1500px already bounds this column to ~780px, so any number written here
+       is either dead (the 42rem/56rem it replaces never applied above 1200px)
+       or a second constant to keep in step with the rail. */
+    flex: 1.25 0 0;
     width: 100%;
-    max-width: 56rem;
+    max-width: none;
     min-width: 0;
-    flex-shrink: 0;
     display: flex;
     align-self: stretch;
     min-height: 0;
@@ -5369,28 +5409,6 @@ html[data-nav-page="home"] #homeView .home-landing-board .home-module {
     height: 100%;
     min-height: 0;
     max-height: none;
-}
-
-/* The scroll hint is `left: 50%` on a containing block the full width of the
-   screen, so it centres on the VIEWPORT while the hero it labels is two
-   asymmetric columns. Already wrong before the board column was widened --
-   measured 28x42px of overlap with the board card at 1920 -- and widening the
-   board turned 28px into 165px, with the hint's own `z-index: 3` painting
-   "SEE YOUR DASHBOARD" across the card's bottom-left corner. Viewport-centre
-   is only the right anchor when the hero is ONE column, so below 1201px the
-   base rule still applies.
-
-   `calc(50% - 750px)` is the rail's left edge whenever the 1500px rail is
-   cap-limited, and the `max()` falls back to the hero's own padding at the
-   widths where it is viewport-limited instead -- the same two-branch geometry
-   the rail itself resolves, rather than a second constant that could drift
-   from it. `transform: none` undoes the base rule's `translateX(-50%)`, which
-   would otherwise pull it a half-width back over the card. */
-@media (min-width: 1201px) {
-    html[data-nav-page="home"] #homeView .home-scroll-hint {
-        left: max(clamp(40px, 5vw, 80px), calc(50% - 750px));
-        transform: none;
-    }
 }
 
 /* Below 1200px the hero stacks to a column (see the unscoped rule further down).


### PR DESCRIPTION
Screen 0's board drew a month of hourly data for 9 series in a **320px plot area** at 1920 while the page kept ~240px of dead margin a side. The board was *widest* at a 1100px viewport and *narrowest* at 2560 — widest on a small laptop, narrowest on a 4K monitor.

**What changed**

| | before | after |
|---|---|---|
| hero rail | `1440px` | `1444px` |
| board column | `flex: 1 1 0` | `flex: 1.25 0 0` |
| board cap | `max-width: 42rem` | `max-width: none` |
| scroll hint | overlapped the card | hero reserves its strip |

Board width at 1920: **660 → 736px** (+11%); +55 to +76px across 1201–2560. The endpoint rail was not shrunk — it needs a ~220px floor (`boardLabelBlockWidth`) regardless of card width, so the fix is a bigger denominator.

**Three constraints that are not free** (all measured in headless Chromium with Inter loaded, each pinned by a mutation-verified guard):

- **`1444`, not `1500`.** Screen 1 caps at 1500px then insets 28px a side, so matching the two `max-width` values aligns the *border boxes* while moving the **content** edges 28px apart. 1444 = 1500 − 56 puts the content jump at **0.0px**.
- **`1.25` is a ceiling the headline sets.** "AI models finished" needs 396/424/454/478/533/575px at 1201/1280/1366/1440/1600/1920. At `1.5` the copy column is under that at *every* width ≥1201px and the headline takes a third line; `1.4` still wraps at 1920+.
- **`max-width: none` is load-bearing.** The unscoped `.home-landing-board` carries `max-width: 42rem`; deleting the scoped cap doesn't uncap the column, it exposes that one and pins the board to 672px.

**The hint is reserved, not moved.** It is `z-index: 3` with live pointer-events, so anything in its band is un-clickable, not merely overlapped. The hero reserves 96px the way the ≤1200px branch already did. Moving it sideways instead trades the board overlap for a CTA overlap — measured, `elementFromPoint` at the "Join our Discord community" link returned `homeScrollHint` at 1600×620, 1440×650, 1366×640 and 1280×600.

Guards: 3 cases, each verified to go red under mutation (rail, padding, reserve, ratio, cap, and re-adding the horizontal move). `styles.css` cache-buster 116 → 117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
