### PR TITLE
fix: restore legacy platform OpenRouter execution

### DIFF
--- a/dashboard/backend/domain/model_providers/repository.py
+++ b/dashboard/backend/domain/model_providers/repository.py
@@ -121,6 +121,10 @@ class ModelProviderStore:
                 result_json TEXT,
                 created_at TEXT NOT NULL
             );
+            CREATE TABLE IF NOT EXISTS model_provider_migrations (
+                migration_id TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            );
             """
         )
         self._ensure_user_credential_columns(conn)
@@ -133,7 +137,7 @@ class ModelProviderStore:
                     provider_id, display_name, adapter_type, approved_base_url,
                     capabilities_json, byok_enabled, platform_enabled, status,
                     created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, 1, 0, 'enabled', ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, 1, ?, 'enabled', ?, ?)
                 ON CONFLICT(provider_id) DO NOTHING
                 """,
                 (
@@ -142,12 +146,60 @@ class ModelProviderStore:
                     item["adapter_type"],
                     item["approved_base_url"],
                     serialize_capabilities(item["capabilities"]),
+                    int(bool(item.get("platform_enabled", False))),
                     now,
                     now,
                 ),
             )
+        self._migrate_legacy_openrouter_platform_flag(conn)
         conn.commit()
         conn.close()
+
+    @staticmethod
+    def _migrate_legacy_openrouter_platform_flag(conn: sqlite3.Connection) -> None:
+        """Enable the legacy Render-backed OpenRouter lane once, safely."""
+
+        migration_id = "openrouter-platform-key-v1"
+        if conn.execute(
+            "SELECT 1 FROM model_provider_migrations WHERE migration_id = ?",
+            (migration_id,),
+        ).fetchone():
+            return
+        if not os.getenv("OPENROUTER_API_KEY", "").strip():
+            return
+        provider = conn.execute(
+            "SELECT status, platform_enabled FROM provider_registry WHERE provider_id = 'openrouter'"
+        ).fetchone()
+        if not provider or provider["status"] != "enabled" or provider["platform_enabled"]:
+            return
+        if conn.execute(
+            "SELECT 1 FROM platform_model_credentials WHERE provider_id = 'openrouter'"
+        ).fetchone():
+            return
+        latest_operation = conn.execute(
+            """
+            SELECT operation, result_json
+            FROM model_provider_admin_operations
+            WHERE provider_id = 'openrouter' AND operation = 'upsert_provider'
+            ORDER BY operation_id DESC
+            LIMIT 1
+            """
+        ).fetchone()
+        if latest_operation:
+            try:
+                snapshot = json.loads(latest_operation["result_json"] or "{}")
+            except (TypeError, ValueError, json.JSONDecodeError):
+                snapshot = {}
+            if snapshot.get("platform_enabled") is False:
+                return
+        conn.execute(
+            "UPDATE provider_registry SET platform_enabled = 1, updated_at = ? WHERE provider_id = 'openrouter'",
+            (_utcnow_iso(),),
+        )
+        conn.execute(
+            "INSERT INTO model_provider_migrations (migration_id, applied_at) VALUES (?, ?)",
+            (migration_id, _utcnow_iso()),
+        )
 
     @staticmethod
     def _ensure_user_credential_columns(conn: sqlite3.Connection) -> None:

--- a/dashboard/backend/domain/model_providers/repository_common.py
+++ b/dashboard/backend/domain/model_providers/repository_common.py
@@ -80,6 +80,7 @@ SEEDED_PROVIDERS = (
         "provider_id": "openrouter",
         "display_name": "OpenRouter",
         "adapter_type": "openrouter",
+        "platform_enabled": True,
         "approved_base_url": "https://openrouter.ai/api/v1",
         "capabilities": ProviderCapabilities(
             model_discovery=True,

--- a/dashboard/backend/domain/model_providers/repository_postgres.py
+++ b/dashboard/backend/domain/model_providers/repository_postgres.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 import json
+import os
 from typing import Any
 
 import psycopg
@@ -96,6 +97,11 @@ CREATE TABLE IF NOT EXISTS model_provider_admin_operations (
     secret_fingerprint TEXT,
     result_json TEXT,
     created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS model_provider_migrations (
+    migration_id TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL
 );
 """
 
@@ -205,7 +211,7 @@ class PostgresModelProviderStore:
                             provider_id, display_name, adapter_type, approved_base_url,
                             capabilities_json, byok_enabled, platform_enabled,
                             status, created_at, updated_at
-                        ) VALUES (%s, %s, %s, %s, %s, TRUE, FALSE, 'enabled', %s, %s)
+                        ) VALUES (%s, %s, %s, %s, %s, TRUE, %s, 'enabled', %s, %s)
                         ON CONFLICT (provider_id) DO NOTHING
                         """,
                         (
@@ -214,10 +220,63 @@ class PostgresModelProviderStore:
                             item["adapter_type"],
                             item["approved_base_url"],
                             serialize_capabilities(item["capabilities"]),
+                            bool(item.get("platform_enabled", False)),
                             now,
                             now,
                         ),
                     )
+                self._migrate_legacy_openrouter_platform_flag(cur)
+
+    @staticmethod
+    def _migrate_legacy_openrouter_platform_flag(cur) -> None:
+        """Enable the legacy Render-backed OpenRouter lane once, safely."""
+
+        migration_id = "openrouter-platform-key-v1"
+        cur.execute(
+            "SELECT 1 FROM model_provider_migrations WHERE migration_id = %s",
+            (migration_id,),
+        )
+        if cur.fetchone():
+            return
+        if not os.getenv("OPENROUTER_API_KEY", "").strip():
+            return
+        cur.execute(
+            "SELECT status, platform_enabled FROM provider_registry WHERE provider_id = 'openrouter'"
+        )
+        provider = cur.fetchone()
+        if not provider or provider["status"] != "enabled" or provider["platform_enabled"]:
+            return
+        cur.execute(
+            "SELECT 1 FROM platform_model_credentials WHERE provider_id = 'openrouter'"
+        )
+        if cur.fetchone():
+            return
+        cur.execute(
+            """
+            SELECT operation, result_json
+            FROM model_provider_admin_operations
+            WHERE provider_id = 'openrouter' AND operation = 'upsert_provider'
+            ORDER BY operation_id DESC
+            LIMIT 1
+            """
+        )
+        latest_operation = cur.fetchone()
+        if latest_operation:
+            try:
+                snapshot = json.loads(latest_operation["result_json"] or "{}")
+            except (TypeError, ValueError, json.JSONDecodeError):
+                snapshot = {}
+            if snapshot.get("platform_enabled") is False:
+                return
+        now = _utcnow_iso()
+        cur.execute(
+            "UPDATE provider_registry SET platform_enabled = TRUE, updated_at = %s WHERE provider_id = 'openrouter'",
+            (now,),
+        )
+        cur.execute(
+            "INSERT INTO model_provider_migrations (migration_id, applied_at) VALUES (%s, %s)",
+            (migration_id, now),
+        )
 
     def list_enabled_providers(self, *, mode: str = "byok") -> list[dict[str, Any]]:
         if mode not in {"byok", "platform"}:

--- a/dashboard/backend/tests/domain/model_providers/test_repository_contract.py
+++ b/dashboard/backend/tests/domain/model_providers/test_repository_contract.py
@@ -78,6 +78,97 @@ def test_seed_initialization_does_not_overwrite_admin_configuration(store_factor
     assert reopened.get_provider("openai")["status"] == "disabled"
 
 
+def test_seeded_openrouter_is_platform_enabled(store):
+    assert store.get_provider("openrouter")["platform_enabled"] is True
+
+
+def test_legacy_openrouter_platform_flag_migrates_when_environment_key_exists(
+    store_factory, monkeypatch
+):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    store = store_factory()
+    connection = store._get_connection()
+    connection.execute(
+        "UPDATE provider_registry SET platform_enabled = 0 WHERE provider_id = 'openrouter'"
+    )
+    connection.commit()
+    connection.close()
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-migration-test-abcd")
+    reopened = store_factory()
+
+    assert reopened.get_provider("openrouter")["platform_enabled"] is True
+    marker = reopened._get_connection().execute(
+        "SELECT migration_id FROM model_provider_migrations"
+    ).fetchone()
+    assert marker[0] == "openrouter-platform-key-v1"
+
+
+def test_legacy_migration_respects_admin_platform_disable(
+    store_factory, monkeypatch
+):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    store = store_factory()
+    provider = store.get_provider("openrouter")
+    store.upsert_provider_with_audit(
+        provider_id="openrouter",
+        display_name=provider["display_name"],
+        adapter_type=provider["adapter_type"],
+        approved_base_url=provider["approved_base_url"],
+        capabilities=provider["capabilities"],
+        byok_enabled=True,
+        platform_enabled=False,
+        status="enabled",
+        audit={
+            "actor_user_id": 11,
+            "operation": "upsert_provider",
+            "provider_id": "openrouter",
+            "source": "admin-console",
+            "reason": "Disable platform access for maintenance.",
+            "idempotency_key": "openrouter-disable-migration-test",
+        },
+    )
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-migration-test-abcd")
+    reopened = store_factory()
+
+    assert reopened.get_provider("openrouter")["platform_enabled"] is False
+    assert (
+        reopened._get_connection()
+        .execute("SELECT COUNT(*) FROM model_provider_migrations")
+        .fetchone()[0]
+        == 0
+    )
+
+
+def test_legacy_migration_does_not_override_existing_platform_credential(
+    store_factory, monkeypatch
+):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    store = store_factory()
+    provider = store.get_provider("openrouter")
+    store.upsert_provider(
+        provider_id="openrouter",
+        display_name=provider["display_name"],
+        adapter_type=provider["adapter_type"],
+        approved_base_url=provider["approved_base_url"],
+        capabilities=provider["capabilities"],
+        byok_enabled=True,
+        platform_enabled=False,
+        status="enabled",
+    )
+    store.upsert_platform_credential(
+        provider_id="openrouter",
+        secret="sk-or-existing-platform-abcd",
+        status="verified",
+    )
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-migration-test-wxyz")
+    reopened = store_factory()
+
+    assert reopened.get_provider("openrouter")["platform_enabled"] is False
+
+
 def test_platform_revoke_crypto_shreds_secret(store):
     store.upsert_platform_credential(
         provider_id="openai",

--- a/dashboard/backend/tests/test_model_credentials_api.py
+++ b/dashboard/backend/tests/test_model_credentials_api.py
@@ -43,6 +43,7 @@ class FakeAdapter:
 
 @pytest.fixture
 def credential_api(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     database_path = tmp_path / "model-credentials-api.db"
     users = users_module.UserStore(database_path)
     store = ModelProviderStore(database_path)


### PR DESCRIPTION
## Summary
- enable the seeded OpenRouter provider for the Platform Credits lane
- migrate legacy deployments when OPENROUTER_API_KEY is configured, without overriding explicit admin disables or stored platform credentials
- keep the API and frontend contracts secret-safe

## Validation
- 56 model provider domain tests passed
- 27 model credentials/admin/platform API tests passed
- 25 BYOK, Credits, and backtest frontend tests passed

No real API keys, local databases, or prohibited workspace files are included.