### PR TITLE
fix(ui): Configure capital edits and Unsaved changes layout

### DIFF
--- a/dashboard/backend/api/routers/agents.py
+++ b/dashboard/backend/api/routers/agents.py
@@ -23,7 +23,6 @@ from dashboard.backend.domain.backtesting.constants import (
     DEFAULT_AGENT_CASH_ALLOCATION,
     MAX_AGENT_CASH_ALLOCATION,
     MAX_BACKTEST_INITIAL_CAPITAL,
-    MIN_BACKTEST_INITIAL_CAPITAL,
 )
 from dashboard.backend.domain.agents.repository import _UNSET
 from dashboard.backend.domain.agents.taxonomy import AgentCategory, coerce_category
@@ -82,7 +81,7 @@ class CreateAgentBody(BaseModel):
     )
     backtest_allocation: Optional[float] = Field(
         default=None,
-        ge=MIN_BACKTEST_INITIAL_CAPITAL,
+        ge=0,
         le=MAX_BACKTEST_INITIAL_CAPITAL,
     )
     category: CategoryField = Field(default=None, description=_CATEGORY_DESCRIPTION)
@@ -114,7 +113,7 @@ class UpdateAgentBody(BaseModel):
     )
     backtest_allocation: Optional[float] = Field(
         default=None,
-        ge=MIN_BACKTEST_INITIAL_CAPITAL,
+        ge=0,
         le=MAX_BACKTEST_INITIAL_CAPITAL,
     )
     live_trading_enabled: Optional[bool] = None

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -451,8 +451,8 @@ class AgentService:
         mechanical creation sequence below is identical between them.
 
         ``backtest_allocation`` is simulated capital with no ledger coupling
-        (validated only by ``ge=MIN_BACKTEST_INITIAL_CAPITAL,
-        le=MAX_BACKTEST_INITIAL_CAPITAL``), so it is safe to copy from a
+        (validated only by ``ge=0, le=MAX_BACKTEST_INITIAL_CAPITAL``), so it
+        is safe to copy from a
         source. ``cash_allocation`` is a real ledger debit and must NOT be
         copied here -- ``create_agent`` below is deliberately not passed one,
         so it falls back to ``DEFAULT_AGENT_CASH_ALLOCATION`` like any other

--- a/dashboard/backend/tests/test_agent_backtest_allocation.py
+++ b/dashboard/backend/tests/test_agent_backtest_allocation.py
@@ -116,7 +116,18 @@ def test_patch_backtest_allocation_alone_is_not_no_fields_to_update(client):
     assert resp.status_code != 400
 
 
-@pytest.mark.parametrize("bad", [0, -100, 3001])
+def test_backtest_allocation_zero_is_accepted(client):
+    headers = _headers()
+    resp = client.post(
+        "/api/v1/agents",
+        json={"name": "alpha", "agent_type": "builtin", "backtest_allocation": 0},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent"]["backtest_allocation"] == 0
+
+
+@pytest.mark.parametrize("bad", [-100, 3001])
 def test_backtest_allocation_out_of_range_is_rejected(client, bad):
     headers = _headers()
     resp = client.post(

--- a/dashboard/backend/tests/test_agent_editor_header_ui.py
+++ b/dashboard/backend/tests/test_agent_editor_header_ui.py
@@ -1,0 +1,47 @@
+"""Configure header chrome: Unsaved changes must not shove fields sideways.
+
+Model / Market / Description / Robinhood used to live in the same flex row as
+the dirty badge. Showing the badge grew the action column and narrowed every
+field beside it. The toolbar is now its own row; those fields sit full-width
+below it. The hidden badge still occupies its slot so the name row does not
+jump either.
+"""
+
+from pathlib import Path
+
+_FRONTEND = Path(__file__).resolve().parents[2] / "frontend"
+_APP_HTML = (_FRONTEND / "app.html").read_text(encoding="utf-8")
+_STYLES = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+
+
+def _slice(text: str, start_marker: str, end_marker: str) -> str:
+    start = text.index(start_marker)
+    end = text.index(end_marker, start)
+    return text[start:end]
+
+
+def test_configure_fields_are_not_in_the_toolbar_row():
+    toolbar = _slice(
+        _APP_HTML, 'class="agent-editor-toolbar"', 'class="agent-editor-header-fields"'
+    )
+    assert 'id="agentEditorDirtyBadge"' in toolbar
+    assert 'id="agentEditorRunBacktestBtn"' in toolbar
+    assert 'id="agentEditorSaveBtn"' in toolbar
+    assert 'id="agentEditorNameInput"' in toolbar
+    assert 'id="agentEditorModelField"' not in toolbar
+    assert 'id="agentEditorCategoryField"' not in toolbar
+    assert 'id="agentEditorDescription"' not in toolbar
+    assert 'id="agentEditorBrokerPanel"' not in toolbar
+
+    fields = _slice(_APP_HTML, 'class="agent-editor-header-fields"', "</header>")
+    assert 'id="agentEditorModelField"' in fields
+    assert 'id="agentEditorCategoryField"' in fields
+    assert 'id="agentEditorDescription"' in fields
+    assert 'id="agentEditorBrokerPanel"' in fields
+    assert 'id="agentEditorDirtyBadge"' not in fields
+
+
+def test_dirty_badge_keeps_its_slot_when_hidden():
+    hidden = _slice(_STYLES, ".agent-editor-dirty-badge[hidden] {", "}")
+    assert "visibility: hidden" in hidden
+    assert "display: inline-flex !important" in hidden

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -190,8 +190,8 @@ def test_cache_busters_bumped():
     # the next bump, so the exact one looks like the broken guard and gets
     # "fixed" by loosening it. That collision has already cost this repo one
     # round of follow-ups (#347/#348).
-    assert "app.js?v=115" in APP_HTML
-    assert "styles.css?v=118" in APP_HTML
+    assert "app.js?v=117" in APP_HTML
+    assert "styles.css?v=119" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML
     assert "js/credits.js?v=3" in APP_HTML

--- a/dashboard/backend/tests/test_my_agents_capital_ui.py
+++ b/dashboard/backend/tests/test_my_agents_capital_ui.py
@@ -63,3 +63,66 @@ def test_run_backtest_modal_links_to_configure():
 
 def test_backtest_capital_resolution_helper_exists():
     assert "function resolveBacktestCapital(" in _APP_JS
+
+
+def test_backtest_capital_input_allows_zero_and_empty_edits():
+    """min=1 plus a ±1 spinner rewriter made the last digit undeletable."""
+    card = _slice(_APP_HTML, 'id="agentEditorBacktestAllocation"', ">")
+    assert 'min="0"' in card
+    assert 'max="3000"' in card
+    assert 'min="1"' not in card
+    start = _APP_JS.index("function bindCashStepInput(")
+    brace = _APP_JS.index("{", start)
+    depth = 0
+    i = brace
+    while True:
+        if _APP_JS[i] == "{":
+            depth += 1
+        elif _APP_JS[i] == "}":
+            depth -= 1
+            if depth == 0:
+                body = _APP_JS[start : i + 1]
+                break
+        i += 1
+    assert "if (input.value === '') return;" in body
+    assert "must be at least $1." not in _EDITOR_JS
+
+
+def test_capital_inputs_accept_any_amount_in_range():
+    """Values like 1, 99, 101, 150 used to snap to the nearest $100 on blur."""
+    for input_id in (
+        "agentEditorCashAllocation",
+        "agentEditorBacktestAllocation",
+        "externalAgentCashAllocation",
+        "builtinAgentCashAllocation",
+    ):
+        tag = _slice(_APP_HTML, f'id="{input_id}"', ">")
+        assert 'step="0.01"' in tag
+        assert 'step="100"' not in tag
+        assert 'min="0"' in tag
+        assert 'max="3000"' in tag
+
+    start = _APP_JS.index("function bindCashStepInput(")
+    brace = _APP_JS.index("{", start)
+    depth = 0
+    i = brace
+    while True:
+        if _APP_JS[i] == "{":
+            depth += 1
+        elif _APP_JS[i] == "}":
+            depth -= 1
+            if depth == 0:
+                bind_body = _APP_JS[start : i + 1]
+                break
+        i += 1
+    assert "value / step" not in bind_body
+    assert "step = '100'" not in bind_body
+    assert "roundCashAmount" in bind_body
+
+    parse = _slice(_APP_JS, "function parseAgentCashAllocationInput(", "function bindCashStepInput")
+    assert "roundCashAmount(value)" in parse
+    round_fn = _slice(_APP_JS, "function roundCashAmount(", "function parseAgentCashAllocationInput")
+    assert "toFixed(2)" in round_fn
+    assert "toFixed(2)" in _EDITOR_JS
+    assert "cash_allocation = Math.round(value)" not in _EDITOR_JS
+    assert "backtest_allocation = Math.round(value)" not in _EDITOR_JS

--- a/dashboard/backend/tests/test_my_agents_card_ui.py
+++ b/dashboard/backend/tests/test_my_agents_card_ui.py
@@ -56,6 +56,7 @@ const MAX_BACKTEST_ALLOCATED_CAPITAL = 3000;
 const DEFAULT_AGENT_CASH_ALLOCATION = 1000;
 function escapeHtml(s) {{ return String(s); }}
 function formatAgentCashAllocation(v) {{ return '$' + Number(v).toLocaleString(); }}
+{_extract_function(_APP_JS, "roundCashAmount")}
 {_extract_function(_APP_JS, "resolveBacktestCapital")}
 {_extract_function(_APP_JS, "renderAgentAllocatedCapitalHero")}
 {body}
@@ -87,20 +88,28 @@ def test_card_backtest_capital_falls_back_to_the_sleeve():
 
 
 def test_zero_paper_sleeve_displays_as_zero_but_backtest_capital_does_not():
-    """The two capitals deliberately diverge at $0 -- this is not a bug.
+    """Unset backtest capital must not inherit a $0 paper sleeve.
 
-    `cash_allocation` is `ge=0` server-side: a $0 paper sleeve is a real,
-    legal state and must be shown honestly, not padded to a default. But
-    `backtest_allocation` is `ge=1` server-side -- a backtest cannot run on
-    $0 -- so `resolveBacktestCapital` treats a non-positive value as absent
-    and falls through to the $1,000 default. Rendering these two the same
-    way would either lie about a user's real (zero) money or hand a $0 into
-    an API call that would 422.
+    `cash_allocation` of $0 is a real paper sleeve and must render as $0.
+    `backtest_allocation: null` means "never set", so the display falls
+    through to the $1,000 default rather than copying the zero sleeve.
+    An explicit saved 0 is a different case and is shown as $0.
     """
     out = _run_node(
         _harness(
             "console.log(renderAgentAllocatedCapitalHero("
             "{cash_allocation: 0, backtest_allocation: null}));"
+        )
+    )
+    assert "$0" in out
+    assert "$1,000" in out
+
+
+def test_explicit_zero_backtest_capital_displays_as_zero():
+    out = _run_node(
+        _harness(
+            "console.log(renderAgentAllocatedCapitalHero("
+            "{cash_allocation: 1000, backtest_allocation: 0}));"
         )
     )
     assert "$0" in out

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=118">
+    <link rel="stylesheet" href="styles.css?v=119">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -785,7 +785,7 @@
                 </label>
                 <label class="auth-field">
                     <span>Paper Trading Allocated Capital (max $3,000)</span>
-                    <input id="externalAgentCashAllocation" type="number" min="0" max="3000" step="100" value="1000" required aria-describedby="externalAgentCashHint">
+                    <input id="externalAgentCashAllocation" type="number" min="0" max="3000" step="0.01" value="1000" required aria-describedby="externalAgentCashHint">
                 </label>
                 <p id="externalAgentCashHint" class="credential-hint">Cash reserved from My Portfolio for this agent's paper trading. Backtests start from this amount by default but never spend it.</p>
                 <p id="createExternalAgentError" class="auth-error" hidden></p>
@@ -818,7 +818,7 @@
                 </label>
                 <label class="auth-field">
                     <span>Paper Trading Allocated Capital (max $3,000)</span>
-                    <input id="builtinAgentCashAllocation" type="number" min="0" max="3000" step="100" value="1000" required aria-describedby="builtinAgentCashHint">
+                    <input id="builtinAgentCashAllocation" type="number" min="0" max="3000" step="0.01" value="1000" required aria-describedby="builtinAgentCashHint">
                 </label>
                 <p id="builtinAgentCashHint" class="credential-hint">Cash reserved from My Portfolio for this agent's paper trading. Backtests start from this amount by default but never spend it.</p>
                 <p id="createBuiltinAgentError" class="auth-error" hidden></p>
@@ -1007,13 +1007,22 @@
     <!-- Fullscreen Agent Editor -->
     <div id="agentEditorView" class="agent-editor-view" hidden>
         <header class="agent-editor-header">
-            <button id="agentEditorBackBtn" class="agent-editor-back-btn" type="button" aria-label="Back to My Agents">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-                Back to My Agents
-            </button>
-            <div class="agent-editor-title-wrap">
-                <input id="agentEditorNameInput" class="agent-editor-name-input" type="text" maxlength="100" placeholder="Agent name" aria-label="Agent name" autocomplete="off">
-                <p id="agentEditorMeta" class="agent-editor-meta"></p>
+            <div class="agent-editor-toolbar">
+                <button id="agentEditorBackBtn" class="agent-editor-back-btn" type="button" aria-label="Back to My Agents">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
+                    Back to My Agents
+                </button>
+                <div class="agent-editor-title-wrap">
+                    <input id="agentEditorNameInput" class="agent-editor-name-input" type="text" maxlength="100" placeholder="Agent name" aria-label="Agent name" autocomplete="off">
+                    <p id="agentEditorMeta" class="agent-editor-meta"></p>
+                </div>
+                <div class="agent-editor-header-actions">
+                    <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>
+                    <button id="agentEditorRunBacktestBtn" class="home-btn home-btn-secondary" type="button">Run Backtest</button>
+                    <button id="agentEditorSaveBtn" class="home-btn home-btn-primary" type="button">Save</button>
+                </div>
+            </div>
+            <div class="agent-editor-header-fields">
                 <label id="agentEditorModelField" class="agent-editor-model-field" for="agentEditorModelSelect">
                     <span class="agent-editor-model-label">Model</span>
                     <select id="agentEditorModelSelect" class="agent-editor-model-select" aria-label="Agent model"></select>
@@ -1047,11 +1056,6 @@
                     <p id="agentEditorLiveRunResult" class="agent-editor-live-result" hidden></p>
                 </div>
             </div>
-            <div class="agent-editor-header-actions">
-                <span id="agentEditorDirtyBadge" class="agent-editor-dirty-badge" hidden>Unsaved changes</span>
-                <button id="agentEditorRunBacktestBtn" class="home-btn home-btn-secondary" type="button">Run Backtest</button>
-                <button id="agentEditorSaveBtn" class="home-btn home-btn-primary" type="button">Save</button>
-            </div>
         </header>
         <div class="agent-editor-body">
             <div class="agent-editor-layout">
@@ -1061,12 +1065,12 @@
                         <div class="agent-capital-grid">
                             <label class="agent-capital-field" for="agentEditorCashAllocation">
                                 <span class="agent-capital-label">Paper Trading <span class="agent-capital-max">max $3,000</span></span>
-                                <input id="agentEditorCashAllocation" class="agent-capital-input" type="number" min="0" max="3000" step="100" placeholder="1000" aria-label="Paper Trading Allocated Capital">
+                                <input id="agentEditorCashAllocation" class="agent-capital-input" type="number" min="0" max="3000" step="0.01" placeholder="1000" aria-label="Paper Trading Allocated Capital">
                                 <span class="agent-capital-note">Reserved from your My Portfolio balance while this agent paper-trades. Backtests use a separate simulated amount and never touch it.</span>
                             </label>
                             <label class="agent-capital-field" for="agentEditorBacktestAllocation">
                                 <span class="agent-capital-label">Backtesting <span class="agent-capital-max">max $3,000</span></span>
-                                <input id="agentEditorBacktestAllocation" class="agent-capital-input" type="number" min="1" max="3000" step="100" placeholder="1000" aria-label="Backtest Allocated Capital">
+                                <input id="agentEditorBacktestAllocation" class="agent-capital-input" type="number" min="0" max="3000" step="0.01" placeholder="1000" aria-label="Backtest Allocated Capital">
                                 <span class="agent-capital-note">Simulated only. Never spends real cash.</span>
                             </label>
                         </div>
@@ -2128,8 +2132,8 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
-    <script src="js/agent-editor.js?v=27" defer></script>
-    <script src="app.js?v=115" defer></script>
+    <script src="js/agent-editor.js?v=29" defer></script>
+    <script src="app.js?v=117" defer></script>
     <script src="js/credits.js?v=3" defer></script>
     <script src="js/admin-model-providers.js?v=1" defer></script>
     <script src="js/leaderboard.js?v=32" defer></script>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -260,8 +260,14 @@ function formatAgentCashAllocation(value) {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
+    maximumFractionDigits: 2,
   }).format(Number(value));
+}
+
+function roundCashAmount(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return n;
+  return Number(n.toFixed(2));
 }
 
 function parseAgentCashAllocationInput(raw) {
@@ -275,13 +281,12 @@ function parseAgentCashAllocationInput(raw) {
   if (value > MAX_AGENT_CASH_ALLOCATION) {
     throw new Error(`Paper Trading Allocated Capital cannot exceed $${MAX_AGENT_CASH_ALLOCATION.toLocaleString()}.`);
   }
-  return Math.round(value);
+  return roundCashAmount(value);
 }
 
 /**
- * Native number spinners sometimes step by 1 on the first click even when a
- * larger step is configured. Intercept arrows and snap ±1 glitches so each
- * capital input follows its configured increment.
+ * Capital fields accept any amount in [min, max]. Round to cents on blur
+ * only — never snap to $100 (that made 1 / 99 / 101 / 150 unsavable).
  */
 const CASH_STEP_INPUT_IDS = [
   'externalAgentCashAllocation',
@@ -290,76 +295,27 @@ const CASH_STEP_INPUT_IDS = [
   'agentEditorBacktestAllocation',
 ];
 
-function cashStepMeta(input) {
-  const step = Math.max(1, Number(input.step) || 100);
+function cashAmountBounds(input) {
   const min = Number(input.min);
   const max = Number(input.max);
   return {
-    step,
     min: Number.isFinite(min) ? min : 0,
     max: Number.isFinite(max) ? max : Number.POSITIVE_INFINITY,
   };
 }
 
-function snapCashStepValue(input, raw) {
-  const { step, min, max } = cashStepMeta(input);
-  let value = Number(raw);
-  if (!Number.isFinite(value)) value = min;
-  value = Math.round(value / step) * step;
-  return Math.min(max, Math.max(min, value));
-}
-
-function nudgeCashStepInput(input, direction) {
-  const { step, min, max } = cashStepMeta(input);
-  const current = snapCashStepValue(input, input.value === '' ? min : input.value);
-  const next = Math.min(max, Math.max(min, current + direction * step));
-  input.value = String(next);
-  input.dispatchEvent(new Event('input', { bubbles: true }));
-  input.dispatchEvent(new Event('change', { bubbles: true }));
-}
-
 function bindCashStepInput(input) {
   if (!input || input.dataset.cashStepBound === '1') return;
   input.dataset.cashStepBound = '1';
-  if (!input.step || input.step === 'any') input.step = '100';
-
-  let lastValue = snapCashStepValue(input, input.value === '' ? 0 : input.value);
-
-  input.addEventListener('keydown', (event) => {
-    if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      nudgeCashStepInput(input, 1);
-      lastValue = Number(input.value);
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      nudgeCashStepInput(input, -1);
-      lastValue = Number(input.value);
-    }
-  });
-
-  input.addEventListener('input', () => {
-    const value = Number(input.value);
-    if (!Number.isFinite(value)) return;
-    const diff = value - lastValue;
-    // Spinner glitch: first click often lands on ±1 instead of ±step.
-    if (Math.abs(diff) === 1) {
-      const step = Number(input.step) || 100;
-      const corrected = snapCashStepValue(
-        input,
-        lastValue + (diff > 0 ? step : -step),
-      );
-      input.value = String(corrected);
-      lastValue = corrected;
-      return;
-    }
-    lastValue = value;
-  });
+  input.step = '0.01';
 
   input.addEventListener('change', () => {
     if (input.value === '') return;
-    const snapped = snapCashStepValue(input, input.value);
-    if (String(snapped) !== input.value) input.value = String(snapped);
-    lastValue = snapped;
+    const value = Number(input.value);
+    if (!Number.isFinite(value)) return;
+    const { min, max } = cashAmountBounds(input);
+    const next = Math.min(max, Math.max(min, roundCashAmount(value)));
+    if (String(next) !== input.value) input.value = String(next);
   });
 }
 
@@ -907,12 +863,16 @@ function formatSignedReturnPct(frac) {
  * did, i.e. starting from its paper sleeve.
  */
 function resolveBacktestCapital(agent) {
-  const candidates = [agent?.backtest_allocation, agent?.cash_allocation];
-  for (const raw of candidates) {
-    const value = Number(raw);
-    if (Number.isFinite(value) && value > 0) {
-      return Math.min(Math.round(value), MAX_BACKTEST_ALLOCATED_CAPITAL);
+  const saved = agent?.backtest_allocation;
+  if (saved != null && saved !== '') {
+    const value = Number(saved);
+    if (Number.isFinite(value) && value >= 0) {
+      return Math.min(roundCashAmount(value), MAX_BACKTEST_ALLOCATED_CAPITAL);
     }
+  }
+  const sleeve = Number(agent?.cash_allocation);
+  if (Number.isFinite(sleeve) && sleeve > 0) {
+    return Math.min(roundCashAmount(sleeve), MAX_BACKTEST_ALLOCATED_CAPITAL);
   }
   return DEFAULT_AGENT_CASH_ALLOCATION;
 }

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -830,7 +830,7 @@
       if (value > 3000) {
         throw new Error('Paper Trading Allocated Capital cannot exceed $3,000.');
       }
-      cash_allocation = Math.round(value);
+      cash_allocation = Number(value.toFixed(2));
     } else {
       cash_allocation = 1000;
     }
@@ -838,20 +838,20 @@
     let backtest_allocation = null;
     if (backtestInput && backtestInput.value !== '') {
       const value = Number(backtestInput.value);
-      if (!Number.isFinite(value) || value < 1) {
-        throw new Error('Backtest Allocated Capital must be at least $1.');
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error('Backtest Allocated Capital must be between $0 and $3,000.');
       }
       if (value > 3000) {
         throw new Error('Backtest Allocated Capital cannot exceed $3,000.');
       }
-      backtest_allocation = Math.round(value);
+      backtest_allocation = Number(value.toFixed(2));
     } else {
-      // Non-positive counts as absent: cash_allocation is legally 0 (a $0 paper
-      // sleeve), but backtest capital is >= 1 server-side, so 0 must fall
-      // through to the default rather than becoming an unsaveable value.
+      // Blank field (mid-edit or never set): fall back to the paper sleeve
+      // when that sleeve is positive, otherwise $1,000. An explicit 0 above
+      // is a real saved value and must not take this path.
       backtest_allocation =
         Number.isFinite(Number(cash_allocation)) && Number(cash_allocation) > 0
-          ? Math.min(Math.round(Number(cash_allocation)), 3000)
+          ? Math.min(Number(Number(cash_allocation).toFixed(2)), 3000)
           : 1000;
     }
     const modelSelect = document.getElementById('agentEditorModelSelect');
@@ -979,16 +979,17 @@
     }
     const backtestInput = document.getElementById('agentEditorBacktestAllocation');
     if (backtestInput) {
-      // Non-positive counts as absent: cash_allocation is legally 0 (a $0 paper
-      // sleeve), but backtest capital is >= 1 server-side, so 0 must fall
-      // through to the default rather than becoming an unsaveable value.
-      const candidates = [agent.backtest_allocation, agent.cash_allocation];
       let resolved = 1000;
-      for (const raw of candidates) {
-        const value = Number(raw);
-        if (Number.isFinite(value) && value > 0) { resolved = value; break; }
+      if (agent.backtest_allocation != null && agent.backtest_allocation !== '') {
+        const saved = Number(agent.backtest_allocation);
+        if (Number.isFinite(saved) && saved >= 0) {
+          resolved = saved;
+        }
+      } else {
+        const sleeve = Number(agent.cash_allocation);
+        if (Number.isFinite(sleeve) && sleeve > 0) resolved = sleeve;
       }
-      backtestInput.value = String(Math.min(Math.round(resolved), 3000));
+      backtestInput.value = String(Math.min(Number(Number(resolved).toFixed(2)), 3000));
     }
     if (meta) {
       meta.textContent = agent.agent_type === 'builtin' ? 'Built-in agent' : 'External agent';

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -9195,13 +9195,27 @@ body.agent-editor-open {
 
 .agent-editor-header {
     display: flex;
-    align-items: flex-start;
-    gap: 16px;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
     padding: 14px 20px;
     border-bottom: 1px solid var(--border-color);
     background: rgba(8, 18, 40, 0.92);
     backdrop-filter: blur(8px);
     flex-shrink: 0;
+}
+
+.agent-editor-toolbar {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.agent-editor-header-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
 }
 
 .agent-editor-back-btn {
@@ -9427,6 +9441,8 @@ body.agent-editor-open {
 }
 
 .agent-editor-dirty-badge {
+    display: inline-flex;
+    align-items: center;
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.03em;
@@ -9436,6 +9452,15 @@ body.agent-editor-open {
     border-radius: 999px;
     background: rgba(251, 191, 36, 0.12);
     border: 1px solid rgba(251, 191, 36, 0.35);
+}
+
+/* Keep the toolbar width stable: [hidden] is display:none, which used to
+   shove Model/Market/Robinhood left when the badge appeared. Visibility
+   hides it without releasing the slot. */
+.agent-editor-dirty-badge[hidden] {
+    display: inline-flex !important;
+    visibility: hidden;
+    pointer-events: none;
 }
 
 .agent-editor-title {
@@ -9644,13 +9669,20 @@ body.agent-editor-open {
 
 @media (max-width: 640px) {
     .agent-editor-header {
-        flex-wrap: wrap;
         padding: 10px 12px;
+    }
+
+    .agent-editor-toolbar {
+        flex-wrap: wrap;
     }
 
     .agent-editor-header-actions {
         width: 100%;
         justify-content: stretch;
+    }
+
+    .agent-editor-dirty-badge[hidden] {
+        display: none !important;
     }
 
     .agent-editor-header-actions .home-btn {
@@ -10213,6 +10245,11 @@ body.agent-editor-open {
 }
 
 /* Agent editor — model picker (Demo 1) */
+.agent-editor-header-fields .agent-editor-model-field,
+.agent-editor-header-fields .agent-editor-managed-model-field {
+    margin-top: 0;
+}
+
 .agent-editor-model-field {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Allocated Capital now accepts any amount in $0–$3,000 (including 1, 99, 150). The last digit can be deleted and rewritten; only values past two decimal places are rounded.
- Split the Configure header so Model / Market / Description / Robinhood sit below the toolbar. The Unsaved changes badge no longer narrows those fields.

## Test plan
- [ ] Open Configure, focus Backtesting, delete the last digit, type `2000`, Save
- [ ] Save `1`, `99`, `101`, `150`, `199` on both Paper Trading and Backtesting; values persist after reload
- [ ] Type `150.239`, blur or Save; field becomes `150.24`
- [ ] Edit any field so Unsaved changes appears; Model / Market / Robinhood do not shift left
- [ ] Save; badge hides and the same fields stay put


Made with [Cursor](https://cursor.com)