### PR TITLE
fix(ui): keep My Agents card submeta on one line

### DIFF
--- a/dashboard/backend/tests/test_frontend_fast_boot.py
+++ b/dashboard/backend/tests/test_frontend_fast_boot.py
@@ -190,8 +190,8 @@ def test_cache_busters_bumped():
     # the next bump, so the exact one looks like the broken guard and gets
     # "fixed" by loosening it. That collision has already cost this repo one
     # round of follow-ups (#347/#348).
-    assert "app.js?v=115" in APP_HTML
-    assert "styles.css?v=124" in APP_HTML
+    assert "app.js?v=116" in APP_HTML
+    assert "styles.css?v=125" in APP_HTML
     assert "js/leaderboard.js?v=32" in APP_HTML
     assert "home-page.js?v=50" in APP_HTML
     assert "js/credits.js?v=4" in APP_HTML

--- a/dashboard/backend/tests/test_my_agents_card_ui.py
+++ b/dashboard/backend/tests/test_my_agents_card_ui.py
@@ -148,3 +148,51 @@ def test_running_animation_respects_reduced_motion():
     css = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
     start = css.index(".agent-card-running-dot")
     assert "prefers-reduced-motion" in css[start:]
+
+
+def _css_rule(css: str, selector: str) -> str:
+    start = css.index(selector)
+    open_brace = css.index("{", start)
+    depth = 0
+    i = open_brace
+    while i < len(css):
+        if css[i] == "{":
+            depth += 1
+        elif css[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return css[start : i + 1]
+        i += 1
+    raise AssertionError(f"unclosed rule for {selector}")
+
+
+def test_submeta_stays_one_line_so_cards_in_a_row_align():
+    """A wrapping model line used to stagger Paper Trading / Configure
+    across cards in the same grid row (high zoom, long names like
+    'Nemotron 3 Nano 30b A3b · Hosted AI · U.S.').
+
+    nowrap+ellipsis is not enough on its own: a grid item's min-width:auto
+    lets the nowrap string grow the card, and a wrap that still happens
+    (cached CSS, high zoom) must not change the box height.
+    """
+    css = (_FRONTEND / "styles.css").read_text(encoding="utf-8")
+    card = _css_rule(css, ".agent-card,\n.participant-card {")
+    assert "min-width: 0" in card
+    identity = _css_rule(css, ".agent-card-identity-text {")
+    assert "overflow: hidden" in identity
+    rule = _css_rule(css, ".agent-card-submeta {")
+    assert "white-space: nowrap" in rule
+    assert "text-overflow: ellipsis" in rule
+    assert "height: 1.35em" in rule
+    assert "max-width: 100%" in rule
+    assert "overflow-wrap: anywhere" not in rule
+    placeholder = _css_rule(css, ".agent-card--placeholder .agent-card-submeta {")
+    assert "white-space: normal" in placeholder
+    assert "height: auto" in placeholder
+
+
+def test_agent_card_submeta_exposes_full_line_on_hover():
+    """Ellipsis hides the tail; title keeps the full model · type · market."""
+    render = _extract_function(_APP_JS, "renderAgentCards")
+    assert 'class="agent-card-submeta" title="' in render
+    assert "overflow-wrap: anywhere" not in render

--- a/dashboard/frontend/app.html
+++ b/dashboard/frontend/app.html
@@ -13,7 +13,7 @@
          because every API call is a CORS request. -->
     <link rel="preconnect" href="https://agentictrading.onrender.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="styles.css?v=124">
+    <link rel="stylesheet" href="styles.css?v=125">
     <!-- defer: ~200KB that was render-blocking. Deferred scripts execute in
          document order (this one first, the body-end ones after), all before
          DOMContentLoaded, so Chart is defined before any chart renders. -->
@@ -2260,7 +2260,7 @@
     <script src="market-events/MarketEventFeed.js" defer></script>
     <script src="js/portfolio.js?v=17" defer></script>
     <script src="js/agent-editor.js?v=27" defer></script>
-    <script src="app.js?v=115" defer></script>
+    <script src="app.js?v=116" defer></script>
     <script src="js/credits.js?v=4" defer></script>
     <script src="js/admin-model-providers.js?v=1" defer></script>
     <script src="js/admin-credits.js?v=5" defer></script>

--- a/dashboard/frontend/app.js
+++ b/dashboard/frontend/app.js
@@ -1413,11 +1413,12 @@ function renderAgentCards(grid, agents, categoryKey) {
     const card = document.createElement('div');
     card.className = `section-card agent-card agent-card--status agent-card--${statusBadge.key}${isBuiltin ? ' agent-card-builtin' : ''}`;
     card.setAttribute('data-agent-id', agent.agent_id);
-    const model = escapeHtml(formatAgentModelLabel(agent.model_name));
-    const type = escapeHtml(agentTypeLabel(agent));
+    const model = formatAgentModelLabel(agent.model_name);
+    const type = agentTypeLabel(agent);
     // Under the All chip the Stocks shelf mixes markets, so the card has to
     // say which. Omitted rather than guessed when agentMarketKey returns ''.
     const market = MARKET_LABELS[agentMarketKey(agent)];
+    const submeta = `${model} · ${type}${market ? ` · ${market}` : ''}`;
     const running = getAgentBacktestRunning(agent.agent_id);
     if (running) card.classList.add('agent-card--running');
 
@@ -1427,7 +1428,7 @@ function renderAgentCards(grid, agents, categoryKey) {
           ${agentRobotIcon()}
           <div class="agent-card-identity-text">
             <h3 class="agent-name">${escapeHtml(agent.name)}${agent.agent_id === defaultId ? ' <span class="agent-default-badge">Default</span>' : ''}</h3>
-            <p class="agent-card-submeta">${model} · ${type}${market ? ` · ${escapeHtml(market)}` : ''}</p>
+            <p class="agent-card-submeta" title="${escapeHtml(submeta)}">${escapeHtml(submeta)}</p>
           </div>
         </div>
         <span class="status-badge ${statusBadge.className}"><span class="status-badge-dot" aria-hidden="true"></span>${statusBadge.label}</span>
@@ -2350,7 +2351,7 @@ function renderMarketplaceGrid() {
           ${agentRobotIcon()}
           <div class="agent-card-identity-text">
             <h3 class="agent-name">${escapeHtml(template.name)}</h3>
-            <p class="agent-card-submeta">${escapeHtml(modelLabel)} · ${escapeHtml(categoryLabel)}</p>
+            <p class="agent-card-submeta" title="${escapeHtml(`${modelLabel} · ${categoryLabel}`)}">${escapeHtml(modelLabel)} · ${escapeHtml(categoryLabel)}</p>
           </div>
         </div>
         <span class="marketplace-mode-chip">${escapeHtml(modeLabel)}</span>

--- a/dashboard/frontend/styles.css
+++ b/dashboard/frontend/styles.css
@@ -7723,6 +7723,10 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     display: flex;
     flex-direction: column;
     gap: 10px;
+    /* Grid items default to min-width: auto, so a long nowrap submeta
+       ("Nemotron 3 Nano 30b A3b · Hosted AI · U.S.") would grow the card
+       instead of ellipsizing. 0 lets the track width win. */
+    min-width: 0;
 }
 
 /* My Agents loading skeletons — shipped in app.html so the grid shows card
@@ -8494,6 +8498,13 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     align-items: flex-start;
     justify-content: space-between;
     gap: 10px;
+    min-width: 0;
+}
+
+.agent-card-top > .status-badge,
+.agent-card-top > .marketplace-mode-chip {
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 .agent-card-identity {
@@ -8501,6 +8512,7 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     align-items: center;
     gap: 12px;
     min-width: 0;
+    flex: 1;
 }
 
 .agent-card-icon {
@@ -8523,6 +8535,8 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
 
 .agent-card-identity-text {
     min-width: 0;
+    flex: 1;
+    overflow: hidden;
 }
 
 .agent-card--status .agent-name {
@@ -8530,14 +8544,36 @@ html[data-nav-page="home"] #homeView .dashboard-bottom-grid .home-module--market
     font-size: 16px;
     font-weight: 700;
     line-height: 1.25;
-    overflow-wrap: anywhere;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .agent-card-submeta {
     margin: 3px 0 0;
     font-size: 13px;
+    line-height: 1.35;
     color: var(--text-secondary);
-    overflow-wrap: anywhere;
+    /* One line, always: wrapping "Claude Haiku 4.5 · Hosted AI · U.S."
+       used to push Paper Trading / Configure down on some cards in a
+       row and not others, so the grid looked staggered at high zoom.
+       Height pins the box to a single line-height so a wrap (cached CSS,
+       min-width:auto on a grid item, high zoom) cannot change card layout;
+       the full string stays on `title` for hover. */
+    display: block;
+    max-width: 100%;
+    min-width: 0;
+    height: 1.35em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.agent-card--placeholder .agent-card-submeta {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+    height: auto;
 }
 
 .agent-card-hero {


### PR DESCRIPTION
## Summary
- Stop long model lines (`Claude Haiku 4.5 · Hosted AI · U.S.`, `Nemotron 3 Nano 30b A3b · …`) wrapping on My Agents cards at high zoom / 4-up grids, which staggered Paper Trading and the empty-state block across the row.
- Pin the submeta to one line with ellipsis (`min-width: 0` on the grid card so the track can shrink), keep the full string on `title` for hover, and bump `styles.css` / `app.js` cache busters so the CSS actually ships.

## Test plan
- [ ] Open My Agents with several cards in one row (wide window / zoomed). Cards with long model+market labels should ellipsize, not wrap; Paper Trading / empty state / Configure line up across the row.
- [ ] Hover a truncated submeta — tooltip shows the full `model · type · market` string.
- [ ] Placeholder “Connect agent” card still wraps its longer helper copy.
- [ ] `pytest dashboard/backend/tests/test_my_agents_card_ui.py dashboard/backend/tests/test_frontend_fast_boot.py -q`


Made with [Cursor](https://cursor.com)