### PR TITLE
Add privacy-safe Admin Analytics foundation

### DIFF
--- a/dashboard/backend/api/rate_limit.py
+++ b/dashboard/backend/api/rate_limit.py
@@ -34,6 +34,11 @@ from typing import Callable, Deque, Dict
 
 from fastapi import HTTPException, Request
 
+from dashboard.backend.infrastructure.request_metadata import (
+    _MAX_IP_KEY_LEN,
+    client_ip,
+)
+
 
 class FixedWindowRateLimiter:
     """Sliding-window counter: at most ``max_events`` per ``window_seconds`` per key.
@@ -198,39 +203,6 @@ def rate_limited_error(
         detail=detail,
         headers={"Retry-After": str(limiter.retry_after_seconds(key))},
     )
-
-
-# Longest textual IPv6 form ("ffff:...:255.255.255.255%eth0" territory). The
-# forwarded header is attacker-controlled and unbounded, and an untruncated
-# value would let one client mint arbitrarily large dict keys.
-_MAX_IP_KEY_LEN = 64
-
-
-def client_ip(request: Request) -> str:
-    """Best-effort originating client IP.
-
-    Reads the left-most ``X-Forwarded-For`` entry before falling back to the
-    socket peer, because behind a PaaS router the peer is *the router* — the
-    same value for every visitor on earth, which collapses a per-client budget
-    into one shared site-wide budget.
-
-    uvicorn can do this itself, but only when the peer appears in
-    ``--forwarded-allow-ips``, which ``uvicorn.Config`` resolves to
-    ``os.environ["FORWARDED_ALLOW_IPS"]`` or ``"127.0.0.1"``. Prod sets that to
-    ``*`` so uvicorn now trusts Render's router too, but this module doesn't
-    rely on it: a launch-config var set in a dashboard nobody here can see is
-    not something to depend on, and dev/test never set it at all. Doing it
-    here keeps the behaviour independent of how the process happens to be
-    launched.
-
-    The header is trivially spoofable, so this is a granularity fix, not a
-    security control — see the module docstring.
-    """
-    for part in request.headers.get("x-forwarded-for", "").split(","):
-        candidate = part.strip()
-        if candidate:
-            return candidate[:_MAX_IP_KEY_LEN]
-    return request.client.host if request.client else "unknown"
 
 
 def client_key(request: Request) -> str:

--- a/dashboard/backend/api/router.py
+++ b/dashboard/backend/api/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from dashboard.backend.api.routers.agent_versions import router as agent_versions_router
 from dashboard.backend.api.routers.agents import router as agents_router
 from dashboard.backend.api.routers.algo import router as algo_router
+from dashboard.backend.api.routers.analytics import router as analytics_router
 from dashboard.backend.api.routers.admin_users import router as admin_users_router
 from dashboard.backend.api.auth import router as auth_router
 from dashboard.backend.api.routers.discord import router as discord_router
@@ -27,6 +28,7 @@ api_router.include_router(auth_router)
 api_router.include_router(admin_users_router)
 api_router.include_router(algo_router)
 api_router.include_router(agents_router)
+api_router.include_router(analytics_router)
 api_router.include_router(discord_router)
 api_router.include_router(credits_router)
 api_router.include_router(admin_credits_router)

--- a/dashboard/backend/api/routers/analytics.py
+++ b/dashboard/backend/api/routers/analytics.py
@@ -1,0 +1,125 @@
+"""Authenticated ingestion for privacy-reduced frontend Analytics events."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import ValidationError
+from starlette.concurrency import run_in_threadpool
+
+from dashboard.backend.api.auth import get_current_user
+from dashboard.backend.api.rate_limit import FixedWindowRateLimiter
+from dashboard.backend.domain.analytics.models import FrontendAnalyticsEvent
+from dashboard.backend.domain.analytics.privacy import request_analytics_context
+from dashboard.backend.domain.analytics.repository_common import (
+    AnalyticsIdempotencyConflictError,
+)
+from dashboard.backend.domain.analytics.service import (
+    AnalyticsService,
+    get_analytics_service,
+)
+
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+MAX_ANALYTICS_BODY_BYTES = 8 * 1024
+_ANALYTICS_INGESTION_LIMITER = FixedWindowRateLimiter(
+    max_events=120,
+    window_seconds=300,
+)
+
+
+def reset_analytics_ingestion_limiter() -> None:
+    _ANALYTICS_INGESTION_LIMITER.reset()
+
+
+def _limit_ingestion(user_id: int) -> None:
+    key = f"analytics-ingestion:{user_id}"
+    if _ANALYTICS_INGESTION_LIMITER.allow(key):
+        return
+    raise HTTPException(
+        status_code=429,
+        detail="Too many analytics events; please try again later.",
+        headers={
+            "Retry-After": str(
+                _ANALYTICS_INGESTION_LIMITER.retry_after_seconds(key)
+            )
+        },
+    )
+
+
+async def _parse_event(request: Request) -> FrontendAnalyticsEvent:
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > MAX_ANALYTICS_BODY_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail="Analytics event is too large.",
+                )
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid request.",
+            ) from None
+
+    chunks: list[bytes] = []
+    received = 0
+    async for chunk in request.stream():
+        received += len(chunk)
+        if received > MAX_ANALYTICS_BODY_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail="Analytics event is too large.",
+            )
+        chunks.append(chunk)
+
+    try:
+        payload = json.loads(b"".join(chunks))
+        if not isinstance(payload, dict):
+            raise ValueError("request body must be an object")
+        return FrontendAnalyticsEvent.model_validate(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError, ValueError):
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid analytics event.",
+        ) from None
+
+
+@router.post("/events", status_code=status.HTTP_202_ACCEPTED)
+async def ingest_analytics_event(
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+    service: AnalyticsService = Depends(get_analytics_service),
+):
+    user_id = int(current_user["id"])
+    _limit_ingestion(user_id)
+    payload = await _parse_event(request)
+    received_at = datetime.now(timezone.utc)
+    try:
+        context = request_analytics_context(request, received_at)
+        await run_in_threadpool(
+            service.accept_frontend_event,
+            user=current_user,
+            payload=payload,
+            context=context,
+            received_at=received_at,
+        )
+    except AnalyticsIdempotencyConflictError:
+        raise HTTPException(
+            status_code=409,
+            detail="Analytics event conflicts with a replay.",
+        ) from None
+    except (ValidationError, ValueError):
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid analytics event.",
+        ) from None
+    except Exception:
+        raise HTTPException(
+            status_code=503,
+            detail="Analytics is temporarily unavailable.",
+        ) from None
+    return {"accepted": True}

--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -235,6 +235,19 @@ async def startup_event():
         print(f"⚠️ legacy session sweep registration error: {e}")
 
     try:
+        from dashboard.backend.domain.analytics.retention import (
+            analytics_retention_coordinator,
+        )
+        from dashboard.backend.domain.runs.service import register_reaper_sweep
+        register_reaper_sweep(analytics_retention_coordinator.run_if_due)
+        print("🧹 Analytics retention sweep registered with the reaper")
+    except Exception as e:
+        print(
+            "WARNING: analytics.retention_registration_failed "
+            f"category={type(e).__name__}"
+        )
+
+    try:
         from dashboard.backend.domain.runs.service import start_reaper
         start_reaper()
         print("🧹 Run reaper started")

--- a/dashboard/backend/domain/analytics/__init__.py
+++ b/dashboard/backend/domain/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Privacy-safe first-party product analytics domain."""

--- a/dashboard/backend/domain/analytics/models.py
+++ b/dashboard/backend/domain/analytics/models.py
@@ -1,0 +1,400 @@
+"""Strict, versioned Analytics event models and property allowlists."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+ANALYTICS_SCHEMA_VERSION = 1
+MAX_PROPERTIES_BYTES = 1024
+
+ALLOWED_FRONTEND_EVENT_NAMES = {
+    "page_viewed",
+    "page_hidden",
+    "session_heartbeat",
+}
+ALLOWED_SERVER_EVENT_NAMES = {
+    "account_signed_up",
+    "authenticated_session_started",
+    "credential_saved",
+    "credential_verified",
+    "credential_defaulted",
+    "credential_reverified",
+    "credential_revoked",
+    "agent_created",
+    "agent_updated",
+    "agent_deleted",
+    "backtest_requested",
+    "backtest_queued",
+    "backtest_started",
+    "backtest_completed",
+    "backtest_failed",
+    "backtest_cancelled",
+    "model_usage_recorded",
+    "credits_reserved",
+    "credits_settled",
+    "credits_refunded",
+    "safe_error_recorded",
+}
+ALLOWED_EVENT_NAMES = ALLOWED_FRONTEND_EVENT_NAMES | ALLOWED_SERVER_EVENT_NAMES
+ALLOWED_PAGE_VIEWS = {
+    "home",
+    "agents",
+    "agent_editor",
+    "backtest",
+    "paper_trading",
+    "competition",
+    "community",
+    "credits",
+    "account",
+}
+ALLOWED_BILLING_MODES = {"byok", "platform_credits"}
+ALLOWED_OUTCOMES = {"succeeded", "failed", "cancelled"}
+ALLOWED_ERROR_CATEGORIES = {
+    "credential_invalid",
+    "credential_missing",
+    "provider_timeout",
+    "provider_unavailable",
+    "credits_unavailable",
+    "model_not_allowed",
+    "internal_error",
+}
+
+EVENT_GROUP_BY_NAME = {
+    "page_viewed": "experience",
+    "page_hidden": "experience",
+    "session_heartbeat": "experience",
+    "account_signed_up": "account",
+    "authenticated_session_started": "account",
+    "credential_saved": "credential",
+    "credential_verified": "credential",
+    "credential_defaulted": "credential",
+    "credential_reverified": "credential",
+    "credential_revoked": "credential",
+    "agent_created": "agent",
+    "agent_updated": "agent",
+    "agent_deleted": "agent",
+    "backtest_requested": "run",
+    "backtest_queued": "run",
+    "backtest_started": "run",
+    "backtest_completed": "run",
+    "backtest_failed": "run",
+    "backtest_cancelled": "run",
+    "model_usage_recorded": "resource",
+    "credits_reserved": "resource",
+    "credits_settled": "resource",
+    "credits_refunded": "resource",
+    "safe_error_recorded": "resource",
+}
+
+_EMPTY_SERVER_EVENTS = ALLOWED_SERVER_EVENT_NAMES - {
+    "model_usage_recorded",
+    "credits_reserved",
+    "credits_settled",
+    "credits_refunded",
+}
+_CREDIT_BUCKETS = {"grant", "purchased"}
+
+
+def _canonical_uuid(value: str, field_name: str) -> str:
+    try:
+        parsed = UUID(value)
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ValueError(f"{field_name} must be a canonical UUID") from exc
+    canonical = str(parsed)
+    if canonical != value.lower():
+        raise ValueError(f"{field_name} must be a canonical UUID")
+    return canonical
+
+
+def _bounded_properties(value: dict[str, Any]) -> dict[str, Any]:
+    try:
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("analytics properties must be JSON-safe") from exc
+    if len(encoded) > MAX_PROPERTIES_BYTES:
+        raise ValueError("analytics properties are too large")
+    return value
+
+
+def sanitize_frontend_properties(
+    event_name: str,
+    properties: object,
+) -> dict[str, Any]:
+    if event_name not in ALLOWED_FRONTEND_EVENT_NAMES:
+        raise ValueError("unknown frontend analytics event")
+    if not isinstance(properties, dict):
+        raise ValueError("analytics properties must be an object")
+    allowed_keys = set() if event_name == "page_viewed" else {"visible_ms"}
+    if set(properties) - allowed_keys:
+        raise ValueError("unknown frontend analytics property")
+    cleaned: dict[str, Any] = {}
+    if "visible_ms" in properties:
+        visible_ms = properties["visible_ms"]
+        if (
+            isinstance(visible_ms, bool)
+            or not isinstance(visible_ms, int)
+            or not 0 <= visible_ms <= 1_800_000
+        ):
+            raise ValueError("visible_ms must be an integer from 0 through 1800000")
+        cleaned["visible_ms"] = visible_ms
+    return _bounded_properties(cleaned)
+
+
+def _bounded_integer(
+    value: object,
+    field_name: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not minimum <= value <= maximum
+    ):
+        raise ValueError(
+            f"{field_name} must be an integer from {minimum} through {maximum}"
+        )
+    return value
+
+
+def sanitize_server_properties(
+    event_name: str,
+    properties: object,
+) -> dict[str, Any]:
+    if event_name not in ALLOWED_SERVER_EVENT_NAMES:
+        raise ValueError("unknown server analytics event")
+    if not isinstance(properties, dict):
+        raise ValueError("analytics properties must be an object")
+    if event_name in _EMPTY_SERVER_EVENTS:
+        if properties:
+            raise ValueError("server analytics event does not accept properties")
+        return {}
+    if event_name == "model_usage_recorded":
+        allowed = {"input_tokens", "output_tokens", "cost_micro_usd"}
+        if set(properties) != allowed:
+            raise ValueError("model usage properties are incomplete or unknown")
+        cleaned = {
+            "input_tokens": _bounded_integer(
+                properties["input_tokens"],
+                "input_tokens",
+                minimum=0,
+                maximum=2_000_000_000,
+            ),
+            "output_tokens": _bounded_integer(
+                properties["output_tokens"],
+                "output_tokens",
+                minimum=0,
+                maximum=2_000_000_000,
+            ),
+            "cost_micro_usd": _bounded_integer(
+                properties["cost_micro_usd"],
+                "cost_micro_usd",
+                minimum=0,
+                maximum=10_000_000_000,
+            ),
+        }
+        return _bounded_properties(cleaned)
+
+    allowed = {"amount_micro", "bucket"}
+    if set(properties) != allowed:
+        raise ValueError("Credits properties are incomplete or unknown")
+    bucket = properties["bucket"]
+    if not isinstance(bucket, str) or bucket not in _CREDIT_BUCKETS:
+        raise ValueError("bucket must be grant or purchased")
+    cleaned = {
+        "amount_micro": _bounded_integer(
+            properties["amount_micro"],
+            "amount_micro",
+            minimum=1,
+            maximum=10_000_000_000,
+        ),
+        "bucket": bucket,
+    }
+    return _bounded_properties(cleaned)
+
+
+class FrontendAnalyticsEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str = Field(min_length=36, max_length=36)
+    schema_version: Literal[1]
+    event_name: Literal["page_viewed", "page_hidden", "session_heartbeat"]
+    session_id: str = Field(min_length=36, max_length=36)
+    occurred_at: datetime
+    page_view: str = Field(min_length=1, max_length=64)
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("event_id", "session_id")
+    @classmethod
+    def validate_uuid(cls, value: str, info) -> str:
+        return _canonical_uuid(value, info.field_name)
+
+    @field_validator("occurred_at")
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("occurred_at must include a timezone")
+        return value
+
+    @field_validator("page_view")
+    @classmethod
+    def validate_page_view(cls, value: str) -> str:
+        if value not in ALLOWED_PAGE_VIEWS:
+            raise ValueError("unknown page view")
+        return value
+
+    @model_validator(mode="after")
+    def validate_properties(self) -> "FrontendAnalyticsEvent":
+        self.properties = sanitize_frontend_properties(
+            self.event_name,
+            self.properties,
+        )
+        return self
+
+
+class AnalyticsEventDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str = Field(min_length=36, max_length=36)
+    schema_version: Literal[1] = 1
+    event_name: str = Field(min_length=1, max_length=64)
+    user_id: int = Field(gt=0)
+    session_id: str | None = Field(default=None, min_length=36, max_length=36)
+    occurred_at: datetime
+    event_source: Literal["frontend", "server", "backfill"]
+    source_event_id: str | None = Field(default=None, min_length=1, max_length=200)
+    source_record_type: str | None = Field(default=None, min_length=1, max_length=64)
+    source_record_id: str | None = Field(default=None, min_length=1, max_length=200)
+    correlation_id: str | None = Field(default=None, min_length=1, max_length=200)
+    page_view: str | None = Field(default=None, min_length=1, max_length=64)
+    provider_id: str | None = Field(default=None, min_length=1, max_length=128)
+    model_id: str | None = Field(default=None, min_length=1, max_length=256)
+    billing_mode: str | None = Field(default=None, min_length=1, max_length=32)
+    outcome: str | None = Field(default=None, min_length=1, max_length=32)
+    error_category: str | None = Field(default=None, min_length=1, max_length=64)
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("event_id")
+    @classmethod
+    def validate_event_id(cls, value: str) -> str:
+        return _canonical_uuid(value, "event_id")
+
+    @field_validator("session_id")
+    @classmethod
+    def validate_session_id(cls, value: str | None) -> str | None:
+        return _canonical_uuid(value, "session_id") if value is not None else None
+
+    @field_validator("occurred_at")
+    @classmethod
+    def require_occurred_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("occurred_at must include a timezone")
+        return value
+
+    @field_validator("event_name")
+    @classmethod
+    def validate_event_name(cls, value: str) -> str:
+        if value not in ALLOWED_EVENT_NAMES:
+            raise ValueError("unknown analytics event")
+        return value
+
+    @model_validator(mode="after")
+    def validate_event_fields(self) -> "AnalyticsEventDraft":
+        if self.billing_mode is not None and self.billing_mode not in ALLOWED_BILLING_MODES:
+            raise ValueError("unknown billing mode")
+        if self.outcome is not None and self.outcome not in ALLOWED_OUTCOMES:
+            raise ValueError("unknown outcome")
+        if (
+            self.error_category is not None
+            and self.error_category not in ALLOWED_ERROR_CATEGORIES
+        ):
+            raise ValueError("unknown error category")
+        if self.page_view is not None and self.page_view not in ALLOWED_PAGE_VIEWS:
+            raise ValueError("unknown page view")
+        if self.event_source == "frontend":
+            if self.event_name not in ALLOWED_FRONTEND_EVENT_NAMES:
+                raise ValueError("frontend source cannot claim server event")
+            if self.source_event_id is not None:
+                raise ValueError("frontend event cannot set source_event_id")
+            self.properties = sanitize_frontend_properties(
+                self.event_name,
+                self.properties,
+            )
+        else:
+            if self.event_name not in ALLOWED_SERVER_EVENT_NAMES:
+                raise ValueError("server source cannot claim frontend event")
+            if self.source_event_id is None:
+                raise ValueError("server and backfill events require source_event_id")
+            self.properties = sanitize_server_properties(
+                self.event_name,
+                self.properties,
+            )
+        return self
+
+
+class AnalyticsEventRecord(AnalyticsEventDraft):
+    event_group: Literal[
+        "experience",
+        "account",
+        "credential",
+        "agent",
+        "run",
+        "resource",
+    ]
+    received_at: datetime
+    country_code: str | None = Field(default=None, pattern=r"^[A-Z]{2}$")
+    device_category: Literal["mobile", "tablet", "desktop", "unknown"] | None = None
+    browser_family: Literal["Edge", "Chrome", "Firefox", "Safari", "Other"] | None = None
+    network_hash: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
+
+    @field_validator("received_at")
+    @classmethod
+    def require_received_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("received_at must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def validate_event_group(self) -> "AnalyticsEventRecord":
+        if self.event_group != EVENT_GROUP_BY_NAME[self.event_name]:
+            raise ValueError("event group does not match event name")
+        return self
+
+
+class AppendEventResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event: AnalyticsEventRecord
+    created: bool
+
+
+class RetentionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    raw_events_deleted: int = Field(default=0, ge=0)
+    access_rows_deleted: int = Field(default=0, ge=0)
+    has_more_raw_events: bool = False
+    has_more_access_rows: bool = False
+
+
+class RequestAnalyticsContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    country_code: str | None = Field(default=None, pattern=r"^[A-Z]{2}$")
+    device_category: Literal["mobile", "tablet", "desktop", "unknown"]
+    browser_family: Literal["Edge", "Chrome", "Firefox", "Safari", "Other"]
+    network_hash: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")

--- a/dashboard/backend/domain/analytics/privacy.py
+++ b/dashboard/backend/domain/analytics/privacy.py
@@ -1,0 +1,108 @@
+"""Reduce request metadata to coarse, non-reversible Analytics dimensions."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import ipaddress
+import os
+import re
+from datetime import datetime, timezone
+
+from fastapi import Request
+
+from dashboard.backend.api.rate_limit import client_ip
+
+from .models import RequestAnalyticsContext
+
+
+_FALSE_VALUES = {"", "0", "false", "no", "off"}
+
+
+def _env_truthy(name: str) -> bool:
+    return (os.getenv(name) or "").strip().lower() not in _FALSE_VALUES
+
+
+def _normalized_ip(value: str | None) -> str | None:
+    if not value or value == "unknown":
+        return None
+    try:
+        return str(ipaddress.ip_address(value.strip()))
+    except ValueError:
+        return None
+
+
+def monthly_network_hash(
+    ip_address: str | None,
+    received_at: datetime,
+) -> str | None:
+    secret = (os.getenv("ANALYTICS_PSEUDONYMIZATION_KEY") or "").strip()
+    normalized_ip = _normalized_ip(ip_address)
+    if normalized_ip is None or len(secret.encode("utf-8")) < 32:
+        return None
+    month = received_at.astimezone(timezone.utc).strftime("%Y-%m")
+    message = f"{month}\n{normalized_ip}".encode("utf-8")
+    return hmac.new(
+        secret.encode("utf-8"),
+        message,
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _browser_family(user_agent: str) -> str:
+    if re.search(r"(?:Edg|Edge)/", user_agent, re.IGNORECASE):
+        return "Edge"
+    if re.search(r"(?:Firefox|FxiOS)/", user_agent, re.IGNORECASE):
+        return "Firefox"
+    if re.search(r"(?:Chrome|CriOS)/", user_agent, re.IGNORECASE):
+        return "Chrome"
+    if "Safari/" in user_agent and "Version/" in user_agent:
+        return "Safari"
+    return "Other"
+
+
+def _device_category(user_agent: str) -> str:
+    lowered = user_agent.lower()
+    if "ipad" in lowered or "tablet" in lowered:
+        return "tablet"
+    if any(token in lowered for token in ("iphone", "android", "mobile")):
+        return "mobile"
+    if any(
+        token in lowered
+        for token in (
+            "mozilla/",
+            "windows",
+            "macintosh",
+            "x11",
+            "linux",
+            "edg/",
+            "chrome/",
+            "firefox/",
+            "safari/",
+        )
+    ):
+        return "desktop"
+    return "unknown"
+
+
+def _trusted_country_code(request: Request) -> str | None:
+    raw: str | None = None
+    if _env_truthy("RENDER"):
+        raw = request.headers.get("cf-ipcountry")
+    elif _env_truthy("VERCEL"):
+        raw = request.headers.get("x-vercel-ip-country")
+    value = (raw or "").strip().upper()
+    return value if re.fullmatch(r"[A-Z]{2}", value) else None
+
+
+def request_analytics_context(
+    request: Request,
+    received_at: datetime,
+) -> RequestAnalyticsContext:
+    user_agent = (request.headers.get("user-agent") or "").strip()
+    return RequestAnalyticsContext(
+        country_code=_trusted_country_code(request),
+        device_category=_device_category(user_agent),
+        browser_family=_browser_family(user_agent),
+        network_hash=monthly_network_hash(client_ip(request), received_at),
+    )

--- a/dashboard/backend/domain/analytics/privacy.py
+++ b/dashboard/backend/domain/analytics/privacy.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 from fastapi import Request
 
-from dashboard.backend.api.rate_limit import client_ip
+from dashboard.backend.infrastructure.request_metadata import client_ip
 
 from .models import RequestAnalyticsContext
 

--- a/dashboard/backend/domain/analytics/repository.py
+++ b/dashboard/backend/domain/analytics/repository.py
@@ -1,0 +1,534 @@
+"""SQLite persistence for privacy-safe first-party Analytics data."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+from dashboard.backend.database import DB_PATH
+
+from .models import AnalyticsEventRecord, AppendEventResult, RetentionResult
+from .repository_common import (
+    AnalyticsIdempotencyConflictError,
+    AnalyticsStoreError,
+    canonical_event_payload,
+    decode_event_cursor,
+    encode_event_cursor,
+    positive_limit,
+    positive_user_id,
+    required_reason,
+    utc_iso,
+    utcnow_iso,
+    validate_access_section,
+)
+
+
+ANALYTICS_SQLITE_DDL = """
+CREATE TABLE IF NOT EXISTS analytics_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE CHECK (length(event_id) = 36),
+    schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+    event_name TEXT NOT NULL CHECK (length(event_name) BETWEEN 1 AND 64),
+    event_group TEXT NOT NULL
+        CHECK (event_group IN ('experience', 'account', 'credential', 'agent', 'run', 'resource')),
+    user_id INTEGER NOT NULL,
+    session_id TEXT CHECK (session_id IS NULL OR length(session_id) = 36),
+    occurred_at TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    event_source TEXT NOT NULL
+        CHECK (event_source IN ('frontend', 'server', 'backfill')),
+    source_event_id TEXT UNIQUE
+        CHECK (source_event_id IS NULL OR length(source_event_id) BETWEEN 1 AND 200),
+    source_record_type TEXT
+        CHECK (source_record_type IS NULL OR length(source_record_type) BETWEEN 1 AND 64),
+    source_record_id TEXT
+        CHECK (source_record_id IS NULL OR length(source_record_id) BETWEEN 1 AND 200),
+    correlation_id TEXT
+        CHECK (correlation_id IS NULL OR length(correlation_id) BETWEEN 1 AND 200),
+    page_view TEXT CHECK (page_view IS NULL OR length(page_view) BETWEEN 1 AND 64),
+    provider_id TEXT CHECK (provider_id IS NULL OR length(provider_id) BETWEEN 1 AND 128),
+    model_id TEXT CHECK (model_id IS NULL OR length(model_id) BETWEEN 1 AND 256),
+    billing_mode TEXT
+        CHECK (billing_mode IS NULL OR billing_mode IN ('byok', 'platform_credits')),
+    outcome TEXT
+        CHECK (outcome IS NULL OR outcome IN ('succeeded', 'failed', 'cancelled')),
+    error_category TEXT CHECK (
+        error_category IS NULL OR error_category IN (
+            'credential_invalid', 'credential_missing', 'provider_timeout',
+            'provider_unavailable', 'credits_unavailable',
+            'model_not_allowed', 'internal_error'
+        )
+    ),
+    country_code TEXT CHECK (country_code IS NULL OR length(country_code) = 2),
+    device_category TEXT CHECK (
+        device_category IS NULL OR device_category IN (
+            'mobile', 'tablet', 'desktop', 'unknown'
+        )
+    ),
+    browser_family TEXT CHECK (
+        browser_family IS NULL OR browser_family IN (
+            'Edge', 'Chrome', 'Firefox', 'Safari', 'Other'
+        )
+    ),
+    network_hash TEXT CHECK (network_hash IS NULL OR length(network_hash) = 64),
+    properties_json TEXT NOT NULL DEFAULT '{}'
+        CHECK (length(properties_json) <= 1024),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_user_time
+    ON analytics_events(user_id, occurred_at DESC, sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_name_time
+    ON analytics_events(event_name, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_session_time
+    ON analytics_events(session_id, occurred_at DESC)
+    WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_analytics_events_outcome_time
+    ON analytics_events(outcome, occurred_at DESC)
+    WHERE outcome IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_analytics_events_error_time
+    ON analytics_events(error_category, occurred_at DESC)
+    WHERE error_category IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS analytics_daily_rollups (
+    rollup_date TEXT NOT NULL CHECK (length(rollup_date) = 10),
+    metric_name TEXT NOT NULL CHECK (length(metric_name) BETWEEN 1 AND 64),
+    event_name TEXT NOT NULL DEFAULT '' CHECK (length(event_name) <= 64),
+    billing_mode TEXT NOT NULL DEFAULT '' CHECK (length(billing_mode) <= 32),
+    provider_id TEXT NOT NULL DEFAULT '' CHECK (length(provider_id) <= 128),
+    model_id TEXT NOT NULL DEFAULT '' CHECK (length(model_id) <= 256),
+    outcome TEXT NOT NULL DEFAULT '' CHECK (length(outcome) <= 32),
+    error_category TEXT NOT NULL DEFAULT '' CHECK (length(error_category) <= 64),
+    user_state TEXT NOT NULL DEFAULT '' CHECK (length(user_state) <= 32),
+    value_count INTEGER NOT NULL DEFAULT 0 CHECK (value_count >= 0),
+    value_sum_micro INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (
+        rollup_date, metric_name, event_name, billing_mode, provider_id,
+        model_id, outcome, error_category, user_state
+    )
+);
+
+CREATE TABLE IF NOT EXISTS user_analytics_snapshots (
+    user_id INTEGER PRIMARY KEY,
+    status TEXT NOT NULL CHECK (
+        status IN ('blocked', 'needs_attention', 'dormant', 'onboarding', 'active')
+    ),
+    reason_code TEXT NOT NULL CHECK (length(reason_code) BETWEEN 1 AND 100),
+    human_readable_reason TEXT NOT NULL
+        CHECK (length(human_readable_reason) BETWEEN 1 AND 500),
+    evidence_event_ids_json TEXT NOT NULL DEFAULT '[]'
+        CHECK (length(evidence_event_ids_json) <= 4096),
+    calculated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS analytics_subject_settings (
+    user_id INTEGER PRIMARY KEY,
+    excluded INTEGER NOT NULL CHECK (excluded IN (0, 1)),
+    actor_user_id INTEGER NOT NULL,
+    reason TEXT NOT NULL CHECK (length(reason) BETWEEN 1 AND 500),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (actor_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS admin_analytics_access_log (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    admin_user_id INTEGER NOT NULL,
+    subject_user_id INTEGER NOT NULL,
+    section TEXT NOT NULL CHECK (
+        section IN ('overview', 'timeline', 'runs', 'usage', 'sessions')
+    ),
+    accessed_at TEXT NOT NULL,
+    FOREIGN KEY (admin_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    FOREIGN KEY (subject_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_analytics_access_subject_time
+    ON admin_analytics_access_log(subject_user_id, accessed_at DESC, sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_analytics_access_admin_time
+    ON admin_analytics_access_log(admin_user_id, accessed_at DESC, sequence DESC);
+"""
+
+
+_EVENT_COLUMNS = (
+    "event_id",
+    "schema_version",
+    "event_name",
+    "event_group",
+    "user_id",
+    "session_id",
+    "occurred_at",
+    "received_at",
+    "event_source",
+    "source_event_id",
+    "source_record_type",
+    "source_record_id",
+    "correlation_id",
+    "page_view",
+    "provider_id",
+    "model_id",
+    "billing_mode",
+    "outcome",
+    "error_category",
+    "country_code",
+    "device_category",
+    "browser_family",
+    "network_hash",
+    "properties_json",
+)
+
+
+def _event_values(event: AnalyticsEventRecord) -> tuple[object, ...]:
+    data = event.model_dump(mode="json")
+    data["occurred_at"] = utc_iso(event.occurred_at)
+    data["received_at"] = utc_iso(event.received_at)
+    data["properties_json"] = json.dumps(
+        event.properties,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return tuple(data.get(column) for column in _EVENT_COLUMNS)
+
+
+def _row_to_event(row: sqlite3.Row | dict[str, Any]) -> AnalyticsEventRecord:
+    data = dict(row)
+    data.pop("sequence", None)
+    raw_properties = data.pop("properties_json", "{}")
+    try:
+        properties = json.loads(raw_properties)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise AnalyticsStoreError("stored Analytics properties are invalid") from exc
+    data["properties"] = properties
+    return AnalyticsEventRecord.model_validate(data)
+
+
+class AnalyticsStore:
+    """Account-scoped Analytics persistence backed by SQLite."""
+
+    def __init__(self, db_path: Path | str | None = None):
+        self.db_path = Path(db_path or DB_PATH)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    @contextmanager
+    def _get_connection(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(str(self.db_path), timeout=30)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        try:
+            with conn:
+                yield conn
+        finally:
+            conn.close()
+
+    def _init_schema(self) -> None:
+        with self._get_connection() as conn:
+            conn.executescript(ANALYTICS_SQLITE_DDL)
+
+    @staticmethod
+    def _existing_rows_for_event(
+        conn: sqlite3.Connection,
+        event: AnalyticsEventRecord,
+    ) -> tuple[sqlite3.Row | None, sqlite3.Row | None]:
+        by_event = conn.execute(
+            "SELECT * FROM analytics_events WHERE event_id = ?",
+            (event.event_id,),
+        ).fetchone()
+        by_source = None
+        if event.source_event_id is not None:
+            by_source = conn.execute(
+                "SELECT * FROM analytics_events WHERE source_event_id = ?",
+                (event.source_event_id,),
+            ).fetchone()
+        return by_event, by_source
+
+    def append_event(self, event: AnalyticsEventRecord) -> AppendEventResult:
+        if not isinstance(event, AnalyticsEventRecord):
+            event = AnalyticsEventRecord.model_validate(event)
+        placeholders = ", ".join("?" for _ in _EVENT_COLUMNS)
+        columns = ", ".join(_EVENT_COLUMNS)
+        with self._get_connection() as conn:
+            try:
+                cursor = conn.execute(
+                    f"INSERT INTO analytics_events ({columns}) VALUES ({placeholders})",
+                    _event_values(event),
+                )
+            except sqlite3.IntegrityError as exc:
+                by_event, by_source = self._existing_rows_for_event(conn, event)
+                if (
+                    by_event is not None
+                    and by_source is not None
+                    and int(by_event["sequence"]) != int(by_source["sequence"])
+                ):
+                    raise AnalyticsIdempotencyConflictError(
+                        "analytics event idempotency conflict"
+                    ) from None
+                existing_row = by_source or by_event
+                if existing_row is None:
+                    raise AnalyticsStoreError(
+                        "Analytics event could not be persisted"
+                    ) from None
+                existing = _row_to_event(existing_row)
+                ignore_event_id = by_source is not None
+                if canonical_event_payload(
+                    existing,
+                    ignore_event_id=ignore_event_id,
+                ) != canonical_event_payload(
+                    event,
+                    ignore_event_id=ignore_event_id,
+                ):
+                    raise AnalyticsIdempotencyConflictError(
+                        "analytics event idempotency conflict"
+                    ) from None
+                return AppendEventResult(event=existing, created=False)
+
+            row = conn.execute(
+                "SELECT * FROM analytics_events WHERE sequence = ?",
+                (int(cursor.lastrowid),),
+            ).fetchone()
+            if row is None:
+                raise AnalyticsStoreError("Analytics event could not be loaded")
+            return AppendEventResult(event=_row_to_event(row), created=True)
+
+    def get_event(self, event_id: str) -> AnalyticsEventRecord | None:
+        if not isinstance(event_id, str) or len(event_id) != 36:
+            raise ValueError("event_id must be a canonical UUID")
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM analytics_events WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+        return _row_to_event(row) if row is not None else None
+
+    def list_user_events(
+        self,
+        user_id: int,
+        *,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        subject_id = positive_user_id(user_id)
+        page_size = positive_limit(limit)
+        params: list[object] = [subject_id]
+        cursor_sql = ""
+        if cursor is not None:
+            occurred_at, sequence = decode_event_cursor(cursor)
+            cursor_sql = (
+                "AND (occurred_at < ? OR (occurred_at = ? AND sequence < ?))"
+            )
+            params.extend([occurred_at, occurred_at, sequence])
+        params.append(page_size + 1)
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT * FROM analytics_events
+                WHERE user_id = ? {cursor_sql}
+                ORDER BY occurred_at DESC, sequence DESC
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+        has_more = len(rows) > page_size
+        page_rows = rows[:page_size]
+        next_cursor = None
+        if has_more and page_rows:
+            last = page_rows[-1]
+            next_cursor = encode_event_cursor(
+                str(last["occurred_at"]),
+                int(last["sequence"]),
+            )
+        return {
+            "items": [_row_to_event(row) for row in page_rows],
+            "next_cursor": next_cursor,
+        }
+
+    def set_subject_exclusion(
+        self,
+        user_id: int,
+        *,
+        excluded: bool,
+        actor_user_id: int,
+        reason: str,
+    ) -> dict[str, Any]:
+        subject_id = positive_user_id(user_id)
+        actor_id = positive_user_id(actor_user_id, "actor_user_id")
+        if not isinstance(excluded, bool):
+            raise ValueError("excluded must be a boolean")
+        safe_reason = required_reason(reason)
+        now = utcnow_iso()
+        with self._get_connection() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO analytics_subject_settings (
+                        user_id, excluded, actor_user_id, reason, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(user_id) DO UPDATE SET
+                        excluded = excluded.excluded,
+                        actor_user_id = excluded.actor_user_id,
+                        reason = excluded.reason,
+                        updated_at = excluded.updated_at
+                    """,
+                    (subject_id, int(excluded), actor_id, safe_reason, now, now),
+                )
+            except sqlite3.IntegrityError:
+                raise AnalyticsStoreError(
+                    "Analytics subject setting could not be persisted"
+                ) from None
+            row = conn.execute(
+                "SELECT * FROM analytics_subject_settings WHERE user_id = ?",
+                (subject_id,),
+            ).fetchone()
+        if row is None:
+            raise AnalyticsStoreError("Analytics subject setting could not be loaded")
+        result = dict(row)
+        result["excluded"] = bool(result["excluded"])
+        return result
+
+    def get_subject_setting(self, user_id: int) -> dict[str, Any] | None:
+        subject_id = positive_user_id(user_id)
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM analytics_subject_settings WHERE user_id = ?",
+                (subject_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["excluded"] = bool(result["excluded"])
+        return result
+
+    def list_excluded_user_ids(
+        self,
+        *,
+        include_admin_accounts: bool = True,
+    ) -> set[int]:
+        if not isinstance(include_admin_accounts, bool):
+            raise ValueError("include_admin_accounts must be a boolean")
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT user_id FROM analytics_subject_settings WHERE excluded = 1"
+            ).fetchall()
+            excluded = {int(row["user_id"]) for row in rows}
+            if include_admin_accounts:
+                admin_rows = conn.execute(
+                    "SELECT id FROM users WHERE role = 'admin'"
+                ).fetchall()
+                excluded.update(int(row["id"]) for row in admin_rows)
+        return excluded
+
+    def record_admin_access(
+        self,
+        admin_user_id: int,
+        subject_user_id: int,
+        section: str,
+    ) -> dict[str, Any]:
+        admin_id = positive_user_id(admin_user_id, "admin_user_id")
+        subject_id = positive_user_id(subject_user_id, "subject_user_id")
+        safe_section = validate_access_section(section)
+        accessed_at = utcnow_iso()
+        with self._get_connection() as conn:
+            try:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO admin_analytics_access_log (
+                        admin_user_id, subject_user_id, section, accessed_at
+                    ) VALUES (?, ?, ?, ?)
+                    """,
+                    (admin_id, subject_id, safe_section, accessed_at),
+                )
+            except sqlite3.IntegrityError:
+                raise AnalyticsStoreError(
+                    "Admin Analytics access could not be recorded"
+                ) from None
+            row = conn.execute(
+                "SELECT * FROM admin_analytics_access_log WHERE sequence = ?",
+                (int(cursor.lastrowid),),
+            ).fetchone()
+        if row is None:
+            raise AnalyticsStoreError("Admin Analytics access could not be loaded")
+        return dict(row)
+
+    def list_admin_access(
+        self,
+        subject_user_id: int,
+        *,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        subject_id = positive_user_id(subject_user_id, "subject_user_id")
+        page_size = positive_limit(limit)
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM admin_analytics_access_log
+                WHERE subject_user_id = ?
+                ORDER BY accessed_at DESC, sequence DESC
+                LIMIT ?
+                """,
+                (subject_id, page_size),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def delete_expired(
+        self,
+        *,
+        raw_before: datetime,
+        access_before: datetime,
+        batch_size: int,
+    ) -> RetentionResult:
+        if (
+            isinstance(batch_size, bool)
+            or not isinstance(batch_size, int)
+            or not 1 <= batch_size <= 10_000
+        ):
+            raise ValueError("batch_size must be an integer from 1 through 10000")
+        raw_cutoff = utc_iso(raw_before)
+        access_cutoff = utc_iso(access_before)
+        with self._get_connection() as conn:
+            raw_cursor = conn.execute(
+                """
+                DELETE FROM analytics_events
+                WHERE sequence IN (
+                    SELECT sequence FROM analytics_events
+                    WHERE received_at < ?
+                    ORDER BY received_at, sequence
+                    LIMIT ?
+                )
+                """,
+                (raw_cutoff, batch_size),
+            )
+            access_cursor = conn.execute(
+                """
+                DELETE FROM admin_analytics_access_log
+                WHERE sequence IN (
+                    SELECT sequence FROM admin_analytics_access_log
+                    WHERE accessed_at < ?
+                    ORDER BY accessed_at, sequence
+                    LIMIT ?
+                )
+                """,
+                (access_cutoff, batch_size),
+            )
+            has_more_raw = conn.execute(
+                "SELECT 1 FROM analytics_events WHERE received_at < ? LIMIT 1",
+                (raw_cutoff,),
+            ).fetchone()
+            has_more_access = conn.execute(
+                "SELECT 1 FROM admin_analytics_access_log WHERE accessed_at < ? LIMIT 1",
+                (access_cutoff,),
+            ).fetchone()
+        return RetentionResult(
+            raw_events_deleted=max(0, int(raw_cursor.rowcount)),
+            access_rows_deleted=max(0, int(access_cursor.rowcount)),
+            has_more_raw_events=has_more_raw is not None,
+            has_more_access_rows=has_more_access is not None,
+        )

--- a/dashboard/backend/domain/analytics/repository_common.py
+++ b/dashboard/backend/domain/analytics/repository_common.py
@@ -1,0 +1,121 @@
+"""Shared validation and cursor helpers for Analytics repositories."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from datetime import datetime, timezone
+
+from .models import AnalyticsEventRecord
+
+
+class AnalyticsStoreError(RuntimeError):
+    """Base class for safe, expected Analytics persistence failures."""
+
+
+class AnalyticsIdempotencyConflictError(AnalyticsStoreError):
+    """An event idempotency key was replayed with different safe data."""
+
+
+def utc_iso(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("analytics timestamp must include a timezone")
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def utcnow_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def positive_user_id(value: object, name: str = "user_id") -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def positive_limit(value: object, *, maximum: int = 100) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= maximum
+    ):
+        raise ValueError(f"limit must be an integer from 1 through {maximum}")
+    return value
+
+
+def required_reason(value: object) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValueError("reason must be a trimmed non-empty string")
+    if len(value) > 500:
+        raise ValueError("reason must be at most 500 characters")
+    return value
+
+
+def validate_access_section(value: object) -> str:
+    allowed = {"overview", "timeline", "runs", "usage", "sessions"}
+    if not isinstance(value, str) or value not in allowed:
+        raise ValueError("section must be a supported Analytics profile section")
+    return value
+
+
+def encode_event_cursor(occurred_at: str, sequence: int) -> str:
+    if not isinstance(occurred_at, str) or not occurred_at or len(occurred_at) > 64:
+        raise ValueError("invalid analytics cursor")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence <= 0:
+        raise ValueError("invalid analytics cursor")
+    payload = json.dumps(
+        [occurred_at, sequence],
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def decode_event_cursor(cursor: str) -> tuple[str, int]:
+    if not isinstance(cursor, str) or not cursor or len(cursor) > 256:
+        raise ValueError("invalid analytics cursor")
+    try:
+        raw = base64.b64decode(
+            cursor + "=" * (-len(cursor) % 4),
+            altchars=b"-_",
+            validate=True,
+        )
+        value = json.loads(raw.decode("utf-8"))
+    except (ValueError, binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid analytics cursor") from exc
+    if not isinstance(value, list) or len(value) != 2:
+        raise ValueError("invalid analytics cursor")
+    occurred_at, sequence = value
+    if (
+        not isinstance(occurred_at, str)
+        or not occurred_at
+        or len(occurred_at) > 64
+        or isinstance(sequence, bool)
+        or not isinstance(sequence, int)
+        or sequence <= 0
+    ):
+        raise ValueError("invalid analytics cursor")
+    return occurred_at, sequence
+
+
+def canonical_event_payload(
+    event: AnalyticsEventRecord,
+    *,
+    ignore_event_id: bool = False,
+) -> dict[str, object]:
+    value = event.model_dump(mode="json")
+    value["occurred_at"] = utc_iso(event.occurred_at)
+    value.pop("received_at", None)
+    if ignore_event_id:
+        value.pop("event_id", None)
+    value["properties"] = json.loads(
+        json.dumps(
+            value["properties"],
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    )
+    return value

--- a/dashboard/backend/domain/analytics/repository_postgres.py
+++ b/dashboard/backend/domain/analytics/repository_postgres.py
@@ -1,19 +1,16 @@
-"""SQLite persistence for privacy-safe first-party Analytics data."""
+"""PostgreSQL twin of the privacy-safe Analytics repository."""
 
 from __future__ import annotations
 
-import json
-import os
-import sqlite3
-from contextlib import contextmanager
 from datetime import datetime
-from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
-from dashboard.backend.database import DB_PATH
-from dashboard.backend.db_url import describe_database_url
+import psycopg
+
+from dashboard.backend.db_url import require_postgres_url
 
 from .models import AnalyticsEventRecord, AppendEventResult, RetentionResult
+from .repository import _EVENT_COLUMNS, _event_values, _row_to_event
 from .repository_common import (
     AnalyticsIdempotencyConflictError,
     AnalyticsStoreError,
@@ -29,15 +26,15 @@ from .repository_common import (
 )
 
 
-ANALYTICS_SQLITE_DDL = """
+ANALYTICS_POSTGRES_DDL = """
 CREATE TABLE IF NOT EXISTS analytics_events (
-    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    sequence BIGSERIAL PRIMARY KEY,
     event_id TEXT NOT NULL UNIQUE CHECK (length(event_id) = 36),
     schema_version INTEGER NOT NULL CHECK (schema_version = 1),
     event_name TEXT NOT NULL CHECK (length(event_name) BETWEEN 1 AND 64),
     event_group TEXT NOT NULL
         CHECK (event_group IN ('experience', 'account', 'credential', 'agent', 'run', 'resource')),
-    user_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     session_id TEXT CHECK (session_id IS NULL OR length(session_id) = 36),
     occurred_at TEXT NOT NULL,
     received_at TEXT NOT NULL,
@@ -78,8 +75,7 @@ CREATE TABLE IF NOT EXISTS analytics_events (
     ),
     network_hash TEXT CHECK (network_hash IS NULL OR length(network_hash) = 64),
     properties_json TEXT NOT NULL DEFAULT '{}'
-        CHECK (length(properties_json) <= 1024),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        CHECK (length(properties_json) <= 1024)
 );
 
 CREATE INDEX IF NOT EXISTS idx_analytics_events_user_time
@@ -106,8 +102,8 @@ CREATE TABLE IF NOT EXISTS analytics_daily_rollups (
     outcome TEXT NOT NULL DEFAULT '' CHECK (length(outcome) <= 32),
     error_category TEXT NOT NULL DEFAULT '' CHECK (length(error_category) <= 64),
     user_state TEXT NOT NULL DEFAULT '' CHECK (length(user_state) <= 32),
-    value_count INTEGER NOT NULL DEFAULT 0 CHECK (value_count >= 0),
-    value_sum_micro INTEGER NOT NULL DEFAULT 0,
+    value_count BIGINT NOT NULL DEFAULT 0 CHECK (value_count >= 0),
+    value_sum_micro BIGINT NOT NULL DEFAULT 0,
     updated_at TEXT NOT NULL,
     PRIMARY KEY (
         rollup_date, metric_name, event_name, billing_mode, provider_id,
@@ -116,7 +112,7 @@ CREATE TABLE IF NOT EXISTS analytics_daily_rollups (
 );
 
 CREATE TABLE IF NOT EXISTS user_analytics_snapshots (
-    user_id INTEGER PRIMARY KEY,
+    user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
     status TEXT NOT NULL CHECK (
         status IN ('blocked', 'needs_attention', 'dormant', 'onboarding', 'active')
     ),
@@ -125,31 +121,26 @@ CREATE TABLE IF NOT EXISTS user_analytics_snapshots (
         CHECK (length(human_readable_reason) BETWEEN 1 AND 500),
     evidence_event_ids_json TEXT NOT NULL DEFAULT '[]'
         CHECK (length(evidence_event_ids_json) <= 4096),
-    calculated_at TEXT NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    calculated_at TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS analytics_subject_settings (
-    user_id INTEGER PRIMARY KEY,
-    excluded INTEGER NOT NULL CHECK (excluded IN (0, 1)),
-    actor_user_id INTEGER NOT NULL,
+    user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    excluded BOOLEAN NOT NULL,
+    actor_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
     reason TEXT NOT NULL CHECK (length(reason) BETWEEN 1 AND 500),
     created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (actor_user_id) REFERENCES users(id) ON DELETE RESTRICT
+    updated_at TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS admin_analytics_access_log (
-    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
-    admin_user_id INTEGER NOT NULL,
-    subject_user_id INTEGER NOT NULL,
+    sequence BIGSERIAL PRIMARY KEY,
+    admin_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    subject_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
     section TEXT NOT NULL CHECK (
         section IN ('overview', 'timeline', 'runs', 'usage', 'sessions')
     ),
-    accessed_at TEXT NOT NULL,
-    FOREIGN KEY (admin_user_id) REFERENCES users(id) ON DELETE RESTRICT,
-    FOREIGN KEY (subject_user_id) REFERENCES users(id) ON DELETE RESTRICT
+    accessed_at TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_admin_analytics_access_subject_time
@@ -159,113 +150,69 @@ CREATE INDEX IF NOT EXISTS idx_admin_analytics_access_admin_time
 """
 
 
-_EVENT_COLUMNS = (
-    "event_id",
-    "schema_version",
-    "event_name",
-    "event_group",
-    "user_id",
-    "session_id",
-    "occurred_at",
-    "received_at",
-    "event_source",
-    "source_event_id",
-    "source_record_type",
-    "source_record_id",
-    "correlation_id",
-    "page_view",
-    "provider_id",
-    "model_id",
-    "billing_mode",
-    "outcome",
-    "error_category",
-    "country_code",
-    "device_category",
-    "browser_family",
-    "network_hash",
-    "properties_json",
-)
+class PostgresAnalyticsStore:
+    """Account-scoped Analytics persistence backed by PostgreSQL."""
 
-
-def _event_values(event: AnalyticsEventRecord) -> tuple[object, ...]:
-    data = event.model_dump(mode="json")
-    data["occurred_at"] = utc_iso(event.occurred_at)
-    data["received_at"] = utc_iso(event.received_at)
-    data["properties_json"] = json.dumps(
-        event.properties,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
-        allow_nan=False,
-    )
-    return tuple(data.get(column) for column in _EVENT_COLUMNS)
-
-
-def _row_to_event(row: sqlite3.Row | dict[str, Any]) -> AnalyticsEventRecord:
-    data = dict(row)
-    data.pop("sequence", None)
-    raw_properties = data.pop("properties_json", "{}")
-    try:
-        properties = json.loads(raw_properties)
-    except (TypeError, json.JSONDecodeError) as exc:
-        raise AnalyticsStoreError("stored Analytics properties are invalid") from exc
-    data["properties"] = properties
-    return AnalyticsEventRecord.model_validate(data)
-
-
-class AnalyticsStore:
-    """Account-scoped Analytics persistence backed by SQLite."""
-
-    def __init__(self, db_path: Path | str | None = None):
-        self.db_path = Path(db_path or DB_PATH)
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+    def __init__(self, database_url: str):
+        self.database_url = require_postgres_url(database_url)
         self._init_schema()
 
-    @contextmanager
-    def _get_connection(self) -> Iterator[sqlite3.Connection]:
-        conn = sqlite3.connect(str(self.db_path), timeout=30)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA foreign_keys = ON")
-        try:
-            with conn:
-                yield conn
-        finally:
-            conn.close()
+    def _get_connection(self):
+        from dashboard.backend.db_pool import get_pool
+
+        return get_pool(self.database_url).connection()
 
     def _init_schema(self) -> None:
         with self._get_connection() as conn:
-            conn.executescript(ANALYTICS_SQLITE_DDL)
+            with conn.cursor() as cur:
+                cur.execute(ANALYTICS_POSTGRES_DDL)
 
     @staticmethod
-    def _existing_rows_for_event(
-        conn: sqlite3.Connection,
-        event: AnalyticsEventRecord,
-    ) -> tuple[sqlite3.Row | None, sqlite3.Row | None]:
-        by_event = conn.execute(
-            "SELECT * FROM analytics_events WHERE event_id = ?",
-            (event.event_id,),
-        ).fetchone()
-        by_source = None
-        if event.source_event_id is not None:
-            by_source = conn.execute(
-                "SELECT * FROM analytics_events WHERE source_event_id = ?",
-                (event.source_event_id,),
-            ).fetchone()
-        return by_event, by_source
+    def _select_event(cur, field: str, value: str | None):
+        if value is None:
+            return None
+        if field not in {"event_id", "source_event_id"}:
+            raise ValueError("unsupported Analytics event lookup")
+        cur.execute(
+            f"SELECT * FROM analytics_events WHERE {field} = %s",
+            (value,),
+        )
+        return cur.fetchone()
 
     def append_event(self, event: AnalyticsEventRecord) -> AppendEventResult:
         if not isinstance(event, AnalyticsEventRecord):
             event = AnalyticsEventRecord.model_validate(event)
-        placeholders = ", ".join("?" for _ in _EVENT_COLUMNS)
         columns = ", ".join(_EVENT_COLUMNS)
+        placeholders = ", ".join("%s" for _ in _EVENT_COLUMNS)
         with self._get_connection() as conn:
-            try:
-                cursor = conn.execute(
-                    f"INSERT INTO analytics_events ({columns}) VALUES ({placeholders})",
-                    _event_values(event),
+            with conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        f"""
+                        INSERT INTO analytics_events ({columns})
+                        VALUES ({placeholders})
+                        ON CONFLICT DO NOTHING
+                        RETURNING *
+                        """,
+                        _event_values(event),
+                    )
+                except psycopg.IntegrityError:
+                    raise AnalyticsStoreError(
+                        "Analytics event could not be persisted"
+                    ) from None
+                created_row = cur.fetchone()
+                if created_row is not None:
+                    return AppendEventResult(
+                        event=_row_to_event(created_row),
+                        created=True,
+                    )
+
+                by_event = self._select_event(cur, "event_id", event.event_id)
+                by_source = self._select_event(
+                    cur,
+                    "source_event_id",
+                    event.source_event_id,
                 )
-            except sqlite3.IntegrityError as exc:
-                by_event, by_source = self._existing_rows_for_event(conn, event)
                 if (
                     by_event is not None
                     and by_source is not None
@@ -273,12 +220,12 @@ class AnalyticsStore:
                 ):
                     raise AnalyticsIdempotencyConflictError(
                         "analytics event idempotency conflict"
-                    ) from None
+                    )
                 existing_row = by_source or by_event
                 if existing_row is None:
                     raise AnalyticsStoreError(
                         "Analytics event could not be persisted"
-                    ) from None
+                    )
                 existing = _row_to_event(existing_row)
                 ignore_event_id = by_source is not None
                 if canonical_event_payload(
@@ -290,25 +237,19 @@ class AnalyticsStore:
                 ):
                     raise AnalyticsIdempotencyConflictError(
                         "analytics event idempotency conflict"
-                    ) from None
+                    )
                 return AppendEventResult(event=existing, created=False)
-
-            row = conn.execute(
-                "SELECT * FROM analytics_events WHERE sequence = ?",
-                (int(cursor.lastrowid),),
-            ).fetchone()
-            if row is None:
-                raise AnalyticsStoreError("Analytics event could not be loaded")
-            return AppendEventResult(event=_row_to_event(row), created=True)
 
     def get_event(self, event_id: str) -> AnalyticsEventRecord | None:
         if not isinstance(event_id, str) or len(event_id) != 36:
             raise ValueError("event_id must be a canonical UUID")
         with self._get_connection() as conn:
-            row = conn.execute(
-                "SELECT * FROM analytics_events WHERE event_id = ?",
-                (event_id,),
-            ).fetchone()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM analytics_events WHERE event_id = %s",
+                    (event_id,),
+                )
+                row = cur.fetchone()
         return _row_to_event(row) if row is not None else None
 
     def list_user_events(
@@ -324,21 +265,21 @@ class AnalyticsStore:
         cursor_sql = ""
         if cursor is not None:
             occurred_at, sequence = decode_event_cursor(cursor)
-            cursor_sql = (
-                "AND (occurred_at < ? OR (occurred_at = ? AND sequence < ?))"
-            )
-            params.extend([occurred_at, occurred_at, sequence])
+            cursor_sql = "AND (occurred_at, sequence) < (%s, %s)"
+            params.extend([occurred_at, sequence])
         params.append(page_size + 1)
         with self._get_connection() as conn:
-            rows = conn.execute(
-                f"""
-                SELECT * FROM analytics_events
-                WHERE user_id = ? {cursor_sql}
-                ORDER BY occurred_at DESC, sequence DESC
-                LIMIT ?
-                """,
-                params,
-            ).fetchall()
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT * FROM analytics_events
+                    WHERE user_id = %s {cursor_sql}
+                    ORDER BY occurred_at DESC, sequence DESC
+                    LIMIT %s
+                    """,
+                    params,
+                )
+                rows = cur.fetchall()
         has_more = len(rows) > page_size
         page_rows = rows[:page_size]
         next_cursor = None
@@ -368,28 +309,28 @@ class AnalyticsStore:
         safe_reason = required_reason(reason)
         now = utcnow_iso()
         with self._get_connection() as conn:
-            try:
-                conn.execute(
-                    """
-                    INSERT INTO analytics_subject_settings (
-                        user_id, excluded, actor_user_id, reason, created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?)
-                    ON CONFLICT(user_id) DO UPDATE SET
-                        excluded = excluded.excluded,
-                        actor_user_id = excluded.actor_user_id,
-                        reason = excluded.reason,
-                        updated_at = excluded.updated_at
-                    """,
-                    (subject_id, int(excluded), actor_id, safe_reason, now, now),
-                )
-            except sqlite3.IntegrityError:
-                raise AnalyticsStoreError(
-                    "Analytics subject setting could not be persisted"
-                ) from None
-            row = conn.execute(
-                "SELECT * FROM analytics_subject_settings WHERE user_id = ?",
-                (subject_id,),
-            ).fetchone()
+            with conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        """
+                        INSERT INTO analytics_subject_settings (
+                            user_id, excluded, actor_user_id, reason,
+                            created_at, updated_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s)
+                        ON CONFLICT(user_id) DO UPDATE SET
+                            excluded = EXCLUDED.excluded,
+                            actor_user_id = EXCLUDED.actor_user_id,
+                            reason = EXCLUDED.reason,
+                            updated_at = EXCLUDED.updated_at
+                        RETURNING *
+                        """,
+                        (subject_id, excluded, actor_id, safe_reason, now, now),
+                    )
+                except psycopg.IntegrityError:
+                    raise AnalyticsStoreError(
+                        "Analytics subject setting could not be persisted"
+                    ) from None
+                row = cur.fetchone()
         if row is None:
             raise AnalyticsStoreError("Analytics subject setting could not be loaded")
         result = dict(row)
@@ -399,10 +340,12 @@ class AnalyticsStore:
     def get_subject_setting(self, user_id: int) -> dict[str, Any] | None:
         subject_id = positive_user_id(user_id)
         with self._get_connection() as conn:
-            row = conn.execute(
-                "SELECT * FROM analytics_subject_settings WHERE user_id = ?",
-                (subject_id,),
-            ).fetchone()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM analytics_subject_settings WHERE user_id = %s",
+                    (subject_id,),
+                )
+                row = cur.fetchone()
         if row is None:
             return None
         result = dict(row)
@@ -417,15 +360,14 @@ class AnalyticsStore:
         if not isinstance(include_admin_accounts, bool):
             raise ValueError("include_admin_accounts must be a boolean")
         with self._get_connection() as conn:
-            rows = conn.execute(
-                "SELECT user_id FROM analytics_subject_settings WHERE excluded = 1"
-            ).fetchall()
-            excluded = {int(row["user_id"]) for row in rows}
-            if include_admin_accounts:
-                admin_rows = conn.execute(
-                    "SELECT id FROM users WHERE role = 'admin'"
-                ).fetchall()
-                excluded.update(int(row["id"]) for row in admin_rows)
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT user_id FROM analytics_subject_settings WHERE excluded = TRUE"
+                )
+                excluded = {int(row["user_id"]) for row in cur.fetchall()}
+                if include_admin_accounts:
+                    cur.execute("SELECT id FROM users WHERE role = 'admin'")
+                    excluded.update(int(row["id"]) for row in cur.fetchall())
         return excluded
 
     def record_admin_access(
@@ -437,25 +379,23 @@ class AnalyticsStore:
         admin_id = positive_user_id(admin_user_id, "admin_user_id")
         subject_id = positive_user_id(subject_user_id, "subject_user_id")
         safe_section = validate_access_section(section)
-        accessed_at = utcnow_iso()
         with self._get_connection() as conn:
-            try:
-                cursor = conn.execute(
-                    """
-                    INSERT INTO admin_analytics_access_log (
-                        admin_user_id, subject_user_id, section, accessed_at
-                    ) VALUES (?, ?, ?, ?)
-                    """,
-                    (admin_id, subject_id, safe_section, accessed_at),
-                )
-            except sqlite3.IntegrityError:
-                raise AnalyticsStoreError(
-                    "Admin Analytics access could not be recorded"
-                ) from None
-            row = conn.execute(
-                "SELECT * FROM admin_analytics_access_log WHERE sequence = ?",
-                (int(cursor.lastrowid),),
-            ).fetchone()
+            with conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        """
+                        INSERT INTO admin_analytics_access_log (
+                            admin_user_id, subject_user_id, section, accessed_at
+                        ) VALUES (%s, %s, %s, %s)
+                        RETURNING *
+                        """,
+                        (admin_id, subject_id, safe_section, utcnow_iso()),
+                    )
+                except psycopg.IntegrityError:
+                    raise AnalyticsStoreError(
+                        "Admin Analytics access could not be recorded"
+                    ) from None
+                row = cur.fetchone()
         if row is None:
             raise AnalyticsStoreError("Admin Analytics access could not be loaded")
         return dict(row)
@@ -469,15 +409,17 @@ class AnalyticsStore:
         subject_id = positive_user_id(subject_user_id, "subject_user_id")
         page_size = positive_limit(limit)
         with self._get_connection() as conn:
-            rows = conn.execute(
-                """
-                SELECT * FROM admin_analytics_access_log
-                WHERE subject_user_id = ?
-                ORDER BY accessed_at DESC, sequence DESC
-                LIMIT ?
-                """,
-                (subject_id, page_size),
-            ).fetchall()
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM admin_analytics_access_log
+                    WHERE subject_user_id = %s
+                    ORDER BY accessed_at DESC, sequence DESC
+                    LIMIT %s
+                    """,
+                    (subject_id, page_size),
+                )
+                rows = cur.fetchall()
         return [dict(row) for row in rows]
 
     def delete_expired(
@@ -496,60 +438,55 @@ class AnalyticsStore:
         raw_cutoff = utc_iso(raw_before)
         access_cutoff = utc_iso(access_before)
         with self._get_connection() as conn:
-            raw_cursor = conn.execute(
-                """
-                DELETE FROM analytics_events
-                WHERE sequence IN (
-                    SELECT sequence FROM analytics_events
-                    WHERE received_at < ?
-                    ORDER BY received_at, sequence
-                    LIMIT ?
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    WITH doomed AS (
+                        SELECT sequence FROM analytics_events
+                        WHERE received_at < %s
+                        ORDER BY received_at, sequence
+                        LIMIT %s
+                    )
+                    DELETE FROM analytics_events AS events
+                    USING doomed
+                    WHERE events.sequence = doomed.sequence
+                    RETURNING events.sequence
+                    """,
+                    (raw_cutoff, batch_size),
                 )
-                """,
-                (raw_cutoff, batch_size),
-            )
-            access_cursor = conn.execute(
-                """
-                DELETE FROM admin_analytics_access_log
-                WHERE sequence IN (
-                    SELECT sequence FROM admin_analytics_access_log
-                    WHERE accessed_at < ?
-                    ORDER BY accessed_at, sequence
-                    LIMIT ?
+                raw_deleted = len(cur.fetchall())
+                cur.execute(
+                    """
+                    WITH doomed AS (
+                        SELECT sequence FROM admin_analytics_access_log
+                        WHERE accessed_at < %s
+                        ORDER BY accessed_at, sequence
+                        LIMIT %s
+                    )
+                    DELETE FROM admin_analytics_access_log AS access_log
+                    USING doomed
+                    WHERE access_log.sequence = doomed.sequence
+                    RETURNING access_log.sequence
+                    """,
+                    (access_cutoff, batch_size),
                 )
-                """,
-                (access_cutoff, batch_size),
-            )
-            has_more_raw = conn.execute(
-                "SELECT 1 FROM analytics_events WHERE received_at < ? LIMIT 1",
-                (raw_cutoff,),
-            ).fetchone()
-            has_more_access = conn.execute(
-                "SELECT 1 FROM admin_analytics_access_log WHERE accessed_at < ? LIMIT 1",
-                (access_cutoff,),
-            ).fetchone()
+                access_deleted = len(cur.fetchall())
+                cur.execute(
+                    "SELECT 1 FROM analytics_events WHERE received_at < %s LIMIT 1",
+                    (raw_cutoff,),
+                )
+                has_more_raw = cur.fetchone() is not None
+                cur.execute(
+                    """
+                    SELECT 1 FROM admin_analytics_access_log
+                    WHERE accessed_at < %s LIMIT 1
+                    """,
+                    (access_cutoff,),
+                )
+                has_more_access = cur.fetchone() is not None
         return RetentionResult(
-            raw_events_deleted=max(0, int(raw_cursor.rowcount)),
-            access_rows_deleted=max(0, int(access_cursor.rowcount)),
-            has_more_raw_events=has_more_raw is not None,
-            has_more_access_rows=has_more_access is not None,
+            raw_events_deleted=raw_deleted,
+            access_rows_deleted=access_deleted,
+            has_more_raw_events=has_more_raw,
+            has_more_access_rows=has_more_access,
         )
-
-
-def _build_analytics_store():
-    """Bind Analytics to the account database and no other persistence plane."""
-
-    database_url = (os.getenv("USERS_DATABASE_URL") or "").strip()
-    if database_url:
-        from .repository_postgres import PostgresAnalyticsStore
-
-        print(
-            "analytics_store backend: postgres "
-            f"({describe_database_url(database_url)})"
-        )
-        return PostgresAnalyticsStore(database_url)
-    print("analytics_store backend: sqlite (ephemeral on Render)")
-    return AnalyticsStore()
-
-
-analytics_store = _build_analytics_store()

--- a/dashboard/backend/domain/analytics/retention.py
+++ b/dashboard/backend/domain/analytics/retention.py
@@ -14,6 +14,10 @@ RAW_EVENT_RETENTION_DAYS = 180
 ADMIN_ACCESS_RETENTION_DAYS = 365
 RETENTION_BATCH_SIZE = 1000
 RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
+# Retention normally runs once a day. A capped run that reports more expired
+# rows retries after a short interval instead of deferring the backlog for a
+# full day.
+RETENTION_BACKLOG_RETRY_SECONDS = 60
 MAX_BATCHES_PER_RUN = 20
 
 
@@ -77,7 +81,7 @@ class AnalyticsRetentionService:
 
 
 class AnalyticsRetentionCoordinator:
-    """Run retention at most daily without blocking or breaking the reaper."""
+    """Run retention daily, with bounded retries while expired rows remain."""
 
     def __init__(
         self,
@@ -114,6 +118,10 @@ class AnalyticsRetentionCoordinator:
                 )
                 return None
             self.consecutive_failures = 0
+            if result.has_more_raw_events or result.has_more_access_rows:
+                self._next_run_at = now + min(
+                    self.interval_seconds, RETENTION_BACKLOG_RETRY_SECONDS
+                )
             return result
         finally:
             self._lock.release()

--- a/dashboard/backend/domain/analytics/retention.py
+++ b/dashboard/backend/domain/analytics/retention.py
@@ -1,0 +1,125 @@
+"""Bounded retention for raw Analytics events and Admin access records."""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+from .models import RetentionResult
+from .repository import analytics_store
+
+
+RAW_EVENT_RETENTION_DAYS = 180
+ADMIN_ACCESS_RETENTION_DAYS = 365
+RETENTION_BATCH_SIZE = 1000
+RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
+MAX_BATCHES_PER_RUN = 20
+
+
+class AnalyticsRetentionService:
+    """Delete expired detail in bounded batches while preserving aggregates."""
+
+    def __init__(
+        self,
+        *,
+        store,
+        batch_size: int = RETENTION_BATCH_SIZE,
+        max_batches: int = MAX_BATCHES_PER_RUN,
+    ) -> None:
+        if (
+            isinstance(batch_size, bool)
+            or not isinstance(batch_size, int)
+            or not 1 <= batch_size <= 10_000
+        ):
+            raise ValueError("batch_size must be an integer from 1 through 10000")
+        if (
+            isinstance(max_batches, bool)
+            or not isinstance(max_batches, int)
+            or max_batches < 1
+        ):
+            raise ValueError("max_batches must be a positive integer")
+        self.store = store
+        self.batch_size = batch_size
+        self.max_batches = max_batches
+
+    def run_once(self, now: datetime | None = None) -> RetentionResult:
+        current = now or datetime.now(timezone.utc)
+        if current.tzinfo is None or current.utcoffset() is None:
+            raise ValueError("now must include a timezone")
+        current = current.astimezone(timezone.utc)
+        raw_before = current - timedelta(days=RAW_EVENT_RETENTION_DAYS)
+        access_before = current - timedelta(days=ADMIN_ACCESS_RETENTION_DAYS)
+        raw_deleted = 0
+        access_deleted = 0
+        has_more_raw = False
+        has_more_access = False
+
+        for _batch in range(self.max_batches):
+            result = self.store.delete_expired(
+                raw_before=raw_before,
+                access_before=access_before,
+                batch_size=self.batch_size,
+            )
+            raw_deleted += result.raw_events_deleted
+            access_deleted += result.access_rows_deleted
+            has_more_raw = result.has_more_raw_events
+            has_more_access = result.has_more_access_rows
+            if not has_more_raw and not has_more_access:
+                break
+
+        return RetentionResult(
+            raw_events_deleted=raw_deleted,
+            access_rows_deleted=access_deleted,
+            has_more_raw_events=has_more_raw,
+            has_more_access_rows=has_more_access,
+        )
+
+
+class AnalyticsRetentionCoordinator:
+    """Run retention at most daily without blocking or breaking the reaper."""
+
+    def __init__(
+        self,
+        *,
+        service: AnalyticsRetentionService,
+        clock=time.monotonic,
+        interval_seconds: float = RETENTION_INTERVAL_SECONDS,
+    ) -> None:
+        self.service = service
+        self.clock = clock
+        self.interval_seconds = interval_seconds
+        self.consecutive_failures = 0
+        self._next_run_at = 0.0
+        self._lock = threading.Lock()
+
+    def run_if_due(self) -> RetentionResult | None:
+        if self.clock() < self._next_run_at:
+            return None
+        if not self._lock.acquire(blocking=False):
+            return None
+        try:
+            now = self.clock()
+            if now < self._next_run_at:
+                return None
+            self._next_run_at = now + self.interval_seconds
+            try:
+                result = self.service.run_once()
+            except Exception as exc:
+                self.consecutive_failures += 1
+                print(
+                    "WARNING: analytics.retention_failed "
+                    f"consecutive_failures={self.consecutive_failures} "
+                    f"category={type(exc).__name__}"
+                )
+                return None
+            self.consecutive_failures = 0
+            return result
+        finally:
+            self._lock.release()
+
+
+analytics_retention_service = AnalyticsRetentionService(store=analytics_store)
+analytics_retention_coordinator = AnalyticsRetentionCoordinator(
+    service=analytics_retention_service,
+)

--- a/dashboard/backend/domain/analytics/service.py
+++ b/dashboard/backend/domain/analytics/service.py
@@ -1,0 +1,188 @@
+"""Application service for safe Analytics event acceptance and auditing."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import uuid4
+
+from .models import (
+    ALLOWED_SERVER_EVENT_NAMES,
+    EVENT_GROUP_BY_NAME,
+    AnalyticsEventRecord,
+    AppendEventResult,
+    FrontendAnalyticsEvent,
+    RequestAnalyticsContext,
+)
+from .repository import analytics_store
+from .repository_common import positive_user_id
+
+
+def _aware_utc(value: datetime, field_name: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return value.astimezone(timezone.utc)
+
+
+def _required_source_event_id(value: object) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValueError("source_event_id must be a trimmed non-empty string")
+    if len(value) > 200:
+        raise ValueError("source_event_id must be at most 200 characters")
+    return value
+
+
+class AnalyticsService:
+    """Normalize trusted identities and safe event metadata before storage."""
+
+    def __init__(self, store):
+        self.store = store
+
+    def accept_frontend_event(
+        self,
+        *,
+        user: dict,
+        payload: FrontendAnalyticsEvent,
+        context: RequestAnalyticsContext,
+        received_at: datetime | None = None,
+    ) -> AppendEventResult:
+        user_id = positive_user_id(user.get("id"))
+        if not isinstance(payload, FrontendAnalyticsEvent):
+            payload = FrontendAnalyticsEvent.model_validate(payload)
+        if not isinstance(context, RequestAnalyticsContext):
+            context = RequestAnalyticsContext.model_validate(context)
+        received = _aware_utc(
+            received_at or datetime.now(timezone.utc),
+            "received_at",
+        )
+        occurred = _aware_utc(payload.occurred_at, "occurred_at")
+        if occurred < received - timedelta(hours=24):
+            raise ValueError("occurred_at is too old")
+        if occurred > received + timedelta(minutes=5):
+            raise ValueError("occurred_at is in the future")
+        event = AnalyticsEventRecord(
+            event_id=payload.event_id,
+            schema_version=payload.schema_version,
+            event_name=payload.event_name,
+            event_group=EVENT_GROUP_BY_NAME[payload.event_name],
+            user_id=user_id,
+            session_id=payload.session_id,
+            occurred_at=occurred,
+            received_at=received,
+            event_source="frontend",
+            page_view=payload.page_view,
+            country_code=context.country_code,
+            device_category=context.device_category,
+            browser_family=context.browser_family,
+            network_hash=context.network_hash,
+            properties=payload.properties,
+        )
+        return self.store.append_event(event)
+
+    def record_server_event(
+        self,
+        *,
+        event_name: str,
+        user_id: int,
+        source_event_id: str,
+        source_record_type: str | None = None,
+        source_record_id: str | None = None,
+        correlation_id: str | None = None,
+        session_id: str | None = None,
+        provider_id: str | None = None,
+        model_id: str | None = None,
+        billing_mode: str | None = None,
+        outcome: str | None = None,
+        error_category: str | None = None,
+        properties: dict[str, Any] | None = None,
+        occurred_at: datetime | None = None,
+        received_at: datetime | None = None,
+    ) -> AppendEventResult:
+        if event_name not in ALLOWED_SERVER_EVENT_NAMES:
+            raise ValueError("event_name must be a supported server event name")
+        subject_id = positive_user_id(user_id)
+        source_id = _required_source_event_id(source_event_id)
+        received = _aware_utc(
+            received_at or datetime.now(timezone.utc),
+            "received_at",
+        )
+        occurred = _aware_utc(occurred_at or received, "occurred_at")
+        event = AnalyticsEventRecord(
+            event_id=str(uuid4()),
+            schema_version=1,
+            event_name=event_name,
+            event_group=EVENT_GROUP_BY_NAME[event_name],
+            user_id=subject_id,
+            session_id=session_id,
+            occurred_at=occurred,
+            received_at=received,
+            event_source="server",
+            source_event_id=source_id,
+            source_record_type=source_record_type,
+            source_record_id=source_record_id,
+            correlation_id=correlation_id,
+            provider_id=provider_id,
+            model_id=model_id,
+            billing_mode=billing_mode,
+            outcome=outcome,
+            error_category=error_category,
+            properties=properties or {},
+        )
+        return self.store.append_event(event)
+
+    def try_record_server_event(self, **kwargs) -> AppendEventResult | None:
+        try:
+            return self.record_server_event(**kwargs)
+        except Exception as exc:
+            event_name = kwargs.get("event_name")
+            safe_event = (
+                event_name
+                if isinstance(event_name, str)
+                and event_name in ALLOWED_SERVER_EVENT_NAMES
+                else "unknown"
+            )
+            category = type(exc).__name__[:80]
+            print(
+                "WARNING: analytics.append_failed "
+                f"event={safe_event} category={category}"
+            )
+            return None
+
+    def set_subject_exclusion(
+        self,
+        *,
+        actor: dict,
+        user_id: int,
+        excluded: bool,
+        reason: str,
+    ) -> dict[str, Any]:
+        if actor.get("role") != "admin":
+            raise PermissionError("admin required")
+        return self.store.set_subject_exclusion(
+            positive_user_id(user_id),
+            excluded=excluded,
+            actor_user_id=positive_user_id(actor.get("id"), "actor_user_id"),
+            reason=reason,
+        )
+
+    def record_admin_profile_access(
+        self,
+        *,
+        actor: dict,
+        subject_user_id: int,
+        section: str,
+    ) -> dict[str, Any]:
+        if actor.get("role") != "admin":
+            raise PermissionError("admin required")
+        return self.store.record_admin_access(
+            positive_user_id(actor.get("id"), "admin_user_id"),
+            positive_user_id(subject_user_id, "subject_user_id"),
+            section,
+        )
+
+
+analytics_service = AnalyticsService(store=analytics_store)
+
+
+def get_analytics_service() -> AnalyticsService:
+    return analytics_service

--- a/dashboard/backend/infrastructure/request_metadata.py
+++ b/dashboard/backend/infrastructure/request_metadata.py
@@ -1,0 +1,25 @@
+"""Request metadata helpers shared by API adapters and domain privacy code."""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+
+# Longest textual IPv6 form ("ffff:...:255.255.255.255%eth0" territory). The
+# forwarded header is attacker-controlled and unbounded, and an untruncated
+# value would let one client mint arbitrarily large dict keys.
+_MAX_IP_KEY_LEN = 64
+
+
+def client_ip(request: Request) -> str:
+    """Best-effort originating client IP.
+
+    Reads the left-most ``X-Forwarded-For`` entry before falling back to the
+    socket peer. The header is caller-suppliable, so this is only a granularity
+    helper for accidental-abuse budgets, never a security boundary.
+    """
+    for part in request.headers.get("x-forwarded-for", "").split(","):
+        candidate = part.strip()
+        if candidate:
+            return candidate[:_MAX_IP_KEY_LEN]
+    return request.client.host if request.client else "unknown"

--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -46,6 +46,9 @@ os.environ["DATABASE_PATH"] = _TEST_DB_PATH
 # time; tests must always fall back to the plain SQLite UserStore.
 os.environ.pop("USERS_DATABASE_URL", None)
 
+# A developer's deployment pseudonymization secret must never affect tests.
+os.environ.pop("ANALYTICS_PSEUDONYMIZATION_KEY", None)
+
 # Hermetic HMAC key for session-token digests (see session_tokens.py).
 os.environ["SESSION_HASH_SECRET"] = "test-session-hash-secret"
 

--- a/dashboard/backend/tests/domain/analytics/__init__.py
+++ b/dashboard/backend/tests/domain/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics domain tests."""

--- a/dashboard/backend/tests/domain/analytics/test_models.py
+++ b/dashboard/backend/tests/domain/analytics/test_models.py
@@ -1,0 +1,183 @@
+"""Closed Analytics event-contract tests."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from dashboard.backend.domain.analytics.models import (
+    ALLOWED_BILLING_MODES,
+    ALLOWED_ERROR_CATEGORIES,
+    ALLOWED_EVENT_NAMES,
+    ALLOWED_FRONTEND_EVENT_NAMES,
+    ALLOWED_PAGE_VIEWS,
+    AnalyticsEventRecord,
+    FrontendAnalyticsEvent,
+    sanitize_server_properties,
+)
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _frontend_payload(**overrides):
+    value = {
+        "event_id": str(uuid4()),
+        "schema_version": 1,
+        "event_name": "page_viewed",
+        "session_id": str(uuid4()),
+        "occurred_at": NOW,
+        "page_view": "home",
+        "properties": {},
+    }
+    value.update(overrides)
+    return value
+
+
+def _record_payload(**overrides):
+    value = {
+        "event_id": str(uuid4()),
+        "schema_version": 1,
+        "event_name": "page_viewed",
+        "event_group": "experience",
+        "user_id": 7,
+        "session_id": str(uuid4()),
+        "occurred_at": NOW,
+        "received_at": NOW,
+        "event_source": "frontend",
+        "page_view": "home",
+        "device_category": "desktop",
+        "browser_family": "Chrome",
+        "properties": {},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_allowlists_are_closed_and_versioned():
+    assert ALLOWED_FRONTEND_EVENT_NAMES == {
+        "page_viewed",
+        "page_hidden",
+        "session_heartbeat",
+    }
+    assert ALLOWED_PAGE_VIEWS == {
+        "home",
+        "agents",
+        "agent_editor",
+        "backtest",
+        "paper_trading",
+        "competition",
+        "community",
+        "credits",
+        "account",
+    }
+    assert ALLOWED_BILLING_MODES == {"byok", "platform_credits"}
+    assert {
+        "credential_invalid",
+        "credential_missing",
+        "provider_timeout",
+        "provider_unavailable",
+        "credits_unavailable",
+        "model_not_allowed",
+        "internal_error",
+    } <= ALLOWED_ERROR_CATEGORIES
+    assert ALLOWED_FRONTEND_EVENT_NAMES < ALLOWED_EVENT_NAMES
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {"schema_version": 2},
+        {"event_name": "backtest_completed"},
+        {"event_name": "clicked_anything"},
+        {"page_view": "admin"},
+        {"session_id": "auth-token-shaped-value"},
+        {"email": "not-accepted@example.test"},
+        {"properties": {"prompt": "must not cross"}},
+        {"properties": {"api_key": "synthetic-secret-canary"}},
+    ],
+)
+def test_frontend_event_rejects_unknown_or_sensitive_shape(patch):
+    with pytest.raises(ValidationError):
+        FrontendAnalyticsEvent.model_validate(_frontend_payload(**patch))
+
+
+def test_frontend_event_accepts_only_bounded_duration_metadata():
+    event = FrontendAnalyticsEvent.model_validate(
+        _frontend_payload(
+            event_name="page_hidden",
+            properties={"visible_ms": 12_500},
+        )
+    )
+    assert event.properties == {"visible_ms": 12_500}
+
+    for invalid in (-1, True, 1_800_001, "12500"):
+        with pytest.raises(ValidationError):
+            FrontendAnalyticsEvent.model_validate(
+                _frontend_payload(
+                    event_name="page_hidden",
+                    properties={"visible_ms": invalid},
+                )
+            )
+
+
+def test_server_properties_are_event_specific_and_bounded():
+    assert sanitize_server_properties(
+        "model_usage_recorded",
+        {"input_tokens": 10, "output_tokens": 4, "cost_micro_usd": 25},
+    ) == {"input_tokens": 10, "output_tokens": 4, "cost_micro_usd": 25}
+    assert sanitize_server_properties(
+        "credits_settled",
+        {"amount_micro": 100, "bucket": "grant"},
+    ) == {"amount_micro": 100, "bucket": "grant"}
+
+    for event_name, properties in (
+        ("agent_created", {"name": "must-not-cross"}),
+        ("model_usage_recorded", {"input_tokens": True}),
+        ("model_usage_recorded", {"cost_micro_usd": -1}),
+        ("credits_settled", {"amount_micro": 0, "bucket": "grant"}),
+        ("credits_settled", {"amount_micro": 100, "bucket": "unknown"}),
+    ):
+        with pytest.raises(ValueError):
+            sanitize_server_properties(event_name, properties)
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {"event_name": "unknown_event"},
+        {"event_group": "run"},
+        {"billing_mode": "free"},
+        {"outcome": "queued"},
+        {"error_category": "raw_provider_error"},
+        {"provider_id": "x" * 129},
+    ],
+)
+def test_stored_event_rejects_incoherent_or_oversized_fields(patch):
+    with pytest.raises(ValidationError):
+        AnalyticsEventRecord.model_validate(_record_payload(**patch))
+
+
+def test_stored_event_accepts_safe_server_usage_metadata():
+    record = AnalyticsEventRecord.model_validate(
+        _record_payload(
+            event_name="model_usage_recorded",
+            event_group="resource",
+            event_source="server",
+            session_id=None,
+            page_view=None,
+            source_event_id="usage:run-1:0",
+            provider_id="openrouter",
+            model_id="openai/gpt-5.5",
+            billing_mode="platform_credits",
+            outcome="succeeded",
+            properties={
+                "input_tokens": 50,
+                "output_tokens": 20,
+                "cost_micro_usd": 123,
+            },
+        )
+    )
+    assert record.event_group == "resource"
+    assert record.properties["cost_micro_usd"] == 123

--- a/dashboard/backend/tests/domain/analytics/test_privacy.py
+++ b/dashboard/backend/tests/domain/analytics/test_privacy.py
@@ -1,0 +1,112 @@
+"""Analytics request privacy-reduction tests."""
+
+from datetime import datetime, timezone
+
+from starlette.requests import Request
+
+from dashboard.backend.domain.analytics.privacy import (
+    monthly_network_hash,
+    request_analytics_context,
+)
+
+
+def _request(headers=None, client=("203.0.113.19", 443)):
+    raw_headers = [
+        (key.lower().encode(), value.encode())
+        for key, value in (headers or {}).items()
+    ]
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/analytics/events",
+            "headers": raw_headers,
+            "client": client,
+            "scheme": "https",
+            "server": ("testserver", 443),
+            "query_string": b"",
+        }
+    )
+
+
+def test_missing_or_short_key_omits_network_hash(monkeypatch):
+    received_at = datetime(2026, 8, 26, tzinfo=timezone.utc)
+    monkeypatch.delenv("ANALYTICS_PSEUDONYMIZATION_KEY", raising=False)
+    assert monthly_network_hash("203.0.113.19", received_at) is None
+
+    monkeypatch.setenv("ANALYTICS_PSEUDONYMIZATION_KEY", "too-short")
+    assert monthly_network_hash("203.0.113.19", received_at) is None
+
+
+def test_network_hash_is_month_scoped_and_never_contains_plain_ip(monkeypatch):
+    monkeypatch.setenv(
+        "ANALYTICS_PSEUDONYMIZATION_KEY",
+        "synthetic-analytics-hmac-key-at-least-32-bytes",
+    )
+    august = monthly_network_hash(
+        "203.0.113.19", datetime(2026, 8, 26, tzinfo=timezone.utc)
+    )
+    september = monthly_network_hash(
+        "203.0.113.19", datetime(2026, 9, 1, tzinfo=timezone.utc)
+    )
+    assert august and september and august != september
+    assert "203.0.113.19" not in august
+    assert len(august) == 64
+
+
+def test_request_context_reduces_user_agent_and_country(monkeypatch):
+    monkeypatch.setenv(
+        "ANALYTICS_PSEUDONYMIZATION_KEY",
+        "synthetic-analytics-hmac-key-at-least-32-bytes",
+    )
+    monkeypatch.setenv("RENDER", "true")
+    raw_agent = (
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) "
+        "AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1 "
+        "synthetic-secret-canary"
+    )
+    context = request_analytics_context(
+        _request({"user-agent": raw_agent, "cf-ipcountry": "US"}),
+        datetime(2026, 8, 26, tzinfo=timezone.utc),
+    )
+    assert context.browser_family == "Safari"
+    assert context.device_category == "mobile"
+    assert context.country_code == "US"
+    assert "synthetic-secret-canary" not in repr(context)
+    assert "Mozilla" not in repr(context)
+    assert "203.0.113.19" not in repr(context)
+
+
+def test_untrusted_or_invalid_country_headers_are_omitted(monkeypatch):
+    monkeypatch.delenv("RENDER", raising=False)
+    monkeypatch.delenv("VERCEL", raising=False)
+    context = request_analytics_context(
+        _request({"cf-ipcountry": "US", "x-vercel-ip-country": "CA"}),
+        datetime(2026, 8, 26, tzinfo=timezone.utc),
+    )
+    assert context.country_code is None
+
+    monkeypatch.setenv("VERCEL", "1")
+    context = request_analytics_context(
+        _request({"x-vercel-ip-country": "USA"}),
+        datetime(2026, 8, 26, tzinfo=timezone.utc),
+    )
+    assert context.country_code is None
+
+
+def test_browser_and_device_reducers_are_allowlisted(monkeypatch):
+    monkeypatch.delenv("ANALYTICS_PSEUDONYMIZATION_KEY", raising=False)
+    cases = [
+        ("Mozilla/5.0 Edg/126.0", "Edge", "desktop"),
+        ("Mozilla/5.0 Android Mobile Chrome/126.0", "Chrome", "mobile"),
+        ("Mozilla/5.0 iPad Version/18.0 Safari/604.1", "Safari", "tablet"),
+        ("curl/8.0", "Other", "unknown"),
+    ]
+    for agent, browser, device in cases:
+        context = request_analytics_context(
+            _request({"user-agent": agent}),
+            datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
+        assert context.browser_family == browser
+        assert context.device_category == device
+        assert context.network_hash is None

--- a/dashboard/backend/tests/domain/analytics/test_repository_contract.py
+++ b/dashboard/backend/tests/domain/analytics/test_repository_contract.py
@@ -1,0 +1,231 @@
+"""Shared behavioral contract for Analytics persistence backends."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from dashboard.backend.domain.analytics.models import AnalyticsEventRecord
+from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.repository_common import (
+    AnalyticsIdempotencyConflictError,
+    AnalyticsStoreError,
+    decode_event_cursor,
+)
+from dashboard.backend.users import UserStore
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def event_record(user_id: int, **overrides) -> AnalyticsEventRecord:
+    value = {
+        "event_id": str(uuid4()),
+        "schema_version": 1,
+        "event_name": "page_viewed",
+        "event_group": "experience",
+        "user_id": user_id,
+        "session_id": str(uuid4()),
+        "occurred_at": NOW,
+        "received_at": NOW + timedelta(seconds=1),
+        "event_source": "frontend",
+        "page_view": "home",
+        "device_category": "desktop",
+        "browser_family": "Chrome",
+        "properties": {},
+    }
+    value.update(overrides)
+    return AnalyticsEventRecord.model_validate(value)
+
+
+@pytest.fixture
+def sqlite_contract(tmp_path):
+    db_path = tmp_path / "analytics.db"
+    users = UserStore(db_path=db_path)
+    admin = users.create_user(
+        "analytics-admin@example.test",
+        "Analytics Admin",
+        "SecurePass1!",
+    )
+    target = users.create_user(
+        "analytics-user@example.test",
+        "Analytics User",
+        "SecurePass1!",
+    )
+    users.apply_admin_patch(admin["id"], role="admin")
+    store = AnalyticsStore(db_path=db_path)
+    return store, int(admin["id"]), int(target["id"])
+
+
+def assert_event_idempotency_contract(store, user_id):
+    event = event_record(
+        user_id,
+        event_id="10000000-0000-4000-8000-000000000001",
+    )
+    first = store.append_event(event)
+    replay = store.append_event(
+        event.model_copy(update={"received_at": event.received_at + timedelta(seconds=5)})
+    )
+    assert first.created is True
+    assert replay.created is False
+    assert replay.event == first.event
+
+    changed = event.model_copy(update={"page_view": "credits"})
+    with pytest.raises(AnalyticsIdempotencyConflictError):
+        store.append_event(changed)
+
+
+def assert_source_event_idempotency_contract(store, user_id):
+    event = event_record(
+        user_id,
+        event_id="10000000-0000-4000-8000-000000000002",
+        event_source="server",
+        source_event_id="run:run_123:completed",
+        source_record_type="run",
+        source_record_id="run_123",
+        event_name="backtest_completed",
+        event_group="run",
+        page_view=None,
+        session_id=None,
+        outcome="succeeded",
+    )
+    assert store.append_event(event).created is True
+    replay = event.model_copy(
+        update={
+            "event_id": "10000000-0000-4000-8000-000000000003",
+            "received_at": event.received_at + timedelta(seconds=10),
+        }
+    )
+    result = store.append_event(replay)
+    assert result.created is False
+    assert result.event.event_id == event.event_id
+
+    changed = replay.model_copy(update={"outcome": "failed"})
+    with pytest.raises(AnalyticsIdempotencyConflictError):
+        store.append_event(changed)
+
+
+def assert_cursor_contract(store, user_id):
+    for index in range(3):
+        store.append_event(
+            event_record(
+                user_id,
+                event_id=f"20000000-0000-4000-8000-00000000000{index}",
+                occurred_at=NOW + timedelta(minutes=index),
+            )
+        )
+    first = store.list_user_events(user_id, limit=2)
+    assert len(first["items"]) == 2
+    assert first["next_cursor"]
+    decode_event_cursor(first["next_cursor"])
+
+    second = store.list_user_events(
+        user_id,
+        limit=2,
+        cursor=first["next_cursor"],
+    )
+    assert len(second["items"]) == 1
+    assert second["next_cursor"] is None
+    first_ids = {item.event_id for item in first["items"]}
+    second_ids = {item.event_id for item in second["items"]}
+    assert not (first_ids & second_ids)
+
+
+def assert_subject_and_access_contract(store, admin_id, user_id):
+    setting = store.set_subject_exclusion(
+        user_id,
+        excluded=True,
+        actor_user_id=admin_id,
+        reason="Synthetic QA account.",
+    )
+    assert setting["excluded"] is True
+    assert user_id in store.list_excluded_user_ids()
+    assert admin_id in store.list_excluded_user_ids(include_admin_accounts=True)
+
+    access = store.record_admin_access(admin_id, user_id, "overview")
+    assert access["admin_user_id"] == admin_id
+    assert access["subject_user_id"] == user_id
+    assert "response" not in access
+    assert store.list_admin_access(user_id)[0]["section"] == "overview"
+
+    cleared = store.set_subject_exclusion(
+        user_id,
+        excluded=False,
+        actor_user_id=admin_id,
+        reason="QA account is now included.",
+    )
+    assert cleared["excluded"] is False
+    assert user_id not in store.list_excluded_user_ids()
+
+
+def test_sqlite_schema_contains_all_foundation_tables(sqlite_contract):
+    store, _admin_id, _user_id = sqlite_contract
+    with store._get_connection() as conn:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+    assert {
+        "analytics_events",
+        "analytics_daily_rollups",
+        "user_analytics_snapshots",
+        "analytics_subject_settings",
+        "admin_analytics_access_log",
+    } <= names
+
+
+def test_sqlite_runs_shared_event_contracts(sqlite_contract):
+    store, _admin_id, user_id = sqlite_contract
+    assert_event_idempotency_contract(store, user_id)
+    assert_source_event_idempotency_contract(store, user_id)
+
+
+def test_sqlite_runs_shared_cursor_contract(sqlite_contract):
+    store, _admin_id, user_id = sqlite_contract
+    assert_cursor_contract(store, user_id)
+
+
+def test_sqlite_runs_shared_subject_and_access_contract(sqlite_contract):
+    store, admin_id, user_id = sqlite_contract
+    assert_subject_and_access_contract(store, admin_id, user_id)
+
+
+@pytest.mark.parametrize("cursor", ["", "not-base64!", "WzEsMl0", "W10"])
+def test_invalid_cursor_is_rejected(sqlite_contract, cursor):
+    store, _admin_id, user_id = sqlite_contract
+    with pytest.raises(ValueError, match="invalid analytics cursor"):
+        store.list_user_events(user_id, cursor=cursor)
+
+
+@pytest.mark.parametrize("limit", [0, 101, True])
+def test_invalid_limits_are_rejected(sqlite_contract, limit):
+    store, _admin_id, user_id = sqlite_contract
+    with pytest.raises(ValueError, match="limit"):
+        store.list_user_events(user_id, limit=limit)
+
+
+def test_subject_reason_and_access_section_are_closed(sqlite_contract):
+    store, admin_id, user_id = sqlite_contract
+    for reason in ("", " padded ", "x" * 501):
+        with pytest.raises(ValueError, match="reason"):
+            store.set_subject_exclusion(
+                user_id,
+                excluded=True,
+                actor_user_id=admin_id,
+                reason=reason,
+            )
+    with pytest.raises(ValueError, match="section"):
+        store.record_admin_access(admin_id, user_id, "raw_response")
+
+
+def test_foreign_keys_reject_missing_users(sqlite_contract):
+    store, _admin_id, _user_id = sqlite_contract
+    with pytest.raises(AnalyticsStoreError):
+        store.append_event(event_record(999_999))
+    with pytest.raises((AnalyticsStoreError, sqlite3.IntegrityError)):
+        store.record_admin_access(999_998, 999_999, "overview")

--- a/dashboard/backend/tests/domain/analytics/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/analytics/test_repository_postgres.py
@@ -1,0 +1,155 @@
+"""Dispatch and live-PostgreSQL tests for the Analytics store twin."""
+
+from __future__ import annotations
+
+import inspect
+import os
+import uuid
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import psycopg
+import pytest
+from psycopg import sql
+
+from dashboard.backend import db_pool
+from dashboard.backend.domain.analytics import repository as repo_module
+from dashboard.backend.domain.analytics import repository_postgres as pg_module
+from dashboard.backend.domain.analytics.repository_postgres import (
+    PostgresAnalyticsStore,
+)
+from dashboard.backend.tests._postgres_testing import require_local_postgres_url
+from dashboard.backend.tests.domain.analytics.test_repository_contract import (
+    assert_cursor_contract,
+    assert_event_idempotency_contract,
+    assert_source_event_idempotency_contract,
+    assert_subject_and_access_contract,
+)
+
+
+TEST_POSTGRES_URL = require_local_postgres_url(os.getenv("TEST_POSTGRES_URL"))
+pg_only = pytest.mark.skipif(
+    not TEST_POSTGRES_URL,
+    reason="TEST_POSTGRES_URL is not configured",
+)
+
+
+def _schema_url(database_url: str, schema: str) -> str:
+    parts = urlsplit(database_url)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    query.append(("options", f"-csearch_path={schema}"))
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), ""))
+
+
+@pytest.fixture
+def postgres_contract_store():
+    require_local_postgres_url(TEST_POSTGRES_URL)
+    schema = f"analytics_{uuid.uuid4().hex}"
+    with psycopg.connect(TEST_POSTGRES_URL, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema)))
+    scoped_url = _schema_url(TEST_POSTGRES_URL, schema)
+    try:
+        with psycopg.connect(scoped_url, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    CREATE TABLE users (
+                        id INTEGER PRIMARY KEY,
+                        role TEXT NOT NULL DEFAULT 'user'
+                    )
+                    """
+                )
+                cur.execute(
+                    "INSERT INTO users (id, role) VALUES (1, 'admin'), (2, 'user')"
+                )
+        yield PostgresAnalyticsStore(scoped_url), 1, 2
+    finally:
+        db_pool._reset_for_tests()
+        with psycopg.connect(TEST_POSTGRES_URL, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql.SQL("DROP SCHEMA {} CASCADE").format(sql.Identifier(schema))
+                )
+
+
+def test_build_analytics_store_defaults_to_sqlite(monkeypatch, capsys):
+    monkeypatch.delenv("USERS_DATABASE_URL", raising=False)
+    store = repo_module._build_analytics_store()
+    assert isinstance(store, repo_module.AnalyticsStore)
+    assert "analytics_store backend: sqlite" in capsys.readouterr().out
+
+
+def test_build_analytics_store_uses_only_users_database_url(monkeypatch, capsys):
+    created = {}
+
+    class FakePostgresAnalyticsStore:
+        def __init__(self, database_url):
+            created["database_url"] = database_url
+
+    monkeypatch.setattr(
+        pg_module,
+        "PostgresAnalyticsStore",
+        FakePostgresAnalyticsStore,
+    )
+    monkeypatch.setenv("USERS_DATABASE_URL", "postgresql://fake/accounts")
+    monkeypatch.setenv("CONTENT_DATABASE_URL", "postgresql://ignored/content")
+    monkeypatch.setenv("AGENT_RUNS_DATABASE_URL", "postgresql://ignored/runs")
+
+    store = repo_module._build_analytics_store()
+
+    assert isinstance(store, FakePostgresAnalyticsStore)
+    assert created["database_url"] == "postgresql://fake/accounts"
+    assert "analytics_store backend: postgres (fake/accounts)" in capsys.readouterr().out
+
+
+def test_dispatch_log_never_contains_database_password(monkeypatch, capsys):
+    monkeypatch.setattr(
+        pg_module,
+        "PostgresAnalyticsStore",
+        lambda database_url: object(),
+    )
+    monkeypatch.setenv(
+        "USERS_DATABASE_URL",
+        "postgresql://admin:synthetic-password@host/accounts",
+    )
+    repo_module._build_analytics_store()
+    output = capsys.readouterr().out
+    assert "synthetic-password" not in output
+    assert "host/accounts" in output
+
+
+def test_postgres_store_rejects_non_postgres_url_before_connecting():
+    with pytest.raises(ValueError, match="postgresql://"):
+        PostgresAnalyticsStore("sqlite:///tmp/not-postgres.db")
+
+
+def test_public_repository_methods_match():
+    def public_methods(cls):
+        return {
+            name
+            for name, value in inspect.getmembers(cls, inspect.isfunction)
+            if not name.startswith("_")
+        }
+
+    assert public_methods(repo_module.AnalyticsStore) == public_methods(
+        PostgresAnalyticsStore
+    )
+
+
+@pg_only
+def test_postgres_runs_shared_event_contracts(postgres_contract_store):
+    store, _admin_id, user_id = postgres_contract_store
+    assert_event_idempotency_contract(store, user_id)
+    assert_source_event_idempotency_contract(store, user_id)
+
+
+@pg_only
+def test_postgres_runs_shared_cursor_contract(postgres_contract_store):
+    store, _admin_id, user_id = postgres_contract_store
+    assert_cursor_contract(store, user_id)
+
+
+@pg_only
+def test_postgres_runs_shared_subject_and_access_contract(postgres_contract_store):
+    store, admin_id, user_id = postgres_contract_store
+    assert_subject_and_access_contract(store, admin_id, user_id)

--- a/dashboard/backend/tests/domain/analytics/test_retention.py
+++ b/dashboard/backend/tests/domain/analytics/test_retention.py
@@ -1,0 +1,232 @@
+"""Bounded Analytics retention and failure-isolated scheduling."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from dashboard.backend.domain.analytics.models import (
+    AnalyticsEventRecord,
+    RetentionResult,
+)
+from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.retention import (
+    ADMIN_ACCESS_RETENTION_DAYS,
+    RAW_EVENT_RETENTION_DAYS,
+    RETENTION_INTERVAL_SECONDS,
+    AnalyticsRetentionCoordinator,
+    AnalyticsRetentionService,
+)
+from dashboard.backend.domain.analytics.repository_common import utc_iso
+from dashboard.backend.users import UserStore
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+class RecordingStore:
+    def __init__(self):
+        self.calls = []
+
+    def delete_expired(self, **kwargs):
+        self.calls.append(kwargs)
+        return RetentionResult()
+
+
+class FakeClock:
+    def __init__(self):
+        self.value = 0.0
+
+    def __call__(self):
+        return self.value
+
+    def advance(self, seconds):
+        self.value += seconds
+
+
+class RecordingRetentionService:
+    def __init__(self):
+        self.calls = 0
+
+    def run_once(self):
+        self.calls += 1
+        return RetentionResult()
+
+
+class FailingRetentionService:
+    def __init__(self, message):
+        self.message = message
+
+    def run_once(self):
+        raise RuntimeError(self.message)
+
+
+def _event(user_id: int, received_at: datetime) -> AnalyticsEventRecord:
+    return AnalyticsEventRecord(
+        event_id=str(uuid4()),
+        schema_version=1,
+        event_name="page_viewed",
+        event_group="experience",
+        user_id=user_id,
+        session_id=str(uuid4()),
+        occurred_at=received_at,
+        received_at=received_at,
+        event_source="frontend",
+        page_view="home",
+        properties={},
+    )
+
+
+def test_run_once_uses_180_and_365_day_cutoffs():
+    store = RecordingStore()
+    service = AnalyticsRetentionService(store=store, batch_size=500)
+
+    result = service.run_once(NOW)
+
+    assert store.calls == [
+        {
+            "raw_before": NOW - timedelta(days=RAW_EVENT_RETENTION_DAYS),
+            "access_before": NOW - timedelta(days=ADMIN_ACCESS_RETENTION_DAYS),
+            "batch_size": 500,
+        }
+    ]
+    assert result == RetentionResult()
+
+
+def test_coordinator_runs_at_most_once_per_24_hours():
+    clock = FakeClock()
+    service = RecordingRetentionService()
+    coordinator = AnalyticsRetentionCoordinator(service=service, clock=clock)
+
+    coordinator.run_if_due()
+    coordinator.run_if_due()
+    assert service.calls == 1
+
+    clock.advance(RETENTION_INTERVAL_SECONDS)
+    coordinator.run_if_due()
+    assert service.calls == 2
+
+
+def test_retention_failure_is_swallowed_and_reports_only_safe_metadata(capsys):
+    coordinator = AnalyticsRetentionCoordinator(
+        service=FailingRetentionService("synthetic-secret-canary"),
+        clock=lambda: 0,
+    )
+
+    assert coordinator.run_if_due() is None
+
+    output = capsys.readouterr().out
+    assert "analytics.retention_failed" in output
+    assert "consecutive_failures=1" in output
+    assert "category=RuntimeError" in output
+    assert "synthetic-secret-canary" not in output
+
+
+def test_success_resets_consecutive_failure_count():
+    clock = FakeClock()
+    coordinator = AnalyticsRetentionCoordinator(
+        service=FailingRetentionService("synthetic failure"),
+        clock=clock,
+    )
+    coordinator.run_if_due()
+    assert coordinator.consecutive_failures == 1
+
+    clock.advance(RETENTION_INTERVAL_SECONDS)
+    coordinator.service = RecordingRetentionService()
+    coordinator.run_if_due()
+    assert coordinator.consecutive_failures == 0
+
+
+def test_sqlite_retention_is_bounded_and_preserves_aggregates(tmp_path):
+    db_path = tmp_path / "analytics_retention.db"
+    users = UserStore(db_path=db_path)
+    admin = users.create_user(
+        "retention-admin@example.test",
+        "Retention Admin",
+        "SecurePass1!",
+    )
+    subject = users.create_user(
+        "retention-user@example.test",
+        "Retention User",
+        "SecurePass1!",
+    )
+    users.apply_admin_patch(admin["id"], role="admin")
+    store = AnalyticsStore(db_path=db_path)
+
+    raw_cutoff = NOW - timedelta(days=RAW_EVENT_RETENTION_DAYS)
+    access_cutoff = NOW - timedelta(days=ADMIN_ACCESS_RETENTION_DAYS)
+    for age in (timedelta(days=181), timedelta(days=200)):
+        store.append_event(_event(int(subject["id"]), NOW - age))
+    recent_event = store.append_event(
+        _event(int(subject["id"]), raw_cutoff + timedelta(seconds=1))
+    ).event
+
+    with store._get_connection() as conn:
+        for accessed_at in (
+            access_cutoff - timedelta(seconds=1),
+            access_cutoff - timedelta(days=5),
+            access_cutoff + timedelta(seconds=1),
+        ):
+            conn.execute(
+                """
+                INSERT INTO admin_analytics_access_log (
+                    admin_user_id, subject_user_id, section, accessed_at
+                ) VALUES (?, ?, 'overview', ?)
+                """,
+                (int(admin["id"]), int(subject["id"]), utc_iso(accessed_at)),
+            )
+        conn.execute(
+            """
+            INSERT INTO analytics_daily_rollups (
+                rollup_date, metric_name, value_count, updated_at
+            ) VALUES ('2025-01-01', 'active_users', 7, ?)
+            """,
+            (utc_iso(NOW),),
+        )
+        conn.execute(
+            """
+            INSERT INTO user_analytics_snapshots (
+                user_id, status, reason_code, human_readable_reason,
+                evidence_event_ids_json, calculated_at
+            ) VALUES (?, 'active', 'recent_activity', 'Recent activity.', '[]', ?)
+            """,
+            (int(subject["id"]), utc_iso(NOW)),
+        )
+
+    class RecordingDeleteStore:
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+            self.results = []
+
+        def delete_expired(self, **kwargs):
+            result = self.wrapped.delete_expired(**kwargs)
+            self.results.append(result)
+            return result
+
+    recording_store = RecordingDeleteStore(store)
+    result = AnalyticsRetentionService(
+        store=recording_store,
+        batch_size=1,
+    ).run_once(NOW)
+
+    assert result.raw_events_deleted == 2
+    assert result.access_rows_deleted == 2
+    assert result.has_more_raw_events is False
+    assert result.has_more_access_rows is False
+    assert all(item.raw_events_deleted <= 1 for item in recording_store.results)
+    assert all(item.access_rows_deleted <= 1 for item in recording_store.results)
+
+    remaining_events = store.list_user_events(int(subject["id"]))["items"]
+    assert [item.event_id for item in remaining_events] == [recent_event.event_id]
+    remaining_access = store.list_admin_access(int(subject["id"]))
+    assert len(remaining_access) == 1
+    assert remaining_access[0]["accessed_at"] == utc_iso(
+        access_cutoff + timedelta(seconds=1)
+    )
+    with store._get_connection() as conn:
+        assert conn.execute(
+            "SELECT value_count FROM analytics_daily_rollups"
+        ).fetchone()[0] == 7
+        assert conn.execute(
+            "SELECT status FROM user_analytics_snapshots"
+        ).fetchone()[0] == "active"

--- a/dashboard/backend/tests/domain/analytics/test_retention.py
+++ b/dashboard/backend/tests/domain/analytics/test_retention.py
@@ -13,6 +13,7 @@ from dashboard.backend.domain.analytics.repository import AnalyticsStore
 from dashboard.backend.domain.analytics.retention import (
     ADMIN_ACCESS_RETENTION_DAYS,
     RAW_EVENT_RETENTION_DAYS,
+    RETENTION_BACKLOG_RETRY_SECONDS,
     RETENTION_INTERVAL_SECONDS,
     AnalyticsRetentionCoordinator,
     AnalyticsRetentionService,
@@ -51,6 +52,15 @@ class RecordingRetentionService:
     def run_once(self):
         self.calls += 1
         return RetentionResult()
+
+
+class AlwaysBackloggedStore:
+    def __init__(self):
+        self.calls = 0
+
+    def delete_expired(self, **_kwargs):
+        self.calls += 1
+        return RetentionResult(raw_events_deleted=1, has_more_raw_events=True)
 
 
 class FailingRetentionService:
@@ -105,6 +115,33 @@ def test_coordinator_runs_at_most_once_per_24_hours():
     clock.advance(RETENTION_INTERVAL_SECONDS)
     coordinator.run_if_due()
     assert service.calls == 2
+
+
+def test_coordinator_retries_soon_when_retention_batch_limit_leaves_backlog():
+    clock = FakeClock()
+    store = AlwaysBackloggedStore()
+    service = AnalyticsRetentionService(
+        store=store,
+        batch_size=1,
+        max_batches=2,
+    )
+    coordinator = AnalyticsRetentionCoordinator(service=service, clock=clock)
+
+    assert coordinator.run_if_due() == RetentionResult(
+        raw_events_deleted=2,
+        has_more_raw_events=True,
+    )
+    assert store.calls == 2
+
+    clock.advance(RETENTION_BACKLOG_RETRY_SECONDS - 1)
+    assert coordinator.run_if_due() is None
+
+    clock.advance(1)
+    assert coordinator.run_if_due() == RetentionResult(
+        raw_events_deleted=2,
+        has_more_raw_events=True,
+    )
+    assert store.calls == 4
 
 
 def test_retention_failure_is_swallowed_and_reports_only_safe_metadata(capsys):

--- a/dashboard/backend/tests/domain/analytics/test_service.py
+++ b/dashboard/backend/tests/domain/analytics/test_service.py
@@ -1,0 +1,208 @@
+"""Analytics foundation service tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from dashboard.backend.domain.analytics.models import (
+    AppendEventResult,
+    FrontendAnalyticsEvent,
+    RequestAnalyticsContext,
+)
+from dashboard.backend.domain.analytics.service import AnalyticsService
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+class RecordingStore:
+    def __init__(self):
+        self.events = []
+        self.exclusions = []
+        self.accesses = []
+
+    def append_event(self, event):
+        self.events.append(event)
+        return AppendEventResult(event=event, created=True)
+
+    def set_subject_exclusion(self, user_id, **kwargs):
+        value = {"user_id": user_id, **kwargs}
+        self.exclusions.append(value)
+        return value
+
+    def record_admin_access(self, admin_user_id, subject_user_id, section):
+        value = {
+            "sequence": len(self.accesses) + 1,
+            "admin_user_id": admin_user_id,
+            "subject_user_id": subject_user_id,
+            "section": section,
+            "accessed_at": NOW.isoformat(),
+        }
+        self.accesses.append(value)
+        return value
+
+
+class FailingStore:
+    def append_event(self, event):
+        raise RuntimeError("synthetic-secret-canary from provider body")
+
+
+def frontend_event(**overrides):
+    value = {
+        "event_id": str(uuid4()),
+        "schema_version": 1,
+        "event_name": "page_viewed",
+        "session_id": str(uuid4()),
+        "occurred_at": NOW,
+        "page_view": "home",
+        "properties": {},
+    }
+    value.update(overrides)
+    return FrontendAnalyticsEvent.model_validate(value)
+
+
+def safe_context():
+    return RequestAnalyticsContext(
+        country_code="US",
+        device_category="desktop",
+        browser_family="Chrome",
+        network_hash="a" * 64,
+    )
+
+
+def test_frontend_event_uses_authenticated_identity_and_server_received_time():
+    store = RecordingStore()
+    service = AnalyticsService(store=store)
+    result = service.accept_frontend_event(
+        user={
+            "id": 42,
+            "role": "user",
+            "email": "must-not-persist@example.test",
+        },
+        payload=frontend_event(),
+        context=safe_context(),
+        received_at=NOW + timedelta(seconds=1),
+    )
+    assert result.event.user_id == 42
+    assert result.event.event_group == "experience"
+    assert result.event.event_source == "frontend"
+    assert result.event.received_at == NOW + timedelta(seconds=1)
+    assert "email" not in result.event.model_dump()
+    assert store.events == [result.event]
+
+
+@pytest.mark.parametrize(
+    "occurred_at",
+    [NOW - timedelta(hours=24, seconds=1), NOW + timedelta(minutes=5, seconds=1)],
+)
+def test_frontend_event_rejects_large_clock_skew(occurred_at):
+    service = AnalyticsService(store=RecordingStore())
+    with pytest.raises(ValueError, match="occurred_at"):
+        service.accept_frontend_event(
+            user={"id": 42, "role": "user"},
+            payload=frontend_event(occurred_at=occurred_at),
+            context=safe_context(),
+            received_at=NOW,
+        )
+
+
+def test_server_event_requires_server_name_and_deterministic_source_id():
+    service = AnalyticsService(store=RecordingStore())
+    with pytest.raises(ValueError, match="server event name"):
+        service.record_server_event(
+            event_name="page_viewed",
+            user_id=42,
+            source_event_id="page:unsafe",
+        )
+    with pytest.raises(ValueError, match="source_event_id"):
+        service.record_server_event(
+            event_name="agent_created",
+            user_id=42,
+            source_event_id="",
+        )
+
+
+def test_server_usage_event_is_normalized_for_future_instrumentation():
+    store = RecordingStore()
+    service = AnalyticsService(store=store)
+    result = service.record_server_event(
+        event_name="model_usage_recorded",
+        user_id=42,
+        source_event_id="usage:run-1:0",
+        source_record_type="run",
+        source_record_id="run-1",
+        correlation_id="run-1",
+        provider_id="openrouter",
+        model_id="openai/gpt-5.5",
+        billing_mode="platform_credits",
+        outcome="succeeded",
+        properties={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cost_micro_usd": 375,
+        },
+        occurred_at=NOW,
+        received_at=NOW + timedelta(seconds=1),
+    )
+    assert result.event.event_group == "resource"
+    assert result.event.event_source == "server"
+    assert result.event.properties["cost_micro_usd"] == 375
+    assert result.event.network_hash is None
+
+
+def test_best_effort_server_event_never_raises_or_prints_sensitive_fields(capsys):
+    failing = AnalyticsService(store=FailingStore())
+    result = failing.try_record_server_event(
+        event_name="credential_verified",
+        user_id=42,
+        source_event_id="credential:synthetic-id:verified",
+        source_record_type="credential",
+        source_record_id="synthetic-id",
+        properties={},
+    )
+    assert result is None
+    output = capsys.readouterr().out
+    assert "synthetic-secret-canary" not in output
+    assert "synthetic-id" not in output
+    assert "42" not in output
+    assert "analytics.append_failed" in output
+    assert "category=RuntimeError" in output
+
+
+def test_subject_exclusion_and_profile_access_require_admin_actor():
+    store = RecordingStore()
+    service = AnalyticsService(store=store)
+    user = {"id": 9, "role": "user"}
+    admin = {"id": 7, "role": "admin"}
+
+    with pytest.raises(PermissionError, match="admin required"):
+        service.set_subject_exclusion(
+            actor=user,
+            user_id=42,
+            excluded=True,
+            reason="Synthetic QA account.",
+        )
+    with pytest.raises(PermissionError, match="admin required"):
+        service.record_admin_profile_access(
+            actor=user,
+            subject_user_id=42,
+            section="overview",
+        )
+
+    setting = service.set_subject_exclusion(
+        actor=admin,
+        user_id=42,
+        excluded=True,
+        reason="Synthetic QA account.",
+    )
+    access = service.record_admin_profile_access(
+        actor=admin,
+        subject_user_id=42,
+        section="overview",
+    )
+    assert setting["actor_user_id"] == 7
+    assert access["admin_user_id"] == 7
+    assert access["subject_user_id"] == 42

--- a/dashboard/backend/tests/test_analytics_api.py
+++ b/dashboard/backend/tests/test_analytics_api.py
@@ -1,0 +1,198 @@
+"""Authenticated, non-echoing Analytics ingestion API tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dashboard.backend import users as users_module
+from dashboard.backend.api.rate_limit import FixedWindowRateLimiter
+from dashboard.backend.api.routers import analytics as analytics_router
+from dashboard.backend.app import app
+from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.service import (
+    AnalyticsService,
+    get_analytics_service,
+)
+from dashboard.backend.users import UserStore
+
+
+def frontend_payload(**overrides):
+    value = {
+        "event_id": str(uuid4()),
+        "schema_version": 1,
+        "event_name": "page_viewed",
+        "session_id": str(uuid4()),
+        "occurred_at": datetime.now(timezone.utc).isoformat(),
+        "page_view": "home",
+        "properties": {},
+    }
+    value.update(overrides)
+    return value
+
+
+@pytest.fixture
+def analytics_api(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "analytics_api.db"
+        user_store = UserStore(db_path=db_path)
+        event_store = AnalyticsStore(db_path=db_path)
+        service = AnalyticsService(store=event_store)
+        monkeypatch.setattr(users_module, "user_store", user_store)
+        app.dependency_overrides[get_analytics_service] = lambda: service
+        analytics_router.reset_analytics_ingestion_limiter()
+        with TestClient(app) as client:
+            yield client, user_store, event_store
+        analytics_router.reset_analytics_ingestion_limiter()
+        app.dependency_overrides.pop(get_analytics_service, None)
+
+
+def _signup(client: TestClient, email="analytics@example.test") -> dict:
+    response = client.post(
+        "/api/auth/signup",
+        json={
+            "email": email,
+            "display_name": "Analytics User",
+            "password": "SecurePass1!",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["user"]
+
+
+def test_analytics_ingestion_requires_authentication(analytics_api):
+    client, _users, _events = analytics_api
+    response = client.post("/api/analytics/events", json=frontend_payload())
+    assert response.status_code == 401
+
+
+def test_analytics_ingestion_returns_generic_acceptance(analytics_api):
+    client, _users, event_store = analytics_api
+    user = _signup(client)
+    response = client.post("/api/analytics/events", json=frontend_payload())
+    assert response.status_code == 202
+    assert response.json() == {"accepted": True}
+    saved = event_store.list_user_events(user["id"])["items"]
+    assert len(saved) == 1
+    assert saved[0].user_id == user["id"]
+
+
+def test_analytics_validation_never_echoes_secret_canary(
+    analytics_api,
+    capsys,
+):
+    client, _users, _events = analytics_api
+    _signup(client)
+    payload = frontend_payload()
+    payload["api_key"] = "synthetic-secret-canary"
+    response = client.post("/api/analytics/events", json=payload)
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Invalid analytics event."}
+    assert "synthetic-secret-canary" not in response.text
+    assert "synthetic-secret-canary" not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_status"),
+    [
+        (b"not-json", 422),
+        (json.dumps(["not", "an", "object"]).encode(), 422),
+        (json.dumps({"x": "y" * 9000}).encode(), 413),
+    ],
+)
+def test_analytics_body_is_bounded_and_generic(
+    analytics_api,
+    body,
+    expected_status,
+):
+    client, _users, _events = analytics_api
+    _signup(client)
+    response = client.post(
+        "/api/analytics/events",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == expected_status
+    assert "y" * 100 not in response.text
+
+
+def test_analytics_declared_body_size_is_bounded(analytics_api):
+    client, _users, _events = analytics_api
+    _signup(client)
+    response = client.post(
+        "/api/analytics/events",
+        content=b"{}",
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": "9000",
+        },
+    )
+    assert response.status_code == 413
+    assert response.json() == {"detail": "Analytics event is too large."}
+
+
+def test_analytics_ingestion_is_rate_limited_per_authenticated_user(
+    analytics_api,
+    monkeypatch,
+):
+    client, _users, _events = analytics_api
+    monkeypatch.setattr(
+        analytics_router,
+        "_ANALYTICS_INGESTION_LIMITER",
+        FixedWindowRateLimiter(max_events=2, window_seconds=300),
+    )
+    _signup(client, "first@example.test")
+    assert client.post("/api/analytics/events", json=frontend_payload()).status_code == 202
+    assert client.post("/api/analytics/events", json=frontend_payload()).status_code == 202
+    blocked = client.post("/api/analytics/events", json=frontend_payload())
+    assert blocked.status_code == 429
+    assert int(blocked.headers["Retry-After"]) >= 1
+
+    _signup(client, "second@example.test")
+    allowed = client.post("/api/analytics/events", json=frontend_payload())
+    assert allowed.status_code == 202
+
+
+def test_analytics_store_failure_returns_generic_503(analytics_api, capsys):
+    client, _users, _events = analytics_api
+    _signup(client)
+
+    class FailingService:
+        def accept_frontend_event(self, **kwargs):
+            raise RuntimeError("synthetic-secret-canary upstream body")
+
+    app.dependency_overrides[get_analytics_service] = lambda: FailingService()
+    response = client.post("/api/analytics/events", json=frontend_payload())
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": "Analytics is temporarily unavailable."
+    }
+    assert "synthetic-secret-canary" not in response.text
+    assert "synthetic-secret-canary" not in capsys.readouterr().out
+
+
+def test_analytics_idempotency_conflict_is_generic(analytics_api):
+    client, _users, _events = analytics_api
+    _signup(client)
+    payload = frontend_payload()
+    assert client.post("/api/analytics/events", json=payload).status_code == 202
+    payload["page_view"] = "credits"
+    conflict = client.post("/api/analytics/events", json=payload)
+    assert conflict.status_code == 409
+    assert conflict.json() == {"detail": "Analytics event conflicts with a replay."}
+
+
+def test_analytics_route_is_registered_once():
+    matches = [
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == "/api/analytics/events"
+        and "POST" in getattr(route, "methods", set())
+    ]
+    assert len(matches) == 1

--- a/dashboard/backend/tests/test_analytics_frontend.py
+++ b/dashboard/backend/tests/test_analytics_frontend.py
@@ -1,0 +1,155 @@
+"""Static safety and lifecycle contracts for browser Analytics events."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from dashboard.backend.tests._frontend_source import APP_HTML, APP_JS, fn_body
+
+
+_ROOT = Path(__file__).resolve().parents[2]
+_ANALYTICS_JS = (_ROOT / "frontend" / "js" / "analytics.js").read_text()
+_AGENT_EDITOR_JS = (_ROOT / "frontend" / "js" / "agent-editor.js").read_text()
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 0
+    quote = None
+    escaped = False
+    for index in range(brace, len(source)):
+        char = source[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in "'\"`":
+            quote = char
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"Unclosed function: {signature}")
+
+
+def test_analytics_script_loads_between_app_and_page_scripts():
+    app_at = APP_HTML.index('<script src="app.js?v=116" defer></script>')
+    analytics_at = APP_HTML.index(
+        '<script src="js/analytics.js?v=1" defer></script>'
+    )
+    editor_at = APP_HTML.index(
+        '<script src="js/agent-editor.js?v=28" defer></script>'
+    )
+    assert app_at < analytics_at < editor_at
+
+
+def test_analytics_session_and_heartbeat_constants_are_pinned():
+    assert "const SESSION_STORAGE_KEY = 'atl-analytics-session-v1';" in _ANALYTICS_JS
+    assert "const SESSION_TIMEOUT_MS = 30 * 60 * 1000;" in _ANALYTICS_JS
+    assert "const HEARTBEAT_INTERVAL_MS = 30 * 1000;" in _ANALYTICS_JS
+
+
+def test_page_view_map_contains_only_approved_identifiers():
+    match = re.search(
+        r"const PAGE_VIEW_MAP = Object\.freeze\(\{(?P<body>.*?)\}\);",
+        _ANALYTICS_JS,
+        re.DOTALL,
+    )
+    assert match
+    values = set(re.findall(r":\s*'([a-z_]+)'", match.group("body")))
+    assert values == {
+        "home",
+        "agents",
+        "agent_editor",
+        "backtest",
+        "paper_trading",
+        "competition",
+        "community",
+        "credits",
+        "account",
+    }
+
+
+def test_event_payload_has_only_the_seven_approved_fields():
+    body = _function_body(_ANALYTICS_JS, "function queueEvent(")
+    payload = body[body.index("const payload = {") : body.index("};", body.index("const payload = {"))]
+    keys = set(re.findall(r"^\s{6}([a-z_]+):", payload, re.MULTILINE))
+    assert keys == {
+        "event_id",
+        "schema_version",
+        "event_name",
+        "session_id",
+        "occurred_at",
+        "page_view",
+        "properties",
+    }
+    assert "credentials: 'include'" in body
+    assert "keepalive: true" in body
+    assert "window.csrfHeaders()" in body
+
+
+def test_analytics_module_has_no_sensitive_payload_fields():
+    forbidden = {
+        "email",
+        "display_name",
+        "role",
+        "api_key",
+        "token",
+        "prompt",
+        "strategy",
+        "provider_response",
+        "user_agent",
+    }
+    for name in forbidden:
+        assert not re.search(rf"[\"']{name}[\"']\s*:", _ANALYTICS_JS), name
+
+
+def test_navigation_records_only_after_final_normalization():
+    body = fn_body("function navigateToPage(")
+    call = "window.ATLAnalytics?.recordNavigation(page, { playgroundTab, competitionTab })"
+    assert call in body
+    assert body.index(call) > body.index("competitionTab === 'daily'")
+    assert body.index(call) > body.index("persistNavigation()")
+
+
+def test_agent_editor_enters_and_leaves_transient_view():
+    open_body = _function_body(_AGENT_EDITOR_JS, "function open(")
+    close_body = _function_body(_AGENT_EDITOR_JS, "function close(")
+    assert "window.ATLAnalytics?.enterTransientView('agent_editor')" in open_body
+    assert open_body.index("view.hidden = false") < open_body.index(
+        "enterTransientView('agent_editor')"
+    )
+    assert "window.ATLAnalytics?.leaveTransientView()" in close_body
+    assert close_body.index("view.hidden = true") < close_body.index(
+        "leaveTransientView()"
+    )
+
+
+def test_visibility_and_heartbeat_lifecycle_is_safe():
+    visibility = _function_body(_ANALYTICS_JS, "function handleVisibilityChange(")
+    hide_view = _function_body(_ANALYTICS_JS, "function hideCurrentView(")
+    show_view = _function_body(_ANALYTICS_JS, "function showCurrentView(")
+    signed_in = _function_body(_ANALYTICS_JS, "function signedIn(")
+    heartbeat = _function_body(_ANALYTICS_JS, "function sendHeartbeat(")
+    assert "hideCurrentView" in visibility
+    assert "showCurrentView" in visibility
+    assert "page_hidden" in hide_view
+    assert "page_viewed" in show_view
+    assert "signedIn()" in heartbeat
+    assert "getStoredAuthUser" in signed_in
+    assert "document.visibilityState !== 'visible'" in heartbeat
+    assert "session_heartbeat" in heartbeat
+
+
+def test_ingestion_failure_never_escapes_into_navigation():
+    body = _function_body(_ANALYTICS_JS, "function queueEvent(")
+    assert ".catch(() =>" in body
+    assert "throw" not in body

--- a/dashboard/backend/tests/test_analytics_frontend.py
+++ b/dashboard/backend/tests/test_analytics_frontend.py
@@ -120,6 +120,14 @@ def test_navigation_records_only_after_final_normalization():
     assert body.index(call) > body.index("persistNavigation()")
 
 
+def test_same_page_playground_tab_switch_records_navigation_after_panel_update():
+    body = fn_body("function switchPlaygroundTab(")
+    call = "window.ATLAnalytics?.recordNavigation('playground', { playgroundTab })"
+    assert call in body
+    assert body.index(call) > body.index("showPlaygroundPanel(tab)")
+    assert body.index(call) < body.index("syncNavigationHistory({ replace: false })")
+
+
 def test_agent_editor_enters_and_leaves_transient_view():
     open_body = _function_body(_AGENT_EDITOR_JS, "function open(")
     close_body = _function_body(_AGENT_EDITOR_JS, "function close(")

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -91,6 +91,7 @@ EXPECTED_FULL_CONTRACT = {
     ("POST", "/api/credits/api-keys/{credential_id}/verify"),
     ("POST", "/api/credits/api-keys/{credential_id}/default"),
     ("DELETE", "/api/credits/api-keys/{credential_id}"),
+    ("POST", "/api/analytics/events"),
     ("GET", "/api/admin/model-providers"),
     ("PUT", "/api/admin/model-providers/{provider_id}"),
     ("PUT", "/api/admin/model-providers/{provider_id}/platform-credential"),

--- a/dashboard/backend/tests/test_csrf.py
+++ b/dashboard/backend/tests/test_csrf.py
@@ -1,6 +1,7 @@
 """CSRF gate for cookie-authenticated mutating requests."""
 
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -318,3 +319,46 @@ def test_admin_grant_mutations_require_csrf_for_cookie_session(
     assert "CSRF" in blocked_reclaim.json()["detail"]
     assert allowed_assign.status_code == 200, allowed_assign.text
     assert allowed_reclaim.status_code == 200, allowed_reclaim.text
+
+
+def test_analytics_ingestion_requires_csrf_for_cookie_session(
+    csrf_client,
+    monkeypatch,
+):
+    from dashboard.backend.domain.analytics.models import AppendEventResult
+    from dashboard.backend.domain.analytics.service import get_analytics_service
+
+    _signup(csrf_client, email="analytics-csrf@example.com")
+
+    class FakeAnalyticsService:
+        def accept_frontend_event(self, **kwargs):
+            event = kwargs["payload"]
+            return AppendEventResult.model_construct(event=event, created=True)
+
+    app.dependency_overrides[get_analytics_service] = lambda: FakeAnalyticsService()
+    payload = {
+        "event_id": "30000000-0000-4000-8000-000000000001",
+        "schema_version": 1,
+        "event_name": "page_viewed",
+        "session_id": "30000000-0000-4000-8000-000000000002",
+        "occurred_at": datetime.now(timezone.utc).isoformat(),
+        "page_view": "home",
+        "properties": {},
+    }
+    try:
+        blocked = csrf_client.post(
+            "/api/analytics/events",
+            headers={"Origin": "http://testserver"},
+            json=payload,
+        )
+        allowed = csrf_client.post(
+            "/api/analytics/events",
+            headers=_csrf_headers(csrf_client),
+            json=payload,
+        )
+    finally:
+        app.dependency_overrides.pop(get_analytics_service, None)
+
+    assert blocked.status_code == 403
+    assert "CSRF" in blocked.json()["detail"]
+    assert allowed.status_code == 202, allowed.text

--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -190,7 +190,8 @@ def test_cache_busters_bumped():
     # the next bump, so the exact one looks like the broken guard and gets
     # "fixed" by loosening it. That collision has already cost this repo one
     # round of follow-ups (#347/#348).
-    assert "app.js?v=115" in APP_HTML
+    assert "app.js?v=116" in APP_HTML
+    assert "js/agent-editor.js?v=28" in APP_HTML
     assert "styles.css?v=124" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML

--- a/dashboard/backend/tests/test_run_lifecycle_unification.py
+++ b/dashboard/backend/tests/test_run_lifecycle_unification.py
@@ -15,6 +15,7 @@ exactly like v1 runs do:
    a second worker's live runs are no longer collateral damage.
 """
 
+import inspect
 import sqlite3
 import uuid
 
@@ -22,6 +23,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import dashboard.backend.api.v2.runs as runs_mod
+import dashboard.backend.app as app_module
 import dashboard.backend.domain.runs.repository as run_store_module
 import dashboard.backend.domain.runs.service as run_service
 from dashboard.backend.app import app
@@ -181,14 +183,20 @@ def test_reap_runs_invokes_registered_sweeps(monkeypatch):
     assert calls == ["swept"]
 
 
-def test_reap_runs_survives_a_raising_sweep(monkeypatch):
+def test_startup_registers_analytics_retention_sweep_once():
+    source = inspect.getsource(app_module.startup_event)
+    call = "register_reaper_sweep(analytics_retention_coordinator.run_if_due)"
+    assert source.count(call) == 1
+
+
+def test_reap_runs_survives_a_raising_analytics_retention_sweep(monkeypatch):
     calls = []
 
-    def _boom():
-        raise RuntimeError("sweep exploded")
+    def analytics_retention_sweep():
+        raise RuntimeError("synthetic retention failure")
 
     monkeypatch.setattr(run_service, "_extra_reaper_sweeps", [])
-    run_service.register_reaper_sweep(_boom)
+    run_service.register_reaper_sweep(analytics_retention_sweep)
     run_service.register_reaper_sweep(lambda: calls.append("still swept"))
     run_service.reap_runs()  # must not raise
     assert calls == ["still swept"]

--- a/dashboard/backend/tests/test_store_twin_parity.py
+++ b/dashboard/backend/tests/test_store_twin_parity.py
@@ -96,6 +96,12 @@ _TWINS = [
         "PostgresStrategyStore",
     ),
     (
+        "dashboard.backend.domain.analytics.repository",
+        "AnalyticsStore",
+        "dashboard.backend.domain.analytics.repository_postgres",
+        "PostgresAnalyticsStore",
+    ),
+    (
         "dashboard.backend.users",
         "UserStore",
         "dashboard.backend.users_postgres",

--- a/dashboard/backend/tests/test_v2_http_runs.py
+++ b/dashboard/backend/tests/test_v2_http_runs.py
@@ -64,7 +64,10 @@ def test_rate_limit_returns_429_envelope_with_retry_after():
     key, sid, agent_id = _agent("rl-agent")
     _register_run("run_rl_http", sid)
     # Drain the bucket so the next call is denied.
-    rate_limit.limiter._buckets[agent_id] = (0.0, time.monotonic())
+    # Keep the bucket empty for the whole request even on a slow CI runner;
+    # with 120 tokens/minute, a real-time timestamp could refill one token
+    # during TestClient startup and make this assertion flaky.
+    rate_limit.limiter._buckets[agent_id] = (0.0, time.monotonic() + 60.0)
     r = client.get("/api/v2/runs/run_rl_http/context", headers={"X-API-Key": key})
     assert r.status_code == 429
     assert r.json()["error"]["code"] == "rate_limited"

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -2259,8 +2259,9 @@
     <script src="market-events/MarketEventCard.js" defer></script>
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
-    <script src="js/agent-editor.js?v=27" defer></script>
-    <script src="app.js?v=115" defer></script>
+    <script src="app.js?v=116" defer></script>
+    <script src="js/analytics.js?v=1" defer></script>
+    <script src="js/agent-editor.js?v=28" defer></script>
     <script src="js/credits.js?v=4" defer></script>
     <script src="js/admin-model-providers.js?v=1" defer></script>
     <script src="js/admin-credits.js?v=5" defer></script>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -214,7 +214,7 @@ const SIMPLE_INSTRUCTION_PRESET_KEY = 'simple_instruction';
 const SIMPLE_INSTRUCTION_OUTPUT_FORMAT =
   'JSON: { "orders": [{ "symbol": "...", "side": "buy|sell|hold", "qty": number, "order_type": "market|limit", "limit_price": number|null, "reason": "..." }] }';
 // Single source of truth for the Simple-mode trading-actions contract. Published
-// on `window` so agent-editor.js (which loads BEFORE this file) reads the exact
+// on `window` so agent-editor.js (which loads after this file) reads the exact
 // same preset key + output format at call time instead of keeping its own copy.
 window.SIMPLE_INSTRUCTION_PRESET_KEY = SIMPLE_INSTRUCTION_PRESET_KEY;
 window.SIMPLE_INSTRUCTION_OUTPUT_FORMAT = SIMPLE_INSTRUCTION_OUTPUT_FORMAT;
@@ -8846,6 +8846,7 @@ function navigateToPage(page, options = {}) {
 
     clearNavBootState();
     persistNavigation();
+    window.ATLAnalytics?.recordNavigation(page, { playgroundTab, competitionTab });
 
     if (historyMode === 'none') return;
     const nextState = getNavigationState();

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -8864,6 +8864,12 @@ function switchPlaygroundTab(tab) {
     // history — syncNavigationHistory early-returns when the URL and state are
     // already the current entry, which is exactly this case.
     showPlaygroundPanel(tab);
+    // showPlaygroundPanel can redirect a retired tab to Community. Only record
+    // the Playground view after the panel has updated and that redirect did not
+    // occur, so heartbeats and visibility events keep the correct page_view.
+    if (currentPage === 'playground') {
+        window.ATLAnalytics?.recordNavigation('playground', { playgroundTab });
+    }
     syncNavigationHistory({ replace: false });
 }
 

--- a/dashboard/frontend/js/agent-editor.js
+++ b/dashboard/frontend/js/agent-editor.js
@@ -126,10 +126,9 @@
       : '';
 
   // The simple-instruction contract (preset key + trading-actions output format)
-  // has a single source of truth in app.js, published on `window`. app.js loads
-  // AFTER this file, so read lazily at call time — every use below is inside an
-  // event-driven function, by which point window.* is populated. The fallbacks
-  // only matter if app.js somehow failed to load (whole app is broken anyway).
+  // has a single source of truth in app.js, published on `window`. Read lazily
+  // at call time so event-driven uses stay decoupled from script evaluation.
+  // The fallbacks only matter if app.js somehow failed to load.
   function simplePresetKey() {
     return (
       (typeof window !== 'undefined' && window.SIMPLE_INSTRUCTION_PRESET_KEY) ||
@@ -1256,6 +1255,7 @@
       view.hidden = false;
       document.body.classList.add('agent-editor-open');
     }
+    window.ATLAnalytics?.enterTransientView('agent_editor');
 
     const playgroundView = document.getElementById('playgroundView');
     if (playgroundView) playgroundView.setAttribute('aria-hidden', 'true');
@@ -1274,6 +1274,7 @@
     hideAiHedgeFundTooltip(activeAiHedgeFundTooltipOption);
     const view = document.getElementById('agentEditorView');
     if (view) view.hidden = true;
+    window.ATLAnalytics?.leaveTransientView();
     document.body.classList.remove('agent-editor-open');
 
     const playgroundView = document.getElementById('playgroundView');

--- a/dashboard/frontend/js/analytics.js
+++ b/dashboard/frontend/js/analytics.js
@@ -1,0 +1,241 @@
+/** Privacy-reduced, authenticated browser Analytics lifecycle events. */
+(function () {
+  'use strict';
+
+  const SESSION_STORAGE_KEY = 'atl-analytics-session-v1';
+  const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+  const HEARTBEAT_INTERVAL_MS = 30 * 1000;
+  const MAX_VISIBLE_MS = 1_800_000;
+  const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+  const PAGE_VIEW_MAP = Object.freeze({
+    home: 'home',
+    playground_agents: 'agents',
+    agent_editor: 'agent_editor',
+    playground_backtest: 'backtest',
+    playground_paper: 'paper_trading',
+    competition: 'competition',
+    community: 'community',
+    credits: 'credits',
+    account: 'account',
+  });
+
+  let memorySession = null;
+  let basePageView = null;
+  let currentPageView = null;
+  let currentViewStartedAt = null;
+  let transientPageView = null;
+  let transientReturnView = null;
+  let viewSuspended = false;
+  let deliveryWarningShown = false;
+
+  function signedIn() {
+    try {
+      return (
+        typeof window.getStoredAuthUser === 'function' &&
+        Boolean(window.getStoredAuthUser())
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function validSession(value, now) {
+    if (!value || typeof value !== 'object') return false;
+    if (!CANONICAL_UUID.test(value.id || '')) return false;
+    if (!Number.isFinite(value.last_activity_at)) return false;
+    const age = now - value.last_activity_at;
+    return age >= 0 && age < SESSION_TIMEOUT_MS;
+  }
+
+  function readSession(now) {
+    let raw;
+    try {
+      raw = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    } catch (error) {
+      return validSession(memorySession, now)
+        ? memorySession
+        : { id: crypto.randomUUID(), last_activity_at: now };
+    }
+    if (raw) {
+      try {
+        const stored = JSON.parse(raw);
+        if (validSession(stored, now)) return stored;
+      } catch (error) {
+        /* malformed state rotates the tab-scoped session */
+      }
+    }
+    return { id: crypto.randomUUID(), last_activity_at: now };
+  }
+
+  function touchSession(now) {
+    const session = readSession(now);
+    session.last_activity_at = now;
+    memorySession = session;
+    try {
+      sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+    } catch (error) {
+      /* the in-memory tab session still keeps events correlated */
+    }
+    return session.id;
+  }
+
+  function warnDeliveryOnce() {
+    if (deliveryWarningShown) return;
+    deliveryWarningShown = true;
+    console.warn('Analytics event delivery failed.');
+  }
+
+  function queueEvent(eventName, pageView, properties) {
+    if (!signedIn() || !pageView) return false;
+    const now = Date.now();
+    const payload = {
+      event_id: crypto.randomUUID(),
+      schema_version: 1,
+      event_name: eventName,
+      session_id: touchSession(now),
+      occurred_at: new Date(now).toISOString(),
+      page_view: pageView,
+      properties: properties || {},
+    };
+    try {
+      const csrf = typeof window.csrfHeaders === 'function'
+        ? window.csrfHeaders()
+        : {};
+      void fetch(API_BASE + '/api/analytics/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...csrf },
+        credentials: 'include',
+        keepalive: true,
+        body: JSON.stringify(payload),
+      }).catch(() => warnDeliveryOnce());
+    } catch (error) {
+      warnDeliveryOnce();
+    }
+    return true;
+  }
+
+  function visibleMs(now) {
+    if (!Number.isFinite(currentViewStartedAt)) return 0;
+    return Math.max(
+      0,
+      Math.min(MAX_VISIBLE_MS, Math.round(now - currentViewStartedAt)),
+    );
+  }
+
+  function hideCurrentView(now) {
+    if (!currentPageView || viewSuspended) return;
+    queueEvent('page_hidden', currentPageView, { visible_ms: visibleMs(now) });
+    currentViewStartedAt = null;
+    viewSuspended = true;
+  }
+
+  function showCurrentView(now) {
+    if (!currentPageView || !signedIn()) return;
+    queueEvent('page_viewed', currentPageView, {});
+    currentViewStartedAt = now;
+    viewSuspended = false;
+  }
+
+  function transitionTo(pageView) {
+    if (pageView === currentPageView && !viewSuspended) return;
+    const now = Date.now();
+    hideCurrentView(now);
+    currentPageView = pageView;
+    currentViewStartedAt = null;
+    viewSuspended = false;
+    if (pageView) showCurrentView(now);
+  }
+
+  function resolvePageView(page, options) {
+    if (page === 'playground') {
+      const tab = options.playgroundTab || document.documentElement.dataset.navPlaygroundTab;
+      return PAGE_VIEW_MAP[`playground_${tab}`] || null;
+    }
+    return PAGE_VIEW_MAP[page] || null;
+  }
+
+  function resetSignedOutState() {
+    currentPageView = null;
+    currentViewStartedAt = null;
+    viewSuspended = false;
+    transientPageView = null;
+    transientReturnView = null;
+  }
+
+  function recordNavigation(page, options = {}) {
+    const pageView = resolvePageView(page, options);
+    basePageView = pageView;
+    if (!signedIn()) {
+      resetSignedOutState();
+      return;
+    }
+    if (transientPageView) {
+      transientReturnView = pageView;
+      return;
+    }
+    transitionTo(pageView);
+  }
+
+  function enterTransientView(pageView) {
+    const approved = PAGE_VIEW_MAP[pageView];
+    if (!approved || !signedIn()) return;
+    if (transientPageView === approved) return;
+    transientReturnView = basePageView || currentPageView;
+    transientPageView = approved;
+    transitionTo(approved);
+  }
+
+  function leaveTransientView() {
+    if (!transientPageView) return;
+    const returnView = basePageView || transientReturnView;
+    transientPageView = null;
+    transientReturnView = null;
+    if (!signedIn()) {
+      resetSignedOutState();
+      return;
+    }
+    transitionTo(returnView);
+  }
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === 'hidden') {
+      hideCurrentView(Date.now());
+      return;
+    }
+    if (document.visibilityState === 'visible' && viewSuspended) {
+      showCurrentView(Date.now());
+    }
+  }
+
+  function sendHeartbeat() {
+    if (!signedIn()) return;
+    if (document.visibilityState !== 'visible') return;
+    if (!currentPageView || viewSuspended) return;
+    const now = Date.now();
+    if (queueEvent('session_heartbeat', currentPageView, { visible_ms: visibleMs(now) })) {
+      currentViewStartedAt = now;
+    }
+  }
+
+  function handlePageHide() {
+    hideCurrentView(Date.now());
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (!signedIn()) return;
+    const html = document.documentElement;
+    recordNavigation(html.dataset.navPage || 'home', {
+      playgroundTab: html.dataset.navPlaygroundTab,
+      competitionTab: html.dataset.navCompetitionTab,
+    });
+  });
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  window.addEventListener('pagehide', handlePageHide);
+  window.setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS);
+
+  window.ATLAnalytics = Object.freeze({
+    recordNavigation,
+    enterTransientView,
+    leaveTransientView,
+  });
+})();

--- a/docs/superpowers/plans/2026-08-26-admin-user-analytics-foundation.md
+++ b/docs/superpowers/plans/2026-08-26-admin-user-analytics-foundation.md
@@ -1,0 +1,1873 @@
+# Admin User Analytics Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the privacy-safe Analytics foundation: durable event storage, strict validation and idempotency, authenticated page-event ingestion, pseudonymous sessions, subject exclusions, Admin profile-access auditing, and bounded retention.
+
+**Architecture:** Analytics lives in a new `dashboard.backend.domain.analytics` package and uses the account database selected by `USERS_DATABASE_URL`, with equivalent SQLite and PostgreSQL stores. The browser sends only allowlisted experience events; the service adds authenticated identity, server timestamps, coarse device/browser data, and an optional monthly HMAC network identifier before persistence. Retention rides the existing run-reaper sweep, so it adds no second scheduler and can fail without changing authentication, Credits, credential, Agent, or backtest outcomes.
+
+**Tech Stack:** Python 3.13, FastAPI, Pydantic v2, SQLite, PostgreSQL/psycopg, vanilla JavaScript, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-admin-user-analytics-design.md`
+
+## Global Constraints
+
+- No Admin Analytics UI or metrics are included in this PR; PR 1 also ships no Admin Analytics query endpoints.
+- Raw `analytics_events` are retained for 180 days; `admin_analytics_access_log` rows are retained for 365 days.
+- `analytics_daily_rollups` and current `user_analytics_snapshots` are not deleted by raw-event retention.
+- Missing or invalid `ANALYTICS_PSEUDONYMIZATION_KEY` omits `network_hash`; plaintext IP fallback is forbidden.
+- Never persist, return, or log API keys, passwords, tokens, prompts, strategy text, portfolio/form input, raw provider bodies, encrypted credential ciphertext, full IP addresses, or raw User-Agent values.
+- Frontend ingestion accepts only `page_viewed`, `page_hidden`, and `session_heartbeat` for an explicit page allowlist.
+- Authentication supplies `user_id`; the client cannot submit identity, role, email, display name, credential metadata, or billing evidence.
+- Analytics failures must not change login, credential, Agent, backtest, model-execution, or Credits results.
+- SQLite and PostgreSQL public repository methods and behavior must remain equivalent.
+- Tests use synthetic values only and never require or display a real API key.
+- Do not commit `.superpowers/`, `work/`, `dashboard/storage/data/backtest.db`, or any local database file.
+- Use TDD and stop at the first failing layer; do not continue stacking changes on a failed test.
+
+---
+
+### Task 1: Define the event contract and privacy reducers
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/__init__.py`
+- Create: `dashboard/backend/domain/analytics/models.py`
+- Create: `dashboard/backend/domain/analytics/privacy.py`
+- Create: `dashboard/backend/tests/domain/analytics/__init__.py`
+- Create: `dashboard/backend/tests/domain/analytics/test_models.py`
+- Create: `dashboard/backend/tests/domain/analytics/test_privacy.py`
+
+**Interfaces:**
+- Consumes: Pydantic v2 `BaseModel`/`ConfigDict`/`Field`/`field_validator` and `dashboard.backend.api.rate_limit.client_ip(request)`.
+- Produces: `FrontendAnalyticsEvent`, `AnalyticsEventDraft`, `AnalyticsEventRecord`, `AppendEventResult`, `RetentionResult`, `RequestAnalyticsContext`, `sanitize_frontend_properties(event_name, properties)`, `sanitize_server_properties(event_name, properties)`, `monthly_network_hash(ip_address, received_at)`, and `request_analytics_context(request, received_at)`.
+
+- [ ] **Step 1: Write failing model-contract tests**
+
+Create `dashboard/backend/tests/domain/analytics/test_models.py` with exact allowlist and rejection coverage:
+
+```python
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from dashboard.backend.domain.analytics.models import (
+    ALLOWED_BILLING_MODES,
+    ALLOWED_ERROR_CATEGORIES,
+    ALLOWED_EVENT_NAMES,
+    ALLOWED_FRONTEND_EVENT_NAMES,
+    ALLOWED_PAGE_VIEWS,
+    FrontendAnalyticsEvent,
+)
+
+
+def _payload(**overrides):
+    value = {
+        "event_id": str(uuid4()),
+        "schema_version": 1,
+        "event_name": "page_viewed",
+        "session_id": str(uuid4()),
+        "occurred_at": datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc),
+        "page_view": "home",
+        "properties": {},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_allowlists_are_closed_and_versioned():
+    assert ALLOWED_FRONTEND_EVENT_NAMES == {
+        "page_viewed",
+        "page_hidden",
+        "session_heartbeat",
+    }
+    assert ALLOWED_PAGE_VIEWS == {
+        "home",
+        "agents",
+        "agent_editor",
+        "backtest",
+        "paper_trading",
+        "competition",
+        "community",
+        "credits",
+        "account",
+    }
+    assert ALLOWED_BILLING_MODES == {"byok", "platform_credits"}
+    assert {
+        "credential_invalid",
+        "credential_missing",
+        "provider_timeout",
+        "provider_unavailable",
+        "credits_unavailable",
+        "model_not_allowed",
+        "internal_error",
+    } <= ALLOWED_ERROR_CATEGORIES
+    assert ALLOWED_FRONTEND_EVENT_NAMES < ALLOWED_EVENT_NAMES
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {"schema_version": 2},
+        {"event_name": "backtest_completed"},
+        {"event_name": "clicked_anything"},
+        {"page_view": "admin"},
+        {"session_id": "auth-token-shaped-value"},
+        {"email": "not-accepted@example.test"},
+        {"properties": {"prompt": "must not cross"}},
+        {"properties": {"api_key": "synthetic-secret-canary"}},
+    ],
+)
+def test_frontend_event_rejects_unknown_or_sensitive_shape(patch):
+    with pytest.raises(ValidationError):
+        FrontendAnalyticsEvent.model_validate(_payload(**patch))
+
+
+def test_frontend_event_accepts_only_bounded_duration_metadata():
+    event = FrontendAnalyticsEvent.model_validate(
+        _payload(event_name="page_hidden", properties={"visible_ms": 12_500})
+    )
+    assert event.properties == {"visible_ms": 12_500}
+    with pytest.raises(ValidationError):
+        FrontendAnalyticsEvent.model_validate(
+            _payload(event_name="page_hidden", properties={"visible_ms": 1_800_001})
+        )
+```
+
+- [ ] **Step 2: Run model tests and verify the import fails**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/domain/analytics/test_models.py
+```
+
+Expected: FAIL during collection with `ModuleNotFoundError: No module named 'dashboard.backend.domain.analytics'`.
+
+- [ ] **Step 3: Implement the closed event models**
+
+Create `models.py` with these public constants and models:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+ANALYTICS_SCHEMA_VERSION = 1
+MAX_PROPERTIES_BYTES = 1024
+
+ALLOWED_FRONTEND_EVENT_NAMES = {
+    "page_viewed", "page_hidden", "session_heartbeat",
+}
+ALLOWED_SERVER_EVENT_NAMES = {
+    "account_signed_up", "authenticated_session_started",
+    "credential_saved", "credential_verified", "credential_defaulted",
+    "credential_reverified", "credential_revoked",
+    "agent_created", "agent_updated", "agent_deleted",
+    "backtest_requested", "backtest_queued", "backtest_started",
+    "backtest_completed", "backtest_failed", "backtest_cancelled",
+    "model_usage_recorded", "credits_reserved", "credits_settled",
+    "credits_refunded", "safe_error_recorded",
+}
+ALLOWED_EVENT_NAMES = ALLOWED_FRONTEND_EVENT_NAMES | ALLOWED_SERVER_EVENT_NAMES
+ALLOWED_PAGE_VIEWS = {
+    "home", "agents", "agent_editor", "backtest", "paper_trading",
+    "competition", "community", "credits", "account",
+}
+ALLOWED_BILLING_MODES = {"byok", "platform_credits"}
+ALLOWED_OUTCOMES = {"succeeded", "failed", "cancelled"}
+ALLOWED_ERROR_CATEGORIES = {
+    "credential_invalid", "credential_missing", "provider_timeout",
+    "provider_unavailable", "credits_unavailable", "model_not_allowed",
+    "internal_error",
+}
+SERVER_EVENT_PROPERTY_RULES = {
+    "account_signed_up": {},
+    "authenticated_session_started": {},
+    "credential_saved": {},
+    "credential_verified": {},
+    "credential_defaulted": {},
+    "credential_reverified": {},
+    "credential_revoked": {},
+    "agent_created": {},
+    "agent_updated": {},
+    "agent_deleted": {},
+    "backtest_requested": {},
+    "backtest_queued": {},
+    "backtest_started": {},
+    "backtest_completed": {},
+    "backtest_failed": {},
+    "backtest_cancelled": {},
+    "model_usage_recorded": {
+        "input_tokens": (int, 0, 2_000_000_000),
+        "output_tokens": (int, 0, 2_000_000_000),
+        "cost_micro_usd": (int, 0, 10_000_000_000),
+    },
+    "credits_reserved": {
+        "amount_micro": (int, 1, 10_000_000_000),
+        "bucket": (str, {"grant", "purchased"}),
+    },
+    "credits_settled": {
+        "amount_micro": (int, 1, 10_000_000_000),
+        "bucket": (str, {"grant", "purchased"}),
+    },
+    "credits_refunded": {
+        "amount_micro": (int, 1, 10_000_000_000),
+        "bucket": (str, {"grant", "purchased"}),
+    },
+    "safe_error_recorded": {},
+}
+EVENT_GROUP_BY_NAME = {
+    "page_viewed": "experience",
+    "page_hidden": "experience",
+    "session_heartbeat": "experience",
+    "account_signed_up": "account",
+    "authenticated_session_started": "account",
+    "credential_saved": "credential",
+    "credential_verified": "credential",
+    "credential_defaulted": "credential",
+    "credential_reverified": "credential",
+    "credential_revoked": "credential",
+    "agent_created": "agent",
+    "agent_updated": "agent",
+    "agent_deleted": "agent",
+    "backtest_requested": "run",
+    "backtest_queued": "run",
+    "backtest_started": "run",
+    "backtest_completed": "run",
+    "backtest_failed": "run",
+    "backtest_cancelled": "run",
+    "model_usage_recorded": "resource",
+    "credits_reserved": "resource",
+    "credits_settled": "resource",
+    "credits_refunded": "resource",
+    "safe_error_recorded": "resource",
+}
+
+
+class FrontendAnalyticsEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str = Field(min_length=36, max_length=36)
+    schema_version: Literal[1]
+    event_name: Literal["page_viewed", "page_hidden", "session_heartbeat"]
+    session_id: str = Field(min_length=36, max_length=36)
+    occurred_at: datetime
+    page_view: str
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("event_id", "session_id")
+    @classmethod
+    def valid_uuid(cls, value: str) -> str:
+        from uuid import UUID
+        parsed = UUID(value)
+        if str(parsed) != value.lower():
+            raise ValueError("identifier must be a canonical UUID")
+        return value.lower()
+
+    @field_validator("page_view")
+    @classmethod
+    def allowed_page(cls, value: str) -> str:
+        if value not in ALLOWED_PAGE_VIEWS:
+            raise ValueError("unknown page view")
+        return value
+
+    @model_validator(mode="after")
+    def allowed_properties(self):
+        self.properties = sanitize_frontend_properties(
+            self.event_name, self.properties
+        )
+        return self
+
+
+class AnalyticsEventDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    event_id: str = Field(min_length=36, max_length=36)
+    schema_version: Literal[1] = 1
+    event_name: str = Field(min_length=1, max_length=64)
+    user_id: int = Field(gt=0)
+    session_id: str | None = Field(default=None, min_length=36, max_length=36)
+    occurred_at: datetime
+    event_source: Literal["frontend", "server", "backfill"]
+    source_event_id: str | None = Field(default=None, min_length=1, max_length=200)
+    source_record_type: str | None = Field(default=None, min_length=1, max_length=64)
+    source_record_id: str | None = Field(default=None, min_length=1, max_length=200)
+    correlation_id: str | None = Field(default=None, min_length=1, max_length=200)
+    page_view: str | None = Field(default=None, min_length=1, max_length=64)
+    provider_id: str | None = Field(default=None, min_length=1, max_length=128)
+    model_id: str | None = Field(default=None, min_length=1, max_length=256)
+    billing_mode: str | None = Field(default=None, min_length=1, max_length=32)
+    outcome: str | None = Field(default=None, min_length=1, max_length=32)
+    error_category: str | None = Field(default=None, min_length=1, max_length=64)
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalyticsEventRecord(AnalyticsEventDraft):
+    event_group: str
+    received_at: datetime
+    country_code: str | None = None
+    device_category: str | None = None
+    browser_family: str | None = None
+    network_hash: str | None = None
+
+
+class AppendEventResult(BaseModel):
+    event: AnalyticsEventRecord
+    created: bool
+
+
+class RetentionResult(BaseModel):
+    raw_events_deleted: int = 0
+    access_rows_deleted: int = 0
+    has_more_raw_events: bool = False
+    has_more_access_rows: bool = False
+```
+
+Implement `sanitize_frontend_properties` before the model class. It must accept no keys for `page_viewed`, accept only `visible_ms` for `page_hidden` and `session_heartbeat`, require a non-boolean integer from 0 through 1,800,000, serialize with compact sorted JSON, and reject a serialized payload over 1,024 bytes.
+
+Implement `sanitize_server_properties` from `SERVER_EVENT_PROPERTY_RULES`. It must reject unknown keys, booleans masquerading as integers, out-of-range token/cost/amount values, unknown bucket strings, and compact JSON over 1,024 bytes. This gives PR 2 a safe instrumentation interface without permitting prompt text or provider response content.
+
+Add `AnalyticsEventDraft`/`AnalyticsEventRecord` validators that reject:
+
+```python
+@field_validator("event_name")
+@classmethod
+def allowed_event_name(cls, value: str) -> str:
+    if value not in ALLOWED_EVENT_NAMES:
+        raise ValueError("unknown analytics event")
+    return value
+
+@model_validator(mode="after")
+def coherent_event(self):
+    if self.billing_mode is not None and self.billing_mode not in ALLOWED_BILLING_MODES:
+        raise ValueError("unknown billing mode")
+    if self.error_category is not None and self.error_category not in ALLOWED_ERROR_CATEGORIES:
+        raise ValueError("unknown error category")
+    if self.outcome is not None and self.outcome not in ALLOWED_OUTCOMES:
+        raise ValueError("unknown outcome")
+    if self.page_view is not None and self.page_view not in ALLOWED_PAGE_VIEWS:
+        raise ValueError("unknown page view")
+    if isinstance(self, AnalyticsEventRecord):
+        expected_group = EVENT_GROUP_BY_NAME[self.event_name]
+        if self.event_group != expected_group:
+            raise ValueError("event group does not match event name")
+    return self
+```
+
+Extend `test_models.py` with a valid `AnalyticsEventRecord` fixture and assert that an unknown event name, mismatched event group, unknown billing mode, unknown error category, and oversized identifier each raise `ValidationError`.
+
+- [ ] **Step 4: Run the model tests**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/domain/analytics/test_models.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing privacy-reducer tests**
+
+Create `test_privacy.py`. Use `synthetic-secret-canary` only as a negative assertion:
+
+```python
+from datetime import datetime, timezone
+
+from starlette.requests import Request
+
+from dashboard.backend.domain.analytics.privacy import (
+    monthly_network_hash,
+    request_analytics_context,
+)
+
+
+def _request(headers=None, client=("203.0.113.19", 443)):
+    raw = [(key.lower().encode(), value.encode()) for key, value in (headers or {}).items()]
+    return Request({
+        "type": "http",
+        "method": "POST",
+        "path": "/api/analytics/events",
+        "headers": raw,
+        "client": client,
+        "scheme": "https",
+        "server": ("testserver", 443),
+        "query_string": b"",
+    })
+
+
+def test_missing_or_short_key_omits_network_hash(monkeypatch):
+    occurred_at = datetime(2026, 8, 26, tzinfo=timezone.utc)
+    monkeypatch.delenv("ANALYTICS_PSEUDONYMIZATION_KEY", raising=False)
+    assert monthly_network_hash("203.0.113.19", occurred_at) is None
+    monkeypatch.setenv("ANALYTICS_PSEUDONYMIZATION_KEY", "too-short")
+    assert monthly_network_hash("203.0.113.19", occurred_at) is None
+
+
+def test_network_hash_is_month_scoped_and_never_contains_plain_ip(monkeypatch):
+    monkeypatch.setenv(
+        "ANALYTICS_PSEUDONYMIZATION_KEY",
+        "synthetic-analytics-hmac-key-at-least-32-bytes",
+    )
+    august = monthly_network_hash(
+        "203.0.113.19", datetime(2026, 8, 26, tzinfo=timezone.utc)
+    )
+    september = monthly_network_hash(
+        "203.0.113.19", datetime(2026, 9, 1, tzinfo=timezone.utc)
+    )
+    assert august and september and august != september
+    assert "203.0.113.19" not in august
+    assert len(august) == 64
+
+
+def test_request_context_reduces_user_agent_and_country(monkeypatch):
+    monkeypatch.setenv(
+        "ANALYTICS_PSEUDONYMIZATION_KEY",
+        "synthetic-analytics-hmac-key-at-least-32-bytes",
+    )
+    monkeypatch.setenv("RENDER", "true")
+    raw_agent = (
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) "
+        "AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1 "
+        "synthetic-secret-canary"
+    )
+    context = request_analytics_context(
+        _request({"user-agent": raw_agent, "cf-ipcountry": "US"}),
+        datetime(2026, 8, 26, tzinfo=timezone.utc),
+    )
+    assert context.browser_family == "Safari"
+    assert context.device_category == "mobile"
+    assert context.country_code == "US"
+    assert "synthetic-secret-canary" not in repr(context)
+    assert "Mozilla" not in repr(context)
+    assert "203.0.113.19" not in repr(context)
+```
+
+- [ ] **Step 6: Run privacy tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/domain/analytics/test_privacy.py
+```
+
+Expected: FAIL because `privacy.py` and `RequestAnalyticsContext` do not exist.
+
+- [ ] **Step 7: Implement privacy reduction without plaintext fallback**
+
+Add this model to `models.py`:
+
+```python
+class RequestAnalyticsContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    country_code: str | None = None
+    device_category: str
+    browser_family: str
+    network_hash: str | None = None
+```
+
+Create `privacy.py` with these exact rules:
+
+```python
+def monthly_network_hash(ip_address: str | None, received_at: datetime) -> str | None:
+    secret = (os.getenv("ANALYTICS_PSEUDONYMIZATION_KEY") or "").strip()
+    if not ip_address or len(secret.encode("utf-8")) < 32:
+        return None
+    month = received_at.astimezone(timezone.utc).strftime("%Y-%m")
+    message = f"{month}\n{ip_address.strip()}".encode("utf-8")
+    return hmac.new(secret.encode("utf-8"), message, hashlib.sha256).hexdigest()
+```
+
+`request_analytics_context` must:
+
+1. Call `client_ip(request)` once, pass the result directly into `monthly_network_hash`, and never return the raw value.
+2. Reduce User-Agent to browser family `Edge`, `Chrome`, `Firefox`, `Safari`, or `Other`.
+3. Reduce device to `mobile`, `tablet`, `desktop`, or `unknown`.
+4. Accept `CF-IPCountry` only when `RENDER` is truthy and `X-Vercel-IP-Country` only when `VERCEL` is truthy.
+5. Accept only two ASCII letters as country code; otherwise return `None`.
+6. Never include headers, raw User-Agent, IP, or the HMAC secret in the returned model or exception text.
+
+- [ ] **Step 8: Run Task 1 tests and commit**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/analytics/test_models.py \
+  dashboard/backend/tests/domain/analytics/test_privacy.py
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  dashboard/backend/domain/analytics/__init__.py \
+  dashboard/backend/domain/analytics/models.py \
+  dashboard/backend/domain/analytics/privacy.py \
+  dashboard/backend/tests/domain/analytics/__init__.py \
+  dashboard/backend/tests/domain/analytics/test_models.py \
+  dashboard/backend/tests/domain/analytics/test_privacy.py
+git commit -m "feat: define analytics event privacy contract"
+```
+
+---
+
+### Task 2: Build the SQLite Analytics repository
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/repository_common.py`
+- Create: `dashboard/backend/domain/analytics/repository.py`
+- Create: `dashboard/backend/tests/domain/analytics/test_repository_contract.py`
+
+**Interfaces:**
+- Consumes: `AnalyticsEventRecord`, `AppendEventResult`, `RetentionResult`, `DB_PATH`, and the existing account `users` table.
+- Produces: `AnalyticsStoreError`, `AnalyticsIdempotencyConflictError`, `encode_event_cursor(occurred_at, sequence)`, `decode_event_cursor(cursor)`, `AnalyticsStore`, and the repository methods listed below.
+
+Repository public methods:
+
+```python
+append_event(event: AnalyticsEventRecord) -> AppendEventResult
+get_event(event_id: str) -> AnalyticsEventRecord | None
+list_user_events(user_id: int, *, limit: int = 50, cursor: str | None = None) -> dict
+set_subject_exclusion(user_id: int, *, excluded: bool, actor_user_id: int, reason: str) -> dict
+get_subject_setting(user_id: int) -> dict | None
+list_excluded_user_ids(*, include_admin_accounts: bool = True) -> set[int]
+record_admin_access(admin_user_id: int, subject_user_id: int, section: str) -> dict
+list_admin_access(subject_user_id: int, *, limit: int = 50) -> list[dict]
+delete_expired(*, raw_before: datetime, access_before: datetime, batch_size: int) -> RetentionResult
+```
+
+- [ ] **Step 1: Write the shared SQLite repository contract**
+
+Create `test_repository_contract.py` with a fixture that creates users through `UserStore` and passes the same database path to `AnalyticsStore`. Define reusable assertion functions so PostgreSQL can run the identical behavior later:
+
+```python
+def assert_event_idempotency_contract(store, user_id):
+    event = event_record(user_id=user_id, event_id="10000000-0000-4000-8000-000000000001")
+    first = store.append_event(event)
+    replay = store.append_event(event)
+    assert first.created is True
+    assert replay.created is False
+    assert replay.event == first.event
+
+    changed = event.model_copy(update={"page_view": "credits"})
+    with pytest.raises(AnalyticsIdempotencyConflictError):
+        store.append_event(changed)
+
+
+def assert_source_event_idempotency_contract(store, user_id):
+    event = event_record(
+        user_id=user_id,
+        event_id="10000000-0000-4000-8000-000000000002",
+        event_source="server",
+        source_event_id="run:run_123:completed",
+        event_name="backtest_completed",
+        event_group="run",
+        page_view=None,
+        session_id=None,
+    )
+    assert store.append_event(event).created is True
+    replay = event.model_copy(
+        update={"event_id": "10000000-0000-4000-8000-000000000003"}
+    )
+    assert store.append_event(replay).created is False
+
+
+def assert_cursor_contract(store, user_id):
+    for index in range(3):
+        store.append_event(event_record(
+            user_id=user_id,
+            event_id=f"20000000-0000-4000-8000-00000000000{index}",
+            occurred_at=datetime(2026, 8, 26, 12, index, tzinfo=timezone.utc),
+        ))
+    first = store.list_user_events(user_id, limit=2)
+    second = store.list_user_events(user_id, limit=2, cursor=first["next_cursor"])
+    assert len(first["items"]) == 2
+    assert len(second["items"]) == 1
+    assert not ({item.event_id for item in first["items"]} & {item.event_id for item in second["items"]})
+
+
+def assert_subject_and_access_contract(store, admin_id, user_id):
+    setting = store.set_subject_exclusion(
+        user_id,
+        excluded=True,
+        actor_user_id=admin_id,
+        reason="Synthetic QA account.",
+    )
+    assert setting["excluded"] is True
+    assert user_id in store.list_excluded_user_ids()
+    access = store.record_admin_access(admin_id, user_id, "overview")
+    assert access["admin_user_id"] == admin_id
+    assert access["subject_user_id"] == user_id
+    assert "response" not in access
+    assert store.list_admin_access(user_id)[0]["section"] == "overview"
+```
+
+Add tests that assert:
+
+- all five tables exist;
+- an invalid cursor raises `ValueError("invalid analytics cursor")`;
+- `limit` accepts 1 through 100 only;
+- access sections accept `overview`, `timeline`, `runs`, `usage`, and `sessions` only;
+- subject reason is trimmed and 1 through 500 characters;
+- Admin users are included by `list_excluded_user_ids(include_admin_accounts=True)` even without a settings row;
+- disabling a settings row removes a normal user from the exclusion set;
+- foreign keys reject nonexistent users.
+
+- [ ] **Step 2: Run the SQLite contract and verify it fails**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/domain/analytics/test_repository_contract.py
+```
+
+Expected: FAIL because the repository modules do not exist.
+
+- [ ] **Step 3: Implement shared errors, cursor encoding, and canonical comparison**
+
+In `repository_common.py` define:
+
+```python
+class AnalyticsStoreError(RuntimeError):
+    pass
+
+
+class AnalyticsIdempotencyConflictError(AnalyticsStoreError):
+    pass
+
+
+def encode_event_cursor(occurred_at: str, sequence: int) -> str:
+    payload = json.dumps(
+        [occurred_at, sequence], ensure_ascii=True, separators=(",", ":")
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def decode_event_cursor(cursor: str) -> tuple[str, int]:
+    if not isinstance(cursor, str) or not cursor or len(cursor) > 256:
+        raise ValueError("invalid analytics cursor")
+    try:
+        raw = base64.b64decode(
+            cursor + "=" * (-len(cursor) % 4),
+            altchars=b"-_",
+            validate=True,
+        )
+        value = json.loads(raw.decode("utf-8"))
+    except (ValueError, binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid analytics cursor") from exc
+    if not isinstance(value, list) or len(value) != 2:
+        raise ValueError("invalid analytics cursor")
+    occurred_at, sequence = value
+    if (
+        not isinstance(occurred_at, str)
+        or not occurred_at
+        or len(occurred_at) > 64
+        or isinstance(sequence, bool)
+        or not isinstance(sequence, int)
+        or sequence <= 0
+    ):
+        raise ValueError("invalid analytics cursor")
+    return occurred_at, sequence
+
+
+def canonical_event_payload(
+    event: AnalyticsEventRecord,
+    *,
+    ignore_event_id: bool = False,
+) -> dict[str, object]:
+    value = event.model_dump(mode="json")
+    value.pop("received_at", None)
+    if ignore_event_id:
+        value.pop("event_id", None)
+    value["properties"] = json.loads(
+        json.dumps(value["properties"], sort_keys=True, separators=(",", ":"))
+    )
+    return value
+```
+
+- [ ] **Step 4: Create all five SQLite tables and indexes**
+
+In `repository.py` create `AnalyticsStore`. Use a connection context manager that enables foreign keys, commits or rolls back, and always closes.
+
+The schema must contain:
+
+1. `analytics_events` with an integer `sequence` primary key, unique `event_id`, nullable unique `source_event_id`, every field in the approved event envelope, compact `properties_json`, and indexes on user/time, event/time, session/time, outcome/time, error/time, and source event.
+2. `analytics_daily_rollups` keyed by `rollup_date`, `metric_name`, and non-null bounded dimension strings for event, billing mode, provider, model, outcome, error category, and user state. Store `value_count` and `value_sum_micro`.
+3. `user_analytics_snapshots` keyed by `user_id` with status, reason code, human-readable reason, `evidence_event_ids_json`, and `calculated_at`.
+4. `analytics_subject_settings` keyed by `user_id` with `excluded`, `actor_user_id`, reason, created time, and updated time.
+5. `admin_analytics_access_log` with integer primary key, Admin user, subject user, section, and access time.
+
+Use `ON DELETE CASCADE` only for event/snapshot/settings rows owned by the subject. Use `ON DELETE RESTRICT` for the Admin actor in subject settings and for both identities in access logs.
+
+Use this concrete SQLite DDL:
+
+```python
+ANALYTICS_SQLITE_DDL = """
+CREATE TABLE IF NOT EXISTS analytics_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE CHECK (length(event_id) = 36),
+    schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+    event_name TEXT NOT NULL CHECK (length(event_name) BETWEEN 1 AND 64),
+    event_group TEXT NOT NULL
+        CHECK (event_group IN ('experience', 'account', 'credential', 'agent', 'run', 'resource')),
+    user_id INTEGER NOT NULL,
+    session_id TEXT CHECK (session_id IS NULL OR length(session_id) = 36),
+    occurred_at TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    event_source TEXT NOT NULL
+        CHECK (event_source IN ('frontend', 'server', 'backfill')),
+    source_event_id TEXT UNIQUE
+        CHECK (source_event_id IS NULL OR length(source_event_id) BETWEEN 1 AND 200),
+    source_record_type TEXT
+        CHECK (source_record_type IS NULL OR length(source_record_type) BETWEEN 1 AND 64),
+    source_record_id TEXT
+        CHECK (source_record_id IS NULL OR length(source_record_id) BETWEEN 1 AND 200),
+    correlation_id TEXT
+        CHECK (correlation_id IS NULL OR length(correlation_id) BETWEEN 1 AND 200),
+    page_view TEXT CHECK (page_view IS NULL OR length(page_view) BETWEEN 1 AND 64),
+    provider_id TEXT CHECK (provider_id IS NULL OR length(provider_id) BETWEEN 1 AND 128),
+    model_id TEXT CHECK (model_id IS NULL OR length(model_id) BETWEEN 1 AND 256),
+    billing_mode TEXT
+        CHECK (billing_mode IS NULL OR billing_mode IN ('byok', 'platform_credits')),
+    outcome TEXT
+        CHECK (outcome IS NULL OR outcome IN ('succeeded', 'failed', 'cancelled')),
+    error_category TEXT CHECK (
+        error_category IS NULL OR error_category IN (
+            'credential_invalid', 'credential_missing', 'provider_timeout',
+            'provider_unavailable', 'credits_unavailable',
+            'model_not_allowed', 'internal_error'
+        )
+    ),
+    country_code TEXT
+        CHECK (country_code IS NULL OR length(country_code) = 2),
+    device_category TEXT CHECK (
+        device_category IS NULL OR device_category IN (
+            'mobile', 'tablet', 'desktop', 'unknown'
+        )
+    ),
+    browser_family TEXT CHECK (
+        browser_family IS NULL OR browser_family IN (
+            'Edge', 'Chrome', 'Firefox', 'Safari', 'Other'
+        )
+    ),
+    network_hash TEXT
+        CHECK (network_hash IS NULL OR length(network_hash) = 64),
+    properties_json TEXT NOT NULL DEFAULT '{}'
+        CHECK (length(properties_json) <= 1024),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_user_time
+    ON analytics_events(user_id, occurred_at DESC, sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_name_time
+    ON analytics_events(event_name, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_session_time
+    ON analytics_events(session_id, occurred_at DESC)
+    WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_analytics_events_outcome_time
+    ON analytics_events(outcome, occurred_at DESC)
+    WHERE outcome IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_analytics_events_error_time
+    ON analytics_events(error_category, occurred_at DESC)
+    WHERE error_category IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS analytics_daily_rollups (
+    rollup_date TEXT NOT NULL CHECK (length(rollup_date) = 10),
+    metric_name TEXT NOT NULL CHECK (length(metric_name) BETWEEN 1 AND 64),
+    event_name TEXT NOT NULL DEFAULT '' CHECK (length(event_name) <= 64),
+    billing_mode TEXT NOT NULL DEFAULT '' CHECK (length(billing_mode) <= 32),
+    provider_id TEXT NOT NULL DEFAULT '' CHECK (length(provider_id) <= 128),
+    model_id TEXT NOT NULL DEFAULT '' CHECK (length(model_id) <= 256),
+    outcome TEXT NOT NULL DEFAULT '' CHECK (length(outcome) <= 32),
+    error_category TEXT NOT NULL DEFAULT '' CHECK (length(error_category) <= 64),
+    user_state TEXT NOT NULL DEFAULT '' CHECK (length(user_state) <= 32),
+    value_count INTEGER NOT NULL DEFAULT 0 CHECK (value_count >= 0),
+    value_sum_micro INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (
+        rollup_date, metric_name, event_name, billing_mode, provider_id,
+        model_id, outcome, error_category, user_state
+    )
+);
+
+CREATE TABLE IF NOT EXISTS user_analytics_snapshots (
+    user_id INTEGER PRIMARY KEY,
+    status TEXT NOT NULL CHECK (
+        status IN ('blocked', 'needs_attention', 'dormant', 'onboarding', 'active')
+    ),
+    reason_code TEXT NOT NULL CHECK (length(reason_code) BETWEEN 1 AND 100),
+    human_readable_reason TEXT NOT NULL
+        CHECK (length(human_readable_reason) BETWEEN 1 AND 500),
+    evidence_event_ids_json TEXT NOT NULL DEFAULT '[]'
+        CHECK (length(evidence_event_ids_json) <= 4096),
+    calculated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS analytics_subject_settings (
+    user_id INTEGER PRIMARY KEY,
+    excluded INTEGER NOT NULL CHECK (excluded IN (0, 1)),
+    actor_user_id INTEGER NOT NULL,
+    reason TEXT NOT NULL CHECK (length(reason) BETWEEN 1 AND 500),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (actor_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS admin_analytics_access_log (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    admin_user_id INTEGER NOT NULL,
+    subject_user_id INTEGER NOT NULL,
+    section TEXT NOT NULL CHECK (
+        section IN ('overview', 'timeline', 'runs', 'usage', 'sessions')
+    ),
+    accessed_at TEXT NOT NULL,
+    FOREIGN KEY (admin_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    FOREIGN KEY (subject_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_analytics_access_subject_time
+    ON admin_analytics_access_log(subject_user_id, accessed_at DESC, sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_analytics_access_admin_time
+    ON admin_analytics_access_log(admin_user_id, accessed_at DESC, sequence DESC);
+"""
+```
+
+- [ ] **Step 5: Implement idempotent append and opaque event pagination**
+
+`append_event` must execute inside one transaction:
+
+1. Attempt the insert.
+2. On uniqueness conflict, look up both `event_id` and a non-null `source_event_id`. If both keys resolve to different stored sequences, raise a conflict immediately. Otherwise use the one resolved row.
+3. Compare `canonical_event_payload` after decoding stored `properties_json`. The helper always ignores server-assigned `received_at`. Pass `ignore_event_id=True` when replaying a non-null `source_event_id` so a retry may carry a fresh transport event UUID while the authoritative source identity remains stable.
+4. Return `created=False` for an exact replay.
+5. Raise `AnalyticsIdempotencyConflictError("analytics event idempotency conflict")` for changed data.
+
+`list_user_events` must order by `occurred_at DESC, sequence DESC`, fetch `limit + 1`, and encode the last returned row into `next_cursor` only when another row exists.
+
+- [ ] **Step 6: Implement exclusions, access audit, and bounded deletion**
+
+`delete_expired` must:
+
+- validate `batch_size` from 1 through 10,000;
+- delete at most one batch from `analytics_events` where `received_at < raw_before`;
+- delete at most one batch from `admin_analytics_access_log` where `accessed_at < access_before`;
+- return exact deletion counts;
+- set each `has_more_*` flag by a bounded `SELECT 1 ... LIMIT 1`;
+- never delete from `analytics_daily_rollups` or `user_analytics_snapshots`.
+
+- [ ] **Step 7: Run the SQLite contract and commit**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/domain/analytics/test_repository_contract.py
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  dashboard/backend/domain/analytics/repository_common.py \
+  dashboard/backend/domain/analytics/repository.py \
+  dashboard/backend/tests/domain/analytics/test_repository_contract.py
+git commit -m "feat: add sqlite analytics repository"
+```
+
+---
+
+### Task 3: Add PostgreSQL parity and account-database dispatch
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/repository_postgres.py`
+- Create: `dashboard/backend/tests/domain/analytics/test_repository_postgres.py`
+- Modify: `dashboard/backend/domain/analytics/repository.py`
+- Modify: `dashboard/backend/tests/test_ci_postgres_wired.py`
+
+**Interfaces:**
+- Consumes: Task 2 contract assertions, `require_postgres_url`, `describe_database_url`, `db_pool.connection`, and `USERS_DATABASE_URL`.
+- Produces: `PostgresAnalyticsStore` and `_build_analytics_store()`; exports singleton `analytics_store`.
+
+- [ ] **Step 1: Write dispatch and live-PostgreSQL tests**
+
+Create `test_repository_postgres.py` with:
+
+```python
+TEST_POSTGRES_URL = require_local_postgres_url(os.getenv("TEST_POSTGRES_URL"))
+pg_only = pytest.mark.skipif(
+    not TEST_POSTGRES_URL,
+    reason="TEST_POSTGRES_URL is not configured",
+)
+
+
+def test_build_analytics_store_defaults_to_sqlite(monkeypatch, capsys):
+    monkeypatch.delenv("USERS_DATABASE_URL", raising=False)
+    store = repo_module._build_analytics_store()
+    assert isinstance(store, repo_module.AnalyticsStore)
+    assert "analytics_store backend: sqlite" in capsys.readouterr().out
+
+
+def test_build_analytics_store_uses_only_users_database_url(monkeypatch):
+    created = {}
+
+    class FakePostgresAnalyticsStore:
+        def __init__(self, database_url):
+            created["database_url"] = database_url
+
+    monkeypatch.setattr(pg_module, "PostgresAnalyticsStore", FakePostgresAnalyticsStore)
+    monkeypatch.setenv("USERS_DATABASE_URL", "postgresql://fake/accounts")
+    monkeypatch.setenv("CONTENT_DATABASE_URL", "postgresql://ignored/content")
+    monkeypatch.setenv("AGENT_RUNS_DATABASE_URL", "postgresql://ignored/runs")
+    assert isinstance(repo_module._build_analytics_store(), FakePostgresAnalyticsStore)
+    assert created["database_url"] == "postgresql://fake/accounts"
+
+
+def test_dispatch_log_never_contains_database_password(monkeypatch, capsys):
+    monkeypatch.setattr(pg_module, "PostgresAnalyticsStore", lambda database_url: object())
+    monkeypatch.setenv(
+        "USERS_DATABASE_URL",
+        "postgresql://admin:synthetic-password@host/accounts",
+    )
+    repo_module._build_analytics_store()
+    output = capsys.readouterr().out
+    assert "synthetic-password" not in output
+    assert "host/accounts" in output
+```
+
+For the live fixture, create a random schema on local `TEST_POSTGRES_URL`, create a minimal `users(id INTEGER PRIMARY KEY, role TEXT NOT NULL)` table inside it, instantiate `PostgresAnalyticsStore` with a URL whose `search_path` is that schema, run every shared contract assertion from Task 2, and drop only that random schema during teardown.
+
+- [ ] **Step 2: Run dispatch tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/analytics/test_repository_postgres.py \
+  -k "build_analytics_store or dispatch_log"
+```
+
+Expected: FAIL because `PostgresAnalyticsStore` and `_build_analytics_store` do not exist.
+
+- [ ] **Step 3: Implement the PostgreSQL schema and methods**
+
+Create `ANALYTICS_POSTGRES_DDL` as a literal string so parity tests can inspect it without a live database. Mirror every SQLite table, column, check, foreign key, uniqueness rule, and index, using `BIGSERIAL` for sequences and `BOOLEAN` for exclusion state.
+
+Use this PostgreSQL DDL:
+
+```python
+ANALYTICS_POSTGRES_DDL = """
+CREATE TABLE IF NOT EXISTS analytics_events (
+    sequence BIGSERIAL PRIMARY KEY,
+    event_id TEXT NOT NULL UNIQUE CHECK (length(event_id) = 36),
+    schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+    event_name TEXT NOT NULL CHECK (length(event_name) BETWEEN 1 AND 64),
+    event_group TEXT NOT NULL
+        CHECK (event_group IN ('experience', 'account', 'credential', 'agent', 'run', 'resource')),
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_id TEXT CHECK (session_id IS NULL OR length(session_id) = 36),
+    occurred_at TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    event_source TEXT NOT NULL
+        CHECK (event_source IN ('frontend', 'server', 'backfill')),
+    source_event_id TEXT UNIQUE
+        CHECK (source_event_id IS NULL OR length(source_event_id) BETWEEN 1 AND 200),
+    source_record_type TEXT
+        CHECK (source_record_type IS NULL OR length(source_record_type) BETWEEN 1 AND 64),
+    source_record_id TEXT
+        CHECK (source_record_id IS NULL OR length(source_record_id) BETWEEN 1 AND 200),
+    correlation_id TEXT
+        CHECK (correlation_id IS NULL OR length(correlation_id) BETWEEN 1 AND 200),
+    page_view TEXT CHECK (page_view IS NULL OR length(page_view) BETWEEN 1 AND 64),
+    provider_id TEXT CHECK (provider_id IS NULL OR length(provider_id) BETWEEN 1 AND 128),
+    model_id TEXT CHECK (model_id IS NULL OR length(model_id) BETWEEN 1 AND 256),
+    billing_mode TEXT
+        CHECK (billing_mode IS NULL OR billing_mode IN ('byok', 'platform_credits')),
+    outcome TEXT
+        CHECK (outcome IS NULL OR outcome IN ('succeeded', 'failed', 'cancelled')),
+    error_category TEXT CHECK (
+        error_category IS NULL OR error_category IN (
+            'credential_invalid', 'credential_missing', 'provider_timeout',
+            'provider_unavailable', 'credits_unavailable',
+            'model_not_allowed', 'internal_error'
+        )
+    ),
+    country_code TEXT
+        CHECK (country_code IS NULL OR length(country_code) = 2),
+    device_category TEXT CHECK (
+        device_category IS NULL OR device_category IN (
+            'mobile', 'tablet', 'desktop', 'unknown'
+        )
+    ),
+    browser_family TEXT CHECK (
+        browser_family IS NULL OR browser_family IN (
+            'Edge', 'Chrome', 'Firefox', 'Safari', 'Other'
+        )
+    ),
+    network_hash TEXT
+        CHECK (network_hash IS NULL OR length(network_hash) = 64),
+    properties_json TEXT NOT NULL DEFAULT '{}'
+        CHECK (length(properties_json) <= 1024)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_user_time
+    ON analytics_events(user_id, occurred_at DESC, sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_name_time
+    ON analytics_events(event_name, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_session_time
+    ON analytics_events(session_id, occurred_at DESC)
+    WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_analytics_events_outcome_time
+    ON analytics_events(outcome, occurred_at DESC)
+    WHERE outcome IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_analytics_events_error_time
+    ON analytics_events(error_category, occurred_at DESC)
+    WHERE error_category IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS analytics_daily_rollups (
+    rollup_date TEXT NOT NULL CHECK (length(rollup_date) = 10),
+    metric_name TEXT NOT NULL CHECK (length(metric_name) BETWEEN 1 AND 64),
+    event_name TEXT NOT NULL DEFAULT '' CHECK (length(event_name) <= 64),
+    billing_mode TEXT NOT NULL DEFAULT '' CHECK (length(billing_mode) <= 32),
+    provider_id TEXT NOT NULL DEFAULT '' CHECK (length(provider_id) <= 128),
+    model_id TEXT NOT NULL DEFAULT '' CHECK (length(model_id) <= 256),
+    outcome TEXT NOT NULL DEFAULT '' CHECK (length(outcome) <= 32),
+    error_category TEXT NOT NULL DEFAULT '' CHECK (length(error_category) <= 64),
+    user_state TEXT NOT NULL DEFAULT '' CHECK (length(user_state) <= 32),
+    value_count BIGINT NOT NULL DEFAULT 0 CHECK (value_count >= 0),
+    value_sum_micro BIGINT NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (
+        rollup_date, metric_name, event_name, billing_mode, provider_id,
+        model_id, outcome, error_category, user_state
+    )
+);
+
+CREATE TABLE IF NOT EXISTS user_analytics_snapshots (
+    user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    status TEXT NOT NULL CHECK (
+        status IN ('blocked', 'needs_attention', 'dormant', 'onboarding', 'active')
+    ),
+    reason_code TEXT NOT NULL CHECK (length(reason_code) BETWEEN 1 AND 100),
+    human_readable_reason TEXT NOT NULL
+        CHECK (length(human_readable_reason) BETWEEN 1 AND 500),
+    evidence_event_ids_json TEXT NOT NULL DEFAULT '[]'
+        CHECK (length(evidence_event_ids_json) <= 4096),
+    calculated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS analytics_subject_settings (
+    user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    excluded BOOLEAN NOT NULL,
+    actor_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    reason TEXT NOT NULL CHECK (length(reason) BETWEEN 1 AND 500),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS admin_analytics_access_log (
+    sequence BIGSERIAL PRIMARY KEY,
+    admin_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    subject_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    section TEXT NOT NULL CHECK (
+        section IN ('overview', 'timeline', 'runs', 'usage', 'sessions')
+    ),
+    accessed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_analytics_access_subject_time
+    ON admin_analytics_access_log(subject_user_id, accessed_at DESC, sequence DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_analytics_access_admin_time
+    ON admin_analytics_access_log(admin_user_id, accessed_at DESC, sequence DESC);
+"""
+```
+
+Implement `PostgresAnalyticsStore` with the same public method names and return shapes as `AnalyticsStore`. Use:
+
+- `require_postgres_url` before connecting;
+- the shared pooled connection helper already used by current PostgreSQL stores;
+- `psycopg.rows.dict_row`;
+- `ON CONFLICT DO NOTHING` followed by a canonical replay comparison for idempotency;
+- tuple comparison `(occurred_at, sequence) < (%s, %s)` for cursor pagination;
+- CTE-limited deletes so each retention call removes at most `batch_size` rows.
+
+- [ ] **Step 4: Implement account-database dispatch**
+
+At the bottom of `repository.py` add:
+
+```python
+def _build_analytics_store():
+    database_url = (os.getenv("USERS_DATABASE_URL") or "").strip()
+    if database_url:
+        from .repository_postgres import PostgresAnalyticsStore
+        print(
+            "analytics_store backend: postgres "
+            f"({describe_database_url(database_url)})"
+        )
+        return PostgresAnalyticsStore(database_url)
+    print("analytics_store backend: sqlite (ephemeral on Render)")
+    return AnalyticsStore()
+
+
+analytics_store = _build_analytics_store()
+```
+
+Do not read `CONTENT_DATABASE_URL` or `AGENT_RUNS_DATABASE_URL`.
+
+- [ ] **Step 5: Add CI wiring guards**
+
+Extend `test_ci_postgres_wired.py` so the PostgreSQL CI command includes `dashboard/backend/tests/domain/analytics/test_repository_postgres.py` and so accidental removal of that path fails the static guard.
+
+- [ ] **Step 6: Run parity tests and commit**
+
+Run the non-live tier first:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/analytics/test_repository_contract.py \
+  dashboard/backend/tests/domain/analytics/test_repository_postgres.py
+```
+
+Expected: PASS with live PostgreSQL cases skipped when `TEST_POSTGRES_URL` is unset.
+
+When a local disposable PostgreSQL URL is available, run:
+
+```bash
+TEST_POSTGRES_URL=postgresql://postgres:test@127.0.0.1:5433/atl_test \
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/analytics/test_repository_postgres.py
+```
+
+Expected: PASS; the fixture must refuse a non-local PostgreSQL host before any destructive SQL.
+
+Commit:
+
+```bash
+git add \
+  dashboard/backend/domain/analytics/repository.py \
+  dashboard/backend/domain/analytics/repository_postgres.py \
+  dashboard/backend/tests/domain/analytics/test_repository_postgres.py \
+  dashboard/backend/tests/test_ci_postgres_wired.py
+git commit -m "feat: add postgres analytics repository"
+```
+
+---
+
+### Task 4: Add the Analytics service, subject controls, and access audit
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/service.py`
+- Create: `dashboard/backend/tests/domain/analytics/test_service.py`
+
+**Interfaces:**
+- Consumes: `AnalyticsStore` contract, `FrontendAnalyticsEvent`, `RequestAnalyticsContext`, `EVENT_GROUP_BY_NAME`.
+- Produces: `AnalyticsService`, `get_analytics_service()`, singleton `analytics_service`, `accept_frontend_event`, `record_server_event`, `try_record_server_event`, `set_subject_exclusion`, and `record_admin_profile_access`.
+
+- [ ] **Step 1: Write failing service tests**
+
+Cover:
+
+```python
+def test_frontend_event_uses_authenticated_identity_and_server_received_time():
+    result = service.accept_frontend_event(
+        user={"id": 42, "role": "user", "email": "must-not-persist@example.test"},
+        payload=frontend_event(),
+        context=RequestAnalyticsContext(
+            country_code="US",
+            device_category="desktop",
+            browser_family="Chrome",
+            network_hash="a" * 64,
+        ),
+        received_at=datetime(2026, 8, 26, 12, 0, 1, tzinfo=timezone.utc),
+    )
+    assert result.event.user_id == 42
+    assert result.event.event_group == "experience"
+    assert result.event.event_source == "frontend"
+    assert result.event.received_at.isoformat() == "2026-08-26T12:00:01+00:00"
+    assert "email" not in result.event.model_dump()
+
+
+def test_frontend_event_rejects_large_clock_skew():
+    with pytest.raises(ValueError, match="occurred_at"):
+        service.accept_frontend_event(
+            user={"id": 42, "role": "user"},
+            payload=frontend_event(occurred_at="2026-08-24T12:00:00Z"),
+            context=safe_context(),
+            received_at=datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc),
+        )
+
+
+def test_best_effort_server_event_never_raises_or_prints_sensitive_fields(capsys):
+    failing = AnalyticsService(store=FailingStore())
+    result = failing.try_record_server_event(
+        event_name="credential_verified",
+        user_id=42,
+        source_event_id="credential:synthetic-id:verified",
+        source_record_type="credential",
+        source_record_id="synthetic-id",
+        properties={},
+    )
+    assert result is None
+    output = capsys.readouterr().out
+    assert "synthetic-secret-canary" not in output
+    assert "analytics.append_failed" in output
+```
+
+Also assert:
+
+- `record_server_event` rejects a frontend event name;
+- frontend `occurred_at` may be at most 24 hours old and 5 minutes in the future;
+- `source_event_id` is required for server and backfill events;
+- server events cannot carry properties outside an event-specific allowlist;
+- `set_subject_exclusion` requires an Admin actor and never changes the user role;
+- `record_admin_profile_access` requires an Admin actor and accepts only the five profile sections;
+- no service result or exception contains the synthetic email, raw IP, raw User-Agent, token, or canary secret.
+
+- [ ] **Step 2: Run service tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/domain/analytics/test_service.py
+```
+
+Expected: FAIL because `service.py` does not exist.
+
+- [ ] **Step 3: Implement normalized frontend acceptance**
+
+Implement:
+
+```python
+class AnalyticsService:
+    def __init__(self, store):
+        self.store = store
+
+    def accept_frontend_event(
+        self,
+        *,
+        user: dict,
+        payload: FrontendAnalyticsEvent,
+        context: RequestAnalyticsContext,
+        received_at: datetime | None = None,
+    ) -> AppendEventResult:
+        received = received_at or datetime.now(timezone.utc)
+        if payload.occurred_at < received - timedelta(hours=24):
+            raise ValueError("occurred_at is too old")
+        if payload.occurred_at > received + timedelta(minutes=5):
+            raise ValueError("occurred_at is in the future")
+        event = AnalyticsEventRecord(
+            event_id=payload.event_id,
+            schema_version=payload.schema_version,
+            event_name=payload.event_name,
+            event_group=EVENT_GROUP_BY_NAME[payload.event_name],
+            user_id=int(user["id"]),
+            session_id=payload.session_id,
+            occurred_at=payload.occurred_at,
+            received_at=received,
+            event_source="frontend",
+            page_view=payload.page_view,
+            country_code=context.country_code,
+            device_category=context.device_category,
+            browser_family=context.browser_family,
+            network_hash=context.network_hash,
+            properties=payload.properties,
+        )
+        return self.store.append_event(event)
+```
+
+Do not pass the complete `user` dictionary to the repository.
+
+- [ ] **Step 4: Implement future instrumentation and failure isolation interfaces**
+
+`record_server_event` must require a deterministic `source_event_id`, generate a fresh `event_id`, force `event_source="server"`, validate event/group/field combinations, and pass only allowlisted normalized values to `append_event`.
+
+`try_record_server_event` must wrap `record_server_event` in `try/except Exception`, print only:
+
+```text
+WARNING: analytics.append_failed event=<event_name> category=<exception-class-name>
+```
+
+and return `None`. It must not print `properties`, source IDs, user IDs, exception text, or stack traces because upstream exceptions can contain provider bodies.
+
+- [ ] **Step 5: Implement Admin-only subject and access methods**
+
+`set_subject_exclusion` and `record_admin_profile_access` must check `actor.get("role") == "admin"` before calling the repository. Raise `PermissionError("admin required")` otherwise. The service methods return display-safe repository rows only and never load an Analytics profile response body into the access log.
+
+- [ ] **Step 6: Run service tests and commit**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/analytics/test_models.py \
+  dashboard/backend/tests/domain/analytics/test_privacy.py \
+  dashboard/backend/tests/domain/analytics/test_repository_contract.py \
+  dashboard/backend/tests/domain/analytics/test_service.py
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  dashboard/backend/domain/analytics/service.py \
+  dashboard/backend/tests/domain/analytics/test_service.py
+git commit -m "feat: add analytics foundation service"
+```
+
+---
+
+### Task 5: Add safe authenticated frontend ingestion
+
+**Files:**
+- Create: `dashboard/backend/api/routers/analytics.py`
+- Create: `dashboard/backend/tests/test_analytics_api.py`
+- Modify: `dashboard/backend/api/router.py`
+- Modify: `dashboard/backend/tests/test_csrf.py`
+
+**Interfaces:**
+- Consumes: `get_current_user`, `FixedWindowRateLimiter`, `FrontendAnalyticsEvent`, `request_analytics_context`, and `get_analytics_service`.
+- Produces: `POST /api/analytics/events` and `reset_analytics_ingestion_limiter()`.
+
+- [ ] **Step 1: Write failing authentication, validation, rate-limit, and secret-canary API tests**
+
+Create `test_analytics_api.py` using an isolated `UserStore` and `AnalyticsStore` on the same temporary database. Patch `get_analytics_service` through FastAPI dependency overrides.
+
+Required assertions:
+
+```python
+def test_analytics_ingestion_requires_authentication(client):
+    response = client.post("/api/analytics/events", json=frontend_payload())
+    assert response.status_code == 401
+
+
+def test_analytics_ingestion_returns_generic_acceptance(client, signed_in_user, store):
+    response = client.post("/api/analytics/events", json=frontend_payload())
+    assert response.status_code == 202
+    assert response.json() == {"accepted": True}
+    saved = store.list_user_events(signed_in_user["id"])["items"]
+    assert len(saved) == 1
+    assert saved[0].user_id == signed_in_user["id"]
+
+
+def test_analytics_validation_never_echoes_secret_canary(client, signed_in_user, capsys):
+    payload = frontend_payload()
+    payload["api_key"] = "synthetic-secret-canary"
+    response = client.post("/api/analytics/events", json=payload)
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Invalid analytics event."}
+    assert "synthetic-secret-canary" not in response.text
+    assert "synthetic-secret-canary" not in capsys.readouterr().out
+```
+
+Also test:
+
+- a declared `Content-Length` or actual body over 8 KiB returns generic `413`;
+- malformed JSON and non-object JSON return generic `422`;
+- the 121st accepted request in five minutes for one user returns `429` and a `Retry-After` header;
+- a second user has an independent limiter bucket;
+- a store failure returns generic `503 {"detail":"Analytics is temporarily unavailable."}` without echoing exception text;
+- the route is registered exactly once beneath `/api`.
+
+- [ ] **Step 2: Run API tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/test_analytics_api.py
+```
+
+Expected: FAIL with `404` or missing module.
+
+- [ ] **Step 3: Implement manual bounded parsing**
+
+Create a router with `prefix="/analytics"` and `tags=["analytics"]`. Do not declare `FrontendAnalyticsEvent` as the body parameter because FastAPI's default validation response can include rejected input values.
+
+Use this parsing shape:
+
+```python
+MAX_ANALYTICS_BODY_BYTES = 8 * 1024
+
+
+async def _parse_event(request: Request) -> FrontendAnalyticsEvent:
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > MAX_ANALYTICS_BODY_BYTES:
+                raise HTTPException(413, "Analytics event is too large.")
+        except ValueError:
+            raise HTTPException(400, "Invalid request.") from None
+    body = await request.body()
+    if len(body) > MAX_ANALYTICS_BODY_BYTES:
+        raise HTTPException(413, "Analytics event is too large.")
+    try:
+        value = json.loads(body)
+        if not isinstance(value, dict):
+            raise ValueError("body must be an object")
+        return FrontendAnalyticsEvent.model_validate(value)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError, ValueError):
+        raise HTTPException(422, "Invalid analytics event.") from None
+```
+
+- [ ] **Step 4: Implement authenticated ingestion and rate limiting**
+
+Use `FixedWindowRateLimiter(max_events=120, window_seconds=300)` keyed only by authenticated user ID. The endpoint must:
+
+1. Resolve `current_user=Depends(get_current_user)`.
+2. Spend the limiter slot before parsing/persistence.
+3. Capture one UTC `received_at` server timestamp.
+4. Build `RequestAnalyticsContext` with that `received_at` timestamp, without logging the request.
+5. Pass the same `received_at` into `accept_frontend_event` and run synchronous service persistence in Starlette's threadpool.
+6. Return status `202` and exactly `{"accepted": True}` for both a newly created event and an exact idempotent replay.
+7. Convert `AnalyticsIdempotencyConflictError` to generic `409`, validation errors to generic `422`, and store errors to generic `503`.
+
+- [ ] **Step 5: Register the router and pin CSRF behavior**
+
+Import and include `analytics_router` in `dashboard/backend/api/router.py`.
+
+Add a `test_csrf.py` case that signs in with `ATL_CSRF=1`, proves the endpoint rejects a cookie-authenticated POST without `X-CSRF-Token`, and accepts the same synthetic payload with `_csrf_headers(client)`.
+
+- [ ] **Step 6: Run API and CSRF tests and commit**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/test_analytics_api.py \
+  dashboard/backend/tests/test_csrf.py
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  dashboard/backend/api/routers/analytics.py \
+  dashboard/backend/api/router.py \
+  dashboard/backend/tests/test_analytics_api.py \
+  dashboard/backend/tests/test_csrf.py
+git commit -m "feat: add authenticated analytics ingestion"
+```
+
+---
+
+### Task 6: Add browser analytics sessions and major-page lifecycle events
+
+**Files:**
+- Create: `dashboard/frontend/js/analytics.js`
+- Create: `dashboard/backend/tests/test_analytics_frontend.py`
+- Modify: `dashboard/frontend/app.html`
+- Modify: `dashboard/frontend/app.js`
+- Modify: `dashboard/frontend/js/agent-editor.js`
+- Modify: `dashboard/backend/tests/test_frontend_fast_boot.py`
+
+**Interfaces:**
+- Consumes: `window.getStoredAuthUser`, `window.csrfHeaders`, navigation state from `navigateToPage`, and `POST /api/analytics/events`.
+- Produces: `window.ATLAnalytics.recordNavigation(page, options)`, `window.ATLAnalytics.enterTransientView(pageView)`, and `window.ATLAnalytics.leaveTransientView()`.
+
+- [ ] **Step 1: Write failing static frontend safety and lifecycle tests**
+
+Create `test_analytics_frontend.py` and read `app.html`, `app.js`, `js/agent-editor.js`, and `js/analytics.js` as text.
+
+Pin these contracts:
+
+- `analytics.js` is deferred after `app.js` and before page-specific scripts that may navigate.
+- The session storage key is `atl-analytics-session-v1`.
+- Session timeout is exactly `30 * 60 * 1000`.
+- Heartbeat interval is exactly `30 * 1000`.
+- Only the nine approved page identifiers appear in `PAGE_VIEW_MAP`.
+- The module sends only `event_id`, `schema_version`, `event_name`, `session_id`, `occurred_at`, `page_view`, and `properties`.
+- It uses `credentials: 'include'`, `keepalive: true`, and `window.csrfHeaders()`.
+- It does not contain payload fields named `email`, `display_name`, `role`, `api_key`, `token`, `prompt`, `strategy`, `provider_response`, or `user_agent`.
+- `navigateToPage` calls `window.ATLAnalytics.recordNavigation(page, options)` only after the final page/subtab normalization.
+- Agent editor `open` calls `enterTransientView('agent_editor')` and `close` calls `leaveTransientView()`.
+- Visibility-hidden sends `page_hidden`; visible restoration sends `page_viewed`.
+- Heartbeats are skipped when signed out or `document.visibilityState !== 'visible'`.
+- The module never throws an ingestion failure into navigation; rejected fetches are swallowed after an optional fixed, data-free warning.
+
+- [ ] **Step 2: Run the frontend contract and verify it fails**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/test_analytics_frontend.py
+```
+
+Expected: FAIL because `analytics.js` is absent.
+
+- [ ] **Step 3: Implement the tab-scoped anonymous Analytics session**
+
+In `analytics.js`:
+
+1. Store `{"id": crypto.randomUUID(), "last_activity_at": <epoch-ms>}` in `sessionStorage`.
+2. Reuse the ID while accepted page activity is less than 30 minutes old.
+3. Rotate after 30 minutes, on malformed state, or when the ID is not a canonical UUID.
+4. Never reuse `trading-session-id`, `browser-owner-id`, an auth token, an Agent ID, or a run ID.
+5. Update `last_activity_at` only when queueing one of the three Analytics events, not during auth refresh or unrelated polling.
+
+- [ ] **Step 4: Implement safe event delivery and view mapping**
+
+Use `fetch(API_BASE + '/api/analytics/events', {...})` with a JSON body containing only the seven approved client fields. Resolve navigation as:
+
+```javascript
+function resolvePageView(page, options) {
+  if (page === 'home') return 'home';
+  if (page === 'credits') return 'credits';
+  if (page === 'account') return 'account';
+  if (page === 'community') return 'community';
+  if (page === 'competition') return 'competition';
+  if (page !== 'playground') return null;
+  const tab = options.playgroundTab || document.documentElement.dataset.navPlaygroundTab;
+  if (tab === 'agents') return 'agents';
+  if (tab === 'backtest') return 'backtest';
+  if (tab === 'paper') return 'paper_trading';
+  return null;
+}
+```
+
+`recordNavigation` must send `page_hidden` for the previous different view, then `page_viewed` for the new view. Re-entering the same view without a visibility transition must not duplicate the event.
+
+Use `visible_ms` only on `page_hidden` and `session_heartbeat`, clamp it to 0 through 1,800,000, and never read form values or DOM text.
+
+- [ ] **Step 5: Integrate navigation, Agent editor, visibility, and heartbeat**
+
+- Call `window.ATLAnalytics?.recordNavigation(page, { playgroundTab, competitionTab })` near the end of `navigateToPage` after the page is visible and navigation state has been normalized.
+- Call `enterTransientView('agent_editor')` after `agentEditorView.hidden = false`.
+- Call `leaveTransientView()` after the editor is hidden.
+- On `DOMContentLoaded`, resolve the already-rendered page and send one initial `page_viewed` only when `getStoredAuthUser()` returns a user.
+- On `visibilitychange`, send hidden/visible lifecycle events.
+- Every 30 seconds, send `session_heartbeat` only while signed in, visible, and holding a current page.
+- On `pagehide`, queue a final `page_hidden` using `keepalive`; do not use `sendBeacon` because it cannot carry the existing CSRF header.
+
+- [ ] **Step 6: Add the deferred script and cache versions**
+
+Add:
+
+```html
+<script src="js/analytics.js?v=1" defer></script>
+```
+
+immediately after `app.js`. Increment `app.js` and `agent-editor.js` cache-buster versions exactly once, and update the exact floors in `test_frontend_fast_boot.py`.
+
+- [ ] **Step 7: Run frontend checks and commit**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/test_analytics_frontend.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py
+node --check dashboard/frontend/js/analytics.js
+node --check dashboard/frontend/app.js
+node --check dashboard/frontend/js/agent-editor.js
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  dashboard/frontend/js/analytics.js \
+  dashboard/frontend/app.html \
+  dashboard/frontend/app.js \
+  dashboard/frontend/js/agent-editor.js \
+  dashboard/backend/tests/test_analytics_frontend.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py
+git commit -m "feat: collect safe analytics page events"
+```
+
+---
+
+### Task 7: Add bounded retention and operator-visible failure reporting
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/retention.py`
+- Create: `dashboard/backend/tests/domain/analytics/test_retention.py`
+- Modify: `dashboard/backend/app.py`
+- Modify: `dashboard/backend/tests/test_run_lifecycle_unification.py`
+- Modify: `dashboard/backend/tests/conftest.py`
+- Modify: `render.yaml`
+
+**Interfaces:**
+- Consumes: repository `delete_expired`, existing `register_reaper_sweep`, and UTC time.
+- Produces: `AnalyticsRetentionService.run_once(now=None)`, `AnalyticsRetentionCoordinator.run_if_due()`, singleton `analytics_retention_coordinator`, and startup registration with the existing reaper.
+
+- [ ] **Step 1: Write failing retention tests**
+
+Create `test_retention.py` with a fake store and deterministic clock. Assert:
+
+```python
+def test_run_once_uses_180_and_365_day_cutoffs():
+    store = RecordingStore()
+    service = AnalyticsRetentionService(store=store, batch_size=500)
+    result = service.run_once(datetime(2026, 8, 26, tzinfo=timezone.utc))
+    assert store.calls == [{
+        "raw_before": datetime(2026, 2, 27, tzinfo=timezone.utc),
+        "access_before": datetime(2025, 8, 26, tzinfo=timezone.utc),
+        "batch_size": 500,
+    }]
+    assert result.raw_events_deleted == 0
+
+
+def test_coordinator_runs_at_most_once_per_24_hours():
+    clock = FakeClock()
+    service = RecordingRetentionService()
+    coordinator = AnalyticsRetentionCoordinator(service=service, clock=clock)
+    coordinator.run_if_due()
+    coordinator.run_if_due()
+    assert service.calls == 1
+    clock.advance(24 * 60 * 60)
+    coordinator.run_if_due()
+    assert service.calls == 2
+
+
+def test_retention_failure_is_swallowed_and_reports_only_safe_metadata(capsys):
+    coordinator = AnalyticsRetentionCoordinator(
+        service=FailingRetentionService("synthetic-secret-canary"),
+        clock=lambda: 0,
+    )
+    assert coordinator.run_if_due() is None
+    output = capsys.readouterr().out
+    assert "analytics.retention_failed" in output
+    assert "consecutive_failures=1" in output
+    assert "synthetic-secret-canary" not in output
+```
+
+Add a real SQLite retention test that inserts rows on each side of both cutoffs, runs with `batch_size=1` until both `has_more` flags are false, and proves:
+
+- old raw events are deleted;
+- recent raw events remain;
+- old access rows are deleted;
+- recent access rows remain;
+- a seeded daily rollup remains;
+- a seeded current snapshot remains;
+- each repository call deletes at most one row from each retained table.
+
+- [ ] **Step 2: Run retention tests and verify they fail**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q dashboard/backend/tests/domain/analytics/test_retention.py
+```
+
+Expected: FAIL because `retention.py` does not exist.
+
+- [ ] **Step 3: Implement the retention service and coordinator**
+
+Use constants:
+
+```python
+RAW_EVENT_RETENTION_DAYS = 180
+ADMIN_ACCESS_RETENTION_DAYS = 365
+RETENTION_BATCH_SIZE = 1000
+RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
+MAX_BATCHES_PER_RUN = 20
+```
+
+`run_once` must call repository deletion repeatedly while either `has_more` flag is true, stop after 20 batches, sum deletion counts, and return a `RetentionResult`. The coordinator must:
+
+- use a lock so concurrent reaper passes cannot overlap;
+- skip until the 24-hour monotonic deadline;
+- catch every exception;
+- increment `consecutive_failures`;
+- print only `WARNING: analytics.retention_failed consecutive_failures=N category=RuntimeError`-shaped metadata, with the category produced by `type(exc).__name__`;
+- reset the failure count after success;
+- return without raising.
+
+- [ ] **Step 4: Register retention with the existing run reaper**
+
+In `startup_event`, import `analytics_retention_coordinator.run_if_due` and register it with `register_reaper_sweep` in its own `try/except` block. Do not create a new thread or timer.
+
+Extend `test_run_lifecycle_unification.py` to assert startup registration includes the Analytics retention sweep exactly once and that a raising retention sweep cannot prevent the next registered sweep.
+
+- [ ] **Step 5: Document deployment pseudonymization configuration**
+
+Add to `render.yaml`:
+
+```yaml
+      # Monthly HMAC key for non-reversible Analytics network grouping.
+      # Missing/invalid values omit network_hash; Analytics never stores plaintext IP.
+      - key: ANALYTICS_PSEUDONYMIZATION_KEY
+        sync: false
+```
+
+Add `os.environ.pop("ANALYTICS_PSEUDONYMIZATION_KEY", None)` to `tests/conftest.py` before backend imports so a developer's real deployment secret cannot affect tests.
+
+- [ ] **Step 6: Run retention and lifecycle tests and commit**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/analytics/test_retention.py \
+  dashboard/backend/tests/test_run_lifecycle_unification.py
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add \
+  dashboard/backend/domain/analytics/retention.py \
+  dashboard/backend/app.py \
+  dashboard/backend/tests/domain/analytics/test_retention.py \
+  dashboard/backend/tests/test_run_lifecycle_unification.py \
+  dashboard/backend/tests/conftest.py \
+  render.yaml
+git commit -m "feat: enforce analytics data retention"
+```
+
+---
+
+### Task 8: Run the PR 1 security and parity acceptance gate
+
+**Files:**
+- Modify only if a failing test identifies a PR 1 defect.
+
+**Interfaces:**
+- Consumes: all Task 1 through Task 7 deliverables.
+- Produces: a clean, reviewable PR 1 foundation branch with no local data or secret material.
+
+- [ ] **Step 1: Run the focused Analytics suite**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/domain/analytics \
+  dashboard/backend/tests/test_analytics_api.py \
+  dashboard/backend/tests/test_analytics_frontend.py \
+  dashboard/backend/tests/test_csrf.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py \
+  dashboard/backend/tests/test_run_lifecycle_unification.py
+```
+
+Expected: PASS. If any test fails, stop here, fix only the first failing layer, rerun this command, and do not proceed until it is green.
+
+- [ ] **Step 2: Run adjacent account/database regression tests**
+
+Run:
+
+```bash
+/opt/anaconda3/bin/python3 -m pytest -q \
+  dashboard/backend/tests/test_auth.py \
+  dashboard/backend/tests/test_admin_users.py \
+  dashboard/backend/tests/test_users_postgres.py \
+  dashboard/backend/tests/test_model_credentials_api.py \
+  dashboard/backend/tests/domain/credits/test_repository_postgres.py
+```
+
+Expected: PASS with live PostgreSQL cases skipped when `TEST_POSTGRES_URL` is unset.
+
+- [ ] **Step 3: Run JavaScript syntax and whitespace checks**
+
+Run:
+
+```bash
+node --check dashboard/frontend/js/analytics.js
+node --check dashboard/frontend/app.js
+node --check dashboard/frontend/js/agent-editor.js
+git diff --check
+```
+
+Expected: all commands exit 0 with no output from `git diff --check`.
+
+- [ ] **Step 4: Scan for prohibited data and local artifacts**
+
+Run:
+
+```bash
+git diff --cached --name-only
+git status --short
+rg -n \
+  "synthetic-secret-canary|BEGIN PRIVATE KEY|sk-[A-Za-z0-9]|api_key_enc|provider_response_body" \
+  dashboard/backend/domain/analytics \
+  dashboard/backend/api/routers/analytics.py \
+  dashboard/frontend/js/analytics.js \
+  dashboard/backend/tests/domain/analytics \
+  dashboard/backend/tests/test_analytics_api.py \
+  dashboard/backend/tests/test_analytics_frontend.py
+```
+
+Expected:
+
+- only explicit synthetic negative-test canaries appear;
+- no real-looking key or private-key material appears;
+- no `.superpowers/`, `work/`, `*.db`, `*.db-wal`, or `*.db-shm` path is staged.
+
+- [ ] **Step 5: Inspect the complete branch diff**
+
+Run:
+
+```bash
+git diff --stat 1aecb635edcd8792d883cf4b091ccbdf5046ee4d..HEAD
+git diff --name-only 1aecb635edcd8792d883cf4b091ccbdf5046ee4d..HEAD
+```
+
+Expected: only PR 1 foundation, tests, `render.yaml`, and this plan/spec documentation are present; no Admin Analytics UI, metrics, rollups computation, state calculation, backfill, or Admin query API implementation is included.
+
+- [ ] **Step 6: Commit any final test-only correction**
+
+Only if Step 1 through Step 5 required a correction:
+
+```bash
+git add \
+  dashboard/backend/domain/analytics \
+  dashboard/backend/api/routers/analytics.py \
+  dashboard/backend/api/router.py \
+  dashboard/backend/app.py \
+  dashboard/frontend/js/analytics.js \
+  dashboard/frontend/js/agent-editor.js \
+  dashboard/frontend/app.js \
+  dashboard/frontend/app.html \
+  dashboard/backend/tests/domain/analytics \
+  dashboard/backend/tests/test_analytics_api.py \
+  dashboard/backend/tests/test_analytics_frontend.py \
+  dashboard/backend/tests/test_csrf.py \
+  dashboard/backend/tests/test_frontend_fast_boot.py \
+  dashboard/backend/tests/test_run_lifecycle_unification.py \
+  dashboard/backend/tests/test_ci_postgres_wired.py \
+  dashboard/backend/tests/conftest.py \
+  render.yaml
+git commit -m "test: harden analytics foundation contracts"
+```
+
+If no correction was required, do not create an empty commit.
+
+- [ ] **Step 7: Prepare the pull request**
+
+Use:
+
+```text
+Title: Add privacy-safe Admin Analytics foundation
+
+Summary:
+- add equivalent SQLite and PostgreSQL Analytics event repositories
+- enforce authenticated allowlisted page-event ingestion and pseudonymous sessions
+- add subject exclusions, Admin profile-access auditing, and bounded retention
+
+Testing:
+- focused Analytics, API, CSRF, frontend, and lifecycle suites
+- adjacent auth, Admin user, credential, Credits, and PostgreSQL regression suites
+- JavaScript syntax checks and git diff validation
+
+Safety:
+- no real API keys or raw sensitive Analytics fields
+- missing pseudonymization configuration omits network hashes
+- no Admin Analytics UI or metrics are included in this PR
+```
+
+Push the current branch and open the PR only after every required test above is green.

--- a/docs/superpowers/specs/2026-08-26-admin-user-analytics-design.md
+++ b/docs/superpowers/specs/2026-08-26-admin-user-analytics-design.md
@@ -1,0 +1,428 @@
+# Admin Footprint and User Analytics Design
+
+**Date:** 2026-08-26  
+**Status:** Approved design  
+**Delivery:** Three sequential pull requests
+
+## Summary
+
+Agentic Trading Lab will add a first-party Admin Analytics system that makes user activation, product usage, model execution, cost, and friction visible without exposing secrets or turning analytics into a second financial ledger.
+
+The Admin console will gain a first-position `Analytics` tab. It will contain a read-only platform overview and link to a dedicated read-only User Analytics Profile for each account. Existing `Users`, `Providers`, and `Activity` tabs will retain mutation controls such as role changes, Grant Credits operations, and provider configuration.
+
+Analytics will collect authenticated business events and major page visits, update within one minute, retain user-level event detail for 180 days, and preserve non-identifying daily aggregates for long-term trend analysis. Raw API keys, passwords, prompts, strategy text, full IP addresses, and upstream provider response bodies are prohibited from analytics storage and responses.
+
+## Goals
+
+1. Show how users progress from signup to first value and repeat usage.
+2. Let administrators understand one user's product footprint, run outcomes, billing lane, and resource usage.
+3. Identify users who are onboarding, active, dormant, blocked, or in need of attention with explainable evidence.
+4. Surface common failure categories and cost trends without exposing sensitive data.
+5. Keep analytics failures isolated from authentication, backtests, model execution, and Credits settlement.
+
+## Non-goals
+
+- Session replay, DOM recording, keystroke capture, or arbitrary click tracking.
+- Recording prompts, strategy content, portfolio contents, API keys, passwords, or complete provider errors.
+- Replacing the Credits ledger, model usage evidence, run records, or existing admin audit trails.
+- Automatically contacting, suspending, refunding, or changing a user based on analytics status.
+- Introducing a third-party analytics platform in the first version.
+- Creating an opaque health score or machine-learning risk model.
+
+## Product Structure
+
+### Admin navigation
+
+The Admin tab order becomes:
+
+1. `Analytics`
+2. `Users`
+3. `Providers`
+4. `Activity`
+
+`Analytics` is the default Admin tab. It is read-only. Any account mutation links back to the existing `Users` tab through an `Open account management` action.
+
+The Admin URL continues to use `adminTab`, with `adminTab=analytics` for the new page. The tab must retain the existing ARIA roles, selected state, keyboard navigation, and URL synchronization behavior.
+
+### Analytics Overview
+
+The overview follows a vertical reading order instead of a dense dashboard grid:
+
+1. **Platform snapshot**
+   - Active users, rolling seven days
+   - First successful run conversion
+   - Backtest success rate
+   - Platform model cost
+2. **Growth and engagement**
+   - Daily active-user and completed-run trend
+   - Activation funnel
+3. **User health and friction**
+   - Counts for the five explainable user states
+   - Top actionable failure categories and affected-user counts
+4. **Users needing attention**
+   - Account identity
+   - Current state and reason
+   - Last meaningful activity
+   - Recent run count and failures
+   - Link to the User Analytics Profile
+
+Global filters support date range, billing mode, provider, and model. Internal accounts are excluded by default. The page shows `Last updated` and allows a manual refresh.
+
+### User Analytics Profile
+
+Selecting a user opens a dedicated read-only page rather than expanding the account-management table.
+
+The profile uses a stable two-column layout:
+
+- **Left account summary**
+  - Display name, email, and user ID
+  - Join date and last meaningful activity
+  - Current explainable state and reason
+  - Primary billing lane and default provider, when available
+  - Coarse region, device category, and browser family, when available
+  - `Open account management` link
+- **Right analytics content**
+  - `Overview`
+  - `Timeline`
+  - `Runs`
+  - `Usage`
+  - `Sessions`
+
+The Overview shows activation milestones, recent footprint events, run summary, billing-lane mix, model tokens, ATL model cost, and top product page. Timeline, Runs, Usage, and Sessions are independently paginated so a profile never loads 180 days of detail in one response.
+
+## Collection Scope
+
+### Server-authoritative events
+
+The backend emits events only after the source operation reaches its authoritative outcome.
+
+Event groups include:
+
+- **Account:** account signup and authenticated session start
+- **Credential:** credential saved, verified, defaulted, reverified, or revoked
+- **Agent:** agent created, updated, or deleted
+- **Run:** requested, queued, started, completed, failed, or cancelled
+- **Resource:** model usage recorded, Credits reserved, settled, or refunded, and safe error classification
+
+The frontend cannot claim server-authoritative outcomes such as `backtest_completed`, `credential_verified`, or `credits_settled`.
+
+### Frontend experience events
+
+The authenticated frontend may submit only an allowlisted set of events, initially:
+
+- `page_viewed`
+- `page_hidden`
+- `session_heartbeat`
+
+Allowed page identifiers are stable product views such as `home`, `agents`, `agent_editor`, `credits`, and `account`. The endpoint rejects unknown event names, unknown page identifiers, unknown property keys, oversized payloads, and unauthenticated requests.
+
+The client never submits email, display name, role, API key metadata, prompt text, strategy text, error bodies, or arbitrary form values. Server authentication supplies `user_id`.
+
+### Sessions and page duration
+
+The browser creates a random analytics session identifier that is unrelated to the authentication token. A session ends after 30 minutes without accepted page activity. Page duration is estimated from accepted visibility and heartbeat events; background polling and authentication refreshes do not extend meaningful activity.
+
+## Event Contract
+
+`analytics_events` stores a narrow, versioned envelope:
+
+```text
+event_id
+schema_version
+event_name
+event_group
+user_id
+session_id
+occurred_at
+received_at
+event_source
+source_event_id
+source_record_type
+source_record_id
+correlation_id
+page_view
+provider_id
+model_id
+billing_mode
+outcome
+error_category
+country_code
+device_category
+browser_family
+network_hash
+properties_json
+```
+
+`source_event_id` is unique when present and provides idempotency for server events and backfill. `correlation_id` links related lifecycle events for a run or another multi-step operation. `properties_json` accepts only event-specific allowlisted keys and has a strict serialized-size limit.
+
+Analytics stores safe error categories, not raw exceptions or upstream bodies. Approved categories include stable values such as `credential_invalid`, `credential_missing`, `provider_timeout`, `provider_unavailable`, `credits_unavailable`, `model_not_allowed`, and `internal_error`.
+
+## Storage Model
+
+SQLite and PostgreSQL implementations must expose the same repository contract.
+
+### `analytics_events`
+
+Stores raw event detail for 180 days. Indexes support:
+
+- user and occurrence time
+- event name and occurrence time
+- session and occurrence time
+- outcome or error category and occurrence time
+- source-event idempotency
+
+### `analytics_daily_rollups`
+
+Stores non-identifying daily aggregates by supported dimensions. Historical completed days read primarily from this table. Rollup dimensions are intentionally bounded to avoid uncontrolled cardinality.
+
+Supported dimensions include event name, billing mode, provider, model, outcome, error category, and user-state count. The system does not aggregate by email, raw session identifier, or network hash.
+
+### `user_analytics_snapshots`
+
+Stores the current state, stable reason code, human-readable reason, evidence event IDs, and `calculated_at` for each user. A relevant new event recalculates that user's snapshot. A periodic repair pass recalculates stale snapshots.
+
+### `analytics_subject_settings`
+
+Stores analytics-specific user settings without expanding the authentication record. It contains `user_id`, exclusion state, actor, reason, and timestamps. Admin accounts and accounts marked `analytics_excluded` are excluded from default analytics queries.
+
+### `admin_analytics_access_log`
+
+Records which administrator opened which user's analytics profile, the requested section, and the access time. It does not store response bodies.
+
+## Privacy and Security
+
+### Prohibited data
+
+The following values must never be persisted, returned, or logged by Analytics:
+
+- Full API keys or authentication tokens
+- Passwords or verification codes
+- Prompt, instruction, strategy, portfolio, or form-input text
+- Raw upstream provider response bodies
+- Full raw IP addresses
+- Raw User-Agent headers
+- Encrypted credential ciphertext
+
+Safe credential references may include provider ID, credential lifecycle outcome, and last four characters only when the existing public credential contract already permits them.
+
+### Network pseudonymization
+
+Analytics uses a dedicated deployment secret:
+
+```text
+ANALYTICS_PSEUDONYMIZATION_KEY
+```
+
+The request IP may exist transiently in process memory while an HMAC network identifier is calculated. The HMAC input includes the UTC calendar month so the identifier cannot link the same network indefinitely across retention periods. The raw value is immediately discarded and is never written to Analytics storage. Raw User-Agent headers are reduced to an allowlisted browser family and device category before storage.
+
+If the key is absent or invalid, Analytics omits `network_hash`. It must never downgrade to plaintext storage. Country or region is optional and may only come from a trusted deployment-platform header; otherwise it is `Unknown`. The first version does not call an external IP geolocation provider.
+
+### Authorization
+
+All `/api/admin/analytics/*` endpoints use the centralized Admin dependency. Non-admin users receive `403`. Opening a user profile creates an Admin analytics access record.
+
+The frontend ingestion endpoint requires an authenticated user, CSRF protection where required by the existing API pattern, rate limiting, and a strict event/property allowlist.
+
+## Metrics
+
+Default metrics exclude Admin accounts and accounts explicitly marked `analytics_excluded`. Admins may temporarily enable `Include internal accounts` for diagnosis.
+
+### Active users, rolling seven days
+
+Distinct users with at least one meaningful accepted page visit or server-authoritative business event in the preceding rolling seven days. Token refresh, background polling, and unattended heartbeat traffic are excluded.
+
+### First successful run conversion
+
+The percentage of mature signup-cohort users who complete a first successful backtest within seven days of signup. A cohort is mature only after its full seven-day observation window has elapsed, preventing recent signups from depressing the metric prematurely.
+
+### Backtest success rate
+
+```text
+completed / (completed + failed)
+```
+
+User-cancelled runs do not enter the denominator. Queued or running records are not terminal and do not enter the calculation.
+
+### Repeat run rate
+
+The percentage of users with a first successful run who complete another successful run at least 24 hours later and no more than 30 days after the first success.
+
+### Platform model cost
+
+The sum of actual model-cost evidence for `platform_credits` execution only. BYOK usage appears separately as token and run usage and never contributes to ATL platform cost or ATL Credits debits.
+
+## Explainable User States
+
+Each user receives one state. Rules are evaluated in this precedence order:
+
+1. **Blocked**
+   - A recent attempted core action produced an unresolved condition that still prevents another run, such as no available billing lane, an administratively disabled provider, or an explicit account restriction. A new user who has not attempted a run remains `Onboarding` rather than `Blocked`.
+2. **Needs Attention**
+   - Three consecutive failed runs within 24 hours, an invalid default credential, or a run beyond its safe execution deadline.
+3. **Dormant**
+   - No meaningful accepted activity for 30 consecutive days.
+4. **Onboarding**
+   - No first successful backtest, while the account remains recently active and is not blocked or in need of attention.
+5. **Active**
+   - A first successful backtest exists and meaningful activity occurred within the previous 30 days.
+
+Every snapshot returns:
+
+```text
+status
+reason_code
+human_readable_reason
+evidence_event_ids
+calculated_at
+```
+
+Status labels do not trigger automatic user mutations. They are explainable administrative support signals only.
+
+## APIs
+
+### Frontend ingestion
+
+```text
+POST /api/analytics/events
+```
+
+Accepts an allowlisted page event envelope. The server supplies user identity and received time, sanitizes every property, and returns a generic accepted response without echoing sensitive input.
+
+### Admin queries
+
+```text
+GET /api/admin/analytics/overview
+GET /api/admin/analytics/users
+GET /api/admin/analytics/users/{user_id}
+GET /api/admin/analytics/users/{user_id}/activity
+```
+
+Overview supports date range, billing mode, provider, model, and internal-account inclusion filters. User listing supports query, status, last-activity range, pagination, and sort. The base user-detail endpoint returns the profile header, current state, milestones, and summary cards. The activity endpoint accepts `section=timeline|runs|usage|sessions` and a cursor so detailed sections remain independently pageable.
+
+Responses contain display-safe identities and Analytics fields only. They never expose secrets, ciphertext, raw provider bodies, full IP addresses, or arbitrary event properties.
+
+## Freshness and Query Strategy
+
+Raw accepted events become visible within one minute. Completed historical days read from `analytics_daily_rollups`; the current incomplete day reads raw events. `AnalyticsQueryService` merges both sources into one response.
+
+Target response times are:
+
+- Analytics Overview: under one second
+- Initial User Analytics Profile: under 500 milliseconds
+- Raw event visibility: under one minute
+
+The UI displays `Last updated`. Sections load independently and use cursors for detailed history.
+
+## Failure Isolation and Recovery
+
+Analytics is observational, not part of a core transaction's success criteria. Server-authoritative events are emitted after the source operation commits. A failed Analytics append:
+
+- does not fail login, credential operations, Agent mutations, backtests, or Credits settlement;
+- records only a safe internal operational error;
+- can be repaired from authoritative source tables when reconstruction is possible.
+
+Stable `source_event_id` values prevent duplicates during retries and backfill.
+
+If one Admin query fails, only that panel shows `This metric is temporarily unavailable.` Other panels remain usable. The page must not fail as a single all-or-nothing request.
+
+## Historical Backfill
+
+The instrumentation delivery includes an idempotent backfill for the previous 180 days using existing authoritative data:
+
+- users
+- agents
+- run records
+- model usage evidence
+- Credits ledger entries
+
+Backfilled records use `event_source = backfill` and deterministic source event IDs. The backfill does not invent historical page views, browser sessions, device metadata, region, or network hashes.
+
+## Retention
+
+A scheduled retention task deletes raw `analytics_events` older than 180 days in bounded batches. Daily non-identifying rollups remain available for long-term trends. Current user snapshots are recalculated rather than treated as immutable history. Admin profile-access records are retained for 365 days because they are a security audit trail, then deleted in bounded batches.
+
+Retention failures are observable but do not block the application. Repeated failures must surface an operator-facing warning because unbounded event retention would violate the approved privacy contract.
+
+## Delivery Plan
+
+### Pull Request 1: Analytics Foundation
+
+- SQLite and PostgreSQL schema and repository parity
+- Event model, validation, and idempotency
+- Authenticated frontend ingestion allowlist
+- Session handling and network pseudonymization
+- Subject exclusions, Admin access log, and retention service
+
+No Admin Analytics tab ships in this pull request.
+
+### Pull Request 2: Instrumentation and Metrics
+
+- Account, credential, Agent, run, resource, and safe error instrumentation
+- Metric calculations and daily rollups
+- Explainable state snapshots
+- Idempotent 180-day authoritative-data backfill
+- Admin query services and APIs
+
+No Admin Analytics tab ships in this pull request.
+
+### Pull Request 3: Admin Analytics UI
+
+- First-position `Analytics` Admin tab
+- Overview filters, metrics, trends, health, friction, and attention table
+- Dedicated User Analytics Profile
+- Independent section pagination and partial-error states
+- Link to existing account management
+
+## Testing Strategy
+
+### Foundation tests
+
+- SQLite and PostgreSQL repository contract parity
+- Event and property allowlists
+- Idempotency and cursor behavior
+- 180-day retention and permanent aggregate preservation
+- Missing pseudonymization key omits network hash without plaintext fallback
+- Secret canaries never appear in storage, responses, logs, or error messages
+
+### Instrumentation and metric tests
+
+- Server outcomes emit exactly one correct event after successful source commits
+- Analytics append failure does not change source-operation outcomes
+- Metric formulas use deterministic UTC boundary fixtures
+- Internal accounts are excluded by default
+- User-state precedence and evidence are deterministic
+- Backfill is idempotent and never fabricates page or Session events
+
+### API and frontend tests
+
+- Non-admin Analytics access returns `403`
+- User-profile access produces an Admin access record
+- Filters, pagination, URL state, ARIA tabs, and keyboard navigation work
+- One failed panel does not blank the page
+- HTML and JavaScript responses contain no secret-bearing fields
+- The Analytics page remains read-only
+
+### End-to-end acceptance scenario
+
+Use synthetic credentials and test data only:
+
+1. Create a non-excluded user and record signup and major page visits.
+2. Create an Agent and verify a fake BYOK credential through a fake adapter.
+3. Record a failed run followed by a successful run.
+4. Record a Platform Credits run with actual usage evidence and settlement.
+5. Verify Overview, state reason, timeline, run history, BYOK/Platform split, cost, and Credits values agree with their authoritative sources.
+
+The scenario must prove that BYOK never debits ATL Credits and that no real API key is required or displayed.
+
+## Acceptance Criteria
+
+- Admin opens `Analytics` as the first and default Admin tab.
+- Overview presents a clear vertical hierarchy: snapshot, engagement, health/friction, and attention queue.
+- Admin can open a dedicated read-only User Analytics Profile.
+- New events appear within one minute.
+- Metrics follow the documented formulas and default exclusions.
+- User states are mutually exclusive, explainable, and supported by evidence.
+- Raw event detail is deleted after 180 days while daily aggregates remain.
+- Analytics failure never changes a core user-operation result.
+- SQLite and PostgreSQL behavior is equivalent.
+- No prohibited sensitive data appears in Analytics storage, APIs, logs, tests, commits, or UI.

--- a/render.yaml
+++ b/render.yaml
@@ -62,6 +62,10 @@ services:
       # session; users sign in again.
       - key: SESSION_HASH_SECRET
         sync: false
+      # Monthly HMAC key for non-reversible Analytics network grouping.
+      # Missing/invalid values omit network_hash; Analytics never stores plaintext IP.
+      - key: ANALYTICS_PSEUDONYMIZATION_KEY
+        sync: false
       # Optional session lifetimes; both default in session_tokens.py.
       # SESSION_TTL_DAYS (7) is the absolute cap, SESSION_IDLE_HOURS (24) the
       # idle window.


### PR DESCRIPTION
## Summary
- add equivalent SQLite and PostgreSQL Analytics event repositories
- enforce authenticated allowlisted page-event ingestion and pseudonymous sessions
- add subject exclusions, Admin profile-access auditing, and bounded retention

## Testing
- focused Analytics, API, CSRF, frontend, and lifecycle suites
- adjacent auth, Admin user, credential, Credits, and PostgreSQL regression suites
- JavaScript syntax checks and git diff validation

## Safety
- no real API keys or raw sensitive Analytics fields
- missing pseudonymization configuration omits network hashes
- no Admin Analytics UI or metrics are included in this PR
