### PR TITLE
Add Admin Analytics instrumentation and metrics

### DIFF
--- a/dashboard/backend/api/auth.py
+++ b/dashboard/backend/api/auth.py
@@ -27,6 +27,7 @@ from dashboard.backend.api.rate_limit import (
     rate_limited_error,
 )
 from dashboard.backend.domain.brokers.repository import broker_store
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 from dashboard.backend.infrastructure.brokers import pending_links, robinhood_oauth
 from dashboard.backend.infrastructure.email import sender as email_sender
 from dashboard.backend import users as users_module
@@ -437,6 +438,12 @@ async def signup(payload: SignupRequest, request: Request):
         raise
 
     token, entitlements = await asyncio.to_thread(_issue_session, user, request)
+    analytics_instrumentation.emit_account_event(
+        event_name="account_signed_up",
+        user_id=user["id"],
+        source_record_id=user["id"],
+        version=None,
+    )
     return _auth_json(user, token, entitlements=entitlements)
 
 
@@ -478,6 +485,11 @@ async def login(payload: LoginRequest, request: Request):
         raise HTTPException(status_code=401, detail=LOGIN_FAILURE_DETAIL)
 
     token, entitlements = await asyncio.to_thread(_issue_session, user, request)
+    analytics_instrumentation.emit_account_event(
+        event_name="authenticated_session_started",
+        user_id=user["id"],
+        source_record_id=user["id"],
+    )
     return _auth_json(public_user(user), token, entitlements=entitlements)
 
 

--- a/dashboard/backend/api/router.py
+++ b/dashboard/backend/api/router.py
@@ -4,6 +4,9 @@ from dashboard.backend.api.routers.agent_versions import router as agent_version
 from dashboard.backend.api.routers.agents import router as agents_router
 from dashboard.backend.api.routers.algo import router as algo_router
 from dashboard.backend.api.routers.analytics import router as analytics_router
+from dashboard.backend.api.routers.admin_analytics import (
+    router as admin_analytics_router,
+)
 from dashboard.backend.api.routers.admin_users import router as admin_users_router
 from dashboard.backend.api.auth import router as auth_router
 from dashboard.backend.api.routers.discord import router as discord_router
@@ -29,6 +32,7 @@ api_router.include_router(admin_users_router)
 api_router.include_router(algo_router)
 api_router.include_router(agents_router)
 api_router.include_router(analytics_router)
+api_router.include_router(admin_analytics_router)
 api_router.include_router(discord_router)
 api_router.include_router(credits_router)
 api_router.include_router(admin_credits_router)

--- a/dashboard/backend/api/routers/admin_analytics.py
+++ b/dashboard/backend/api/routers/admin_analytics.py
@@ -1,0 +1,334 @@
+"""Admin-only, display-safe Analytics query endpoints."""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Never
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import ValidationError
+
+from dashboard.backend.api.auth import require_admin
+from dashboard.backend.domain.analytics.metrics import AnalyticsMetricFilters
+from dashboard.backend.domain.analytics.query_service import (
+    AnalyticsActivityPage,
+    AnalyticsOverview,
+    AnalyticsQueryService,
+    AnalyticsUserFilters,
+    AnalyticsUserProfile,
+    PaginatedUsers,
+    get_analytics_query_service,
+)
+from dashboard.backend.domain.analytics.service import (
+    AnalyticsService,
+    get_analytics_service,
+)
+
+
+router = APIRouter(
+    prefix="/admin/analytics",
+    tags=["admin-analytics"],
+    dependencies=[Depends(require_admin)],
+)
+
+_INVALID_QUERY_DETAIL = "Invalid Analytics query."
+_NOT_FOUND_DETAIL = "Analytics user was not found."
+_UNAVAILABLE_DETAIL = "Analytics is temporarily unavailable."
+_PROVIDER_ID_PATTERN = re.compile(r"^[a-z0-9_]{2,64}$")
+_MODEL_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/\-:]{0,255}$")
+_POSITIVE_INTEGER_PATTERN = re.compile(r"^[0-9]+$")
+_USER_STATES = {"blocked", "needs_attention", "dormant", "onboarding", "active"}
+_USER_SORTS = {"last_activity", "joined_at", "recent_runs", "recent_failures"}
+_SORT_ORDERS = {"asc", "desc"}
+_ACTIVITY_SECTIONS = {"timeline", "runs", "usage", "sessions"}
+
+
+def _invalid_query() -> Never:
+    raise HTTPException(status_code=422, detail=_INVALID_QUERY_DETAIL)
+
+
+def _query_values(request: Request, allowed: set[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for key, value in request.query_params.multi_items():
+        if key not in allowed or key in values:
+            _invalid_query()
+        values[key] = value
+    return values
+
+
+def _parse_date(value: str) -> date:
+    if len(value) != 10:
+        _invalid_query()
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        _invalid_query()
+    if parsed.isoformat() != value:
+        _invalid_query()
+    return parsed
+
+
+def _utc_midnight(value: date) -> datetime:
+    return datetime.combine(value, time.min, tzinfo=timezone.utc)
+
+
+def _exclusive_date_end(value: date) -> datetime:
+    try:
+        return _utc_midnight(value + timedelta(days=1))
+    except OverflowError:
+        _invalid_query()
+
+
+def _parse_bool(value: str) -> bool:
+    normalized = value.lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    _invalid_query()
+
+
+def _parse_integer(
+    value: str,
+    *,
+    minimum: int,
+    maximum: int | None = None,
+) -> int:
+    if len(value) > 20 or not _POSITIVE_INTEGER_PATTERN.fullmatch(value):
+        _invalid_query()
+    parsed = int(value)
+    if parsed < minimum or (maximum is not None and parsed > maximum):
+        _invalid_query()
+    return parsed
+
+
+def _parse_user_id(value: str) -> int:
+    return _parse_integer(value, minimum=1)
+
+
+def _overview_filters(request: Request) -> AnalyticsMetricFilters:
+    values = _query_values(
+        request,
+        {"from", "to", "billing_mode", "provider", "model", "include_internal"},
+    )
+    now = datetime.now(timezone.utc)
+    from_date = _parse_date(values["from"]) if "from" in values else None
+    to_date = _parse_date(values["to"]) if "to" in values else None
+    if from_date is not None and to_date is not None and to_date < from_date:
+        _invalid_query()
+
+    end = _exclusive_date_end(to_date) if to_date else now
+    try:
+        start = _utc_midnight(from_date) if from_date else end - timedelta(days=30)
+    except OverflowError:
+        _invalid_query()
+
+    billing_mode = values.get("billing_mode")
+    if billing_mode not in {None, "byok", "platform_credits"}:
+        _invalid_query()
+    provider_id = values.get("provider")
+    if provider_id is not None and not _PROVIDER_ID_PATTERN.fullmatch(provider_id):
+        _invalid_query()
+    model_id = values.get("model")
+    if model_id is not None and not _MODEL_ID_PATTERN.fullmatch(model_id):
+        _invalid_query()
+
+    try:
+        return AnalyticsMetricFilters(
+            start=start,
+            end=end,
+            billing_mode=billing_mode,
+            provider_id=provider_id,
+            model_id=model_id,
+            include_internal=(
+                _parse_bool(values["include_internal"])
+                if "include_internal" in values
+                else False
+            ),
+        )
+    except (ValidationError, ValueError):
+        _invalid_query()
+
+
+def _user_filters(request: Request) -> tuple[AnalyticsUserFilters, int, int]:
+    values = _query_values(
+        request,
+        {
+            "q",
+            "status",
+            "last_activity_from",
+            "last_activity_to",
+            "sort",
+            "order",
+            "limit",
+            "offset",
+            "include_internal",
+        },
+    )
+    query = values.get("q")
+    if query is not None and len(query) > 100:
+        _invalid_query()
+    status = values.get("status")
+    if status is not None and status not in _USER_STATES:
+        _invalid_query()
+    sort = values.get("sort", "last_activity")
+    if sort not in _USER_SORTS:
+        _invalid_query()
+    order = values.get("order", "desc")
+    if order not in _SORT_ORDERS:
+        _invalid_query()
+
+    from_date = (
+        _parse_date(values["last_activity_from"])
+        if "last_activity_from" in values
+        else None
+    )
+    to_date = (
+        _parse_date(values["last_activity_to"])
+        if "last_activity_to" in values
+        else None
+    )
+    if from_date is not None and to_date is not None and to_date < from_date:
+        _invalid_query()
+    activity_start = _utc_midnight(from_date) if from_date else None
+    activity_end = (
+        _exclusive_date_end(to_date) - timedelta(microseconds=1)
+        if to_date
+        else None
+    )
+
+    try:
+        filters = AnalyticsUserFilters(
+            q=query,
+            status=status,
+            last_activity_from=activity_start,
+            last_activity_to=activity_end,
+            sort=sort,
+            order=order,
+            include_internal=(
+                _parse_bool(values["include_internal"])
+                if "include_internal" in values
+                else False
+            ),
+        )
+    except (ValidationError, ValueError):
+        _invalid_query()
+    limit = _parse_integer(values.get("limit", "50"), minimum=1, maximum=100)
+    offset = _parse_integer(values.get("offset", "0"), minimum=0)
+    return filters, limit, offset
+
+
+def _activity_query(request: Request) -> tuple[str, int, str | None]:
+    values = _query_values(request, {"section", "limit", "cursor"})
+    section = values.get("section")
+    if section not in _ACTIVITY_SECTIONS:
+        _invalid_query()
+    limit = _parse_integer(values.get("limit", "50"), minimum=1, maximum=100)
+    cursor = values.get("cursor")
+    if cursor is not None and (not cursor or len(cursor) > 256):
+        _invalid_query()
+    return section, limit, cursor
+
+
+def _raise_service_error(exc: Exception) -> Never:
+    if isinstance(exc, LookupError):
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL) from None
+    if isinstance(exc, (ValidationError, ValueError)):
+        raise HTTPException(status_code=422, detail=_INVALID_QUERY_DETAIL) from None
+    raise HTTPException(status_code=503, detail=_UNAVAILABLE_DETAIL) from None
+
+
+def _record_access(
+    service: AnalyticsService,
+    *,
+    admin: dict,
+    subject_user_id: int,
+    section: str,
+) -> None:
+    try:
+        service.record_admin_profile_access(
+            actor=admin,
+            subject_user_id=subject_user_id,
+            section=section,
+        )
+    except Exception:
+        raise HTTPException(status_code=503, detail=_UNAVAILABLE_DETAIL) from None
+
+
+@router.get("/overview", response_model=AnalyticsOverview)
+def get_overview(
+    request: Request,
+    service: AnalyticsQueryService = Depends(get_analytics_query_service),
+):
+    filters = _overview_filters(request)
+    try:
+        return service.get_overview(filters=filters)
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.get("/users", response_model=PaginatedUsers)
+def list_users(
+    request: Request,
+    service: AnalyticsQueryService = Depends(get_analytics_query_service),
+):
+    filters, limit, offset = _user_filters(request)
+    try:
+        return service.list_users(filters=filters, limit=limit, offset=offset)
+    except Exception as exc:
+        _raise_service_error(exc)
+
+
+@router.get("/users/{user_id}", response_model=AnalyticsUserProfile)
+def get_user_profile(
+    user_id: str,
+    request: Request,
+    admin: dict = Depends(require_admin),
+    query_service: AnalyticsQueryService = Depends(get_analytics_query_service),
+    analytics_service: AnalyticsService = Depends(get_analytics_service),
+):
+    _query_values(request, set())
+    subject_user_id = _parse_user_id(user_id)
+    try:
+        profile = query_service.get_user_profile(user_id=subject_user_id)
+    except Exception as exc:
+        _raise_service_error(exc)
+    _record_access(
+        analytics_service,
+        admin=admin,
+        subject_user_id=subject_user_id,
+        section="overview",
+    )
+    return profile
+
+
+@router.get("/users/{user_id}/activity", response_model=AnalyticsActivityPage)
+def get_user_activity(
+    user_id: str,
+    request: Request,
+    admin: dict = Depends(require_admin),
+    query_service: AnalyticsQueryService = Depends(get_analytics_query_service),
+    analytics_service: AnalyticsService = Depends(get_analytics_service),
+):
+    subject_user_id = _parse_user_id(user_id)
+    section, limit, cursor = _activity_query(request)
+    try:
+        activity = query_service.get_user_activity(
+            user_id=subject_user_id,
+            section=section,
+            limit=limit,
+            cursor=cursor,
+        )
+    except Exception as exc:
+        _raise_service_error(exc)
+    _record_access(
+        analytics_service,
+        admin=admin,
+        subject_user_id=subject_user_id,
+        section=section,
+    )
+    return activity
+
+
+__all__ = ["router"]

--- a/dashboard/backend/api/routers/backtests.py
+++ b/dashboard/backend/api/routers/backtests.py
@@ -76,6 +76,7 @@ from dashboard.backend.domain.model_providers.service import (
     CredentialResolutionError,
     get_model_provider_service,
 )
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 from dashboard.backend.domain.credits.service import credits_service
 from dashboard.backend.api.rate_limit import FixedWindowRateLimiter, client_key
 from dashboard.backend.domain.agents.service import agent_service
@@ -659,6 +660,13 @@ def _update_slot(live_run_id: str, **fields: Any) -> None:
             _mirror_slot_to_legacy(slot)
 
 
+def _slot_analytics_user_id(live_run_id: str) -> Optional[int]:
+    with _backtest_slots_lock:
+        slot = _active_slots.get(live_run_id) or _recent_slots.get(live_run_id)
+        user_id = slot.get("user_id") if slot else None
+    return int(user_id) if user_id is not None else None
+
+
 def _finalize_slot(live_run_id: str, *, error: Optional[str], runs_count: int) -> None:
     with _backtest_slots_lock:
         slot = _active_slots.pop(live_run_id, None)
@@ -685,6 +693,15 @@ def _finalize_slot(live_run_id: str, *, error: Optional[str], runs_count: int) -
             _mirror_slot_to_legacy(slot)
             backtest_status["progress_file"] = None
             backtest_status["started_at"] = None
+    user_id = slot.get("user_id")
+    if user_id is not None:
+        succeeded = error is None and runs_count > 0
+        analytics_instrumentation.emit_run_event(
+            event_name=("backtest_completed" if succeeded else "backtest_failed"),
+            user_id=int(user_id),
+            run_id=live_run_id,
+            error_category=(None if succeeded else "internal_error"),
+        )
 
 
 def _release_slot(live_run_id: str) -> None:
@@ -922,6 +939,13 @@ def run_backtest_background(
             progress_file=progress_file,
             session_id=session_id,
         )
+        analytics_user_id = _slot_analytics_user_id(resolved_live_run_id)
+        if analytics_user_id is not None:
+            analytics_instrumentation.emit_run_event(
+                event_name="backtest_started",
+                user_id=analytics_user_id,
+                run_id=resolved_live_run_id,
+            )
         # Legacy mirror for code paths that still read the globals directly.
         backtest_session_id = session_id
 
@@ -1890,6 +1914,18 @@ def run_backtest_endpoint(
             "error": refusal,
         }
 
+    if user_id is not None:
+        analytics_instrumentation.emit_run_event(
+            event_name="backtest_requested",
+            user_id=int(user_id),
+            run_id=live_run_id,
+        )
+        analytics_instrumentation.emit_run_event(
+            event_name="backtest_queued",
+            user_id=int(user_id),
+            run_id=live_run_id,
+        )
+
     # Start backtest in background thread
     print(f"🧵 Starting background thread for backtest", flush=True)
     # Keyword args, not positional: this call passes 14 of them and universe /
@@ -1926,6 +1962,13 @@ def run_backtest_endpoint(
         # unwind: leaving it held would burn one of the owner's concurrent
         # slots, and one of the server's, for the life of the process.
         _release_slot(live_run_id)
+        if user_id is not None:
+            analytics_instrumentation.emit_run_event(
+                event_name="backtest_failed",
+                user_id=int(user_id),
+                run_id=live_run_id,
+                error_category="internal_error",
+            )
         raise
 
     response = {

--- a/dashboard/backend/api/routers/external_backtest.py
+++ b/dashboard/backend/api/routers/external_backtest.py
@@ -114,6 +114,7 @@ def api_start_backtest(
             # protocol_runs, so the entitlement/per-agent/global caps on the
             # /v1/runs and /v2 surfaces are all blind to them.
             enforce_session_cap=True,
+            emit_analytics=True,
         )
     except BacktestCapacityError as exc:
         raise HTTPException(

--- a/dashboard/backend/api/v2/runs.py
+++ b/dashboard/backend/api/v2/runs.py
@@ -36,7 +36,9 @@ from dashboard.backend.domain.runs.service import (
     check_owner_active_run_cap,
     owner_cap_message,
     resolve_owner_cap_context,
+    _analytics_owner_user_id,
 )
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 # Late-bound module reference (run_repo.run_store) so tests that swap the
 # run_store singleton cover this module too.
 from dashboard.backend.domain.runs import repository as run_repo
@@ -128,6 +130,18 @@ def _archive_run(run_id: str, entry: Dict[str, Any], backend: Any) -> None:
         # Keep the backend live so the next sweep retries.
         print(f"⚠️ v2 archive: row update failed for {run_id}, retrying next sweep: {exc}")
         return
+    owner_user_id = _analytics_owner_user_id(entry.get("agent_id"))
+    if owner_user_id is not None:
+        event_name = {
+            "completed": "backtest_completed",
+            "closed": "backtest_cancelled",
+        }.get(status, "backtest_failed")
+        analytics_instrumentation.emit_run_event(
+            event_name=event_name,
+            user_id=owner_user_id,
+            run_id=run_id,
+            error_category=("internal_error" if event_name == "backtest_failed" else None),
+        )
     archived = ArchivedBacktestBackend(
         run_id=run_id,
         session_id=entry["session_id"],
@@ -412,13 +426,33 @@ def create_run(body: CreateRunBody, response: Response,
             backtest_id=None,
             status="loading",
         )
+        owner_user_id = agent.get("owner_user_id")
+        if owner_user_id is not None:
+            analytics_instrumentation.emit_run_event(
+                event_name="backtest_requested",
+                user_id=int(owner_user_id),
+                run_id=run_id,
+            )
         try:
             backend.start_background_load()
             register_run(run_id, backend, agent["session_id"], agent["agent_id"])
+            if owner_user_id is not None:
+                analytics_instrumentation.emit_run_event(
+                    event_name="backtest_started",
+                    user_id=int(owner_user_id),
+                    run_id=run_id,
+                )
         except Exception:
             # Never leak an active-looking row for a run that never started.
             try:
                 run_repo.run_store.update_run(run_id, status="failed")
+                if owner_user_id is not None:
+                    analytics_instrumentation.emit_run_event(
+                        event_name="backtest_failed",
+                        user_id=int(owner_user_id),
+                        run_id=run_id,
+                        error_category="internal_error",
+                    )
             except Exception:
                 pass
             raise
@@ -489,6 +523,22 @@ def cancel_run(run_id: str, agent: dict = Depends(require_scope("runs:write"))):
         # reads "completed" and that is what lands — never a downgrade.
         try:
             run_repo.run_store.update_run(run_id, status=status)
+            owner_user_id = agent.get("owner_user_id")
+            if owner_user_id is not None:
+                analytics_instrumentation.emit_run_event(
+                    event_name=(
+                        "backtest_completed"
+                        if status == "completed"
+                        else "backtest_cancelled"
+                        if status == "closed"
+                        else "backtest_failed"
+                    ),
+                    user_id=int(owner_user_id),
+                    run_id=run_id,
+                    error_category=(
+                        "internal_error" if status not in {"completed", "closed"} else None
+                    ),
+                )
         except Exception:
             pass  # best-effort; the sweep reconciles
     return {"run_id": run_id, "status": status}

--- a/dashboard/backend/app.py
+++ b/dashboard/backend/app.py
@@ -248,6 +248,20 @@ async def startup_event():
         )
 
     try:
+        from dashboard.backend.domain.analytics.maintenance import (
+            run_analytics_maintenance,
+        )
+        from dashboard.backend.domain.runs.service import register_reaper_sweep
+
+        register_reaper_sweep(run_analytics_maintenance)
+        print("🧹 Analytics maintenance sweep registered with the reaper")
+    except Exception as e:
+        print(
+            "WARNING: analytics.maintenance_registration_failed "
+            f"category={type(e).__name__}"
+        )
+
+    try:
         from dashboard.backend.domain.runs.service import start_reaper
         start_reaper()
         print("🧹 Run reaper started")

--- a/dashboard/backend/domain/agents/service.py
+++ b/dashboard/backend/domain/agents/service.py
@@ -33,6 +33,7 @@ from dashboard.backend.domain.agents.version_repository import (
     agent_version_store,
 )
 from dashboard.backend.database import db
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 
 
 # Baseline comparison series written alongside every backtest. They are plotted
@@ -365,6 +366,14 @@ class AgentService:
             # credential routes gate on the *current* runtime, so the value
             # would survive with no way for its owner to see or remove it.
             agent_credential_store.delete_all(agent_id)
+        owner_user_id = agent.get("owner_user_id")
+        if owner_user_id is not None:
+            analytics_instrumentation.emit_agent_event(
+                event_name="agent_updated",
+                user_id=int(owner_user_id),
+                agent_id=agent_id,
+                version=agent.get("last_used_at"),
+            )
         return self.attach_equity_sparklines([self.agent_with_stats(agent)])[0]
 
     def create_agent(
@@ -425,6 +434,12 @@ class AgentService:
             pipeline = default_starter_pipeline()
             self.agents.update_agent(agent["agent_id"], pipeline=pipeline)
             agent["pipeline"] = pipeline
+        if owner_user_id is not None:
+            analytics_instrumentation.emit_agent_event(
+                event_name="agent_created",
+                user_id=int(owner_user_id),
+                agent_id=agent["agent_id"],
+            )
         return agent
 
     def _create_builtin_copy(
@@ -676,8 +691,15 @@ class AgentService:
         return self.agents.resolve_api_key(api_key)
 
     def delete_agent(self, agent_id: str) -> bool:
+        current = self.agents.get_agent(agent_id)
         result = self.agents.delete_agent(agent_id)
         auth_cache.invalidate_agent(agent_id)
+        if result and current and current.get("owner_user_id") is not None:
+            analytics_instrumentation.emit_agent_event(
+                event_name="agent_deleted",
+                user_id=int(current["owner_user_id"]),
+                agent_id=agent_id,
+            )
         return result
 
     def rotate_api_key(self, agent_id: str) -> Optional[str]:

--- a/dashboard/backend/domain/analytics/backfill.py
+++ b/dashboard/backend/domain/analytics/backfill.py
@@ -1,0 +1,717 @@
+"""Deterministic, authoritative Analytics history reconstruction.
+
+Only source records that prove an authenticated owner and a safe lifecycle
+outcome become Analytics events.  Browser/session/network history is never
+invented.  The source adapter deliberately reads each database independently;
+cross-database ownership is resolved in Python.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Iterable, Protocol
+from uuid import UUID, uuid5
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from dashboard.backend.infrastructure.llm.execution.models import LLMRunEvidence
+
+from .models import (
+    ALLOWED_SERVER_EVENT_NAMES,
+    EVENT_GROUP_BY_NAME,
+    AnalyticsEventRecord,
+)
+from .repository import analytics_store
+
+
+_BACKFILL_EVENT_NAMESPACE = UUID("bfa8a3a5-9691-5fe4-8871-6174934f73a8")
+_TERMINAL_RUN_EVENTS = {
+    "completed": ("backtest_completed", "succeeded", None),
+    "failed": ("backtest_failed", "failed", None),
+    "cancelled": ("backtest_cancelled", "cancelled", None),
+    "canceled": ("backtest_cancelled", "cancelled", None),
+    "closed": ("backtest_cancelled", "cancelled", None),
+}
+
+
+def _as_utc(value: object, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        text = value.strip()
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be a valid timestamp") from exc
+    else:
+        raise ValueError(f"{field_name} must be a valid timestamp")
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        # Existing SQLite CURRENT_TIMESTAMP rows are timezone-naive UTC.
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+class BackfillCandidate(BaseModel):
+    """One safe event reconstructed from an authoritative source record."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    event_name: str = Field(min_length=1, max_length=64)
+    user_id: int = Field(gt=0)
+    occurred_at: datetime
+    source_event_id: str = Field(min_length=1, max_length=200)
+    source_record_type: str = Field(min_length=1, max_length=64)
+    source_record_id: str = Field(min_length=1, max_length=200)
+    correlation_id: str | None = Field(default=None, min_length=1, max_length=200)
+    provider_id: str | None = Field(default=None, min_length=1, max_length=128)
+    model_id: str | None = Field(default=None, min_length=1, max_length=256)
+    billing_mode: str | None = Field(default=None, min_length=1, max_length=32)
+    outcome: str | None = Field(default=None, min_length=1, max_length=32)
+    error_category: str | None = Field(default=None, min_length=1, max_length=64)
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("event_name")
+    @classmethod
+    def require_server_event(cls, value: str) -> str:
+        if value not in ALLOWED_SERVER_EVENT_NAMES:
+            raise ValueError("backfill accepts only server-authoritative events")
+        return value
+
+    @field_validator("occurred_at")
+    @classmethod
+    def require_utc_timestamp(cls, value: datetime) -> datetime:
+        return _as_utc(value, "occurred_at")
+
+
+class BackfillCollection(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    candidates: list[BackfillCandidate] = Field(default_factory=list)
+    skipped_unmapped_owner: int = Field(default=0, ge=0)
+    skipped_invalid: int = Field(default=0, ge=0)
+
+
+class BackfillReport(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    considered: int = Field(default=0, ge=0)
+    would_insert: int = Field(default=0, ge=0)
+    inserted: int = Field(default=0, ge=0)
+    duplicates: int = Field(default=0, ge=0)
+    skipped_outside_window: int = Field(default=0, ge=0)
+    skipped_unmapped_owner: int = Field(default=0, ge=0)
+    skipped_invalid: int = Field(default=0, ge=0)
+    write_failures: int = Field(default=0, ge=0)
+    repair_failures: int = Field(default=0, ge=0)
+    affected_users: int = Field(default=0, ge=0)
+    repaired_snapshots: int = Field(default=0, ge=0)
+    rebuilt_rollup_days: int = Field(default=0, ge=0)
+    source_event_ids: list[str] = Field(default_factory=list)
+
+
+class BackfillSource(Protocol):
+    def collect(self, *, start: datetime, end: datetime) -> BackfillCollection: ...
+
+
+def _query_all(store: Any, sql: str) -> list[dict[str, Any]]:
+    """Read safe source columns from either store twin without joining stores."""
+
+    if hasattr(store, "database_url"):
+        with store._get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql)
+                return [dict(row) for row in cur.fetchall()]
+    conn = store._get_connection()
+    try:
+        return [dict(row) for row in conn.execute(sql).fetchall()]
+    finally:
+        conn.close()
+
+
+def _all_users(user_store: Any) -> list[dict[str, Any]]:
+    users: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        page = user_store.list_users_admin(limit=500, offset=offset)
+        users.extend(page)
+        if len(page) < 500:
+            return users
+        offset += len(page)
+
+
+def _credit_candidates(
+    credits_store: Any,
+) -> tuple[list[BackfillCandidate], int]:
+    candidates: list[BackfillCandidate] = []
+    invalid = 0
+    try:
+        reservations = _query_all(
+            credits_store,
+            """
+            SELECT reservation_id, user_id, run_id, call_index,
+                   reserved_grant_micro, reserved_purchased_micro,
+                   status, created_at, updated_at
+            FROM credit_llm_reservations
+            ORDER BY created_at, reservation_id
+            """,
+        )
+        usage_entries = _query_all(
+            credits_store,
+            """
+            SELECT id, user_id, reservation_id, run_id, call_index,
+                   bucket, amount_micro, created_at
+            FROM credit_llm_usage_entries
+            ORDER BY created_at, id
+            """,
+        )
+    except Exception:
+        return [], 1
+
+    debited_by_reservation: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"grant": 0, "purchased": 0}
+    )
+    for row in usage_entries:
+        try:
+            bucket = str(row["bucket"])
+            amount = -int(row["amount_micro"])
+            if bucket not in {"grant", "purchased"} or amount <= 0:
+                raise ValueError("invalid Credits usage row")
+            reservation_id = str(row["reservation_id"])
+            debited_by_reservation[reservation_id][bucket] += amount
+            candidates.append(
+                BackfillCandidate(
+                    event_name="credits_settled",
+                    user_id=int(row["user_id"]),
+                    occurred_at=_as_utc(row["created_at"], "created_at"),
+                    source_event_id=(
+                        f"resource:credits_settled:{reservation_id}:{bucket}"
+                    ),
+                    source_record_type="credit_reservation",
+                    source_record_id=reservation_id,
+                    correlation_id=str(row["run_id"]),
+                    billing_mode="platform_credits",
+                    properties={"amount_micro": amount, "bucket": bucket},
+                )
+            )
+        except Exception:
+            invalid += 1
+
+    for row in reservations:
+        try:
+            reservation_id = str(row["reservation_id"])
+            user_id = int(row["user_id"])
+            run_id = str(row["run_id"])
+            reserved = {
+                "grant": int(row.get("reserved_grant_micro") or 0),
+                "purchased": int(row.get("reserved_purchased_micro") or 0),
+            }
+            for bucket, amount in reserved.items():
+                if amount <= 0:
+                    continue
+                candidates.append(
+                    BackfillCandidate(
+                        event_name="credits_reserved",
+                        user_id=user_id,
+                        occurred_at=_as_utc(row["created_at"], "created_at"),
+                        source_event_id=(
+                            f"resource:credits_reserved:{reservation_id}:{bucket}"
+                        ),
+                        source_record_type="credit_reservation",
+                        source_record_id=reservation_id,
+                        correlation_id=run_id,
+                        billing_mode="platform_credits",
+                        properties={"amount_micro": amount, "bucket": bucket},
+                    )
+                )
+            if str(row.get("status")) not in {"released", "settled"}:
+                continue
+            for bucket, reserved_amount in reserved.items():
+                released = max(
+                    0,
+                    reserved_amount
+                    - debited_by_reservation[reservation_id][bucket],
+                )
+                if released <= 0:
+                    continue
+                candidates.append(
+                    BackfillCandidate(
+                        event_name="credits_refunded",
+                        user_id=user_id,
+                        occurred_at=_as_utc(row["updated_at"], "updated_at"),
+                        source_event_id=(
+                            f"resource:credits_refunded:{reservation_id}:{bucket}"
+                        ),
+                        source_record_type="credit_reservation",
+                        source_record_id=reservation_id,
+                        correlation_id=run_id,
+                        billing_mode="platform_credits",
+                        properties={"amount_micro": released, "bucket": bucket},
+                    )
+                )
+        except Exception:
+            invalid += 1
+    return candidates, invalid
+
+
+def _usage_candidate(
+    run: dict[str, Any],
+    *,
+    user_id: int,
+) -> BackfillCandidate | None:
+    metadata = run.get("metadata")
+    raw = metadata.get("llm_execution") if isinstance(metadata, dict) else None
+    if not isinstance(raw, dict):
+        return None
+    safe_projection = {
+        name: raw[name]
+        for name in LLMRunEvidence.model_fields
+        if name in raw
+    }
+    evidence = LLMRunEvidence.model_validate(safe_projection)
+    # Aggregate evidence cannot be split into truthful per-call token counts.
+    # A one-call run maps exactly to the live call_index=0 identity; multi-call
+    # aggregates are skipped instead of fabricating call-level rows.
+    if evidence.call_count != 1:
+        raise ValueError("multi-call evidence lacks per-call usage")
+    run_id = str(run["run_id"])
+    cost_usd = 0.0
+    if evidence.billing_mode.value == "platform_credits":
+        cost_usd = (
+            evidence.provider_cost_usd
+            if evidence.provider_cost_usd is not None
+            else evidence.estimated_cost_usd or 0.0
+        )
+    return BackfillCandidate(
+        event_name="model_usage_recorded",
+        user_id=user_id,
+        occurred_at=_as_utc(
+            run.get("updated_at") or run.get("created_at"),
+            "usage occurred_at",
+        ),
+        source_event_id=f"resource:model_usage_recorded:{run_id}:0",
+        source_record_type="run",
+        source_record_id=run_id,
+        correlation_id=run_id,
+        provider_id=evidence.provider_id,
+        model_id=evidence.model_id,
+        billing_mode=evidence.billing_mode.value,
+        outcome="succeeded",
+        properties={
+            "input_tokens": evidence.input_tokens,
+            "output_tokens": evidence.output_tokens,
+            "cost_micro_usd": max(0, round(cost_usd * 1_000_000)),
+        },
+    )
+
+
+class AuthoritativeBackfillSource:
+    """Compose existing source stores without cross-database joins."""
+
+    def __init__(
+        self,
+        *,
+        user_store: Any | None = None,
+        agent_store: Any | None = None,
+        protocol_run_store: Any | None = None,
+        run_history_store: Any | None = None,
+        credits_store: Any | None = None,
+    ):
+        if user_store is None:
+            from dashboard.backend.users import user_store as default_user_store
+
+            user_store = default_user_store
+        if agent_store is None:
+            from dashboard.backend.domain.agents.repository import (
+                agent_store as default_agent_store,
+            )
+
+            agent_store = default_agent_store
+        if protocol_run_store is None:
+            from dashboard.backend.domain.runs.repository import (
+                run_store as default_protocol_run_store,
+            )
+
+            protocol_run_store = default_protocol_run_store
+        if run_history_store is None:
+            from dashboard.backend.database import db as default_run_history_store
+
+            run_history_store = default_run_history_store
+        if credits_store is None:
+            from dashboard.backend.domain.credits.repository import (
+                credits_store as default_credits_store,
+            )
+
+            credits_store = default_credits_store
+        self.user_store = user_store
+        self.agent_store = agent_store
+        self.protocol_run_store = protocol_run_store
+        self.run_history_store = run_history_store
+        self.credits_store = credits_store
+
+    def collect(self, *, start: datetime, end: datetime) -> BackfillCollection:
+        del start, end  # The service applies the authoritative inclusive window.
+        candidates: list[BackfillCandidate] = []
+        invalid = 0
+        unmapped = 0
+
+        users = _all_users(self.user_store)
+        user_ids = {int(user["id"]) for user in users}
+        for user in users:
+            try:
+                user_id = int(user["id"])
+                candidates.append(
+                    BackfillCandidate(
+                        event_name="account_signed_up",
+                        user_id=user_id,
+                        occurred_at=_as_utc(user["created_at"], "created_at"),
+                        source_event_id=f"account:account_signed_up:{user_id}",
+                        source_record_type="user",
+                        source_record_id=str(user_id),
+                    )
+                )
+            except Exception:
+                invalid += 1
+
+        try:
+            agents = _query_all(
+                self.agent_store,
+                """
+                SELECT agent_id, session_id, owner_user_id, created_at
+                FROM external_agents
+                ORDER BY created_at, agent_id
+                """,
+            )
+        except Exception:
+            agents = []
+            invalid += 1
+
+        owned_agents: list[dict[str, Any]] = []
+        for agent in agents:
+            owner = agent.get("owner_user_id")
+            if owner is None or int(owner) not in user_ids:
+                unmapped += 1
+                continue
+            owned_agents.append(agent)
+            try:
+                candidates.append(
+                    BackfillCandidate(
+                        event_name="agent_created",
+                        user_id=int(owner),
+                        occurred_at=_as_utc(agent["created_at"], "created_at"),
+                        source_event_id=(
+                            f"agent:agent_created:{str(agent['agent_id'])}"
+                        ),
+                        source_record_type="agent",
+                        source_record_id=str(agent["agent_id"]),
+                    )
+                )
+            except Exception:
+                invalid += 1
+
+        result_run_ids: set[str] = set()
+        for agent in owned_agents:
+            owner = int(agent["owner_user_id"])
+            try:
+                protocol_runs = self.protocol_run_store.list_runs(
+                    str(agent["agent_id"])
+                )
+            except Exception:
+                invalid += 1
+                continue
+            for run in protocol_runs:
+                if run.get("result_run_id"):
+                    result_run_ids.add(str(run["result_run_id"]))
+                terminal = _TERMINAL_RUN_EVENTS.get(str(run.get("status")).lower())
+                if terminal is None:
+                    continue
+                try:
+                    event_name, outcome, error_category = terminal
+                    run_id = str(run["run_id"])
+                    candidates.append(
+                        BackfillCandidate(
+                            event_name=event_name,
+                            user_id=owner,
+                            occurred_at=_as_utc(
+                                run.get("updated_at") or run.get("created_at"),
+                                "run occurred_at",
+                            ),
+                            source_event_id=f"run:{event_name}:{run_id}",
+                            source_record_type="run",
+                            source_record_id=run_id,
+                            correlation_id=run_id,
+                            outcome=outcome,
+                            error_category=error_category,
+                        )
+                    )
+                except Exception:
+                    invalid += 1
+
+        sessions = [
+            str(agent["session_id"])
+            for agent in owned_agents
+            if agent.get("session_id")
+        ]
+        try:
+            runs_by_session = self.run_history_store.get_runs_by_sessions(sessions)
+        except Exception:
+            runs_by_session = {}
+            invalid += 1
+        for agent in owned_agents:
+            owner = int(agent["owner_user_id"])
+            for run in runs_by_session.get(str(agent.get("session_id")), []):
+                run_id = str(run.get("run_id") or "")
+                if not run_id or run_id in result_run_ids:
+                    continue
+                if str(run.get("mode") or "").lower() in {
+                    "baseline",
+                    "paper_baseline",
+                }:
+                    continue
+                try:
+                    occurred_at = _as_utc(
+                        run.get("updated_at") or run.get("created_at"),
+                        "run occurred_at",
+                    )
+                    candidates.append(
+                        BackfillCandidate(
+                            event_name="backtest_completed",
+                            user_id=owner,
+                            occurred_at=occurred_at,
+                            source_event_id=f"run:backtest_completed:{run_id}",
+                            source_record_type="run",
+                            source_record_id=run_id,
+                            correlation_id=run_id,
+                            outcome="succeeded",
+                        )
+                    )
+                    usage = _usage_candidate(run, user_id=owner)
+                    if usage is not None:
+                        candidates.append(usage)
+                except Exception:
+                    invalid += 1
+
+        credit_rows, credit_invalid = _credit_candidates(self.credits_store)
+        candidates.extend(credit_rows)
+        invalid += credit_invalid
+        return BackfillCollection(
+            candidates=candidates,
+            skipped_unmapped_owner=unmapped,
+            skipped_invalid=invalid,
+        )
+
+
+def _existing_source_event_ids(store: Any, source_ids: Iterable[str]) -> set[str]:
+    values = sorted(set(source_ids))
+    if not values or not hasattr(store, "_get_connection"):
+        return set()
+    existing: set[str] = set()
+    for offset in range(0, len(values), 500):
+        chunk = values[offset : offset + 500]
+        if hasattr(store, "database_url"):
+            with store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT source_event_id FROM analytics_events "
+                        "WHERE source_event_id = ANY(%s)",
+                        (chunk,),
+                    )
+                    existing.update(
+                        str(row["source_event_id"]) for row in cur.fetchall()
+                    )
+        else:
+            placeholders = ",".join("?" for _ in chunk)
+            with store._get_connection() as conn:
+                rows = conn.execute(
+                    "SELECT source_event_id FROM analytics_events "
+                    f"WHERE source_event_id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+            existing.update(str(row["source_event_id"]) for row in rows)
+    return existing
+
+
+def _event(candidate: BackfillCandidate, *, received_at: datetime) -> AnalyticsEventRecord:
+    return AnalyticsEventRecord(
+        event_id=str(uuid5(_BACKFILL_EVENT_NAMESPACE, candidate.source_event_id)),
+        schema_version=1,
+        event_name=candidate.event_name,
+        event_group=EVENT_GROUP_BY_NAME[candidate.event_name],
+        user_id=candidate.user_id,
+        session_id=None,
+        occurred_at=candidate.occurred_at,
+        received_at=received_at,
+        event_source="backfill",
+        source_event_id=candidate.source_event_id,
+        source_record_type=candidate.source_record_type,
+        source_record_id=candidate.source_record_id,
+        correlation_id=candidate.correlation_id,
+        page_view=None,
+        provider_id=candidate.provider_id,
+        model_id=candidate.model_id,
+        billing_mode=candidate.billing_mode,
+        outcome=candidate.outcome,
+        error_category=candidate.error_category,
+        country_code=None,
+        device_category=None,
+        browser_family=None,
+        network_hash=None,
+        properties=candidate.properties,
+    )
+
+
+def backfill_analytics(
+    *,
+    now: datetime | None = None,
+    days: int = 180,
+    before: datetime | None = None,
+    dry_run: bool = False,
+    source: BackfillSource | None = None,
+    store: Any = analytics_store,
+    recalculate_snapshot: Any | None = None,
+    rebuild_rollup: Any | None = None,
+) -> BackfillReport:
+    """Reconstruct safe events inside ``[now - days, before]``.
+
+    Bulk repairs run once per affected subject/day after all inserts complete.
+    Dry runs enumerate and validate sources but perform no writes at all.
+    """
+
+    if isinstance(days, bool) or not isinstance(days, int) or not 1 <= days <= 180:
+        raise ValueError("days must be an integer from 1 through 180")
+    if not isinstance(dry_run, bool):
+        raise ValueError("dry_run must be a boolean")
+    current = _as_utc(now or datetime.now(timezone.utc), "now")
+    end = _as_utc(before or current, "before")
+    start = current - timedelta(days=days)
+    if end > current:
+        raise ValueError("before cannot be in the future")
+    if end < start:
+        raise ValueError("before cannot be earlier than the backfill window")
+
+    collection = (source or AuthoritativeBackfillSource()).collect(
+        start=start,
+        end=end,
+    )
+    candidates = sorted(
+        collection.candidates,
+        key=lambda item: (item.occurred_at, item.source_event_id),
+    )
+    in_window = [item for item in candidates if start <= item.occurred_at <= end]
+    skipped_outside = len(candidates) - len(in_window)
+    existing = _existing_source_event_ids(
+        store,
+        (item.source_event_id for item in in_window),
+    )
+    pending = [item for item in in_window if item.source_event_id not in existing]
+    prepared: list[tuple[BackfillCandidate, AnalyticsEventRecord]] = []
+    validation_failures = 0
+    for candidate in pending:
+        try:
+            prepared.append((candidate, _event(candidate, received_at=current)))
+        except Exception:
+            validation_failures += 1
+    if dry_run:
+        return BackfillReport(
+            considered=len(candidates),
+            would_insert=len(prepared),
+            inserted=0,
+            duplicates=len(in_window) - len(pending),
+            skipped_outside_window=skipped_outside,
+            skipped_unmapped_owner=collection.skipped_unmapped_owner,
+            skipped_invalid=collection.skipped_invalid + validation_failures,
+            affected_users=len({item.user_id for item, _event_record in prepared}),
+            rebuilt_rollup_days=len(
+                {
+                    item.occurred_at.date()
+                    for item, _event_record in prepared
+                    if item.occurred_at.date() < current.date()
+                }
+            ),
+            source_event_ids=[
+                item.source_event_id for item, _event_record in prepared
+            ],
+        )
+
+    inserted_ids: list[str] = []
+    affected_users: set[int] = set()
+    affected_days: set[date] = set()
+    duplicates = len(in_window) - len(pending)
+    write_failures = 0
+    for candidate, event_record in prepared:
+        try:
+            result = store.append_event(event_record)
+        except Exception:
+            write_failures += 1
+            continue
+        if not result.created:
+            duplicates += 1
+            continue
+        inserted_ids.append(candidate.source_event_id)
+        affected_users.add(candidate.user_id)
+        if candidate.occurred_at.date() < current.date():
+            affected_days.add(candidate.occurred_at.date())
+
+    if recalculate_snapshot is None:
+        from .states import AnalyticsStateStore, recalculate_user_snapshot
+
+        state_store = AnalyticsStateStore(store)
+
+        def recalculate_snapshot(user_id: int, **kwargs: Any) -> Any:
+            return recalculate_user_snapshot(user_id, store=state_store, **kwargs)
+
+    if rebuild_rollup is None:
+        from .rollups import AnalyticsRollupStore, rollup_day
+
+        rollup_store = AnalyticsRollupStore(store)
+
+        def rebuild_rollup(day: date, **kwargs: Any) -> Any:
+            return rollup_day(day, store=rollup_store, **kwargs)
+
+    repair_failures = 0
+    repaired_snapshots = 0
+    rebuilt_rollup_days = 0
+    for user_id in sorted(affected_users):
+        try:
+            recalculate_snapshot(user_id, now=current)
+            repaired_snapshots += 1
+        except Exception:
+            repair_failures += 1
+    for day in sorted(affected_days):
+        try:
+            rebuild_rollup(day, now=datetime.combine(
+                day + timedelta(days=1),
+                datetime.min.time(),
+                tzinfo=timezone.utc,
+            ))
+            rebuilt_rollup_days += 1
+        except Exception:
+            repair_failures += 1
+
+    return BackfillReport(
+        considered=len(candidates),
+        would_insert=len(prepared),
+        inserted=len(inserted_ids),
+        duplicates=duplicates,
+        skipped_outside_window=skipped_outside,
+        skipped_unmapped_owner=collection.skipped_unmapped_owner,
+        skipped_invalid=collection.skipped_invalid + validation_failures,
+        write_failures=write_failures,
+        repair_failures=repair_failures,
+        affected_users=len(affected_users),
+        repaired_snapshots=repaired_snapshots,
+        rebuilt_rollup_days=rebuilt_rollup_days,
+        source_event_ids=inserted_ids,
+    )
+
+
+__all__ = [
+    "AuthoritativeBackfillSource",
+    "BackfillCandidate",
+    "BackfillCollection",
+    "BackfillReport",
+    "BackfillSource",
+    "backfill_analytics",
+]

--- a/dashboard/backend/domain/analytics/instrumentation.py
+++ b/dashboard/backend/domain/analytics/instrumentation.py
@@ -1,0 +1,286 @@
+"""Best-effort server-authoritative Analytics instrumentation helpers.
+
+The source domains call this module only after their authoritative writes
+commit.  Every public emitter contains validation and storage failures so
+Analytics can never change the source operation's outcome.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Any
+
+from .models import ALLOWED_ERROR_CATEGORIES
+from .service import get_analytics_service
+
+
+_ACCOUNT_EVENTS = {
+    "account_signed_up",
+    "authenticated_session_started",
+}
+_CREDENTIAL_EVENTS = {
+    "credential_saved",
+    "credential_verified",
+    "credential_defaulted",
+    "credential_reverified",
+    "credential_revoked",
+}
+_AGENT_EVENTS = {
+    "agent_created",
+    "agent_updated",
+    "agent_deleted",
+}
+_RUN_EVENTS = {
+    "backtest_requested",
+    "backtest_queued",
+    "backtest_started",
+    "backtest_completed",
+    "backtest_failed",
+    "backtest_cancelled",
+}
+_RESOURCE_EVENTS = {
+    "model_usage_recorded",
+    "credits_reserved",
+    "credits_settled",
+    "credits_refunded",
+}
+
+
+def _safe_warning(exc: BaseException) -> None:
+    """Log only an exception category, never exception text or identifiers."""
+
+    print(
+        "WARNING: analytics.instrumentation_failed "
+        f"category={type(exc).__name__[:80]}"
+    )
+
+
+def _occurred_at(value: datetime | None) -> datetime:
+    return value or datetime.now(timezone.utc)
+
+
+def _source_event_id(
+    *,
+    group: str,
+    event_name: str,
+    source_record_id: str,
+    version: str | int | None,
+) -> str:
+    record_id = str(source_record_id).strip()
+    if not record_id:
+        raise ValueError("source_record_id is required")
+    parts = [group, event_name, record_id]
+    if version is not None:
+        normalized_version = str(version).strip()
+        if not normalized_version:
+            raise ValueError("version must be non-empty when provided")
+        parts.append(normalized_version)
+    candidate = ":".join(parts)
+    if len(candidate) <= 200:
+        return candidate
+    digest = hashlib.sha256(candidate.encode("utf-8")).hexdigest()
+    prefix = f"{group}:{event_name}:"
+    return f"{prefix}{digest}"[:200]
+
+
+def _emit(*, allowed_names: set[str], group: str, **kwargs: Any) -> None:
+    try:
+        event_name = kwargs.get("event_name")
+        if event_name not in allowed_names:
+            raise ValueError("unsupported analytics event name")
+        source_record_id = kwargs.get("source_record_id")
+        if source_record_id is None:
+            raise ValueError("source_record_id is required")
+        version = kwargs.pop("version", None)
+        kwargs["source_event_id"] = _source_event_id(
+            group=group,
+            event_name=event_name,
+            source_record_id=source_record_id,
+            version=version,
+        )
+        get_analytics_service().try_record_server_event(**kwargs)
+    except Exception as exc:
+        _safe_warning(exc)
+
+
+def emit_account_event(
+    *,
+    event_name: str,
+    user_id: int,
+    source_record_id: str | int,
+    occurred_at: datetime | None = None,
+    version: str | int | None = None,
+) -> None:
+    occurred = _occurred_at(occurred_at)
+    if version is None and event_name == "authenticated_session_started":
+        version = occurred.astimezone(timezone.utc).isoformat()
+    _emit(
+        allowed_names=_ACCOUNT_EVENTS,
+        group="account",
+        event_name=event_name,
+        user_id=user_id,
+        source_record_type="user",
+        source_record_id=str(source_record_id),
+        properties={},
+        occurred_at=occurred,
+        version=version,
+    )
+
+
+def emit_credential_event(
+    *,
+    event_name: str,
+    user_id: int,
+    credential_id: str,
+    provider_id: str | None = None,
+    occurred_at: datetime | None = None,
+    version: str | int | None = None,
+) -> None:
+    _emit(
+        allowed_names=_CREDENTIAL_EVENTS,
+        group="credential",
+        event_name=event_name,
+        user_id=user_id,
+        source_record_type="credential",
+        source_record_id=str(credential_id),
+        provider_id=provider_id,
+        properties={},
+        occurred_at=_occurred_at(occurred_at),
+        version=version,
+    )
+
+
+def emit_agent_event(
+    *,
+    event_name: str,
+    user_id: int,
+    agent_id: str,
+    occurred_at: datetime | None = None,
+    version: str | int | None = None,
+) -> None:
+    _emit(
+        allowed_names=_AGENT_EVENTS,
+        group="agent",
+        event_name=event_name,
+        user_id=user_id,
+        source_record_type="agent",
+        source_record_id=str(agent_id),
+        properties={},
+        occurred_at=_occurred_at(occurred_at),
+        version=version,
+    )
+
+
+def emit_run_event(
+    *,
+    event_name: str,
+    user_id: int,
+    run_id: str,
+    correlation_id: str | None = None,
+    outcome: str | None = None,
+    error_category: str | None = None,
+    occurred_at: datetime | None = None,
+    version: str | int | None = None,
+) -> None:
+    if outcome is None:
+        outcome = {
+            "backtest_completed": "succeeded",
+            "backtest_failed": "failed",
+            "backtest_cancelled": "cancelled",
+        }.get(event_name)
+    _emit(
+        allowed_names=_RUN_EVENTS,
+        group="run",
+        event_name=event_name,
+        user_id=user_id,
+        source_record_type="run",
+        source_record_id=str(run_id),
+        correlation_id=correlation_id or str(run_id),
+        outcome=outcome,
+        error_category=error_category,
+        properties={},
+        occurred_at=_occurred_at(occurred_at),
+        version=version,
+    )
+
+
+def emit_resource_event(
+    *,
+    event_name: str,
+    user_id: int,
+    source_record_type: str,
+    source_record_id: str,
+    properties: dict[str, Any],
+    correlation_id: str | None = None,
+    provider_id: str | None = None,
+    model_id: str | None = None,
+    billing_mode: str | None = None,
+    outcome: str | None = None,
+    occurred_at: datetime | None = None,
+    version: str | int | None = None,
+) -> None:
+    _emit(
+        allowed_names=_RESOURCE_EVENTS,
+        group="resource",
+        event_name=event_name,
+        user_id=user_id,
+        source_record_type=source_record_type,
+        source_record_id=str(source_record_id),
+        correlation_id=correlation_id,
+        provider_id=provider_id,
+        model_id=model_id,
+        billing_mode=billing_mode,
+        outcome=outcome,
+        properties=properties,
+        occurred_at=_occurred_at(occurred_at),
+        version=version,
+    )
+
+
+def classify_safe_error(exc: BaseException) -> str:
+    """Reduce arbitrary failures to the fixed Analytics error taxonomy."""
+
+    if isinstance(exc, TimeoutError):
+        return "provider_timeout"
+    if isinstance(exc, PermissionError):
+        return "credential_invalid"
+    if isinstance(exc, LookupError):
+        return "credential_missing"
+    if isinstance(exc, ConnectionError):
+        return "provider_unavailable"
+    return "internal_error"
+
+
+def emit_safe_error_event(
+    *,
+    user_id: int,
+    source_record_type: str,
+    source_record_id: str,
+    exc: BaseException | None = None,
+    error_category: str | None = None,
+    correlation_id: str | None = None,
+    occurred_at: datetime | None = None,
+    version: str | int | None = None,
+) -> None:
+    try:
+        category = error_category or classify_safe_error(
+            exc or RuntimeError()
+        )
+        if category not in ALLOWED_ERROR_CATEGORIES:
+            raise ValueError("unsupported analytics error category")
+        _emit(
+            allowed_names={"safe_error_recorded"},
+            group="resource",
+            event_name="safe_error_recorded",
+            user_id=user_id,
+            source_record_type=source_record_type,
+            source_record_id=str(source_record_id),
+            correlation_id=correlation_id,
+            error_category=category,
+            properties={},
+            occurred_at=_occurred_at(occurred_at),
+            version=version or category,
+        )
+    except Exception as facade_exc:
+        _safe_warning(facade_exc)

--- a/dashboard/backend/domain/analytics/instrumentation.py
+++ b/dashboard/backend/domain/analytics/instrumentation.py
@@ -45,6 +45,33 @@ _RESOURCE_EVENTS = {
     "credits_settled",
     "credits_refunded",
 }
+SNAPSHOT_RELEVANT_EVENTS = (
+    _ACCOUNT_EVENTS
+    | _CREDENTIAL_EVENTS
+    | _AGENT_EVENTS
+    | _RUN_EVENTS
+    | _RESOURCE_EVENTS
+    | {"safe_error_recorded"}
+)
+_snapshot_recalculator: Any = None
+
+
+def register_snapshot_recalculator(callback: Any) -> None:
+    global _snapshot_recalculator
+    if callback is not None and not callable(callback):
+        raise TypeError("snapshot recalculator must be callable")
+    _snapshot_recalculator = callback
+
+
+def _recalculate_snapshot(user_id: int, event_name: str) -> None:
+    if event_name not in SNAPSHOT_RELEVANT_EVENTS:
+        return
+    callback = _snapshot_recalculator
+    if callback is None:
+        from .states import recalculate_user_snapshot
+
+        callback = recalculate_user_snapshot
+    callback(user_id)
 
 
 def _safe_warning(exc: BaseException) -> None:
@@ -99,7 +126,9 @@ def _emit(*, allowed_names: set[str], group: str, **kwargs: Any) -> None:
             source_record_id=source_record_id,
             version=version,
         )
-        get_analytics_service().try_record_server_event(**kwargs)
+        result = get_analytics_service().try_record_server_event(**kwargs)
+        if result is not None:
+            _recalculate_snapshot(int(kwargs["user_id"]), str(event_name))
     except Exception as exc:
         _safe_warning(exc)
 

--- a/dashboard/backend/domain/analytics/maintenance.py
+++ b/dashboard/backend/domain/analytics/maintenance.py
@@ -1,0 +1,121 @@
+"""Bounded Analytics rollup and snapshot repair maintenance."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from threading import Lock
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AnalyticsMaintenanceReport(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    rollup_days: tuple[date, ...]
+    rollup_rebuilt: bool = False
+    repaired_snapshots: int = Field(default=0, ge=0)
+    failures: int = Field(default=0, ge=0)
+
+
+_guard_lock = Lock()
+_last_rollup_day: date | None = None
+
+
+def _current_utc(value: datetime | None) -> datetime:
+    current = value or datetime.now(timezone.utc)
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise ValueError("now must include a timezone")
+    return current.astimezone(timezone.utc)
+
+
+def reset_maintenance_guard_for_tests() -> None:
+    """Reset only the process-local scheduling guard."""
+
+    global _last_rollup_day
+    with _guard_lock:
+        _last_rollup_day = None
+
+
+def run_analytics_maintenance(
+    *,
+    now: datetime | None = None,
+    snapshot_limit: int = 100,
+    rebuild_rollup: Any | None = None,
+    repair_snapshots: Any | None = None,
+) -> AnalyticsMaintenanceReport:
+    """Rebuild yesterday once per process and repair one bounded snapshot batch."""
+
+    global _last_rollup_day
+    current = _current_utc(now)
+    if isinstance(snapshot_limit, bool) or not isinstance(snapshot_limit, int):
+        raise ValueError("snapshot_limit must be an integer")
+    page_size = max(1, min(snapshot_limit, 100))
+    completed_day = current.date() - timedelta(days=1)
+    failures = 0
+    rebuilt = False
+
+    if rebuild_rollup is None:
+        from .rollups import rollup_day
+
+        rebuild_rollup = rollup_day
+    if repair_snapshots is None:
+        from .states import repair_stale_snapshots
+
+        repair_snapshots = repair_stale_snapshots
+
+    with _guard_lock:
+        should_rebuild = _last_rollup_day != completed_day
+        if should_rebuild:
+            # Reserve the day before doing I/O so concurrent reaper passes do
+            # not rebuild it twice.  A failure clears the reservation below.
+            _last_rollup_day = completed_day
+    if should_rebuild:
+        try:
+            rebuild_rollup(
+                completed_day,
+                now=datetime.combine(
+                    current.date(),
+                    datetime.min.time(),
+                    tzinfo=timezone.utc,
+                ),
+            )
+            rebuilt = True
+        except Exception as exc:
+            failures += 1
+            with _guard_lock:
+                if _last_rollup_day == completed_day:
+                    _last_rollup_day = None
+            print(
+                "WARNING: analytics.rollup_maintenance_failed "
+                f"category={type(exc).__name__[:80]}"
+            )
+
+    repaired = 0
+    try:
+        repaired = int(
+            repair_snapshots(
+                now=current,
+                limit=page_size,
+            )
+        )
+    except Exception as exc:
+        failures += 1
+        print(
+            "WARNING: analytics.snapshot_maintenance_failed "
+            f"category={type(exc).__name__[:80]}"
+        )
+
+    return AnalyticsMaintenanceReport(
+        rollup_days=(completed_day,),
+        rollup_rebuilt=rebuilt,
+        repaired_snapshots=max(0, repaired),
+        failures=failures,
+    )
+
+
+__all__ = [
+    "AnalyticsMaintenanceReport",
+    "reset_maintenance_guard_for_tests",
+    "run_analytics_maintenance",
+]

--- a/dashboard/backend/domain/analytics/metrics.py
+++ b/dashboard/backend/domain/analytics/metrics.py
@@ -1,0 +1,264 @@
+"""Deterministic, UTC-bounded Analytics metric formulas."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta, timezone
+from typing import Iterable
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .models import AnalyticsEventRecord
+
+
+_MEANINGFUL_EXPERIENCE_EVENTS = {"page_viewed"}
+_TERMINAL_SUCCESS = "backtest_completed"
+_TERMINAL_FAILURE = "backtest_failed"
+
+
+def _utc(value: datetime, field_name: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return value.astimezone(timezone.utc)
+
+
+class AnalyticsMetricFilters(BaseModel):
+    """Normalized query filters shared by rollups and Admin APIs."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    start: datetime
+    end: datetime
+    billing_mode: str | None = None
+    provider_id: str | None = Field(default=None, max_length=128)
+    model_id: str | None = Field(default=None, max_length=256)
+    include_internal: bool = False
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "AnalyticsMetricFilters":
+        start = _utc(self.start, "start")
+        end = _utc(self.end, "end")
+        if end <= start:
+            raise ValueError("end must be after start")
+        if self.billing_mode not in {None, "byok", "platform_credits"}:
+            raise ValueError("billing_mode must be byok or platform_credits")
+        object.__setattr__(self, "start", start)
+        object.__setattr__(self, "end", end)
+        return self
+
+    @classmethod
+    def default(cls, *, now: datetime | None = None, days: int = 30):
+        current = _utc(now or datetime.now(timezone.utc), "now")
+        if isinstance(days, bool) or not isinstance(days, int) or not 1 <= days <= 180:
+            raise ValueError("days must be an integer from 1 through 180")
+        return cls(start=current - timedelta(days=days), end=current)
+
+
+class AnalyticsOverviewMetrics(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    active_users_7d: int = 0
+    mature_signup_cohort_users: int = 0
+    first_success_within_7d_users: int = 0
+    first_success_conversion: float | None = None
+    completed_runs: int = 0
+    failed_runs: int = 0
+    backtest_success_rate: float | None = None
+    users_with_first_success: int = 0
+    users_with_repeat_success: int = 0
+    repeat_run_rate: float | None = None
+    platform_model_cost_usd: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    affected_users: int = 0
+    daily_active_users: dict[str, int] = Field(default_factory=dict)
+    daily_completed_runs: dict[str, int] = Field(default_factory=dict)
+    top_failure_categories: dict[str, int] = Field(default_factory=dict)
+
+
+def backtest_success_rate(*, completed: int, failed: int) -> float | None:
+    denominator = completed + failed
+    return None if denominator == 0 else completed / denominator
+
+
+def repeat_run_rate(
+    *,
+    users_with_first_success: int,
+    users_with_repeat_success: int,
+) -> float | None:
+    if users_with_first_success == 0:
+        return None
+    return users_with_repeat_success / users_with_first_success
+
+
+def is_meaningful_event(event: AnalyticsEventRecord) -> bool:
+    if event.event_group == "experience":
+        return event.event_name in _MEANINGFUL_EXPERIENCE_EVENTS
+    return True
+
+
+def _matches_dimensions(
+    event: AnalyticsEventRecord,
+    *,
+    billing_mode: str | None,
+    provider_id: str | None,
+    model_id: str | None,
+) -> bool:
+    if billing_mode is not None and event.billing_mode != billing_mode:
+        return False
+    if provider_id is not None and event.provider_id != provider_id:
+        return False
+    if model_id is not None and event.model_id != model_id:
+        return False
+    return True
+
+
+def calculate_overview_metrics(
+    events: Iterable[AnalyticsEventRecord],
+    *,
+    start: datetime,
+    end: datetime,
+    excluded_user_ids: set[int] | None = None,
+    billing_mode: str | None = None,
+    provider_id: str | None = None,
+    model_id: str | None = None,
+) -> AnalyticsOverviewMetrics:
+    """Calculate exact metrics from a bounded event set.
+
+    Callers must include signup and successful-run context needed by cohort and
+    repeat formulas. Values counted for the requested range still use the
+    half-open interval ``[start, end)``.
+    """
+
+    range_start = _utc(start, "start")
+    range_end = _utc(end, "end")
+    if range_end <= range_start:
+        raise ValueError("end must be after start")
+    excluded = excluded_user_ids or set()
+    eligible = [
+        event
+        for event in events
+        if event.user_id not in excluded
+        and _matches_dimensions(
+            event,
+            billing_mode=billing_mode,
+            provider_id=provider_id,
+            model_id=model_id,
+        )
+    ]
+    in_range = [
+        event
+        for event in eligible
+        if range_start <= event.occurred_at.astimezone(timezone.utc) < range_end
+    ]
+
+    active_start = range_end - timedelta(days=7)
+    active_users = {
+        event.user_id
+        for event in eligible
+        if active_start <= event.occurred_at.astimezone(timezone.utc) < range_end
+        and is_meaningful_event(event)
+    }
+    affected_users = {
+        event.user_id for event in in_range if is_meaningful_event(event)
+    }
+
+    successes_by_user: dict[int, list[datetime]] = defaultdict(list)
+    for event in eligible:
+        if event.event_name == _TERMINAL_SUCCESS:
+            successes_by_user[event.user_id].append(
+                event.occurred_at.astimezone(timezone.utc)
+            )
+    for values in successes_by_user.values():
+        values.sort()
+
+    mature_signups: dict[int, datetime] = {}
+    for event in eligible:
+        if event.event_name != "account_signed_up":
+            continue
+        signup_at = event.occurred_at.astimezone(timezone.utc)
+        if range_start <= signup_at < range_end and signup_at + timedelta(days=7) <= range_end:
+            mature_signups.setdefault(event.user_id, signup_at)
+    converted = 0
+    for user_id, signup_at in mature_signups.items():
+        if any(
+            signup_at <= success_at <= signup_at + timedelta(days=7)
+            for success_at in successes_by_user.get(user_id, [])
+        ):
+            converted += 1
+
+    users_with_first_success = len(successes_by_user)
+    users_with_repeat = 0
+    for success_times in successes_by_user.values():
+        first = success_times[0]
+        if any(
+            first + timedelta(hours=24) <= later <= first + timedelta(days=30)
+            for later in success_times[1:]
+        ):
+            users_with_repeat += 1
+
+    completed = sum(event.event_name == _TERMINAL_SUCCESS for event in in_range)
+    failed = sum(event.event_name == _TERMINAL_FAILURE for event in in_range)
+    input_tokens = 0
+    output_tokens = 0
+    platform_cost_micro = 0
+    daily_users: dict[date, set[int]] = defaultdict(set)
+    daily_completed: Counter[date] = Counter()
+    failures: Counter[str] = Counter()
+    for event in in_range:
+        event_day = event.occurred_at.astimezone(timezone.utc).date()
+        if is_meaningful_event(event):
+            daily_users[event_day].add(event.user_id)
+        if event.event_name == _TERMINAL_SUCCESS:
+            daily_completed[event_day] += 1
+        if event.error_category:
+            failures[event.error_category] += 1
+        if event.event_name == "model_usage_recorded":
+            input_tokens += int(event.properties.get("input_tokens", 0))
+            output_tokens += int(event.properties.get("output_tokens", 0))
+            if event.billing_mode == "platform_credits":
+                platform_cost_micro += int(
+                    event.properties.get("cost_micro_usd", 0)
+                )
+
+    return AnalyticsOverviewMetrics(
+        active_users_7d=len(active_users),
+        mature_signup_cohort_users=len(mature_signups),
+        first_success_within_7d_users=converted,
+        first_success_conversion=(
+            None if not mature_signups else converted / len(mature_signups)
+        ),
+        completed_runs=completed,
+        failed_runs=failed,
+        backtest_success_rate=backtest_success_rate(
+            completed=completed,
+            failed=failed,
+        ),
+        users_with_first_success=users_with_first_success,
+        users_with_repeat_success=users_with_repeat,
+        repeat_run_rate=repeat_run_rate(
+            users_with_first_success=users_with_first_success,
+            users_with_repeat_success=users_with_repeat,
+        ),
+        platform_model_cost_usd=platform_cost_micro / 1_000_000,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        affected_users=len(affected_users),
+        daily_active_users={
+            day.isoformat(): len(users) for day, users in sorted(daily_users.items())
+        },
+        daily_completed_runs={
+            day.isoformat(): count for day, count in sorted(daily_completed.items())
+        },
+        top_failure_categories=dict(failures.most_common(10)),
+    )
+
+
+__all__ = [
+    "AnalyticsMetricFilters",
+    "AnalyticsOverviewMetrics",
+    "backtest_success_rate",
+    "calculate_overview_metrics",
+    "is_meaningful_event",
+    "repeat_run_rate",
+]

--- a/dashboard/backend/domain/analytics/query_service.py
+++ b/dashboard/backend/domain/analytics/query_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
@@ -21,6 +22,7 @@ from .repository_common import (
     encode_event_cursor,
     positive_limit,
     positive_user_id,
+    utc_iso,
 )
 from .rollups import AnalyticsRollupStore, DailyRollup
 from .states import (
@@ -45,6 +47,19 @@ _USAGE_EVENTS = {
     "credits_settled",
     "credits_refunded",
 }
+
+
+@dataclass(frozen=True)
+class _MetricEvent:
+    event_name: str
+    event_group: str
+    user_id: int
+    occurred_at: datetime
+    provider_id: str | None
+    model_id: str | None
+    billing_mode: str | None
+    error_category: str | None
+    properties: dict[str, Any]
 
 
 def _utc(value: datetime, field_name: str) -> datetime:
@@ -296,6 +311,157 @@ class AnalyticsQueryStore:
             result[snapshot.user_id] = snapshot
         return result
 
+    def list_metric_events(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        include_internal: bool,
+    ) -> list[_MetricEvent]:
+        """Load only fields used by Overview formulas.
+
+        Full Analytics event validation is intentionally reserved for detail
+        responses. Overview can touch tens of thousands of rows, and rebuilding
+        UUID/session/source models for fields it never returns dominated the
+        page latency without adding a privacy or correctness check.
+        """
+
+        params = (utc_iso(start), utc_iso(end))
+        sql = """
+            SELECT event_name, event_group, user_id, occurred_at,
+                   provider_id, model_id, billing_mode, error_category,
+                   properties_json
+            FROM analytics_events
+            WHERE occurred_at >= {start_placeholder}
+              AND occurred_at < {end_placeholder}
+            ORDER BY occurred_at ASC, sequence ASC
+        """
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        sql.format(
+                            start_placeholder="%s",
+                            end_placeholder="%s",
+                        ),
+                        params,
+                    )
+                    rows = cur.fetchall()
+        else:
+            with self.base_store._get_connection() as conn:
+                rows = conn.execute(
+                    sql.format(
+                        start_placeholder="?",
+                        end_placeholder="?",
+                    ),
+                    params,
+                ).fetchall()
+        excluded = (
+            set()
+            if include_internal
+            else self.base_store.list_excluded_user_ids(
+                include_admin_accounts=True
+            )
+        )
+        events = []
+        for row in rows:
+            user_id = int(row["user_id"])
+            if user_id in excluded:
+                continue
+            event_name = str(row["event_name"])
+            properties = (
+                json.loads(str(row["properties_json"]))
+                if event_name == "model_usage_recorded"
+                else {}
+            )
+            if not isinstance(properties, dict):
+                raise ValueError("stored Analytics properties are invalid")
+            events.append(
+                _MetricEvent(
+                    event_name=event_name,
+                    event_group=str(row["event_group"]),
+                    user_id=user_id,
+                    occurred_at=_parse_timestamp(row["occurred_at"]),
+                    provider_id=(
+                        str(row["provider_id"])
+                        if row["provider_id"] is not None
+                        else None
+                    ),
+                    model_id=(
+                        str(row["model_id"])
+                        if row["model_id"] is not None
+                        else None
+                    ),
+                    billing_mode=(
+                        str(row["billing_mode"])
+                        if row["billing_mode"] is not None
+                        else None
+                    ),
+                    error_category=(
+                        str(row["error_category"])
+                        if row["error_category"] is not None
+                        else None
+                    ),
+                    properties=properties,
+                )
+            )
+        return events
+
+    def summarize_users(
+        self,
+        *,
+        user_ids: set[int],
+        start: datetime,
+        end: datetime,
+    ) -> dict[int, dict[str, Any]]:
+        """Return bounded 30-day summaries without hydrating event models."""
+
+        if not user_ids:
+            return {}
+        result: dict[int, dict[str, Any]] = {}
+        ordered_ids = sorted(positive_user_id(user_id) for user_id in user_ids)
+        for offset in range(0, len(ordered_ids), 500):
+            chunk = ordered_ids[offset : offset + 500]
+            placeholder = "%s" if self.is_postgres else "?"
+            id_placeholders = ", ".join(placeholder for _ in chunk)
+            params: list[Any] = [utc_iso(start), utc_iso(end), *chunk]
+            sql = f"""
+                SELECT user_id,
+                       MAX(CASE
+                           WHEN event_group <> 'experience'
+                                OR event_name = 'page_viewed'
+                           THEN occurred_at
+                       END) AS last_meaningful_activity,
+                       SUM(CASE WHEN event_group = 'run' THEN 1 ELSE 0 END)
+                           AS recent_runs,
+                       SUM(CASE WHEN event_name = 'backtest_failed' THEN 1 ELSE 0 END)
+                           AS recent_failures
+                FROM analytics_events
+                WHERE occurred_at >= {placeholder}
+                  AND occurred_at < {placeholder}
+                  AND user_id IN ({id_placeholders})
+                GROUP BY user_id
+            """
+            if self.is_postgres:
+                with self.base_store._get_connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(sql, params)
+                        rows = cur.fetchall()
+            else:
+                with self.base_store._get_connection() as conn:
+                    rows = conn.execute(sql, params).fetchall()
+            for row in rows:
+                result[int(row["user_id"])] = {
+                    "last_meaningful_activity": (
+                        _parse_timestamp(row["last_meaningful_activity"])
+                        if row["last_meaningful_activity"] is not None
+                        else None
+                    ),
+                    "recent_runs": int(row["recent_runs"] or 0),
+                    "recent_failures": int(row["recent_failures"] or 0),
+                }
+        return result
+
     def list_activity_rows(
         self,
         *,
@@ -510,11 +676,11 @@ class AnalyticsQueryService:
         daily_completed: dict[str, int] = {}
         funnel: dict[str, int] = {}
         failures: list[FailureCategoryCount] = []
-        raw_events: list[AnalyticsEventRecord] = []
+        raw_events: list[_MetricEvent] = []
 
         if effective_end > filters.start:
             try:
-                raw_events = self.query_store.rollups.list_events(
+                raw_events = self.query_store.list_metric_events(
                     start=filters.start,
                     end=effective_end,
                     include_internal=filters.include_internal,
@@ -701,6 +867,9 @@ class AnalyticsQueryService:
 
         state_counts: dict[str, int] = {}
         attention: list[AnalyticsUserListItem] = []
+        snapshots: dict[int, UserAnalyticsSnapshot] = {}
+        excluded: set[int] = set()
+        snapshots_available = False
         try:
             snapshots = self.query_store.list_snapshots()
             excluded = (
@@ -715,22 +884,57 @@ class AnalyticsQueryService:
                     if user_id not in excluded
                 )
             )
+            snapshots_available = True
         except Exception:
             availability["friction"] = _availability(False)
         try:
-            listed = self.list_users(
-                filters=AnalyticsUserFilters(
-                    sort="recent_failures",
-                    order="desc",
-                    include_internal=filters.include_internal,
-                ),
-                limit=100,
-                offset=0,
-                now=current,
+            if not snapshots_available:
+                raise RuntimeError("Analytics snapshots are unavailable")
+            attention_ids = {
+                user_id
+                for user_id, snapshot in snapshots.items()
+                if user_id not in excluded
+                and snapshot.status in _ATTENTION_STATES
+            }
+            summaries = self.query_store.summarize_users(
+                user_ids=attention_ids,
+                start=current - timedelta(days=30),
+                end=current + timedelta(microseconds=1),
             )
-            attention = [
-                item for item in listed.items if item.status in _ATTENTION_STATES
-            ][:10]
+            identities = {
+                int(user["id"]): user
+                for user in _all_users(self.user_store)
+                if int(user["id"]) in attention_ids
+            }
+            candidates = []
+            for user_id in attention_ids:
+                user = identities.get(user_id)
+                if user is None:
+                    continue
+                snapshot = snapshots[user_id]
+                summary = summaries.get(user_id, {})
+                candidates.append(
+                    AnalyticsUserListItem(
+                        user_id=user_id,
+                        display_name=str(user.get("display_name") or ""),
+                        email=str(user.get("email") or ""),
+                        joined_at=_parse_timestamp(user["created_at"]),
+                        status=snapshot.status,
+                        reason_code=snapshot.reason_code,
+                        human_readable_reason=snapshot.human_readable_reason,
+                        last_meaningful_activity=summary.get(
+                            "last_meaningful_activity"
+                        ),
+                        recent_runs=int(summary.get("recent_runs", 0)),
+                        recent_failures=int(summary.get("recent_failures", 0)),
+                        profile_path=f"/admin/analytics/users/{user_id}",
+                    )
+                )
+            candidates.sort(
+                key=lambda item: (item.recent_failures, item.user_id),
+                reverse=True,
+            )
+            attention = candidates[:10]
         except Exception:
             availability["attention"] = _availability(False)
 
@@ -1075,7 +1279,7 @@ class AnalyticsQueryService:
 
 
 def _event_matches_filters(
-    event: AnalyticsEventRecord,
+    event: AnalyticsEventRecord | _MetricEvent,
     filters: AnalyticsMetricFilters,
 ) -> bool:
     if filters.billing_mode is not None and event.billing_mode != filters.billing_mode:

--- a/dashboard/backend/domain/analytics/query_service.py
+++ b/dashboard/backend/domain/analytics/query_service.py
@@ -1,0 +1,1112 @@
+"""Read-only, display-safe Admin Analytics query composition."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .metrics import (
+    AnalyticsMetricFilters,
+    calculate_overview_metrics,
+    is_meaningful_event,
+)
+from .models import AnalyticsEventRecord
+from .repository import _row_to_event, analytics_store
+from .repository_common import (
+    decode_event_cursor,
+    encode_event_cursor,
+    positive_limit,
+    positive_user_id,
+)
+from .rollups import AnalyticsRollupStore, DailyRollup
+from .states import (
+    AnalyticsStateStore,
+    UserAnalyticsSnapshot,
+    calculate_user_state,
+)
+
+
+ActivitySection = Literal["timeline", "runs", "usage", "sessions"]
+_USER_STATES = {"blocked", "needs_attention", "dormant", "onboarding", "active"}
+_ATTENTION_STATES = {"blocked", "needs_attention"}
+_ACTIVATION_EVENTS = (
+    "account_signed_up",
+    "credential_verified",
+    "agent_created",
+    "backtest_completed",
+)
+_USAGE_EVENTS = {
+    "model_usage_recorded",
+    "credits_reserved",
+    "credits_settled",
+    "credits_refunded",
+}
+
+
+def _utc(value: datetime, field_name: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return value.astimezone(timezone.utc)
+
+
+def _parse_timestamp(value: object) -> datetime:
+    parsed = datetime.fromisoformat(str(value))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+class PanelAvailability(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    available: bool = True
+    error_code: Literal["temporarily_unavailable"] | None = None
+
+    @model_validator(mode="after")
+    def match_error_to_availability(self) -> "PanelAvailability":
+        expected = None if self.available else "temporarily_unavailable"
+        object.__setattr__(self, "error_code", expected)
+        return self
+
+
+class FailureCategoryCount(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    error_category: str
+    affected_users: int = Field(ge=0)
+
+
+class AnalyticsStateSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: str
+    reason_code: str
+    human_readable_reason: str
+    evidence_event_ids: list[str] = Field(default_factory=list)
+    calculated_at: datetime
+
+
+class AnalyticsUserListItem(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    user_id: int = Field(gt=0)
+    display_name: str
+    email: str
+    joined_at: datetime
+    status: str
+    reason_code: str
+    human_readable_reason: str
+    last_meaningful_activity: datetime | None = None
+    recent_runs: int = Field(default=0, ge=0)
+    recent_failures: int = Field(default=0, ge=0)
+    profile_path: str
+
+
+class AnalyticsUserFilters(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    q: str | None = Field(default=None, max_length=100)
+    status: str | None = None
+    last_activity_from: datetime | None = None
+    last_activity_to: datetime | None = None
+    sort: Literal[
+        "last_activity", "joined_at", "recent_runs", "recent_failures"
+    ] = "last_activity"
+    order: Literal["asc", "desc"] = "desc"
+    include_internal: bool = False
+
+    @field_validator("q")
+    @classmethod
+    def normalize_query(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, value: str | None) -> str | None:
+        if value is not None and value not in _USER_STATES:
+            raise ValueError("status must be a supported Analytics user state")
+        return value
+
+    @model_validator(mode="after")
+    def validate_activity_range(self) -> "AnalyticsUserFilters":
+        start = self.last_activity_from
+        end = self.last_activity_to
+        if start is not None:
+            object.__setattr__(self, "last_activity_from", _utc(start, "last_activity_from"))
+        if end is not None:
+            object.__setattr__(self, "last_activity_to", _utc(end, "last_activity_to"))
+        if start is not None and end is not None and _utc(end, "last_activity_to") < _utc(start, "last_activity_from"):
+            raise ValueError("last_activity_to cannot be before last_activity_from")
+        return self
+
+
+class PaginatedUsers(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    items: list[AnalyticsUserListItem]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1, le=100)
+    offset: int = Field(ge=0)
+
+
+class AnalyticsFootprintItem(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    event_id: str
+    event_name: str
+    occurred_at: datetime
+    page_view: str | None = None
+    provider_id: str | None = None
+    model_id: str | None = None
+    billing_mode: str | None = None
+    outcome: str | None = None
+    error_category: str | None = None
+
+
+class AnalyticsUserProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    user_id: int = Field(gt=0)
+    display_name: str
+    email: str
+    joined_at: datetime
+    last_meaningful_activity: datetime | None = None
+    state: AnalyticsStateSummary
+    primary_billing_lane: str | None = None
+    default_provider: str | None = None
+    country_code: str | None = None
+    device_category: str | None = None
+    browser_family: str | None = None
+    activation_milestones: dict[str, datetime]
+    recent_footprint: list[AnalyticsFootprintItem]
+    run_summary: dict[str, int]
+    billing_lane_mix: dict[str, int]
+    input_tokens: int = Field(default=0, ge=0)
+    output_tokens: int = Field(default=0, ge=0)
+    platform_model_cost_usd: float = Field(default=0, ge=0)
+    credits_debited_micro: int = Field(default=0, ge=0)
+    top_product_page: str | None = None
+
+
+class AnalyticsActivityItem(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    item_type: Literal["event", "run", "usage", "session"]
+    event_id: str | None = None
+    event_name: str
+    occurred_at: datetime
+    outcome: str | None = None
+    error_category: str | None = None
+    page_view: str | None = None
+    provider_id: str | None = None
+    model_id: str | None = None
+    billing_mode: str | None = None
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    cost_micro_usd: int | None = Field(default=None, ge=0)
+    amount_micro: int | None = Field(default=None, ge=0)
+    bucket: str | None = None
+    session_event_count: int | None = Field(default=None, ge=0)
+    visible_ms: int | None = Field(default=None, ge=0)
+    country_code: str | None = None
+    device_category: str | None = None
+    browser_family: str | None = None
+
+
+class AnalyticsActivityPage(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    items: list[AnalyticsActivityItem]
+    next_cursor: str | None = None
+
+
+class AnalyticsOverview(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    active_users_7d: int | None = Field(default=None, ge=0)
+    first_success_conversion: float | None = Field(default=None, ge=0, le=1)
+    backtest_success_rate: float | None = Field(default=None, ge=0, le=1)
+    repeat_run_rate: float | None = Field(default=None, ge=0, le=1)
+    platform_model_cost_usd: float | None = Field(default=None, ge=0)
+    completed_runs: int | None = Field(default=None, ge=0)
+    failed_runs: int | None = Field(default=None, ge=0)
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    daily_active_users: dict[str, int]
+    daily_completed_runs: dict[str, int]
+    activation_funnel: dict[str, int]
+    user_state_counts: dict[str, int]
+    top_failure_categories: list[FailureCategoryCount]
+    users_needing_attention: list[AnalyticsUserListItem]
+    last_updated: datetime
+    filters: AnalyticsMetricFilters
+    availability: dict[str, PanelAvailability]
+
+
+def _all_users(user_store: Any) -> list[dict[str, Any]]:
+    users: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        page = user_store.list_users_admin(limit=500, offset=offset)
+        users.extend(page)
+        if len(page) < 500:
+            return users
+        offset += len(page)
+
+
+class AnalyticsQueryStore:
+    """PR 2 read companions over the PR 1 Analytics tables."""
+
+    def __init__(self, base_store: Any = analytics_store):
+        self.base_store = base_store
+        self.rollups = AnalyticsRollupStore(base_store)
+        self.states = AnalyticsStateStore(base_store)
+        self.is_postgres = hasattr(base_store, "database_url")
+
+    def list_snapshots(self) -> dict[int, UserAnalyticsSnapshot]:
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT * FROM user_analytics_snapshots ORDER BY user_id")
+                    rows = cur.fetchall()
+        else:
+            with self.base_store._get_connection() as conn:
+                rows = conn.execute(
+                    "SELECT * FROM user_analytics_snapshots ORDER BY user_id"
+                ).fetchall()
+        result = {}
+        for row in rows:
+            snapshot = UserAnalyticsSnapshot(
+                user_id=int(row["user_id"]),
+                status=str(row["status"]),
+                reason_code=str(row["reason_code"]),
+                human_readable_reason=str(row["human_readable_reason"]),
+                evidence_event_ids=list(
+                    json.loads(str(row["evidence_event_ids_json"]))
+                ),
+                calculated_at=_parse_timestamp(row["calculated_at"]),
+            )
+            result[snapshot.user_id] = snapshot
+        return result
+
+    def list_activity_rows(
+        self,
+        *,
+        user_id: int,
+        section: ActivitySection,
+        limit: int,
+        cursor: str | None,
+    ) -> tuple[list[tuple[int, AnalyticsEventRecord]], str | None]:
+        subject_id = positive_user_id(user_id)
+        page_size = positive_limit(limit)
+        where = {
+            "timeline": "event_name NOT IN ('session_heartbeat', 'page_hidden')",
+            "runs": "event_group = 'run'",
+            "usage": (
+                "event_name IN ('model_usage_recorded', 'credits_reserved', "
+                "'credits_settled', 'credits_refunded')"
+            ),
+        }.get(section)
+        if where is None:
+            raise ValueError("section must be timeline, runs, or usage")
+        cursor_values = decode_event_cursor(cursor) if cursor is not None else None
+        params: list[Any] = [subject_id]
+        cursor_sql = ""
+        if cursor_values is not None:
+            occurred_at, sequence = cursor_values
+            if self.is_postgres:
+                cursor_sql = "AND (occurred_at, sequence) < (%s, %s)"
+                params.extend([occurred_at, sequence])
+            else:
+                cursor_sql = (
+                    "AND (occurred_at < ? OR (occurred_at = ? AND sequence < ?))"
+                )
+                params.extend([occurred_at, occurred_at, sequence])
+        params.append(page_size + 1)
+        placeholder = "%s" if self.is_postgres else "?"
+        sql = f"""
+            SELECT * FROM analytics_events
+            WHERE user_id = {placeholder} AND {where} {cursor_sql}
+            ORDER BY occurred_at DESC, sequence DESC
+            LIMIT {placeholder}
+        """
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(sql, params)
+                    rows = cur.fetchall()
+        else:
+            with self.base_store._get_connection() as conn:
+                rows = conn.execute(sql, params).fetchall()
+        has_more = len(rows) > page_size
+        page_rows = rows[:page_size]
+        next_cursor = None
+        if has_more and page_rows:
+            last = page_rows[-1]
+            next_cursor = encode_event_cursor(
+                str(last["occurred_at"]),
+                int(last["sequence"]),
+            )
+        return [
+            (int(row["sequence"]), _row_to_event(row)) for row in page_rows
+        ], next_cursor
+
+    def list_session_rows(
+        self,
+        *,
+        user_id: int,
+        limit: int,
+        cursor: str | None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        subject_id = positive_user_id(user_id)
+        page_size = positive_limit(limit)
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT * FROM analytics_events
+                        WHERE user_id = %s AND event_group = 'experience'
+                          AND session_id IS NOT NULL
+                        ORDER BY occurred_at DESC, sequence DESC
+                        """,
+                        (subject_id,),
+                    )
+                    rows = cur.fetchall()
+        else:
+            with self.base_store._get_connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM analytics_events
+                    WHERE user_id = ? AND event_group = 'experience'
+                      AND session_id IS NOT NULL
+                    ORDER BY occurred_at DESC, sequence DESC
+                    """,
+                    (subject_id,),
+                ).fetchall()
+        grouped: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            event = _row_to_event(row)
+            session_id = event.session_id
+            if session_id is None:
+                continue
+            group = grouped.setdefault(
+                session_id,
+                {
+                    "occurred_at": event.occurred_at,
+                    "sequence": int(row["sequence"]),
+                    "event_count": 0,
+                    "visible_ms": 0,
+                    "country_code": event.country_code,
+                    "device_category": event.device_category,
+                    "browser_family": event.browser_family,
+                },
+            )
+            group["event_count"] += 1
+            group["visible_ms"] += int(event.properties.get("visible_ms", 0))
+        sessions = sorted(
+            grouped.values(),
+            key=lambda row: (row["occurred_at"], row["sequence"]),
+            reverse=True,
+        )
+        if cursor is not None:
+            cursor_time, cursor_sequence = decode_event_cursor(cursor)
+            cursor_at = _parse_timestamp(cursor_time)
+            sessions = [
+                row
+                for row in sessions
+                if (row["occurred_at"], row["sequence"])
+                < (cursor_at, cursor_sequence)
+            ]
+        page_rows = sessions[: page_size + 1]
+        has_more = len(page_rows) > page_size
+        page_rows = page_rows[:page_size]
+        next_cursor = None
+        if has_more and page_rows:
+            last = page_rows[-1]
+            next_cursor = encode_event_cursor(
+                last["occurred_at"].isoformat(),
+                last["sequence"],
+            )
+        return page_rows, next_cursor
+
+
+def _snapshot_summary(snapshot: UserAnalyticsSnapshot) -> AnalyticsStateSummary:
+    return AnalyticsStateSummary(
+        status=snapshot.status,
+        reason_code=snapshot.reason_code,
+        human_readable_reason=snapshot.human_readable_reason,
+        evidence_event_ids=snapshot.evidence_event_ids,
+        calculated_at=snapshot.calculated_at,
+    )
+
+
+def _availability(available: bool = True) -> PanelAvailability:
+    return PanelAvailability(available=available)
+
+
+def _matches_rollup_dimensions(
+    row: DailyRollup,
+    filters: AnalyticsMetricFilters,
+) -> bool:
+    if filters.billing_mode is not None and row.billing_mode != filters.billing_mode:
+        return False
+    if filters.provider_id is not None and row.provider_id != filters.provider_id:
+        return False
+    if filters.model_id is not None and row.model_id != filters.model_id:
+        return False
+    return True
+
+
+class AnalyticsQueryService:
+    def __init__(
+        self,
+        *,
+        store: Any = analytics_store,
+        user_store: Any | None = None,
+    ):
+        if user_store is None:
+            from dashboard.backend.users import user_store as default_user_store
+
+            user_store = default_user_store
+        self.store = store
+        self.user_store = user_store
+        self.query_store = AnalyticsQueryStore(store)
+
+    def get_overview(
+        self,
+        *,
+        filters: AnalyticsMetricFilters,
+        now: datetime | None = None,
+    ) -> AnalyticsOverview:
+        if not isinstance(filters, AnalyticsMetricFilters):
+            filters = AnalyticsMetricFilters.model_validate(filters)
+        current = _utc(now or datetime.now(timezone.utc), "now")
+        effective_end = min(filters.end, current)
+        availability = {
+            "snapshot": _availability(),
+            "growth": _availability(),
+            "funnel": _availability(),
+            "friction": _availability(),
+            "attention": _availability(),
+        }
+        active_users: int | None = None
+        conversion: float | None = None
+        success_rate: float | None = None
+        repeat_rate: float | None = None
+        completed: int | None = None
+        failed: int | None = None
+        platform_cost: float | None = None
+        input_tokens: int | None = None
+        output_tokens: int | None = None
+        daily_active: dict[str, int] = {}
+        daily_completed: dict[str, int] = {}
+        funnel: dict[str, int] = {}
+        failures: list[FailureCategoryCount] = []
+        raw_events: list[AnalyticsEventRecord] = []
+
+        if effective_end > filters.start:
+            try:
+                raw_events = self.query_store.rollups.list_events(
+                    start=filters.start,
+                    end=effective_end,
+                    include_internal=filters.include_internal,
+                )
+                raw_metrics = calculate_overview_metrics(
+                    raw_events,
+                    start=filters.start,
+                    end=effective_end,
+                    billing_mode=filters.billing_mode,
+                    provider_id=filters.provider_id,
+                    model_id=filters.model_id,
+                )
+                active_users = raw_metrics.active_users_7d
+                conversion = raw_metrics.first_success_conversion
+                repeat_rate = raw_metrics.repeat_run_rate
+                funnel = {
+                    event_name: len(
+                        {
+                            event.user_id
+                            for event in raw_events
+                            if event.event_name == event_name
+                            and _event_matches_filters(event, filters)
+                        }
+                    )
+                    for event_name in _ACTIVATION_EVENTS
+                }
+                failure_users: dict[str, set[int]] = defaultdict(set)
+                for event in raw_events:
+                    if event.error_category and _event_matches_filters(event, filters):
+                        failure_users[event.error_category].add(event.user_id)
+                failures = [
+                    FailureCategoryCount(
+                        error_category=category,
+                        affected_users=len(users),
+                    )
+                    for category, users in sorted(
+                        failure_users.items(),
+                        key=lambda item: (-len(item[1]), item[0]),
+                    )[:10]
+                ]
+            except Exception:
+                availability["snapshot"] = _availability(False)
+                availability["funnel"] = _availability(False)
+                availability["friction"] = _availability(False)
+
+        try:
+            historical_end = min(effective_end.date(), current.date())
+            rollups = self.query_store.rollups.list_rollups(
+                start=filters.start.date(),
+                end=historical_end,
+            )
+            dimensional = any(
+                value is not None
+                for value in (
+                    filters.billing_mode,
+                    filters.provider_id,
+                    filters.model_id,
+                )
+            )
+            if dimensional:
+                historical_completed = sum(
+                    row.value_count
+                    for row in rollups
+                    if row.metric_name == "event_count"
+                    and row.event_name == "backtest_completed"
+                    and _matches_rollup_dimensions(row, filters)
+                )
+                historical_failed = sum(
+                    row.value_count
+                    for row in rollups
+                    if row.metric_name == "event_count"
+                    and row.event_name == "backtest_failed"
+                    and _matches_rollup_dimensions(row, filters)
+                )
+            else:
+                historical_completed = sum(
+                    row.value_count
+                    for row in rollups
+                    if row.metric_name == "terminal_completed"
+                    and not row.event_name
+                    and not row.provider_id
+                    and not row.model_id
+                )
+                historical_failed = sum(
+                    row.value_count
+                    for row in rollups
+                    if row.metric_name == "terminal_failed"
+                    and not row.event_name
+                    and not row.provider_id
+                    and not row.model_id
+                )
+            today_start = datetime.combine(
+                current.date(), datetime.min.time(), tzinfo=timezone.utc
+            )
+            current_events = [
+                event
+                for event in raw_events
+                if max(filters.start, today_start)
+                <= event.occurred_at
+                < effective_end
+                and _event_matches_filters(event, filters)
+            ]
+            current_completed = sum(
+                event.event_name == "backtest_completed" for event in current_events
+            )
+            current_failed = sum(
+                event.event_name == "backtest_failed" for event in current_events
+            )
+            completed = historical_completed + current_completed
+            failed = historical_failed + current_failed
+            denominator = completed + failed
+            success_rate = None if denominator == 0 else completed / denominator
+
+            if filters.billing_mode == "byok":
+                platform_micro = 0
+            elif filters.provider_id is not None or filters.model_id is not None:
+                platform_micro = sum(
+                    row.value_sum_micro
+                    for row in rollups
+                    if row.metric_name == "platform_model_cost_usd"
+                    and row.billing_mode == "platform_credits"
+                    and bool(row.provider_id)
+                    and bool(row.model_id)
+                    and (
+                        filters.provider_id is None
+                        or row.provider_id == filters.provider_id
+                    )
+                    and (
+                        filters.model_id is None or row.model_id == filters.model_id
+                    )
+                )
+            else:
+                platform_micro = sum(
+                    row.value_sum_micro
+                    for row in rollups
+                    if row.metric_name == "platform_model_cost_usd"
+                    and row.billing_mode == "platform_credits"
+                    and not row.provider_id
+                    and not row.model_id
+                )
+            platform_micro += sum(
+                int(event.properties.get("cost_micro_usd", 0))
+                for event in current_events
+                if event.event_name == "model_usage_recorded"
+                and event.billing_mode == "platform_credits"
+            )
+            platform_cost = platform_micro / 1_000_000
+            input_tokens = sum(
+                int(event.properties.get("input_tokens", 0))
+                for event in raw_events
+                if event.event_name == "model_usage_recorded"
+                and _event_matches_filters(event, filters)
+            )
+            output_tokens = sum(
+                int(event.properties.get("output_tokens", 0))
+                for event in raw_events
+                if event.event_name == "model_usage_recorded"
+                and _event_matches_filters(event, filters)
+            )
+            for row in rollups:
+                key = row.rollup_date.isoformat()
+                if row.metric_name == "daily_active_users" and not dimensional:
+                    daily_active[key] = row.value_count
+                if row.metric_name in {"completed_runs", "terminal_completed"} and not dimensional:
+                    daily_completed[key] = row.value_count
+                if (
+                    dimensional
+                    and row.metric_name == "event_count"
+                    and row.event_name == "backtest_completed"
+                    and _matches_rollup_dimensions(row, filters)
+                ):
+                    daily_completed[key] = daily_completed.get(key, 0) + row.value_count
+            current_day_events = [
+                event for event in current_events if is_meaningful_event(event)
+            ]
+            if current_events:
+                day_key = current.date().isoformat()
+                daily_active[day_key] = len(
+                    {event.user_id for event in current_day_events}
+                )
+                daily_completed[day_key] = current_completed
+        except Exception:
+            availability["growth"] = _availability(False)
+
+        state_counts: dict[str, int] = {}
+        attention: list[AnalyticsUserListItem] = []
+        try:
+            snapshots = self.query_store.list_snapshots()
+            excluded = (
+                set()
+                if filters.include_internal
+                else self.store.list_excluded_user_ids(include_admin_accounts=True)
+            )
+            state_counts = dict(
+                Counter(
+                    snapshot.status
+                    for user_id, snapshot in snapshots.items()
+                    if user_id not in excluded
+                )
+            )
+        except Exception:
+            availability["friction"] = _availability(False)
+        try:
+            listed = self.list_users(
+                filters=AnalyticsUserFilters(
+                    sort="recent_failures",
+                    order="desc",
+                    include_internal=filters.include_internal,
+                ),
+                limit=100,
+                offset=0,
+                now=current,
+            )
+            attention = [
+                item for item in listed.items if item.status in _ATTENTION_STATES
+            ][:10]
+        except Exception:
+            availability["attention"] = _availability(False)
+
+        return AnalyticsOverview(
+            active_users_7d=active_users,
+            first_success_conversion=conversion,
+            backtest_success_rate=success_rate,
+            repeat_run_rate=repeat_rate,
+            platform_model_cost_usd=platform_cost,
+            completed_runs=completed,
+            failed_runs=failed,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            daily_active_users=daily_active,
+            daily_completed_runs=daily_completed,
+            activation_funnel=funnel,
+            user_state_counts=state_counts,
+            top_failure_categories=failures,
+            users_needing_attention=attention,
+            last_updated=current,
+            filters=filters,
+            availability=availability,
+        )
+
+    def list_users(
+        self,
+        *,
+        filters: AnalyticsUserFilters,
+        limit: int,
+        offset: int,
+        now: datetime | None = None,
+    ) -> PaginatedUsers:
+        if not isinstance(filters, AnalyticsUserFilters):
+            filters = AnalyticsUserFilters.model_validate(filters)
+        page_size = positive_limit(limit)
+        if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+            raise ValueError("offset must be a non-negative integer")
+        current = _utc(now or datetime.now(timezone.utc), "now")
+        users = _all_users(self.user_store)
+        excluded = (
+            set()
+            if filters.include_internal
+            else self.store.list_excluded_user_ids(include_admin_accounts=True)
+        )
+        snapshots = self.query_store.list_snapshots()
+        events = self.query_store.rollups.list_events(
+            start=current - timedelta(days=30),
+            end=current + timedelta(microseconds=1),
+            include_internal=True,
+        )
+        by_user: dict[int, list[AnalyticsEventRecord]] = defaultdict(list)
+        for event in events:
+            by_user[event.user_id].append(event)
+
+        items: list[AnalyticsUserListItem] = []
+        for user in users:
+            user_id = int(user["id"])
+            if user_id in excluded:
+                continue
+            user_events = sorted(
+                by_user.get(user_id, []),
+                key=lambda event: event.occurred_at,
+                reverse=True,
+            )
+            meaningful = [event for event in user_events if is_meaningful_event(event)]
+            last_activity = meaningful[0].occurred_at if meaningful else None
+            snapshot = snapshots.get(user_id)
+            if snapshot is None:
+                snapshot = calculate_user_state(
+                    user_id,
+                    now=current,
+                    store=self.query_store.states,
+                )
+            item = AnalyticsUserListItem(
+                user_id=user_id,
+                display_name=str(user.get("display_name") or ""),
+                email=str(user.get("email") or ""),
+                joined_at=_parse_timestamp(user["created_at"]),
+                status=snapshot.status,
+                reason_code=snapshot.reason_code,
+                human_readable_reason=snapshot.human_readable_reason,
+                last_meaningful_activity=last_activity,
+                recent_runs=sum(event.event_group == "run" for event in user_events),
+                recent_failures=sum(
+                    event.event_name == "backtest_failed" for event in user_events
+                ),
+                profile_path=f"/admin/analytics/users/{user_id}",
+            )
+            if filters.q is not None:
+                needle = filters.q.lower()
+                if needle not in item.email.lower() and needle not in item.display_name.lower():
+                    continue
+            if filters.status is not None and item.status != filters.status:
+                continue
+            if (
+                filters.last_activity_from is not None
+                and (
+                    item.last_meaningful_activity is None
+                    or item.last_meaningful_activity < filters.last_activity_from
+                )
+            ):
+                continue
+            if (
+                filters.last_activity_to is not None
+                and (
+                    item.last_meaningful_activity is None
+                    or item.last_meaningful_activity > filters.last_activity_to
+                )
+            ):
+                continue
+            items.append(item)
+
+        def sort_value(item: AnalyticsUserListItem):
+            if filters.sort == "joined_at":
+                return item.joined_at
+            if filters.sort == "recent_runs":
+                return item.recent_runs
+            if filters.sort == "recent_failures":
+                return item.recent_failures
+            return item.last_meaningful_activity or datetime.min.replace(
+                tzinfo=timezone.utc
+            )
+
+        items.sort(
+            key=lambda item: (sort_value(item), item.user_id),
+            reverse=filters.order == "desc",
+        )
+        return PaginatedUsers(
+            items=items[offset : offset + page_size],
+            total=len(items),
+            limit=page_size,
+            offset=offset,
+        )
+
+    def get_user_profile(
+        self,
+        *,
+        user_id: int,
+        now: datetime | None = None,
+    ) -> AnalyticsUserProfile:
+        subject_id = positive_user_id(user_id)
+        current = _utc(now or datetime.now(timezone.utc), "now")
+        user = self.user_store.get_user_admin(subject_id)
+        if user is None:
+            raise LookupError("Analytics user was not found")
+        snapshot = self.query_store.states.get_snapshot(subject_id)
+        if snapshot is None:
+            snapshot = calculate_user_state(
+                subject_id,
+                now=current,
+                store=self.query_store.states,
+            )
+        events = self.query_store.rollups.list_events(
+            start=current - timedelta(days=180),
+            end=current + timedelta(microseconds=1),
+            include_internal=True,
+            user_id=subject_id,
+        )
+        ordered = sorted(events, key=lambda event: event.occurred_at, reverse=True)
+        meaningful = [event for event in ordered if is_meaningful_event(event)]
+        milestones: dict[str, datetime] = {}
+        for event_name in _ACTIVATION_EVENTS:
+            matches = [
+                event.occurred_at for event in events if event.event_name == event_name
+            ]
+            if matches:
+                milestones[event_name] = min(matches)
+        lane_counts = Counter(
+            event.billing_mode
+            for event in events
+            if event.event_name == "model_usage_recorded" and event.billing_mode
+        )
+        page_counts = Counter(
+            event.page_view
+            for event in events
+            if event.event_name == "page_viewed" and event.page_view
+        )
+        provider_event = next(
+            (
+                event
+                for event in ordered
+                if event.provider_id
+                and event.event_name
+                in {"credential_defaulted", "credential_verified", "model_usage_recorded"}
+            ),
+            None,
+        )
+        client_event = next(
+            (
+                event
+                for event in ordered
+                if event.country_code or event.device_category or event.browser_family
+            ),
+            None,
+        )
+        recent = [
+            AnalyticsFootprintItem(
+                event_id=event.event_id,
+                event_name=event.event_name,
+                occurred_at=event.occurred_at,
+                page_view=event.page_view,
+                provider_id=event.provider_id,
+                model_id=event.model_id,
+                billing_mode=event.billing_mode,
+                outcome=event.outcome,
+                error_category=event.error_category,
+            )
+            for event in meaningful[:20]
+        ]
+        return AnalyticsUserProfile(
+            user_id=subject_id,
+            display_name=str(user.get("display_name") or ""),
+            email=str(user.get("email") or ""),
+            joined_at=_parse_timestamp(user["created_at"]),
+            last_meaningful_activity=(meaningful[0].occurred_at if meaningful else None),
+            state=_snapshot_summary(snapshot),
+            primary_billing_lane=(lane_counts.most_common(1)[0][0] if lane_counts else None),
+            default_provider=(provider_event.provider_id if provider_event else None),
+            country_code=(client_event.country_code if client_event else None),
+            device_category=(client_event.device_category if client_event else None),
+            browser_family=(client_event.browser_family if client_event else None),
+            activation_milestones=milestones,
+            recent_footprint=recent,
+            run_summary={
+                "requested": sum(event.event_name == "backtest_requested" for event in events),
+                "completed": sum(event.event_name == "backtest_completed" for event in events),
+                "failed": sum(event.event_name == "backtest_failed" for event in events),
+                "cancelled": sum(event.event_name == "backtest_cancelled" for event in events),
+            },
+            billing_lane_mix=dict(lane_counts),
+            input_tokens=sum(
+                int(event.properties.get("input_tokens", 0))
+                for event in events
+                if event.event_name == "model_usage_recorded"
+            ),
+            output_tokens=sum(
+                int(event.properties.get("output_tokens", 0))
+                for event in events
+                if event.event_name == "model_usage_recorded"
+            ),
+            platform_model_cost_usd=sum(
+                int(event.properties.get("cost_micro_usd", 0))
+                for event in events
+                if event.event_name == "model_usage_recorded"
+                and event.billing_mode == "platform_credits"
+            )
+            / 1_000_000,
+            credits_debited_micro=sum(
+                int(event.properties.get("amount_micro", 0))
+                for event in events
+                if event.event_name == "credits_settled"
+            ),
+            top_product_page=(page_counts.most_common(1)[0][0] if page_counts else None),
+        )
+
+    def get_user_activity(
+        self,
+        *,
+        user_id: int,
+        section: ActivitySection,
+        limit: int,
+        cursor: str | None,
+    ) -> AnalyticsActivityPage:
+        if section not in {"timeline", "runs", "usage", "sessions"}:
+            raise ValueError("section must be a supported Analytics activity section")
+        page_size = positive_limit(limit)
+        if section == "sessions":
+            rows, next_cursor = self.query_store.list_session_rows(
+                user_id=user_id,
+                limit=page_size,
+                cursor=cursor,
+            )
+            return AnalyticsActivityPage(
+                items=[
+                    AnalyticsActivityItem(
+                        item_type="session",
+                        event_name="session",
+                        occurred_at=row["occurred_at"],
+                        session_event_count=row["event_count"],
+                        visible_ms=row["visible_ms"],
+                        country_code=row["country_code"],
+                        device_category=row["device_category"],
+                        browser_family=row["browser_family"],
+                    )
+                    for row in rows
+                ],
+                next_cursor=next_cursor,
+            )
+        rows, next_cursor = self.query_store.list_activity_rows(
+            user_id=user_id,
+            section=section,
+            limit=page_size,
+            cursor=cursor,
+        )
+        items = []
+        for _sequence, event in rows:
+            properties = event.properties
+            items.append(
+                AnalyticsActivityItem(
+                    item_type=(
+                        "run" if section == "runs" else "usage" if section == "usage" else "event"
+                    ),
+                    event_id=event.event_id,
+                    event_name=event.event_name,
+                    occurred_at=event.occurred_at,
+                    outcome=event.outcome,
+                    error_category=event.error_category,
+                    page_view=event.page_view,
+                    provider_id=event.provider_id,
+                    model_id=event.model_id,
+                    billing_mode=event.billing_mode,
+                    input_tokens=(
+                        int(properties.get("input_tokens", 0))
+                        if event.event_name == "model_usage_recorded"
+                        else None
+                    ),
+                    output_tokens=(
+                        int(properties.get("output_tokens", 0))
+                        if event.event_name == "model_usage_recorded"
+                        else None
+                    ),
+                    cost_micro_usd=(
+                        int(properties.get("cost_micro_usd", 0))
+                        if event.event_name == "model_usage_recorded"
+                        else None
+                    ),
+                    amount_micro=(
+                        int(properties.get("amount_micro", 0))
+                        if event.event_name in _USAGE_EVENTS
+                        and event.event_name != "model_usage_recorded"
+                        else None
+                    ),
+                    bucket=(
+                        str(properties.get("bucket"))
+                        if event.event_name in _USAGE_EVENTS
+                        and event.event_name != "model_usage_recorded"
+                        else None
+                    ),
+                )
+            )
+        return AnalyticsActivityPage(items=items, next_cursor=next_cursor)
+
+
+def _event_matches_filters(
+    event: AnalyticsEventRecord,
+    filters: AnalyticsMetricFilters,
+) -> bool:
+    if filters.billing_mode is not None and event.billing_mode != filters.billing_mode:
+        return False
+    if filters.provider_id is not None and event.provider_id != filters.provider_id:
+        return False
+    if filters.model_id is not None and event.model_id != filters.model_id:
+        return False
+    return True
+
+
+analytics_query_service = AnalyticsQueryService()
+
+
+def get_analytics_query_service() -> AnalyticsQueryService:
+    return analytics_query_service
+
+
+__all__ = [
+    "ActivitySection",
+    "AnalyticsActivityItem",
+    "AnalyticsActivityPage",
+    "AnalyticsFootprintItem",
+    "AnalyticsOverview",
+    "AnalyticsQueryService",
+    "AnalyticsStateSummary",
+    "AnalyticsUserFilters",
+    "AnalyticsUserListItem",
+    "AnalyticsUserProfile",
+    "FailureCategoryCount",
+    "PaginatedUsers",
+    "PanelAvailability",
+    "get_analytics_query_service",
+]

--- a/dashboard/backend/domain/analytics/rollups.py
+++ b/dashboard/backend/domain/analytics/rollups.py
@@ -1,0 +1,457 @@
+"""Companion repository and deterministic daily Analytics rollups.
+
+PR 1 owns the tables.  PR 2 owns these bounded aggregate operations so the
+Foundation repository contract remains unchanged.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any, Iterable, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .metrics import calculate_overview_metrics
+from .models import AnalyticsEventRecord
+from .repository import _row_to_event, analytics_store
+from .repository_common import utc_iso
+
+
+class DailyRollup(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    rollup_date: date
+    metric_name: str = Field(min_length=1, max_length=64)
+    event_name: str = ""
+    billing_mode: str = ""
+    provider_id: str = ""
+    model_id: str = ""
+    outcome: str = ""
+    error_category: str = ""
+    user_state: str = ""
+    value_count: int = Field(default=0, ge=0)
+    value_sum_micro: int = 0
+    updated_at: datetime
+
+
+def _day_start(day: date) -> datetime:
+    return datetime.combine(day, time.min, tzinfo=timezone.utc)
+
+
+class AnalyticsRollupStore:
+    """SQLite/PostgreSQL twin operations over PR 1 aggregate tables."""
+
+    def __init__(self, base_store=analytics_store):
+        self.base_store = base_store
+        self.is_postgres = hasattr(base_store, "database_url")
+
+    def list_events(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        include_internal: bool = False,
+        user_id: int | None = None,
+    ) -> list[AnalyticsEventRecord]:
+        params: list[Any] = [utc_iso(start), utc_iso(end)]
+        user_sql = ""
+        if user_id is not None:
+            user_sql = "AND user_id = " + ("%s" if self.is_postgres else "?")
+            params.append(int(user_id))
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"""
+                        SELECT * FROM analytics_events
+                        WHERE occurred_at >= %s AND occurred_at < %s {user_sql}
+                        ORDER BY occurred_at ASC, sequence ASC
+                        """,
+                        params,
+                    )
+                    rows = cur.fetchall()
+        else:
+            with self.base_store._get_connection() as conn:
+                rows = conn.execute(
+                    f"""
+                    SELECT * FROM analytics_events
+                    WHERE occurred_at >= ? AND occurred_at < ? {user_sql}
+                    ORDER BY occurred_at ASC, sequence ASC
+                    """,
+                    params,
+                ).fetchall()
+        events = [_row_to_event(row) for row in rows]
+        if include_internal:
+            return events
+        excluded = self.base_store.list_excluded_user_ids(
+            include_admin_accounts=True
+        )
+        return [event for event in events if event.user_id not in excluded]
+
+    def replace_day(self, day: date, rows: Iterable[DailyRollup]) -> None:
+        values = list(rows)
+        columns = (
+            "rollup_date",
+            "metric_name",
+            "event_name",
+            "billing_mode",
+            "provider_id",
+            "model_id",
+            "outcome",
+            "error_category",
+            "user_state",
+            "value_count",
+            "value_sum_micro",
+            "updated_at",
+        )
+        payloads = [
+            (
+                row.rollup_date.isoformat(),
+                row.metric_name,
+                row.event_name,
+                row.billing_mode,
+                row.provider_id,
+                row.model_id,
+                row.outcome,
+                row.error_category,
+                row.user_state,
+                row.value_count,
+                row.value_sum_micro,
+                utc_iso(row.updated_at),
+            )
+            for row in values
+        ]
+        if self.is_postgres:
+            placeholders = ", ".join("%s" for _ in columns)
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "DELETE FROM analytics_daily_rollups WHERE rollup_date = %s",
+                        (day.isoformat(),),
+                    )
+                    if payloads:
+                        cur.executemany(
+                            f"INSERT INTO analytics_daily_rollups ({', '.join(columns)}) "
+                            f"VALUES ({placeholders})",
+                            payloads,
+                        )
+        else:
+            placeholders = ", ".join("?" for _ in columns)
+            with self.base_store._get_connection() as conn:
+                conn.execute(
+                    "DELETE FROM analytics_daily_rollups WHERE rollup_date = ?",
+                    (day.isoformat(),),
+                )
+                if payloads:
+                    conn.executemany(
+                        f"INSERT INTO analytics_daily_rollups ({', '.join(columns)}) "
+                        f"VALUES ({placeholders})",
+                        payloads,
+                    )
+
+    def list_rollups(self, *, start: date, end: date) -> list[DailyRollup]:
+        params = (start.isoformat(), end.isoformat())
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT * FROM analytics_daily_rollups
+                        WHERE rollup_date >= %s AND rollup_date < %s
+                        ORDER BY rollup_date, metric_name, event_name,
+                                 billing_mode, provider_id, model_id,
+                                 outcome, error_category, user_state
+                        """,
+                        params,
+                    )
+                    rows = cur.fetchall()
+        else:
+            with self.base_store._get_connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM analytics_daily_rollups
+                    WHERE rollup_date >= ? AND rollup_date < ?
+                    ORDER BY rollup_date, metric_name, event_name,
+                             billing_mode, provider_id, model_id,
+                             outcome, error_category, user_state
+                    """,
+                    params,
+                ).fetchall()
+        return [
+            DailyRollup(
+                rollup_date=date.fromisoformat(str(row["rollup_date"])),
+                metric_name=str(row["metric_name"]),
+                event_name=str(row["event_name"]),
+                billing_mode=str(row["billing_mode"]),
+                provider_id=str(row["provider_id"]),
+                model_id=str(row["model_id"]),
+                outcome=str(row["outcome"]),
+                error_category=str(row["error_category"]),
+                user_state=str(row["user_state"]),
+                value_count=int(row["value_count"]),
+                value_sum_micro=int(row["value_sum_micro"]),
+                updated_at=datetime.fromisoformat(str(row["updated_at"])),
+            )
+            for row in rows
+        ]
+
+
+def _row(
+    day: date,
+    metric_name: str,
+    *,
+    count: int = 0,
+    sum_micro: int = 0,
+    updated_at: datetime,
+    **dimensions: str,
+) -> DailyRollup:
+    return DailyRollup(
+        rollup_date=day,
+        metric_name=metric_name,
+        value_count=count,
+        value_sum_micro=sum_micro,
+        updated_at=updated_at,
+        **dimensions,
+    )
+
+
+def rollup_day(
+    day: date,
+    *,
+    store: AnalyticsRollupStore | None = None,
+    state_counts: Mapping[str, int] | None = None,
+    include_internal: bool = False,
+    now: datetime | None = None,
+) -> list[DailyRollup]:
+    aggregate_store = store or AnalyticsRollupStore()
+    start = _day_start(day)
+    end = start + timedelta(days=1)
+    # Completed-day rebuilds are deterministic: rerunning the same source rows
+    # yields byte-equivalent aggregate values, including the stored timestamp.
+    current = now or end
+    events = aggregate_store.list_events(
+        start=start - timedelta(days=30),
+        end=end,
+        include_internal=include_internal,
+    )
+    day_events = [event for event in events if start <= event.occurred_at < end]
+    overview = calculate_overview_metrics(
+        events,
+        start=start,
+        end=end,
+    )
+    cohort_start = start - timedelta(days=7)
+    signups = {
+        event.user_id: event.occurred_at
+        for event in events
+        if event.event_name == "account_signed_up"
+        and cohort_start <= event.occurred_at < cohort_start + timedelta(days=1)
+    }
+    successes_by_user: dict[int, list[datetime]] = defaultdict(list)
+    for event in events:
+        if event.event_name == "backtest_completed":
+            successes_by_user[event.user_id].append(event.occurred_at)
+    mature_converted = sum(
+        any(
+            signup_at <= success_at <= signup_at + timedelta(days=7)
+            for success_at in successes_by_user.get(user_id, [])
+        )
+        for user_id, signup_at in signups.items()
+    )
+    rows: list[DailyRollup] = [
+        _row(day, "daily_active_users", count=overview.affected_users, updated_at=current),
+        _row(day, "rolling_active_users_7d", count=overview.active_users_7d, updated_at=current),
+        _row(day, "completed_runs", count=overview.completed_runs, updated_at=current),
+        _row(day, "terminal_completed", count=overview.completed_runs, updated_at=current),
+        _row(day, "terminal_failed", count=overview.failed_runs, updated_at=current),
+        _row(
+            day,
+            "mature_signup_cohort_users",
+            count=len(signups),
+            updated_at=current,
+        ),
+        _row(
+            day,
+            "first_success_within_7d_users",
+            count=mature_converted,
+            updated_at=current,
+        ),
+        _row(
+            day,
+            "users_with_first_success",
+            count=overview.users_with_first_success,
+            updated_at=current,
+        ),
+        _row(
+            day,
+            "users_with_repeat_success_24h_30d",
+            count=overview.users_with_repeat_success,
+            updated_at=current,
+        ),
+        _row(
+            day,
+            "platform_model_cost_usd",
+            sum_micro=round(overview.platform_model_cost_usd * 1_000_000),
+            billing_mode="platform_credits",
+            updated_at=current,
+        ),
+        _row(day, "input_tokens", count=overview.input_tokens, updated_at=current),
+        _row(day, "output_tokens", count=overview.output_tokens, updated_at=current),
+        _row(day, "affected_users", count=overview.affected_users, updated_at=current),
+    ]
+
+    event_dimensions = Counter(
+        (
+            event.event_name,
+            event.billing_mode or "",
+            event.provider_id or "",
+            event.model_id or "",
+            event.outcome or "",
+            event.error_category or "",
+        )
+        for event in day_events
+    )
+    for dimensions, count in sorted(event_dimensions.items()):
+        (
+            event_name,
+            event_billing_mode,
+            event_provider_id,
+            event_model_id,
+            event_outcome,
+            event_error_category,
+        ) = dimensions
+        rows.append(
+            _row(
+                day,
+                "event_count",
+                count=count,
+                event_name=event_name,
+                billing_mode=event_billing_mode,
+                provider_id=event_provider_id,
+                model_id=event_model_id,
+                outcome=event_outcome,
+                error_category=event_error_category,
+                updated_at=current,
+            )
+        )
+    usage_dimensions: dict[tuple[str, str, str], dict[str, int]] = defaultdict(
+        lambda: {"input_tokens": 0, "output_tokens": 0, "cost_micro_usd": 0}
+    )
+    for event in day_events:
+        if event.event_name != "model_usage_recorded":
+            continue
+        key = (
+            event.billing_mode or "",
+            event.provider_id or "",
+            event.model_id or "",
+        )
+        usage_dimensions[key]["input_tokens"] += int(
+            event.properties.get("input_tokens", 0)
+        )
+        usage_dimensions[key]["output_tokens"] += int(
+            event.properties.get("output_tokens", 0)
+        )
+        if event.billing_mode == "platform_credits":
+            usage_dimensions[key]["cost_micro_usd"] += int(
+                event.properties.get("cost_micro_usd", 0)
+            )
+    for (mode, provider, model), values in sorted(usage_dimensions.items()):
+        rows.extend(
+            [
+                _row(
+                    day,
+                    "input_tokens",
+                    count=values["input_tokens"],
+                    billing_mode=mode,
+                    provider_id=provider,
+                    model_id=model,
+                    updated_at=current,
+                ),
+                _row(
+                    day,
+                    "output_tokens",
+                    count=values["output_tokens"],
+                    billing_mode=mode,
+                    provider_id=provider,
+                    model_id=model,
+                    updated_at=current,
+                ),
+            ]
+        )
+        if mode == "platform_credits":
+            rows.append(
+                _row(
+                    day,
+                    "platform_model_cost_usd",
+                    sum_micro=values["cost_micro_usd"],
+                    billing_mode=mode,
+                    provider_id=provider,
+                    model_id=model,
+                    updated_at=current,
+                )
+            )
+    failure_users: dict[str, set[int]] = defaultdict(set)
+    for event in day_events:
+        if event.error_category:
+            failure_users[event.error_category].add(event.user_id)
+    for category, users in sorted(failure_users.items()):
+        rows.append(
+            _row(
+                day,
+                "affected_users",
+                count=len(users),
+                error_category=category,
+                updated_at=current,
+            )
+        )
+    for status, count in sorted((state_counts or {}).items()):
+        rows.append(
+            _row(
+                day,
+                "user_state_count",
+                count=int(count),
+                user_state=status,
+                updated_at=current,
+            )
+        )
+
+    rows.sort(
+        key=lambda row: (
+            row.metric_name,
+            row.event_name,
+            row.billing_mode,
+            row.provider_id,
+            row.model_id,
+            row.outcome,
+            row.error_category,
+            row.user_state,
+        )
+    )
+    aggregate_store.replace_day(day, rows)
+    return rows
+
+
+def rollup_current_day(
+    *,
+    store: AnalyticsRollupStore | None = None,
+    now: datetime | None = None,
+    include_internal: bool = False,
+):
+    current = now or datetime.now(timezone.utc)
+    start = _day_start(current.astimezone(timezone.utc).date())
+    aggregate_store = store or AnalyticsRollupStore()
+    events = aggregate_store.list_events(
+        start=start - timedelta(days=30),
+        end=current,
+        include_internal=include_internal,
+    )
+    return calculate_overview_metrics(events, start=start, end=current)
+
+
+__all__ = [
+    "AnalyticsRollupStore",
+    "DailyRollup",
+    "rollup_current_day",
+    "rollup_day",
+]

--- a/dashboard/backend/domain/analytics/states.py
+++ b/dashboard/backend/domain/analytics/states.py
@@ -1,0 +1,466 @@
+"""Explainable five-state Analytics snapshots and bounded repair logic."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .metrics import is_meaningful_event
+from .models import AnalyticsEventRecord
+from .repository import analytics_store
+from .repository_common import positive_limit, positive_user_id, utc_iso
+from .rollups import AnalyticsRollupStore
+
+
+_REASONS = {
+    "billing_lane_unavailable": "The latest attempted run has no usable billing lane.",
+    "provider_disabled": "The selected model provider is currently unavailable.",
+    "account_restricted": "The account is currently restricted from model spending.",
+    "invalid_default_credential": "The default model credential is invalid.",
+    "three_consecutive_failed_runs": "The three newest terminal runs failed within 24 hours.",
+    "run_deadline_exceeded": "A run remains non-terminal beyond its safe deadline.",
+    "no_meaningful_activity_30d": "No meaningful product activity was observed for 30 days.",
+    "no_successful_run": "The user has not completed a successful backtest yet.",
+    "recent_successful_run_and_activity": "A successful run and recent meaningful activity are present.",
+    "successful_run_missing": "A successful run is expected but cannot be found.",
+}
+
+
+class UserAnalyticsSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    user_id: int = Field(gt=0)
+    status: str
+    reason_code: str = Field(min_length=1, max_length=100)
+    human_readable_reason: str = Field(min_length=1, max_length=500)
+    evidence_event_ids: list[str] = Field(default_factory=list, max_length=5)
+    calculated_at: datetime
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, value: str) -> str:
+        allowed = {"blocked", "needs_attention", "dormant", "onboarding", "active"}
+        if value not in allowed:
+            raise ValueError("unsupported Analytics user state")
+        return value
+
+    @field_validator("calculated_at")
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("calculated_at must include a timezone")
+        return value.astimezone(timezone.utc)
+
+
+def _parse_timestamp(value: object) -> datetime:
+    parsed = datetime.fromisoformat(str(value))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+class AnalyticsStateStore:
+    """Snapshot companion operations over PR 1 tables."""
+
+    def __init__(self, base_store=analytics_store):
+        self.base_store = base_store
+        self.rollups = AnalyticsRollupStore(base_store)
+        self.is_postgres = hasattr(base_store, "database_url")
+
+    def get_user(self, user_id: int) -> dict[str, Any] | None:
+        subject_id = positive_user_id(user_id)
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT * FROM users WHERE id = %s", (subject_id,))
+                    row = cur.fetchone()
+        else:
+            with self.base_store._get_connection() as conn:
+                row = conn.execute(
+                    "SELECT * FROM users WHERE id = ?", (subject_id,)
+                ).fetchone()
+        return dict(row) if row is not None else None
+
+    def list_user_events(
+        self,
+        user_id: int,
+        *,
+        now: datetime,
+        days: int = 180,
+    ) -> list[AnalyticsEventRecord]:
+        return self.rollups.list_events(
+            start=now - timedelta(days=days),
+            end=now + timedelta(microseconds=1),
+            include_internal=True,
+            user_id=positive_user_id(user_id),
+        )
+
+    def upsert_snapshot(
+        self,
+        snapshot: UserAnalyticsSnapshot,
+    ) -> UserAnalyticsSnapshot:
+        payload = (
+            snapshot.user_id,
+            snapshot.status,
+            snapshot.reason_code,
+            snapshot.human_readable_reason,
+            json.dumps(snapshot.evidence_event_ids, separators=(",", ":")),
+            utc_iso(snapshot.calculated_at),
+        )
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO user_analytics_snapshots (
+                            user_id, status, reason_code, human_readable_reason,
+                            evidence_event_ids_json, calculated_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s)
+                        ON CONFLICT(user_id) DO UPDATE SET
+                            status = EXCLUDED.status,
+                            reason_code = EXCLUDED.reason_code,
+                            human_readable_reason = EXCLUDED.human_readable_reason,
+                            evidence_event_ids_json = EXCLUDED.evidence_event_ids_json,
+                            calculated_at = EXCLUDED.calculated_at
+                        """,
+                        payload,
+                    )
+        else:
+            with self.base_store._get_connection() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO user_analytics_snapshots (
+                        user_id, status, reason_code, human_readable_reason,
+                        evidence_event_ids_json, calculated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(user_id) DO UPDATE SET
+                        status = excluded.status,
+                        reason_code = excluded.reason_code,
+                        human_readable_reason = excluded.human_readable_reason,
+                        evidence_event_ids_json = excluded.evidence_event_ids_json,
+                        calculated_at = excluded.calculated_at
+                    """,
+                    payload,
+                )
+        return snapshot
+
+    def get_snapshot(self, user_id: int) -> UserAnalyticsSnapshot | None:
+        subject_id = positive_user_id(user_id)
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT * FROM user_analytics_snapshots WHERE user_id = %s",
+                        (subject_id,),
+                    )
+                    row = cur.fetchone()
+        else:
+            with self.base_store._get_connection() as conn:
+                row = conn.execute(
+                    "SELECT * FROM user_analytics_snapshots WHERE user_id = ?",
+                    (subject_id,),
+                ).fetchone()
+        if row is None:
+            return None
+        return UserAnalyticsSnapshot(
+            user_id=int(row["user_id"]),
+            status=str(row["status"]),
+            reason_code=str(row["reason_code"]),
+            human_readable_reason=str(row["human_readable_reason"]),
+            evidence_event_ids=list(
+                json.loads(str(row["evidence_event_ids_json"]))
+            ),
+            calculated_at=_parse_timestamp(row["calculated_at"]),
+        )
+
+    def list_stale_user_ids(
+        self,
+        *,
+        before: datetime,
+        limit: int,
+    ) -> list[int]:
+        page_size = positive_limit(limit)
+        cutoff = utc_iso(before)
+        if self.is_postgres:
+            with self.base_store._get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT users.id
+                        FROM users
+                        LEFT JOIN user_analytics_snapshots AS snapshots
+                          ON snapshots.user_id = users.id
+                        LEFT JOIN analytics_subject_settings AS settings
+                          ON settings.user_id = users.id
+                        WHERE users.role <> 'admin'
+                          AND COALESCE(settings.excluded, FALSE) = FALSE
+                          AND (snapshots.user_id IS NULL OR snapshots.calculated_at < %s)
+                        ORDER BY users.id
+                        LIMIT %s
+                        """,
+                        (cutoff, page_size),
+                    )
+                    rows = cur.fetchall()
+        else:
+            with self.base_store._get_connection() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT users.id
+                    FROM users
+                    LEFT JOIN user_analytics_snapshots AS snapshots
+                      ON snapshots.user_id = users.id
+                    LEFT JOIN analytics_subject_settings AS settings
+                      ON settings.user_id = users.id
+                    WHERE users.role <> 'admin'
+                      AND COALESCE(settings.excluded, 0) = 0
+                      AND (snapshots.user_id IS NULL OR snapshots.calculated_at < ?)
+                    ORDER BY users.id
+                    LIMIT ?
+                    """,
+                    (cutoff, page_size),
+                ).fetchall()
+        return [int(row["id"]) for row in rows]
+
+
+def _ordered_evidence(events: list[AnalyticsEventRecord]) -> list[str]:
+    by_id = sorted(events, key=lambda event: event.event_id)
+    ordered = sorted(
+        by_id,
+        key=lambda event: event.occurred_at.astimezone(timezone.utc),
+        reverse=True,
+    )
+    return [event.event_id for event in ordered[:5]]
+
+
+def _snapshot(
+    *,
+    user_id: int,
+    status: str,
+    reason_code: str,
+    evidence: list[AnalyticsEventRecord],
+    now: datetime,
+) -> UserAnalyticsSnapshot:
+    return UserAnalyticsSnapshot(
+        user_id=user_id,
+        status=status,
+        reason_code=reason_code,
+        human_readable_reason=_REASONS[reason_code],
+        evidence_event_ids=_ordered_evidence(evidence),
+        calculated_at=now,
+    )
+
+
+def calculate_user_state(
+    user_id: int,
+    *,
+    now: datetime | None = None,
+    store: AnalyticsStateStore | None = None,
+) -> UserAnalyticsSnapshot:
+    subject_id = positive_user_id(user_id)
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise ValueError("now must include a timezone")
+    current = current.astimezone(timezone.utc)
+    state_store = store or AnalyticsStateStore()
+    user = state_store.get_user(subject_id)
+    if user is None:
+        raise LookupError("Analytics user was not found")
+    events = state_store.list_user_events(subject_id, now=current)
+    events_desc = sorted(events, key=lambda event: event.occurred_at, reverse=True)
+    attempted_core = any(
+        event.event_group == "run"
+        or (
+            event.event_name == "safe_error_recorded"
+            and event.source_record_type == "run"
+        )
+        for event in events
+    )
+
+    blocking_categories = {
+        "credential_missing",
+        "provider_unavailable",
+        "credits_unavailable",
+        "model_not_allowed",
+    }
+    resolvers = {
+        "credential_verified",
+        "credential_reverified",
+        "credential_defaulted",
+        "credits_settled",
+        "backtest_completed",
+    }
+    latest_resolver = next(
+        (event for event in events_desc if event.event_name in resolvers),
+        None,
+    )
+    blocker = next(
+        (
+            event
+            for event in events_desc
+            if event.event_name == "safe_error_recorded"
+            and event.error_category in blocking_categories
+        ),
+        None,
+    )
+    if (
+        attempted_core
+        and blocker is not None
+        and (
+            latest_resolver is None
+            or blocker.occurred_at > latest_resolver.occurred_at
+        )
+    ):
+        reason = (
+            "provider_disabled"
+            if blocker.error_category in {"provider_unavailable", "model_not_allowed"}
+            else "billing_lane_unavailable"
+        )
+        return _snapshot(
+            user_id=subject_id,
+            status="blocked",
+            reason_code=reason,
+            evidence=[blocker],
+            now=current,
+        )
+
+    invalid_credential = next(
+        (
+            event
+            for event in events_desc
+            if event.event_name == "safe_error_recorded"
+            and event.error_category == "credential_invalid"
+        ),
+        None,
+    )
+    credential_resolver = next(
+        (
+            event
+            for event in events_desc
+            if event.event_name
+            in {"credential_verified", "credential_reverified", "credential_defaulted"}
+        ),
+        None,
+    )
+    if invalid_credential is not None and (
+        credential_resolver is None
+        or invalid_credential.occurred_at > credential_resolver.occurred_at
+    ):
+        return _snapshot(
+            user_id=subject_id,
+            status="needs_attention",
+            reason_code="invalid_default_credential",
+            evidence=[invalid_credential],
+            now=current,
+        )
+
+    terminal_24h = [
+        event
+        for event in events_desc
+        if event.event_name
+        in {"backtest_completed", "backtest_failed", "backtest_cancelled"}
+        and current - timedelta(hours=24) <= event.occurred_at <= current
+    ]
+    newest_three = terminal_24h[:3]
+    if len(newest_three) == 3 and all(
+        event.event_name == "backtest_failed" for event in newest_three
+    ):
+        return _snapshot(
+            user_id=subject_id,
+            status="needs_attention",
+            reason_code="three_consecutive_failed_runs",
+            evidence=newest_three,
+            now=current,
+        )
+
+    meaningful = [event for event in events_desc if is_meaningful_event(event)]
+    last_meaningful = meaningful[0] if meaningful else None
+    created_at = _parse_timestamp(user["created_at"])
+    if (
+        last_meaningful is not None
+        and last_meaningful.occurred_at < current - timedelta(days=30)
+    ) or (
+        last_meaningful is None
+        and created_at < current - timedelta(days=30)
+    ):
+        return _snapshot(
+            user_id=subject_id,
+            status="dormant",
+            reason_code="no_meaningful_activity_30d",
+            evidence=([last_meaningful] if last_meaningful else []),
+            now=current,
+        )
+
+    successes = [
+        event for event in events_desc if event.event_name == "backtest_completed"
+    ]
+    if not successes:
+        signup = next(
+            (event for event in events_desc if event.event_name == "account_signed_up"),
+            None,
+        )
+        return _snapshot(
+            user_id=subject_id,
+            status="onboarding",
+            reason_code="no_successful_run",
+            evidence=([signup] if signup else []),
+            now=current,
+        )
+
+    return _snapshot(
+        user_id=subject_id,
+        status="active",
+        reason_code="recent_successful_run_and_activity",
+        evidence=[successes[0]] + ([last_meaningful] if last_meaningful else []),
+        now=current,
+    )
+
+
+def recalculate_user_snapshot(
+    user_id: int,
+    *,
+    now: datetime | None = None,
+    store: AnalyticsStateStore | None = None,
+) -> UserAnalyticsSnapshot:
+    state_store = store or AnalyticsStateStore()
+    snapshot = calculate_user_state(user_id, now=now, store=state_store)
+    return state_store.upsert_snapshot(snapshot)
+
+
+def repair_stale_snapshots(
+    *,
+    now: datetime | None = None,
+    limit: int = 100,
+    stale_after: timedelta = timedelta(minutes=15),
+    store: AnalyticsStateStore | None = None,
+) -> int:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise ValueError("now must include a timezone")
+    state_store = store or AnalyticsStateStore()
+    user_ids = state_store.list_stale_user_ids(
+        before=current - stale_after,
+        limit=limit,
+    )
+    repaired = 0
+    for user_id in user_ids:
+        try:
+            recalculate_user_snapshot(user_id, now=current, store=state_store)
+            repaired += 1
+        except Exception as exc:
+            print(
+                "WARNING: analytics.snapshot_repair_failed "
+                f"category={type(exc).__name__[:80]}"
+            )
+    return repaired
+
+
+__all__ = [
+    "AnalyticsStateStore",
+    "UserAnalyticsSnapshot",
+    "calculate_user_state",
+    "recalculate_user_snapshot",
+    "repair_stale_snapshots",
+]

--- a/dashboard/backend/domain/backtesting/external_run_service.py
+++ b/dashboard/backend/domain/backtesting/external_run_service.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 
 import dashboard.backend.infrastructure.llm.token_cost as token_cost
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 from dashboard.backend.domain.agents.repository import agent_store
 from dashboard.backend.database import db
 from dashboard.backend.execution.base import TERMINAL_STATUSES
@@ -717,6 +718,15 @@ class ExternalBacktestSession:
         db.insert_trades(self.run_id, self.manager.trades)
         db.insert_decisions(self.run_id, self.decision_log)
 
+        analytics_user_id = getattr(self, "analytics_user_id", None)
+        if analytics_user_id is not None:
+            analytics_instrumentation.emit_run_event(
+                event_name="backtest_completed",
+                user_id=int(analytics_user_id),
+                run_id=self.run_id,
+                correlation_id=self.backtest_id,
+            )
+
         # The run is fully persisted now — publish "completed" here, in-request.
         # is_active()/cancel() read self.status without _step_lock, so the flip
         # must land before this method returns (T1 already moved the slow work —
@@ -1034,6 +1044,7 @@ def start_backtest(
     symbols: Optional[List[str]] = None,
     initial_capital: Optional[float] = None,
     enforce_session_cap: bool = False,
+    emit_analytics: bool = False,
 ) -> Dict[str, Any]:
     """Open an external-agent backtest session.
 
@@ -1058,6 +1069,15 @@ def start_backtest(
         initial_capital=initial_capital,
     )
     session.status = "loading"
+    session.analytics_user_id = None
+    if emit_analytics:
+        try:
+            agent = agent_store.get_agent_by_session(session_id)
+            owner_user_id = agent.get("owner_user_id") if agent else None
+            if owner_user_id is not None:
+                session.analytics_user_id = int(owner_user_id)
+        except Exception:
+            pass
 
     with _lock:
         # Counted and inserted under one acquisition: as a check in the router
@@ -1067,6 +1087,18 @@ def start_backtest(
         if enforce_session_cap:
             _raise_if_at_capacity(session_id)
         _sessions[backtest_id] = session
+
+    if session.analytics_user_id is not None:
+        analytics_instrumentation.emit_run_event(
+            event_name="backtest_requested",
+            user_id=session.analytics_user_id,
+            run_id=backtest_id,
+        )
+        analytics_instrumentation.emit_run_event(
+            event_name="backtest_started",
+            user_id=session.analytics_user_id,
+            run_id=backtest_id,
+        )
 
     # Fast path: creation runs under the caller's _create_lock, where blocking
     # is forbidden — peek() is non-blocking. A resident dataset means no loader
@@ -1089,6 +1121,13 @@ def start_backtest(
             except (Exception, SystemExit) as exc:
                 session.status = "failed"
                 session.error = str(exc)
+                if session.analytics_user_id is not None:
+                    analytics_instrumentation.emit_run_event(
+                        event_name="backtest_failed",
+                        user_id=session.analytics_user_id,
+                        run_id=backtest_id,
+                        error_category="provider_unavailable",
+                    )
 
         threading.Thread(target=_load_in_background, daemon=True).start()
 

--- a/dashboard/backend/domain/credits/service.py
+++ b/dashboard/backend/domain/credits/service.py
@@ -35,6 +35,7 @@ from dashboard.backend.domain.credits.stripe_gateway import (
     StripeTestGateway,
     StripeWebhookEvent,
 )
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 
 
 class CreditsServiceError(RuntimeError):
@@ -242,17 +243,25 @@ class CreditsService:
         reservation_id = _operation_id(
             "llm_res", user_id, run_id, call_index, operation_key
         )
-        return self._llm_reservation_model(
-            self.store.reserve_llm_credits(
-                reservation_id=reservation_id,
-                user_id=int(user_id),
-                run_id=str(run_id),
-                call_index=int(call_index),
-                reserved_micro=int(amount_micro),
-                operation_key=operation_key,
-                request_digest=request_digest,
-            )
+        raw = self.store.reserve_llm_credits(
+            reservation_id=reservation_id,
+            user_id=int(user_id),
+            run_id=str(run_id),
+            call_index=int(call_index),
+            reserved_micro=int(amount_micro),
+            operation_key=operation_key,
+            request_digest=request_digest,
         )
+        result = self._llm_reservation_model(raw)
+        self._emit_credit_buckets(
+            event_name="credits_reserved",
+            raw=raw,
+            amounts={
+                "grant": int(raw.get("reserved_grant_micro") or 0),
+                "purchased": int(raw.get("reserved_purchased_micro") or 0),
+            },
+        )
+        return result
 
     def settle_llm_credits(
         self,
@@ -263,13 +272,22 @@ class CreditsService:
     ) -> LLMSettlementResult:
         """Debit the held amount, recording and restricting on any overage."""
 
-        return self._llm_settlement_model(
-            self.store.settle_llm_credits(
-                reservation_id,
-                actual_micro=int(actual_micro),
-                evidence=dict(evidence),
-            )
+        raw = self.store.settle_llm_credits(
+            reservation_id,
+            actual_micro=int(actual_micro),
+            evidence=dict(evidence),
         )
+        result = self._llm_settlement_model(raw)
+        self._emit_credit_buckets(
+            event_name="credits_settled",
+            raw=raw,
+            amounts={
+                "grant": result.grant_debited_micro,
+                "purchased": result.purchased_debited_micro,
+            },
+        )
+        self._emit_released_credit_buckets(raw, result)
+        return result
 
     def release_llm_credits(
         self,
@@ -279,9 +297,10 @@ class CreditsService:
     ) -> LLMSettlementResult:
         """Release an unused usage ceiling without creating a debit."""
 
-        return self._llm_settlement_model(
-            self.store.release_llm_credits(reservation_id, reason=reason)
-        )
+        raw = self.store.release_llm_credits(reservation_id, reason=reason)
+        result = self._llm_settlement_model(raw)
+        self._emit_released_credit_buckets(raw, result)
+        return result
 
     def release_run_llm_reservations(
         self,
@@ -289,12 +308,60 @@ class CreditsService:
         *,
         reason: str,
     ) -> list[LLMSettlementResult]:
-        return [
-            self._llm_settlement_model(result)
-            for result in self.store.release_run_llm_reservations(
-                run_id, reason=reason
+        results = []
+        for raw in self.store.release_run_llm_reservations(run_id, reason=reason):
+            result = self._llm_settlement_model(raw)
+            self._emit_released_credit_buckets(raw, result)
+            results.append(result)
+        return results
+
+    @staticmethod
+    def _emit_credit_buckets(
+        *,
+        event_name: str,
+        raw: Mapping[str, Any],
+        amounts: Mapping[str, int],
+    ) -> None:
+        for bucket in ("grant", "purchased"):
+            amount_micro = int(amounts.get(bucket) or 0)
+            if amount_micro <= 0:
+                continue
+            analytics_instrumentation.emit_resource_event(
+                event_name=event_name,
+                user_id=int(raw["user_id"]),
+                source_record_type="credit_reservation",
+                source_record_id=str(raw["reservation_id"]),
+                correlation_id=str(raw["run_id"]),
+                billing_mode="platform_credits",
+                properties={
+                    "amount_micro": amount_micro,
+                    "bucket": bucket,
+                },
+                version=bucket,
             )
-        ]
+
+    @classmethod
+    def _emit_released_credit_buckets(
+        cls,
+        raw: Mapping[str, Any],
+        result: LLMSettlementResult,
+    ) -> None:
+        cls._emit_credit_buckets(
+            event_name="credits_refunded",
+            raw=raw,
+            amounts={
+                "grant": max(
+                    0,
+                    int(raw.get("reserved_grant_micro") or 0)
+                    - result.grant_debited_micro,
+                ),
+                "purchased": max(
+                    0,
+                    int(raw.get("reserved_purchased_micro") or 0)
+                    - result.purchased_debited_micro,
+                ),
+            },
+        )
 
     def get_grant_pool_summary(
         self, pool_id: str = "default", month_start_iso: str | None = None

--- a/dashboard/backend/domain/model_providers/service.py
+++ b/dashboard/backend/domain/model_providers/service.py
@@ -16,6 +16,7 @@ from dashboard.backend.infrastructure.llm.execution.errors import (
     ExecutionErrorCategory,
     LLMExecutionError,
 )
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 
 from .execution_catalog import (
     ExecutionModelRoute,
@@ -680,7 +681,45 @@ class ModelProviderService:
                 _utcnow_iso() if validation.status == "verified" else None
             ),
         )
-        return UserCredentialPublic.model_validate(created)
+        result = UserCredentialPublic.model_validate(created)
+        analytics_instrumentation.emit_credential_event(
+            event_name="credential_saved",
+            user_id=user_id,
+            credential_id=str(result.credential_id),
+            provider_id=result.provider_id,
+        )
+        if result.status == "verified":
+            analytics_instrumentation.emit_credential_event(
+                event_name="credential_verified",
+                user_id=user_id,
+                credential_id=str(result.credential_id),
+                provider_id=result.provider_id,
+            )
+            if result.is_default:
+                analytics_instrumentation.emit_credential_event(
+                    event_name="credential_defaulted",
+                    user_id=user_id,
+                    credential_id=str(result.credential_id),
+                    provider_id=result.provider_id,
+                    version=result.updated_at,
+                )
+        elif result.status == "invalid":
+            analytics_instrumentation.emit_safe_error_event(
+                user_id=user_id,
+                source_record_type="credential",
+                source_record_id=str(result.credential_id),
+                error_category="credential_invalid",
+                version=result.updated_at,
+            )
+        elif result.status == "verification_unavailable":
+            analytics_instrumentation.emit_safe_error_event(
+                user_id=user_id,
+                source_record_type="credential",
+                source_record_id=str(result.credential_id),
+                error_category="provider_unavailable",
+                version=result.updated_at,
+            )
+        return result
 
     def list_credentials(
         self,
@@ -704,31 +743,67 @@ class ModelProviderService:
         if credential["status"] == "revoked":
             raise CredentialConflictError("revoked credentials cannot be verified")
         provider = self._get_byok_provider(credential["provider_id"])
-        return self._verify_and_update(
+        result = self._verify_and_update(
             user_id=user_id,
             credential=credential,
             provider=provider,
             secret=secret,
             set_default=False,
         )
+        if result.status == "verified":
+            analytics_instrumentation.emit_credential_event(
+                event_name="credential_reverified",
+                user_id=user_id,
+                credential_id=str(result.credential_id),
+                provider_id=result.provider_id,
+                version=result.updated_at,
+            )
+        else:
+            analytics_instrumentation.emit_safe_error_event(
+                user_id=user_id,
+                source_record_type="credential",
+                source_record_id=str(result.credential_id),
+                error_category=(
+                    "credential_invalid"
+                    if result.status == "invalid"
+                    else "provider_unavailable"
+                ),
+                version=result.updated_at,
+            )
+        return result
 
     def set_default_credential(
         self,
         user_id: int,
         credential_id: str,
     ) -> UserCredentialPublic:
-        return UserCredentialPublic.model_validate(
+        result = UserCredentialPublic.model_validate(
             self.store.set_default_user_credential(user_id, credential_id)
         )
+        analytics_instrumentation.emit_credential_event(
+            event_name="credential_defaulted",
+            user_id=user_id,
+            credential_id=str(result.credential_id),
+            provider_id=result.provider_id,
+            version=result.updated_at,
+        )
+        return result
 
     def revoke_credential(
         self,
         user_id: int,
         credential_id: str,
     ) -> UserCredentialPublic:
-        return UserCredentialPublic.model_validate(
+        result = UserCredentialPublic.model_validate(
             self.store.revoke_user_credential(user_id, credential_id)
         )
+        analytics_instrumentation.emit_credential_event(
+            event_name="credential_revoked",
+            user_id=user_id,
+            credential_id=str(result.credential_id),
+            provider_id=result.provider_id,
+        )
+        return result
 
     def _get_byok_provider(self, provider_id: str) -> dict[str, Any]:
         provider = self.store.get_provider(provider_id)

--- a/dashboard/backend/domain/runs/service.py
+++ b/dashboard/backend/domain/runs/service.py
@@ -45,6 +45,7 @@ from dashboard.backend.domain.runs.protocol import (
     resolve_order_quantity,
 )
 from dashboard.backend.domain.runs.repository import run_store
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 
 _runs: Dict[str, "ProtocolRun"] = {}
 _registry_lock = threading.Lock()
@@ -78,6 +79,39 @@ _reaper_lock = threading.Lock()
 # must serialize on the same lock or an agent could race one create per surface
 # past the combined cap.
 _create_lock = threading.Lock()
+
+
+def _analytics_owner_user_id(agent_id: Optional[str]) -> Optional[int]:
+    """Resolve a persisted Agent owner without inventing API-only subjects."""
+
+    if not agent_id:
+        return None
+    try:
+        from dashboard.backend.domain.agents.repository import agent_store
+
+        agent = agent_store.get_agent(agent_id)
+        owner_user_id = agent.get("owner_user_id") if agent else None
+        return int(owner_user_id) if owner_user_id is not None else None
+    except Exception:
+        return None
+
+
+def _emit_run_transition(
+    *,
+    event_name: str,
+    run_id: str,
+    agent_id: Optional[str],
+    error_category: Optional[str] = None,
+) -> None:
+    user_id = _analytics_owner_user_id(agent_id)
+    if user_id is None:
+        return
+    analytics_instrumentation.emit_run_event(
+        event_name=event_name,
+        user_id=user_id,
+        run_id=run_id,
+        error_category=error_category,
+    )
 
 
 def resolve_owner_cap_context(agent: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -383,7 +417,9 @@ def _sync_status(run: "ProtocolRun") -> Dict[str, Any]:
 
     engine_status = session.get_status()  # applies timeout side-effects
     estatus = engine_status.get("status")
+    previous_status = run.status
     run.status = _RUN_STATUS_MAP.get(estatus, run.status)
+    record = run_store.get_run(run.run_id) or {}
 
     if estatus == "completed" and not run.result_run_id and session.run_id:
         run.result_run_id = session.run_id
@@ -392,8 +428,21 @@ def _sync_status(run: "ProtocolRun") -> Dict[str, Any]:
             result_run_id=session.run_id,
             status="completed",
         )
+        if previous_status != "completed":
+            _emit_run_transition(
+                event_name="backtest_completed",
+                run_id=run.run_id,
+                agent_id=record.get("agent_id"),
+            )
     elif estatus == "failed":
         run_store.update_run(run.run_id, status="failed")
+        if previous_status != "failed":
+            _emit_run_transition(
+                event_name="backtest_failed",
+                run_id=run.run_id,
+                agent_id=record.get("agent_id"),
+                error_category="internal_error",
+            )
     return {"engine_status": engine_status, "run_status": run.status}
 
 
@@ -635,6 +684,19 @@ def create_run(
             backtest_id=backtest_id,
             status="running",
         )
+
+        owner_user_id = agent.get("owner_user_id")
+        if owner_user_id is not None:
+            analytics_instrumentation.emit_run_event(
+                event_name="backtest_requested",
+                user_id=int(owner_user_id),
+                run_id=record["run_id"],
+            )
+            analytics_instrumentation.emit_run_event(
+                event_name="backtest_started",
+                user_id=int(owner_user_id),
+                run_id=record["run_id"],
+            )
 
         run = ProtocolRun(record=record, environment=environment)
         with _registry_lock:

--- a/dashboard/backend/infrastructure/llm/execution/service.py
+++ b/dashboard/backend/infrastructure/llm/execution/service.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from dashboard.backend.domain.credits.models import LLMSettlementResult
 from dashboard.backend.domain.credits.service import CreditsService
+from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation
 from dashboard.backend.domain.model_providers.models import ProviderRecord
 from dashboard.backend.domain.model_providers.service import (
     ModelProviderService,
@@ -102,38 +103,102 @@ class LLMExecutionService:
 
     def execute(self, request: LLMExecutionRequest) -> LLMExecutionResult:
         """Run exactly one requested model call with its selected payment lane."""
-
-        provider = self._resolve_provider(request.provider_id)
-        credential = self._resolve_credential(request)
-        pricing_snapshot = self.pricing_snapshot_factory(
-            request.model_id, request.provider_id
-        )
-        self._validate_pricing_snapshot(request, pricing_snapshot)
-        adapter = self._resolve_adapter(provider)
-
-        if request.billing_mode is BillingMode.BYOK:
-            response = self._complete(adapter, request, credential, provider)
-            usage = self._result_usage(response)
-            billing = self._build_evidence(
-                request=request,
-                usage=usage,
-                provider_cost_usd=response.provider_cost_usd,
-                pricing_snapshot=pricing_snapshot,
+        try:
+            provider = self._resolve_provider(request.provider_id)
+            credential = self._resolve_credential(request)
+            pricing_snapshot = self.pricing_snapshot_factory(
+                request.model_id, request.provider_id
             )
-            return self._result(
-                request=request,
-                credential=credential,
-                usage=usage,
-                billing=billing,
-                text=response.text,
-            )
+            self._validate_pricing_snapshot(request, pricing_snapshot)
+            adapter = self._resolve_adapter(provider)
 
-        return self._execute_platform(
-            request=request,
-            provider=provider,
-            credential=credential,
-            adapter=adapter,
-            pricing_snapshot=pricing_snapshot,
+            if request.billing_mode is BillingMode.BYOK:
+                response = self._complete(adapter, request, credential, provider)
+                usage = self._result_usage(response)
+                billing = self._build_evidence(
+                    request=request,
+                    usage=usage,
+                    provider_cost_usd=response.provider_cost_usd,
+                    pricing_snapshot=pricing_snapshot,
+                )
+                result = self._result(
+                    request=request,
+                    credential=credential,
+                    usage=usage,
+                    billing=billing,
+                    text=response.text,
+                )
+            else:
+                result = self._execute_platform(
+                    request=request,
+                    provider=provider,
+                    credential=credential,
+                    adapter=adapter,
+                    pricing_snapshot=pricing_snapshot,
+                )
+            self._emit_model_usage(request, result)
+            return result
+        except LLMExecutionError as exc:
+            analytics_instrumentation.emit_safe_error_event(
+                user_id=request.user_id,
+                source_record_type="run",
+                source_record_id=request.run_id,
+                error_category=self._analytics_error_category(exc.category),
+                correlation_id=request.run_id,
+                version=f"{request.call_index}:{exc.category.value}",
+            )
+            raise
+        except Exception:
+            analytics_instrumentation.emit_safe_error_event(
+                user_id=request.user_id,
+                source_record_type="run",
+                source_record_id=request.run_id,
+                error_category="internal_error",
+                correlation_id=request.run_id,
+                version=f"{request.call_index}:internal_error",
+            )
+            raise
+
+    @staticmethod
+    def _analytics_error_category(
+        category: ExecutionErrorCategory,
+    ) -> str:
+        return {
+            ExecutionErrorCategory.CREDENTIAL_MISSING: "credential_missing",
+            ExecutionErrorCategory.CREDENTIAL_INVALID: "credential_invalid",
+            ExecutionErrorCategory.PROVIDER_UNAVAILABLE: "provider_unavailable",
+            ExecutionErrorCategory.PROVIDER_TIMEOUT: "provider_timeout",
+            ExecutionErrorCategory.BILLING_FAILED: "credits_unavailable",
+        }.get(category, "internal_error")
+
+    @staticmethod
+    def _emit_model_usage(
+        request: LLMExecutionRequest,
+        result: LLMExecutionResult,
+    ) -> None:
+        cost_usd = 0.0
+        if request.billing_mode is BillingMode.PLATFORM_CREDITS:
+            cost_usd = (
+                result.billing.provider_cost_usd
+                if result.billing.provider_cost_usd is not None
+                else result.billing.estimated_cost_usd or 0.0
+            )
+        analytics_instrumentation.emit_resource_event(
+            event_name="model_usage_recorded",
+            user_id=request.user_id,
+            source_record_type="run",
+            source_record_id=request.run_id,
+            correlation_id=request.run_id,
+            provider_id=request.provider_id,
+            model_id=request.model_id,
+            billing_mode=request.billing_mode.value,
+            outcome="succeeded",
+            properties={
+                "input_tokens": result.usage.input_tokens,
+                "output_tokens": result.usage.output_tokens,
+                "cost_micro_usd": max(0, round(cost_usd * 1_000_000)),
+            },
+            version=request.call_index,
         )
 
     def finalize_run(

--- a/dashboard/backend/tests/domain/agents/test_service.py
+++ b/dashboard/backend/tests/domain/agents/test_service.py
@@ -95,6 +95,52 @@ def test_create_agent_returns_full_schema(svc):
     assert agent["api_key"].startswith("ag_")
 
 
+def test_owned_agent_lifecycle_emits_after_repository_success(svc, monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        service_module.analytics_instrumentation,
+        "emit_agent_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    agent = svc.create_agent(
+        name="owned",
+        model_name="model",
+        owner_user_id=7,
+        owner_browser_session="browser",
+    )
+    svc.update_agent(agent["agent_id"], name="updated")
+    assert svc.delete_agent(agent["agent_id"]) is True
+    assert svc.delete_agent(agent["agent_id"]) is False
+
+    assert [event["event_name"] for event in events] == [
+        "agent_created",
+        "agent_updated",
+        "agent_deleted",
+    ]
+    assert all(event["user_id"] == 7 for event in events)
+
+
+def test_guest_agent_lifecycle_is_not_attributed_to_user(svc, monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        service_module.analytics_instrumentation,
+        "emit_agent_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    agent = svc.create_agent(
+        name="guest",
+        model_name="model",
+        owner_user_id=None,
+        owner_browser_session="browser",
+    )
+    svc.update_agent(agent["agent_id"], name="updated")
+    svc.delete_agent(agent["agent_id"])
+
+    assert events == []
+
+
 def test_runtime_type_update_resets_runtime_specific_config(svc):
     agent = svc.create_agent(
         name="hosted",

--- a/dashboard/backend/tests/domain/analytics/test_backfill.py
+++ b/dashboard/backend/tests/domain/analytics/test_backfill.py
@@ -1,0 +1,459 @@
+"""Authoritative Analytics backfill is bounded, safe, and replayable."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dashboard.backend.domain.analytics.backfill import (
+    AuthoritativeBackfillSource,
+    BackfillCandidate,
+    BackfillCollection,
+    backfill_analytics,
+)
+from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.service import AnalyticsService
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+class StaticSource:
+    def __init__(self, candidates, *, skipped_unmapped_owner=0, skipped_invalid=0):
+        self.collection = BackfillCollection(
+            candidates=list(candidates),
+            skipped_unmapped_owner=skipped_unmapped_owner,
+            skipped_invalid=skipped_invalid,
+        )
+
+    def collect(self, *, start, end):
+        return self.collection
+
+
+def _analytics_store(tmp_path):
+    path = tmp_path / "backfill.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO users VALUES (?, ?, ?, 'x', 'user', ?)",
+            [
+                (1, "one@example.test", "One", (NOW - timedelta(days=10)).isoformat()),
+                (2, "two@example.test", "Two", (NOW - timedelta(days=5)).isoformat()),
+            ],
+        )
+    return AnalyticsStore(path)
+
+
+def _candidate(
+    event_name,
+    source_event_id,
+    occurred_at,
+    *,
+    user_id=1,
+    source_record_type="run",
+    source_record_id="run-1",
+    **kwargs,
+):
+    return BackfillCandidate(
+        event_name=event_name,
+        user_id=user_id,
+        occurred_at=occurred_at,
+        source_event_id=source_event_id,
+        source_record_type=source_record_type,
+        source_record_id=source_record_id,
+        **kwargs,
+    )
+
+
+def test_backfill_uses_only_authoritative_candidates(tmp_path):
+    store = _analytics_store(tmp_path)
+    source = StaticSource(
+        [
+            _candidate(
+                "account_signed_up",
+                "account:account_signed_up:1",
+                NOW - timedelta(days=10),
+                source_record_type="user",
+                source_record_id="1",
+            ),
+            _candidate(
+                "agent_created",
+                "agent:agent_created:agent-1",
+                NOW - timedelta(days=9),
+                source_record_type="agent",
+                source_record_id="agent-1",
+            ),
+            _candidate(
+                "backtest_completed",
+                "run:backtest_completed:run-1",
+                NOW - timedelta(days=8),
+                outcome="succeeded",
+            ),
+        ]
+    )
+
+    report = backfill_analytics(
+        now=NOW,
+        source=source,
+        store=store,
+        recalculate_snapshot=lambda *_args, **_kwargs: None,
+        rebuild_rollup=lambda *_args, **_kwargs: None,
+    )
+    events = store.list_user_events(1, limit=50)["items"]
+
+    assert report.inserted == 3
+    assert all(event.event_source == "backfill" for event in events)
+    assert all(event.session_id is None and event.page_view is None for event in events)
+    assert all(event.network_hash is None for event in events)
+    assert not any(event.event_name == "page_viewed" for event in events)
+
+
+def test_backfill_ids_are_deterministic_and_idempotent(tmp_path):
+    store = _analytics_store(tmp_path)
+    candidate = _candidate(
+        "backtest_failed",
+        "run:backtest_failed:run-1",
+        NOW - timedelta(days=2),
+        outcome="failed",
+        error_category="internal_error",
+    )
+    source = StaticSource([candidate])
+
+    first = backfill_analytics(
+        now=NOW,
+        source=source,
+        store=store,
+        recalculate_snapshot=lambda *_args, **_kwargs: None,
+        rebuild_rollup=lambda *_args, **_kwargs: None,
+    )
+    first_event_id = store.list_user_events(1, limit=10)["items"][0].event_id
+    second = backfill_analytics(
+        now=NOW,
+        source=source,
+        store=store,
+        recalculate_snapshot=lambda *_args, **_kwargs: None,
+        rebuild_rollup=lambda *_args, **_kwargs: None,
+    )
+    second_event_id = store.list_user_events(1, limit=10)["items"][0].event_id
+
+    assert first.inserted == 1
+    assert second.inserted == 0
+    assert second.duplicates == 1
+    assert first.source_event_ids == ["run:backtest_failed:run-1"]
+    assert first_event_id == second_event_id
+
+
+def test_backfill_treats_existing_live_source_event_as_duplicate(tmp_path):
+    store = _analytics_store(tmp_path)
+    at = NOW - timedelta(days=1)
+    AnalyticsService(store).record_server_event(
+        event_name="backtest_completed",
+        user_id=1,
+        source_event_id="run:backtest_completed:run-live",
+        source_record_type="run",
+        source_record_id="run-live",
+        correlation_id="run-live",
+        outcome="succeeded",
+        occurred_at=at,
+    )
+
+    report = backfill_analytics(
+        now=NOW,
+        source=StaticSource(
+            [
+                _candidate(
+                    "backtest_completed",
+                    "run:backtest_completed:run-live",
+                    at,
+                    source_record_id="run-live",
+                    correlation_id="run-live",
+                    outcome="succeeded",
+                )
+            ]
+        ),
+        store=store,
+        recalculate_snapshot=lambda *_args, **_kwargs: None,
+        rebuild_rollup=lambda *_args, **_kwargs: None,
+    )
+
+    assert report.inserted == 0
+    assert report.duplicates == 1
+    assert len(store.list_user_events(1, limit=10)["items"]) == 1
+
+
+def test_backfill_enforces_window_dry_run_and_bulk_repairs(tmp_path):
+    store = _analytics_store(tmp_path)
+    snapshots = []
+    rollup_days = []
+    source = StaticSource(
+        [
+            _candidate(
+                "backtest_completed",
+                "run:backtest_completed:old",
+                NOW - timedelta(days=181),
+                source_record_id="old",
+                outcome="succeeded",
+            ),
+            _candidate(
+                "backtest_completed",
+                "run:backtest_completed:yesterday",
+                NOW - timedelta(days=1),
+                source_record_id="yesterday",
+                outcome="succeeded",
+            ),
+            _candidate(
+                "agent_created",
+                "agent:agent_created:today",
+                NOW - timedelta(hours=1),
+                user_id=2,
+                source_record_type="agent",
+                source_record_id="today",
+            ),
+        ],
+        skipped_unmapped_owner=2,
+    )
+
+    dry = backfill_analytics(
+        now=NOW,
+        source=source,
+        store=store,
+        dry_run=True,
+        recalculate_snapshot=lambda user_id, **_kwargs: snapshots.append(user_id),
+        rebuild_rollup=lambda day, **_kwargs: rollup_days.append(day),
+    )
+    written = backfill_analytics(
+        now=NOW,
+        source=source,
+        store=store,
+        recalculate_snapshot=lambda user_id, **_kwargs: snapshots.append(user_id),
+        rebuild_rollup=lambda day, **_kwargs: rollup_days.append(day),
+    )
+
+    assert dry.would_insert == 2
+    assert dry.inserted == 0
+    assert written.inserted == 2
+    assert written.skipped_outside_window == 1
+    assert written.skipped_unmapped_owner == 2
+    assert snapshots == [1, 2]
+    assert rollup_days == [(NOW - timedelta(days=1)).date()]
+
+
+def test_dry_run_validates_event_properties_without_writing(tmp_path):
+    store = _analytics_store(tmp_path)
+    report = backfill_analytics(
+        now=NOW,
+        dry_run=True,
+        source=StaticSource(
+            [
+                _candidate(
+                    "credits_reserved",
+                    "resource:credits_reserved:invalid:grant",
+                    NOW - timedelta(days=1),
+                    source_record_type="credit_reservation",
+                    source_record_id="invalid",
+                    billing_mode="platform_credits",
+                    properties={"amount_micro": 0, "bucket": "grant"},
+                )
+            ]
+        ),
+        store=store,
+    )
+
+    assert report.would_insert == 0
+    assert report.skipped_invalid == 1
+    assert store.list_user_events(1, limit=10)["items"] == []
+
+
+@pytest.mark.parametrize("days", [0, 181, True])
+def test_backfill_rejects_invalid_day_bounds(tmp_path, days):
+    with pytest.raises(ValueError, match="days"):
+        backfill_analytics(
+            now=NOW,
+            days=days,
+            source=StaticSource([]),
+            store=_analytics_store(tmp_path),
+        )
+
+
+class SqliteRows:
+    def __init__(self, path):
+        self.path = path
+
+    def _get_connection(self):
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+
+class FakeUsers:
+    def list_users_admin(self, *, limit, offset, query=None):
+        del limit, query
+        rows = [
+            {
+                "id": 1,
+                "email": "one@example.test",
+                "display_name": "One",
+                "role": "user",
+                "created_at": (NOW - timedelta(days=10)).isoformat(),
+            }
+        ]
+        return rows[offset:]
+
+
+class FakeProtocolRuns:
+    def list_runs(self, agent_id):
+        assert agent_id == "agent-1"
+        return [
+            {
+                "run_id": "protocol-1",
+                "status": "failed",
+                "created_at": (NOW - timedelta(days=4)).isoformat(),
+                "updated_at": (NOW - timedelta(days=3)).isoformat(),
+                "result_run_id": None,
+            }
+        ]
+
+
+class FakeRunHistory:
+    def get_runs_by_sessions(self, session_ids):
+        assert session_ids == ["session-1"]
+        return {
+            "session-1": [
+                {
+                    "run_id": "legacy-1",
+                    "mode": "backtest",
+                    "created_at": (NOW - timedelta(days=2)).isoformat(),
+                    "updated_at": (NOW - timedelta(days=2)).isoformat(),
+                    "metadata": {
+                        "llm_execution": {
+                            "billing_mode": "byok",
+                            "provider_id": "openrouter",
+                            "model_id": "openai/gpt-5.5",
+                            "credential_id": "credential-reference",
+                            "credential_key_last_four": "1234",
+                            "call_count": 1,
+                            "input_tokens": 100,
+                            "output_tokens": 25,
+                            "usage_available": True,
+                            "provider_cost_usd": None,
+                            "estimated_cost_usd": None,
+                            "pricing_snapshot": None,
+                            "debited_credits_micro": 0,
+                            "outstanding_credits_micro": 0,
+                            "outcome": "byok",
+                        }
+                    },
+                }
+            ]
+        }
+
+
+def test_authoritative_source_combines_safe_independent_store_evidence(tmp_path):
+    content_path = tmp_path / "content.db"
+    with sqlite3.connect(content_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE external_agents (
+                agent_id TEXT, session_id TEXT, owner_user_id INTEGER, created_at TEXT
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO external_agents VALUES (?, ?, ?, ?)",
+            [
+                (
+                    "agent-1",
+                    "session-1",
+                    1,
+                    (NOW - timedelta(days=9)).isoformat(),
+                ),
+                (
+                    "guest-agent",
+                    "guest-session",
+                    None,
+                    (NOW - timedelta(days=8)).isoformat(),
+                ),
+            ],
+        )
+    credits_path = tmp_path / "credits.db"
+    with sqlite3.connect(credits_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE credit_llm_reservations (
+                reservation_id TEXT, user_id INTEGER, run_id TEXT, call_index INTEGER,
+                reserved_grant_micro INTEGER, reserved_purchased_micro INTEGER,
+                status TEXT, created_at TEXT, updated_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE credit_llm_usage_entries (
+                id INTEGER, user_id INTEGER, reservation_id TEXT, run_id TEXT,
+                call_index INTEGER, bucket TEXT, amount_micro INTEGER, created_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO credit_llm_reservations VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "reservation-1",
+                1,
+                "legacy-1",
+                0,
+                90,
+                10,
+                "settled",
+                (NOW - timedelta(days=2, hours=1)).isoformat(),
+                (NOW - timedelta(days=2)).isoformat(),
+            ),
+        )
+        conn.execute(
+            "INSERT INTO credit_llm_usage_entries VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                1,
+                1,
+                "reservation-1",
+                "legacy-1",
+                0,
+                "grant",
+                -80,
+                (NOW - timedelta(days=2)).isoformat(),
+            ),
+        )
+
+    collection = AuthoritativeBackfillSource(
+        user_store=FakeUsers(),
+        agent_store=SqliteRows(content_path),
+        protocol_run_store=FakeProtocolRuns(),
+        run_history_store=FakeRunHistory(),
+        credits_store=SqliteRows(credits_path),
+    ).collect(start=NOW - timedelta(days=180), end=NOW)
+    by_source_id = {item.source_event_id: item for item in collection.candidates}
+
+    assert collection.skipped_unmapped_owner == 1
+    assert "account:account_signed_up:1" in by_source_id
+    assert "agent:agent_created:agent-1" in by_source_id
+    assert "run:backtest_failed:protocol-1" in by_source_id
+    assert "run:backtest_completed:legacy-1" in by_source_id
+    assert "resource:model_usage_recorded:legacy-1:0" in by_source_id
+    assert "resource:credits_reserved:reservation-1:grant" in by_source_id
+    assert "resource:credits_settled:reservation-1:grant" in by_source_id
+    assert "resource:credits_refunded:reservation-1:grant" in by_source_id
+    usage = by_source_id["resource:model_usage_recorded:legacy-1:0"]
+    assert usage.billing_mode == "byok"
+    assert usage.properties["cost_micro_usd"] == 0
+    assert "credential" not in str(usage.model_dump()).lower()

--- a/dashboard/backend/tests/domain/analytics/test_instrumentation.py
+++ b/dashboard/backend/tests/domain/analytics/test_instrumentation.py
@@ -1,0 +1,156 @@
+"""Best-effort server-authoritative Analytics instrumentation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dashboard.backend.domain.analytics import instrumentation
+from dashboard.backend.domain.analytics.models import AppendEventResult
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+class RecordingService:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def try_record_server_event(self, **kwargs):
+        self.calls.append(kwargs)
+        return AppendEventResult.model_construct(event=None, created=True)
+
+
+def _service(monkeypatch) -> RecordingService:
+    service = RecordingService()
+    monkeypatch.setattr(instrumentation, "get_analytics_service", lambda: service)
+    return service
+
+
+def test_credential_event_contains_only_safe_envelope_fields(monkeypatch):
+    service = _service(monkeypatch)
+
+    instrumentation.emit_credential_event(
+        event_name="credential_verified",
+        user_id=7,
+        credential_id="cred-1",
+        provider_id="openrouter",
+        occurred_at=NOW,
+        version="2026-08-26T12:00:00+00:00",
+    )
+
+    call = service.calls[0]
+    assert call["event_name"] == "credential_verified"
+    assert call["source_event_id"].startswith(
+        "credential:credential_verified:cred-1:"
+    )
+    assert call["source_record_type"] == "credential"
+    assert call["source_record_id"] == "cred-1"
+    assert call["provider_id"] == "openrouter"
+    assert call["properties"] == {}
+    assert "api_key" not in repr(call)
+
+
+def test_server_event_failure_never_escapes_or_prints_exception_text(
+    monkeypatch,
+    capsys,
+):
+    class FailingService:
+        def try_record_server_event(self, **kwargs):
+            raise RuntimeError("synthetic-secret-canary from provider body")
+
+    monkeypatch.setattr(
+        instrumentation,
+        "get_analytics_service",
+        lambda: FailingService(),
+    )
+
+    instrumentation.emit_run_event(
+        event_name="backtest_requested",
+        user_id=7,
+        run_id="run-1",
+        occurred_at=NOW,
+    )
+
+    output = capsys.readouterr().out
+    assert "synthetic-secret-canary" not in output
+    assert "run-1" not in output
+    assert "analytics.instrumentation_failed" in output
+    assert "category=RuntimeError" in output
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (TimeoutError(), "provider_timeout"),
+        (PermissionError(), "credential_invalid"),
+        (LookupError(), "credential_missing"),
+        (ConnectionError(), "provider_unavailable"),
+        (RuntimeError(), "internal_error"),
+    ],
+)
+def test_safe_error_event_uses_stable_categories(
+    monkeypatch,
+    exc,
+    expected,
+):
+    service = _service(monkeypatch)
+
+    instrumentation.emit_safe_error_event(
+        user_id=7,
+        source_record_type="run",
+        source_record_id="run-1",
+        exc=exc,
+        occurred_at=NOW,
+    )
+
+    call = service.calls[0]
+    assert call["event_name"] == "safe_error_recorded"
+    assert call["error_category"] == expected
+    assert call["properties"] == {}
+
+
+def test_model_usage_requires_exact_bounded_usage_properties(monkeypatch):
+    service = _service(monkeypatch)
+
+    instrumentation.emit_resource_event(
+        event_name="model_usage_recorded",
+        user_id=7,
+        source_record_type="run",
+        source_record_id="run-1",
+        correlation_id="run-1",
+        provider_id="openrouter",
+        model_id="openai/gpt-5.5",
+        billing_mode="byok",
+        outcome="succeeded",
+        properties={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cost_micro_usd": 0,
+        },
+        version="3",
+        occurred_at=NOW,
+    )
+
+    call = service.calls[0]
+    assert call["source_event_id"] == "resource:model_usage_recorded:run-1:3"
+    assert call["properties"] == {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cost_micro_usd": 0,
+    }
+
+
+def test_unsupported_event_name_is_contained(monkeypatch, capsys):
+    service = _service(monkeypatch)
+
+    instrumentation.emit_agent_event(
+        event_name="agent_prompt_recorded",
+        user_id=7,
+        agent_id="agent-1",
+        occurred_at=NOW,
+    )
+
+    assert service.calls == []
+    assert "category=ValueError" in capsys.readouterr().out

--- a/dashboard/backend/tests/domain/analytics/test_instrumentation.py
+++ b/dashboard/backend/tests/domain/analytics/test_instrumentation.py
@@ -25,6 +25,7 @@ class RecordingService:
 def _service(monkeypatch) -> RecordingService:
     service = RecordingService()
     monkeypatch.setattr(instrumentation, "get_analytics_service", lambda: service)
+    monkeypatch.setattr(instrumentation, "_snapshot_recalculator", lambda _user_id: None)
     return service
 
 
@@ -154,3 +155,45 @@ def test_unsupported_event_name_is_contained(monkeypatch, capsys):
 
     assert service.calls == []
     assert "category=ValueError" in capsys.readouterr().out
+
+
+def test_stored_event_recalculates_snapshot_best_effort(monkeypatch):
+    _service(monkeypatch)
+    users = []
+    monkeypatch.setattr(
+        instrumentation,
+        "_snapshot_recalculator",
+        lambda user_id: users.append(user_id),
+    )
+
+    instrumentation.emit_agent_event(
+        event_name="agent_created",
+        user_id=7,
+        agent_id="agent-1",
+        occurred_at=NOW,
+    )
+
+    assert users == [7]
+
+
+def test_snapshot_failure_never_escapes_or_logs_exception_text(
+    monkeypatch,
+    capsys,
+):
+    _service(monkeypatch)
+
+    def fail(_user_id):
+        raise RuntimeError("snapshot-secret-canary")
+
+    monkeypatch.setattr(instrumentation, "_snapshot_recalculator", fail)
+
+    instrumentation.emit_agent_event(
+        event_name="agent_created",
+        user_id=7,
+        agent_id="agent-1",
+        occurred_at=NOW,
+    )
+
+    output = capsys.readouterr().out
+    assert "snapshot-secret-canary" not in output
+    assert "category=RuntimeError" in output

--- a/dashboard/backend/tests/domain/analytics/test_metrics.py
+++ b/dashboard/backend/tests/domain/analytics/test_metrics.py
@@ -1,0 +1,158 @@
+"""Deterministic Analytics metric formulas at fixed UTC boundaries."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from dashboard.backend.domain.analytics.metrics import (
+    backtest_success_rate,
+    calculate_overview_metrics,
+    repeat_run_rate,
+)
+from dashboard.backend.domain.analytics.models import (
+    EVENT_GROUP_BY_NAME,
+    AnalyticsEventRecord,
+)
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _event(name: str, user_id: int, at: datetime, **kwargs) -> AnalyticsEventRecord:
+    if name in {"page_viewed", "page_hidden", "session_heartbeat"}:
+        return AnalyticsEventRecord(
+            event_id=str(uuid4()),
+            event_name=name,
+            event_group=EVENT_GROUP_BY_NAME[name],
+            user_id=user_id,
+            session_id=str(uuid4()),
+            occurred_at=at,
+            received_at=at,
+            event_source="frontend",
+            page_view=kwargs.pop("page_view", "home"),
+            properties=kwargs.pop("properties", {}),
+            **kwargs,
+        )
+    return AnalyticsEventRecord(
+        event_id=str(uuid4()),
+        event_name=name,
+        event_group=EVENT_GROUP_BY_NAME[name],
+        user_id=user_id,
+        occurred_at=at,
+        received_at=at,
+        event_source="server",
+        source_event_id=f"test:{name}:{user_id}:{uuid4()}",
+        properties=kwargs.pop("properties", {}),
+        **kwargs,
+    )
+
+
+def test_active_users_excludes_unattended_heartbeat():
+    events = [
+        _event("page_viewed", 1, NOW - timedelta(days=1), page_view="home"),
+        AnalyticsEventRecord(
+            event_id=str(uuid4()),
+            event_name="session_heartbeat",
+            event_group="experience",
+            user_id=2,
+            session_id=str(uuid4()),
+            occurred_at=NOW - timedelta(days=1),
+            received_at=NOW - timedelta(days=1),
+            event_source="frontend",
+            page_view="home",
+            properties={"visible_ms": 1000},
+        ),
+    ]
+
+    result = calculate_overview_metrics(
+        events,
+        start=NOW - timedelta(days=30),
+        end=NOW,
+    )
+
+    assert result.active_users_7d == 1
+
+
+def test_first_success_conversion_excludes_immature_cohort():
+    events = [
+        _event("account_signed_up", 1, NOW - timedelta(days=8)),
+        _event("account_signed_up", 2, NOW - timedelta(days=2)),
+        _event("backtest_completed", 1, NOW - timedelta(days=7, hours=1)),
+    ]
+
+    result = calculate_overview_metrics(
+        events,
+        start=NOW - timedelta(days=30),
+        end=NOW,
+    )
+
+    assert result.mature_signup_cohort_users == 1
+    assert result.first_success_within_7d_users == 1
+    assert result.first_success_conversion == 1.0
+
+
+def test_success_and_repeat_rate_formulas():
+    assert backtest_success_rate(completed=1, failed=1) == 0.5
+    assert backtest_success_rate(completed=0, failed=0) is None
+    assert repeat_run_rate(users_with_first_success=2, users_with_repeat_success=1) == 0.5
+    assert repeat_run_rate(users_with_first_success=0, users_with_repeat_success=0) is None
+
+
+def test_cancelled_runs_and_byok_cost_are_excluded():
+    events = [
+        _event("backtest_completed", 1, NOW - timedelta(days=1)),
+        _event("backtest_failed", 2, NOW - timedelta(days=1)),
+        _event("backtest_cancelled", 3, NOW - timedelta(days=1)),
+        _event(
+            "model_usage_recorded",
+            1,
+            NOW - timedelta(days=1),
+            billing_mode="platform_credits",
+            properties={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cost_micro_usd": 1_250_000,
+            },
+        ),
+        _event(
+            "model_usage_recorded",
+            2,
+            NOW - timedelta(days=1),
+            billing_mode="byok",
+            properties={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cost_micro_usd": 0,
+            },
+        ),
+    ]
+
+    result = calculate_overview_metrics(
+        events,
+        start=NOW - timedelta(days=30),
+        end=NOW,
+    )
+
+    assert result.backtest_success_rate == 0.5
+    assert result.platform_model_cost_usd == 1.25
+    assert result.input_tokens == 200
+    assert result.output_tokens == 100
+
+
+def test_excluded_users_do_not_contribute():
+    events = [
+        _event("backtest_completed", 1, NOW - timedelta(days=1)),
+        _event("backtest_failed", 2, NOW - timedelta(days=1)),
+    ]
+
+    result = calculate_overview_metrics(
+        events,
+        start=NOW - timedelta(days=30),
+        end=NOW,
+        excluded_user_ids={2},
+    )
+
+    assert result.completed_runs == 1
+    assert result.failed_runs == 0
+    assert result.backtest_success_rate == 1.0

--- a/dashboard/backend/tests/domain/analytics/test_repository_contract.py
+++ b/dashboard/backend/tests/domain/analytics/test_repository_contract.py
@@ -8,12 +8,23 @@ from uuid import uuid4
 
 import pytest
 
+from dashboard.backend.domain.analytics.metrics import AnalyticsMetricFilters
 from dashboard.backend.domain.analytics.models import AnalyticsEventRecord
+from dashboard.backend.domain.analytics.query_service import (
+    AnalyticsQueryService,
+    AnalyticsUserFilters,
+)
 from dashboard.backend.domain.analytics.repository import AnalyticsStore
 from dashboard.backend.domain.analytics.repository_common import (
     AnalyticsIdempotencyConflictError,
     AnalyticsStoreError,
     decode_event_cursor,
+)
+from dashboard.backend.domain.analytics.service import AnalyticsService
+from dashboard.backend.domain.analytics.states import (
+    AnalyticsStateStore,
+    UserAnalyticsSnapshot,
+    recalculate_user_snapshot,
 )
 from dashboard.backend.users import UserStore
 
@@ -161,6 +172,158 @@ def assert_subject_and_access_contract(store, admin_id, user_id):
     assert user_id not in store.list_excluded_user_ids()
 
 
+class ContractUsers:
+    def __init__(self, user_id: int):
+        self.user = {
+            "id": user_id,
+            "email": "analytics-user@example.test",
+            "display_name": "Analytics User",
+            "role": "user",
+            "created_at": (NOW - timedelta(days=20)).isoformat(),
+        }
+
+    def list_users_admin(self, *, limit=100, offset=0, query=None):
+        rows = [self.user]
+        if query:
+            needle = query.lower()
+            rows = [
+                row
+                for row in rows
+                if needle in row["email"].lower()
+                or needle in row["display_name"].lower()
+            ]
+        return rows[offset : offset + limit]
+
+    def get_user_admin(self, user_id):
+        return self.user if user_id == self.user["id"] else None
+
+
+def assert_pr2_query_contract(store, user_id):
+    events = AnalyticsService(store)
+    common = {
+        "user_id": user_id,
+        "source_record_type": "run",
+        "received_at": NOW,
+    }
+    events.record_server_event(
+        event_name="account_signed_up",
+        source_event_id=f"account:account_signed_up:{user_id}",
+        source_record_type="user",
+        source_record_id=str(user_id),
+        occurred_at=NOW - timedelta(days=20),
+        **{key: value for key, value in common.items() if key != "source_record_type"},
+    )
+    events.record_server_event(
+        event_name="backtest_failed",
+        source_event_id="run:backtest_failed:contract-failed",
+        source_record_id="contract-failed",
+        correlation_id="contract-failed",
+        outcome="failed",
+        error_category="provider_timeout",
+        occurred_at=NOW - timedelta(hours=3),
+        **common,
+    )
+    completed = events.record_server_event(
+        event_name="backtest_completed",
+        source_event_id="run:backtest_completed:contract-success",
+        source_record_id="contract-success",
+        correlation_id="contract-success",
+        outcome="succeeded",
+        occurred_at=NOW - timedelta(hours=2),
+        **common,
+    ).event
+    events.record_server_event(
+        event_name="model_usage_recorded",
+        source_event_id="resource:model_usage_recorded:contract-success:0",
+        source_record_id="contract-success",
+        correlation_id="contract-success",
+        provider_id="openrouter",
+        model_id="openai/gpt-5.5",
+        billing_mode="platform_credits",
+        outcome="succeeded",
+        properties={
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "cost_micro_usd": 250_000,
+        },
+        occurred_at=NOW - timedelta(hours=1),
+        **common,
+    )
+    events.record_server_event(
+        event_name="credits_settled",
+        source_event_id="resource:credits_settled:contract-success:0",
+        source_record_type="credit_reservation",
+        source_record_id="contract-reservation",
+        correlation_id="contract-success",
+        billing_mode="platform_credits",
+        properties={"amount_micro": 100, "bucket": "grant"},
+        occurred_at=NOW - timedelta(minutes=59),
+        **{key: value for key, value in common.items() if key != "source_record_type"},
+    )
+    state_store = AnalyticsStateStore(store)
+    recalculate_user_snapshot(user_id, now=NOW, store=state_store)
+    service = AnalyticsQueryService(
+        store=store,
+        user_store=ContractUsers(user_id),
+    )
+
+    overview = service.get_overview(
+        filters=AnalyticsMetricFilters(
+            start=NOW - timedelta(days=30),
+            end=NOW + timedelta(seconds=1),
+        ),
+        now=NOW,
+    )
+    users = service.list_users(
+        filters=AnalyticsUserFilters(),
+        limit=10,
+        offset=0,
+        now=NOW,
+    )
+    profile = service.get_user_profile(user_id=user_id, now=NOW)
+    activity = service.get_user_activity(
+        user_id=user_id,
+        section="runs",
+        limit=10,
+        cursor=None,
+    )
+    state_store.upsert_snapshot(
+        UserAnalyticsSnapshot(
+            user_id=user_id,
+            status="needs_attention",
+            reason_code="invalid_default_credential",
+            human_readable_reason="The default model credential is invalid.",
+            evidence_event_ids=[completed.event_id],
+            calculated_at=NOW,
+        )
+    )
+    attention_overview = service.get_overview(
+        filters=AnalyticsMetricFilters(
+            start=NOW - timedelta(days=30),
+            end=NOW + timedelta(seconds=1),
+        ),
+        now=NOW,
+    )
+
+    assert overview.completed_runs == 1
+    assert overview.failed_runs == 1
+    assert overview.platform_model_cost_usd == 0.25
+    assert users.total == 1
+    assert users.items[0].status == "active"
+    assert profile.state.status == "active"
+    assert completed.event_id in profile.state.evidence_event_ids
+    assert profile.input_tokens == 120
+    assert profile.output_tokens == 30
+    assert profile.credits_debited_micro == 100
+    assert [item.event_name for item in activity.items] == [
+        "backtest_completed",
+        "backtest_failed",
+    ]
+    assert activity.next_cursor is None
+    assert attention_overview.users_needing_attention[0].user_id == user_id
+    assert attention_overview.users_needing_attention[0].recent_failures == 1
+
+
 def test_sqlite_schema_contains_all_foundation_tables(sqlite_contract):
     store, _admin_id, _user_id = sqlite_contract
     with store._get_connection() as conn:
@@ -193,6 +356,11 @@ def test_sqlite_runs_shared_cursor_contract(sqlite_contract):
 def test_sqlite_runs_shared_subject_and_access_contract(sqlite_contract):
     store, admin_id, user_id = sqlite_contract
     assert_subject_and_access_contract(store, admin_id, user_id)
+
+
+def test_sqlite_runs_pr2_query_contract(sqlite_contract):
+    store, _admin_id, user_id = sqlite_contract
+    assert_pr2_query_contract(store, user_id)
 
 
 @pytest.mark.parametrize("cursor", ["", "not-base64!", "WzEsMl0", "W10"])

--- a/dashboard/backend/tests/domain/analytics/test_repository_postgres.py
+++ b/dashboard/backend/tests/domain/analytics/test_repository_postgres.py
@@ -21,6 +21,7 @@ from dashboard.backend.tests._postgres_testing import require_local_postgres_url
 from dashboard.backend.tests.domain.analytics.test_repository_contract import (
     assert_cursor_contract,
     assert_event_idempotency_contract,
+    assert_pr2_query_contract,
     assert_source_event_idempotency_contract,
     assert_subject_and_access_contract,
 )
@@ -55,12 +56,24 @@ def postgres_contract_store():
                     """
                     CREATE TABLE users (
                         id INTEGER PRIMARY KEY,
-                        role TEXT NOT NULL DEFAULT 'user'
+                        email TEXT NOT NULL,
+                        display_name TEXT NOT NULL,
+                        password_hash TEXT NOT NULL,
+                        role TEXT NOT NULL DEFAULT 'user',
+                        created_at TEXT NOT NULL
                     )
                     """
                 )
                 cur.execute(
-                    "INSERT INTO users (id, role) VALUES (1, 'admin'), (2, 'user')"
+                    """
+                    INSERT INTO users (
+                        id, email, display_name, password_hash, role, created_at
+                    ) VALUES
+                        (1, 'admin@example.test', 'Admin', 'x', 'admin',
+                         '2026-08-01T00:00:00+00:00'),
+                        (2, 'analytics-user@example.test', 'Analytics User', 'x',
+                         'user', '2026-08-06T12:00:00+00:00')
+                    """
                 )
         yield PostgresAnalyticsStore(scoped_url), 1, 2
     finally:
@@ -153,3 +166,9 @@ def test_postgres_runs_shared_cursor_contract(postgres_contract_store):
 def test_postgres_runs_shared_subject_and_access_contract(postgres_contract_store):
     store, admin_id, user_id = postgres_contract_store
     assert_subject_and_access_contract(store, admin_id, user_id)
+
+
+@pg_only
+def test_postgres_runs_pr2_query_contract(postgres_contract_store):
+    store, _admin_id, user_id = postgres_contract_store
+    assert_pr2_query_contract(store, user_id)

--- a/dashboard/backend/tests/domain/analytics/test_rollups.py
+++ b/dashboard/backend/tests/domain/analytics/test_rollups.py
@@ -1,0 +1,99 @@
+"""Daily Analytics rollups use bounded dimensions and idempotent upserts."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date, datetime, timezone
+
+from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.rollups import (
+    AnalyticsRollupStore,
+    rollup_day,
+)
+from dashboard.backend.domain.analytics.service import AnalyticsService
+
+
+def _store(tmp_path):
+    path = tmp_path / "rollups.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO users VALUES (1, 'user@example.test', 'User', 'x', 'user', ?) ",
+            ("2026-08-01T00:00:00+00:00",),
+        )
+    analytics = AnalyticsStore(path)
+    return analytics, AnalyticsRollupStore(analytics)
+
+
+def test_rollup_day_is_idempotent_and_contains_no_user_dimension(tmp_path):
+    analytics, rollups = _store(tmp_path)
+    service = AnalyticsService(analytics)
+    at = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+    service.record_server_event(
+        event_name="backtest_completed",
+        user_id=1,
+        source_event_id="run:backtest_completed:run-1",
+        source_record_type="run",
+        source_record_id="run-1",
+        occurred_at=at,
+    )
+
+    first = rollup_day(date(2026, 8, 25), store=rollups)
+    second = rollup_day(date(2026, 8, 25), store=rollups)
+    stored = rollups.list_rollups(
+        start=date(2026, 8, 25),
+        end=date(2026, 8, 26),
+    )
+
+    assert first == second
+    assert any(
+        row.metric_name == "terminal_completed" and row.value_count == 1
+        for row in stored
+    )
+    assert all("user" not in row.model_dump() for row in stored)
+
+
+def test_rollup_records_platform_cost_as_micro_usd(tmp_path):
+    analytics, rollups = _store(tmp_path)
+    service = AnalyticsService(analytics)
+    at = datetime(2026, 8, 25, 13, 0, tzinfo=timezone.utc)
+    service.record_server_event(
+        event_name="model_usage_recorded",
+        user_id=1,
+        source_event_id="resource:model_usage_recorded:run-1:0",
+        source_record_type="run",
+        source_record_id="run-1",
+        billing_mode="platform_credits",
+        provider_id="openrouter",
+        model_id="openai/gpt-5.5",
+        properties={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cost_micro_usd": 1_250_000,
+        },
+        occurred_at=at,
+    )
+
+    rollup_day(date(2026, 8, 25), store=rollups)
+    cost = next(
+        row
+        for row in rollups.list_rollups(
+            start=date(2026, 8, 25),
+            end=date(2026, 8, 26),
+        )
+        if row.metric_name == "platform_model_cost_usd"
+    )
+
+    assert cost.value_sum_micro == 1_250_000
+    assert cost.billing_mode == "platform_credits"

--- a/dashboard/backend/tests/domain/analytics/test_states.py
+++ b/dashboard/backend/tests/domain/analytics/test_states.py
@@ -1,0 +1,145 @@
+"""Explainable Analytics user-state precedence and snapshot persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.service import AnalyticsService
+from dashboard.backend.domain.analytics.states import (
+    AnalyticsStateStore,
+    calculate_user_state,
+    recalculate_user_snapshot,
+)
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _fixture(tmp_path, *, created_at=NOW - timedelta(days=1)):
+    path = tmp_path / "states.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO users VALUES (1, 'user@example.test', 'User', 'x', 'user', ?)",
+            (created_at.isoformat(),),
+        )
+    analytics = AnalyticsStore(path)
+    return AnalyticsService(analytics), AnalyticsStateStore(analytics)
+
+
+def _run(service, name, index, at, *, error_category=None):
+    return service.record_server_event(
+        event_name=name,
+        user_id=1,
+        source_event_id=f"run:{name}:run-{index}",
+        source_record_type="run",
+        source_record_id=f"run-{index}",
+        correlation_id=f"run-{index}",
+        error_category=error_category,
+        occurred_at=at,
+    ).event
+
+
+def test_blocked_wins_over_needs_attention(tmp_path):
+    service, store = _fixture(tmp_path)
+    for index in range(3):
+        _run(
+            service,
+            "backtest_failed",
+            index,
+            NOW - timedelta(hours=index + 2),
+            error_category="internal_error",
+        )
+    blocked = service.record_server_event(
+        event_name="safe_error_recorded",
+        user_id=1,
+        source_event_id="resource:safe_error_recorded:run-blocked:credits_unavailable",
+        source_record_type="run",
+        source_record_id="run-blocked",
+        error_category="credits_unavailable",
+        occurred_at=NOW - timedelta(hours=1),
+    ).event
+
+    snapshot = calculate_user_state(1, now=NOW, store=store)
+
+    assert snapshot.status == "blocked"
+    assert snapshot.reason_code == "billing_lane_unavailable"
+    assert snapshot.evidence_event_ids == [blocked.event_id]
+
+
+def test_new_user_without_run_is_onboarding(tmp_path):
+    _service, store = _fixture(tmp_path)
+
+    snapshot = calculate_user_state(1, now=NOW, store=store)
+
+    assert snapshot.status == "onboarding"
+    assert snapshot.reason_code == "no_successful_run"
+
+
+def test_three_newest_terminal_failures_need_attention(tmp_path):
+    service, store = _fixture(tmp_path)
+    failures = [
+        _run(
+            service,
+            "backtest_failed",
+            index,
+            NOW - timedelta(hours=index + 1),
+            error_category="internal_error",
+        )
+        for index in range(3)
+    ]
+
+    snapshot = calculate_user_state(1, now=NOW, store=store)
+
+    assert snapshot.status == "needs_attention"
+    assert snapshot.reason_code == "three_consecutive_failed_runs"
+    assert set(snapshot.evidence_event_ids) == {event.event_id for event in failures}
+
+
+def test_completed_or_cancelled_run_breaks_failure_sequence(tmp_path):
+    service, store = _fixture(tmp_path)
+    _run(service, "backtest_failed", 1, NOW - timedelta(hours=1))
+    _run(service, "backtest_cancelled", 2, NOW - timedelta(hours=2))
+    _run(service, "backtest_failed", 3, NOW - timedelta(hours=3))
+    _run(service, "backtest_failed", 4, NOW - timedelta(hours=4))
+
+    snapshot = calculate_user_state(1, now=NOW, store=store)
+
+    assert snapshot.status == "onboarding"
+
+
+def test_dormant_and_active_use_thirty_day_activity(tmp_path):
+    service, store = _fixture(tmp_path, created_at=NOW - timedelta(days=60))
+    _run(service, "backtest_completed", 1, NOW - timedelta(days=45))
+
+    dormant = calculate_user_state(1, now=NOW, store=store)
+    _run(service, "backtest_completed", 2, NOW - timedelta(days=1))
+    active = calculate_user_state(1, now=NOW, store=store)
+
+    assert dormant.status == "dormant"
+    assert dormant.reason_code == "no_meaningful_activity_30d"
+    assert active.status == "active"
+
+
+def test_recalculate_upserts_one_current_snapshot(tmp_path):
+    service, store = _fixture(tmp_path)
+    first = recalculate_user_snapshot(1, now=NOW, store=store)
+    _run(service, "backtest_completed", 1, NOW - timedelta(hours=1))
+    second = recalculate_user_snapshot(1, now=NOW, store=store)
+
+    assert first.status == "onboarding"
+    assert second.status == "active"
+    assert store.get_snapshot(1) == second

--- a/dashboard/backend/tests/domain/model_providers/test_service.py
+++ b/dashboard/backend/tests/domain/model_providers/test_service.py
@@ -22,6 +22,7 @@ from dashboard.backend.domain.model_providers.service import (
     CredentialResolutionError,
     ModelProviderService,
 )
+from dashboard.backend.domain.model_providers import service as service_module
 from dashboard.backend.infrastructure.llm.execution.errors import ExecutionErrorCategory
 
 
@@ -96,6 +97,67 @@ def test_create_encrypts_verifies_and_returns_only_public_metadata(tmp_path):
         ).fetchone()[0]
     assert stored != "sk-or-fake-service-abcd"
     assert "sk-or-fake-service-abcd" not in stored
+
+
+def test_credential_lifecycle_emits_only_post_commit_safe_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    adapter = FakeAdapter(_validation("verified"), _validation("verified"))
+    service, _store = _service(tmp_path, adapter)
+    events = []
+    errors = []
+    monkeypatch.setattr(
+        service_module.analytics_instrumentation,
+        "emit_credential_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    monkeypatch.setattr(
+        service_module.analytics_instrumentation,
+        "emit_safe_error_event",
+        lambda **kwargs: errors.append(kwargs),
+    )
+
+    created = service.create_credential(7, _request(set_default=True))
+    service.reverify_credential(7, str(created.credential_id))
+    service.set_default_credential(7, str(created.credential_id))
+    service.revoke_credential(7, str(created.credential_id))
+
+    assert [event["event_name"] for event in events] == [
+        "credential_saved",
+        "credential_verified",
+        "credential_defaulted",
+        "credential_reverified",
+        "credential_defaulted",
+        "credential_revoked",
+    ]
+    assert errors == []
+    assert "sk-or-fake-service-abcd" not in repr(events)
+
+
+def test_invalid_credential_emits_safe_category_not_adapter_detail(
+    tmp_path,
+    monkeypatch,
+):
+    service, _store = _service(tmp_path, FakeAdapter(_validation("invalid")))
+    events = []
+    errors = []
+    monkeypatch.setattr(
+        service_module.analytics_instrumentation,
+        "emit_credential_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    monkeypatch.setattr(
+        service_module.analytics_instrumentation,
+        "emit_safe_error_event",
+        lambda **kwargs: errors.append(kwargs),
+    )
+
+    service.create_credential(7, _request())
+
+    assert [event["event_name"] for event in events] == ["credential_saved"]
+    assert errors[0]["error_category"] == "credential_invalid"
+    assert "api_key" not in repr(errors)
 
 
 @pytest.mark.parametrize("status", ["invalid", "verification_unavailable"])

--- a/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
+++ b/dashboard/backend/tests/infrastructure/llm/test_platform_credits_env_fallback.py
@@ -16,14 +16,17 @@ from dashboard.backend.infrastructure.llm.execution.errors import (
     LLMExecutionError,
 )
 from dashboard.backend.infrastructure.llm.execution.models import (
+    BillingEvidence,
     BillingMode,
     LLMExecutionRequest,
+    LLMExecutionResult,
     LLMMessage,
     LLMUsage,
     PricingSnapshot,
     UsagePolicy,
 )
 from dashboard.backend.infrastructure.llm.execution.service import LLMExecutionService
+from dashboard.backend.infrastructure.llm.execution import service as execution_service_module
 
 
 USER_ID = 1
@@ -189,6 +192,93 @@ def test_platform_execution_uses_env_key_and_debits_grant_before_purchased(
     balance = credits_store.get_balance_projection(USER_ID)
     assert balance["grant_available_micro"] == 0
     assert balance["purchased_available_micro"] == 900_000
+
+
+def test_platform_execution_emits_bucketed_resource_evidence(
+    tmp_path,
+    monkeypatch,
+):
+    adapter = FakeExecutionAdapter(LLMUsage(input_tokens=100, output_tokens=100))
+    service, _credits_store = _execution_service(tmp_path, monkeypatch, adapter)
+    events = []
+    monkeypatch.setattr(
+        execution_service_module.analytics_instrumentation,
+        "emit_resource_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    service.execute(_request("analytics-platform-run"))
+
+    names = [event["event_name"] for event in events]
+    assert names == [
+        "credits_reserved",
+        "credits_reserved",
+        "credits_settled",
+        "credits_settled",
+        "credits_refunded",
+        "model_usage_recorded",
+    ]
+    usage = events[-1]
+    assert usage["billing_mode"] == "platform_credits"
+    assert usage["properties"] == {
+        "input_tokens": 100,
+        "output_tokens": 100,
+        "cost_micro_usd": 200_000,
+    }
+    assert "sk-or-execution-test-abcd" not in repr(events)
+
+
+def test_byok_usage_reports_tokens_with_zero_atl_cost(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        execution_service_module.analytics_instrumentation,
+        "emit_resource_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    request = _request("analytics-byok-run").model_copy(
+        update={"billing_mode": BillingMode.BYOK}
+    )
+    result = LLMExecutionResult(
+        text="BUY",
+        provider_id="openrouter",
+        model_id=MODEL_ID,
+        usage=LLMUsage(input_tokens=50, output_tokens=25),
+        billing=BillingEvidence(
+            billing_source=BillingMode.BYOK,
+            usage_authority="not_billable_by_atl",
+            provider_cost_usd=99.0,
+        ),
+    )
+
+    LLMExecutionService._emit_model_usage(request, result)
+
+    assert events[0]["billing_mode"] == "byok"
+    assert events[0]["properties"] == {
+        "input_tokens": 50,
+        "output_tokens": 25,
+        "cost_micro_usd": 0,
+    }
+
+
+def test_execution_failure_emits_only_safe_error_category(
+    tmp_path,
+    monkeypatch,
+):
+    adapter = FakeExecutionAdapter(None)
+    service, _credits_store = _execution_service(tmp_path, monkeypatch, adapter)
+    errors = []
+    monkeypatch.setattr(
+        execution_service_module.analytics_instrumentation,
+        "emit_safe_error_event",
+        lambda **kwargs: errors.append(kwargs),
+    )
+
+    with pytest.raises(LLMExecutionError):
+        service.execute(_request("analytics-failed-run"))
+
+    assert errors[0]["error_category"] == "internal_error"
+    assert "Analyze the market" not in repr(errors[0])
+    assert "sk-or-execution-test-abcd" not in repr(errors[0])
 
 
 def test_platform_execution_releases_reservation_when_usage_is_missing(

--- a/dashboard/backend/tests/test_admin_analytics_api.py
+++ b/dashboard/backend/tests/test_admin_analytics_api.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from datetime import date, datetime, timedelta, timezone
 from uuid import uuid4
 
+import pytest
+from fastapi.testclient import TestClient
+
+from dashboard.backend import users as users_module
+from dashboard.backend.app import app
 from dashboard.backend.domain.analytics.metrics import AnalyticsMetricFilters
 from dashboard.backend.domain.analytics.query_service import (
     AnalyticsQueryService,
     AnalyticsUserFilters,
+    get_analytics_query_service,
 )
 from dashboard.backend.domain.analytics.repository import AnalyticsStore
 from dashboard.backend.domain.analytics.rollups import (
@@ -17,6 +25,7 @@ from dashboard.backend.domain.analytics.rollups import (
     DailyRollup,
 )
 from dashboard.backend.domain.analytics.service import AnalyticsService
+from dashboard.backend.domain.analytics.service import get_analytics_service
 from dashboard.backend.domain.analytics.models import (
     FrontendAnalyticsEvent,
     RequestAnalyticsContext,
@@ -25,6 +34,7 @@ from dashboard.backend.domain.analytics.states import (
     AnalyticsStateStore,
     recalculate_user_snapshot,
 )
+from dashboard.backend.users import UserStore
 
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
@@ -324,3 +334,221 @@ def test_overview_marks_only_failed_rollup_panel_unavailable(tmp_path, monkeypat
     assert overview.availability["snapshot"].available is True
     assert overview.availability["growth"].available is False
     assert overview.availability["growth"].error_code == "temporarily_unavailable"
+
+
+@pytest.fixture
+def admin_analytics_api(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "admin-analytics.db"
+        users = UserStore(path)
+        admin = users.create_user(
+            "admin@example.test", "Analytics Admin", "SecurePass1!"
+        )
+        users.apply_admin_patch(admin["id"], role="admin")
+        outsider = users.create_user(
+            "outsider@example.test", "Outsider", "SecurePass1!"
+        )
+        subject = users.create_user(
+            "subject@example.test", "Subject", "SecurePass1!"
+        )
+        analytics = AnalyticsStore(path)
+        event_service = AnalyticsService(analytics)
+        at = datetime.now(timezone.utc).replace(microsecond=0)
+        event_service.record_server_event(
+            event_name="account_signed_up",
+            user_id=subject["id"],
+            source_event_id=f"account:account_signed_up:{subject['id']}",
+            source_record_type="user",
+            source_record_id=str(subject["id"]),
+            occurred_at=at - timedelta(days=10),
+        )
+        for index in range(3):
+            event_service.record_server_event(
+                event_name="backtest_completed",
+                user_id=subject["id"],
+                source_event_id=f"run:backtest_completed:api-run-{index}",
+                source_record_type="run",
+                source_record_id=f"api-run-{index}",
+                correlation_id=f"api-run-{index}",
+                outcome="succeeded",
+                occurred_at=at - timedelta(minutes=index + 1),
+            )
+        state_store = AnalyticsStateStore(analytics)
+        recalculate_user_snapshot(subject["id"], now=at, store=state_store)
+        query_service = AnalyticsQueryService(store=analytics, user_store=users)
+        monkeypatch.setattr(users_module, "user_store", users)
+        app.dependency_overrides[get_analytics_query_service] = lambda: query_service
+        app.dependency_overrides[get_analytics_service] = lambda: event_service
+        admin_token = users.create_session(admin["id"])
+        outsider_token = users.create_session(outsider["id"])
+        with TestClient(app) as client:
+            yield {
+                "client": client,
+                "analytics": analytics,
+                "event_service": event_service,
+                "query_service": query_service,
+                "admin": admin,
+                "subject": subject,
+                "admin_headers": {"Authorization": f"Bearer {admin_token}"},
+                "outsider_headers": {"Authorization": f"Bearer {outsider_token}"},
+            }
+        app.dependency_overrides.pop(get_analytics_query_service, None)
+        app.dependency_overrides.pop(get_analytics_service, None)
+
+
+def test_non_admin_cannot_query_any_admin_analytics_route(admin_analytics_api):
+    api = admin_analytics_api
+    subject_id = api["subject"]["id"]
+    calls = [
+        ("/api/admin/analytics/overview", {}),
+        ("/api/admin/analytics/users", {}),
+        (f"/api/admin/analytics/users/{subject_id}", {}),
+        (
+            f"/api/admin/analytics/users/{subject_id}/activity",
+            {"section": "runs"},
+        ),
+    ]
+
+    for path, params in calls:
+        response = api["client"].get(
+            path,
+            params=params,
+            headers=api["outsider_headers"],
+        )
+        assert response.status_code == 403, (path, response.text)
+
+
+def test_admin_overview_accepts_documented_filters(admin_analytics_api):
+    api = admin_analytics_api
+    response = api["client"].get(
+        "/api/admin/analytics/overview",
+        params={
+            "from": "2026-08-01",
+            "to": "2026-08-26",
+            "billing_mode": "byok",
+            "provider": "openrouter",
+            "model": "openai/gpt-5.5",
+            "include_internal": "false",
+        },
+        headers=api["admin_headers"],
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["filters"]["billing_mode"] == "byok"
+    assert body["filters"]["provider_id"] == "openrouter"
+    assert body["filters"]["model_id"] == "openai/gpt-5.5"
+
+
+def test_profile_and_activity_reads_record_access_without_body(admin_analytics_api):
+    api = admin_analytics_api
+    subject_id = api["subject"]["id"]
+    profile = api["client"].get(
+        f"/api/admin/analytics/users/{subject_id}",
+        headers=api["admin_headers"],
+    )
+    activity = api["client"].get(
+        f"/api/admin/analytics/users/{subject_id}/activity",
+        params={"section": "runs", "limit": 2},
+        headers=api["admin_headers"],
+    )
+    access = api["analytics"].list_admin_access(subject_id, limit=10)
+
+    assert profile.status_code == 200, profile.text
+    assert activity.status_code == 200, activity.text
+    assert activity.json()["next_cursor"] is not None
+    assert [row["section"] for row in access[:2]] == ["runs", "overview"]
+    assert all("response" not in row for row in access)
+
+
+def test_admin_analytics_rejects_invalid_queries_without_echo(admin_analytics_api):
+    api = admin_analytics_api
+    canary = "synthetic-secret-query-canary"
+    response = api["client"].get(
+        "/api/admin/analytics/overview",
+        params={"provider": f"{canary}!"},
+        headers=api["admin_headers"],
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Invalid Analytics query."}
+    assert canary not in response.text
+
+
+def test_admin_user_list_accepts_documented_filters(admin_analytics_api):
+    api = admin_analytics_api
+    today = datetime.now(timezone.utc).date()
+    response = api["client"].get(
+        "/api/admin/analytics/users",
+        params={
+            "q": "Subject",
+            "status": "active",
+            "last_activity_from": (today - timedelta(days=1)).isoformat(),
+            "last_activity_to": today.isoformat(),
+            "sort": "recent_runs",
+            "order": "desc",
+            "limit": "1",
+            "offset": "0",
+        },
+        headers=api["admin_headers"],
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["total"] == 1
+    assert response.json()["items"][0]["user_id"] == api["subject"]["id"]
+
+
+def test_admin_analytics_maps_not_found_and_cursor_errors_safely(
+    admin_analytics_api,
+):
+    api = admin_analytics_api
+    canary = "synthetic-secret-cursor-canary"
+    missing = api["client"].get(
+        "/api/admin/analytics/users/999999",
+        headers=api["admin_headers"],
+    )
+    invalid_cursor = api["client"].get(
+        f"/api/admin/analytics/users/{api['subject']['id']}/activity",
+        params={"section": "runs", "cursor": f"{canary}!"},
+        headers=api["admin_headers"],
+    )
+
+    assert missing.status_code == 404
+    assert missing.json() == {"detail": "Analytics user was not found."}
+    assert invalid_cursor.status_code == 422
+    assert invalid_cursor.json() == {"detail": "Invalid Analytics query."}
+    assert canary not in invalid_cursor.text
+
+
+def test_admin_analytics_maps_service_and_access_failures_safely(
+    admin_analytics_api,
+    monkeypatch,
+):
+    api = admin_analytics_api
+    canary = "synthetic-secret-storage-canary"
+    monkeypatch.setattr(
+        api["query_service"],
+        "get_overview",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError(canary)),
+    )
+    overview = api["client"].get(
+        "/api/admin/analytics/overview",
+        headers=api["admin_headers"],
+    )
+
+    monkeypatch.setattr(
+        api["event_service"],
+        "record_admin_profile_access",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError(canary)),
+    )
+    profile = api["client"].get(
+        f"/api/admin/analytics/users/{api['subject']['id']}",
+        headers=api["admin_headers"],
+    )
+
+    for response in (overview, profile):
+        assert response.status_code == 503
+        assert response.json() == {
+            "detail": "Analytics is temporarily unavailable."
+        }
+        assert canary not in response.text

--- a/dashboard/backend/tests/test_admin_analytics_api.py
+++ b/dashboard/backend/tests/test_admin_analytics_api.py
@@ -1,0 +1,326 @@
+"""Admin Analytics query-service and API contract coverage."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date, datetime, timedelta, timezone
+from uuid import uuid4
+
+from dashboard.backend.domain.analytics.metrics import AnalyticsMetricFilters
+from dashboard.backend.domain.analytics.query_service import (
+    AnalyticsQueryService,
+    AnalyticsUserFilters,
+)
+from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.rollups import (
+    AnalyticsRollupStore,
+    DailyRollup,
+)
+from dashboard.backend.domain.analytics.service import AnalyticsService
+from dashboard.backend.domain.analytics.models import (
+    FrontendAnalyticsEvent,
+    RequestAnalyticsContext,
+)
+from dashboard.backend.domain.analytics.states import (
+    AnalyticsStateStore,
+    recalculate_user_snapshot,
+)
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+class QueryUsers:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def list_users_admin(self, *, limit=100, offset=0, query=None):
+        rows = self.rows
+        if query:
+            needle = query.lower()
+            rows = [
+                row
+                for row in rows
+                if needle in row["email"].lower()
+                or needle in row["display_name"].lower()
+            ]
+        return rows[offset : offset + limit]
+
+    def get_user_admin(self, user_id):
+        return next((row for row in self.rows if row["id"] == user_id), None)
+
+
+def _fixture(tmp_path):
+    path = tmp_path / "query.db"
+    users = [
+        {
+            "id": 1,
+            "email": "one@example.test",
+            "display_name": "One",
+            "role": "user",
+            "created_at": (NOW - timedelta(days=20)).isoformat(),
+        },
+        {
+            "id": 2,
+            "email": "admin@example.test",
+            "display_name": "Admin",
+            "role": "admin",
+            "created_at": (NOW - timedelta(days=30)).isoformat(),
+        },
+    ]
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO users VALUES (?, ?, ?, 'x', ?, ?)",
+            [
+                (
+                    row["id"],
+                    row["email"],
+                    row["display_name"],
+                    row["role"],
+                    row["created_at"],
+                )
+                for row in users
+            ],
+        )
+    analytics = AnalyticsStore(path)
+    return (
+        analytics,
+        AnalyticsService(analytics),
+        AnalyticsRollupStore(analytics),
+        AnalyticsStateStore(analytics),
+        QueryUsers(users),
+    )
+
+
+def _event(service, name, at, source_id, **kwargs):
+    return service.record_server_event(
+        event_name=name,
+        user_id=1,
+        source_event_id=source_id,
+        source_record_type=kwargs.pop("source_record_type", "run"),
+        source_record_id=kwargs.pop("source_record_id", source_id.rsplit(":", 1)[-1]),
+        occurred_at=at,
+        **kwargs,
+    ).event
+
+
+def test_query_service_merges_completed_rollups_with_current_raw_day(tmp_path):
+    analytics, events, rollups, _states, users = _fixture(tmp_path)
+    yesterday = NOW.date() - timedelta(days=1)
+    rollups.replace_day(
+        yesterday,
+        [
+            DailyRollup(
+                rollup_date=yesterday,
+                metric_name="terminal_completed",
+                value_count=4,
+                updated_at=datetime.combine(
+                    NOW.date(), datetime.min.time(), tzinfo=timezone.utc
+                ),
+            ),
+            DailyRollup(
+                rollup_date=yesterday,
+                metric_name="daily_active_users",
+                value_count=3,
+                updated_at=datetime.combine(
+                    NOW.date(), datetime.min.time(), tzinfo=timezone.utc
+                ),
+            ),
+        ],
+    )
+    _event(
+        events,
+        "backtest_completed",
+        NOW - timedelta(minutes=2),
+        "run:backtest_completed:today",
+        outcome="succeeded",
+    )
+    service = AnalyticsQueryService(store=analytics, user_store=users)
+
+    overview = service.get_overview(
+        now=NOW,
+        filters=AnalyticsMetricFilters(
+            start=datetime.combine(
+                yesterday, datetime.min.time(), tzinfo=timezone.utc
+            ),
+            end=NOW,
+        ),
+    )
+
+    assert overview.completed_runs == 5
+    assert overview.daily_completed_runs[yesterday.isoformat()] == 4
+    assert overview.daily_completed_runs[NOW.date().isoformat()] == 1
+    assert overview.last_updated == NOW
+    assert overview.availability["growth"].available is True
+
+
+def test_user_list_and_profile_are_display_safe(tmp_path):
+    analytics, events, _rollups, states, users = _fixture(tmp_path)
+    _event(
+        events,
+        "account_signed_up",
+        NOW - timedelta(days=20),
+        "account:account_signed_up:1",
+        source_record_type="user",
+        source_record_id="1",
+    )
+    success = _event(
+        events,
+        "backtest_completed",
+        NOW - timedelta(hours=1),
+        "run:backtest_completed:run-1",
+        correlation_id="run-1",
+        outcome="succeeded",
+    )
+    _event(
+        events,
+        "model_usage_recorded",
+        NOW - timedelta(minutes=50),
+        "resource:model_usage_recorded:run-1:0",
+        correlation_id="run-1",
+        provider_id="openrouter",
+        model_id="openai/gpt-5.5",
+        billing_mode="platform_credits",
+        outcome="succeeded",
+        properties={
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "cost_micro_usd": 250_000,
+        },
+    )
+    _event(
+        events,
+        "credits_settled",
+        NOW - timedelta(minutes=49),
+        "resource:credits_settled:reservation-1:grant",
+        source_record_type="credit_reservation",
+        source_record_id="reservation-1",
+        correlation_id="run-1",
+        billing_mode="platform_credits",
+        properties={"amount_micro": 100, "bucket": "grant"},
+    )
+    recalculate_user_snapshot(1, now=NOW, store=states)
+    service = AnalyticsQueryService(store=analytics, user_store=users)
+
+    listing = service.list_users(
+        filters=AnalyticsUserFilters(),
+        limit=25,
+        offset=0,
+        now=NOW,
+    )
+    profile = service.get_user_profile(user_id=1, now=NOW)
+    serialized = profile.model_dump(mode="json")
+
+    assert listing.total == 1
+    assert listing.items[0].user_id == 1
+    assert profile.state.status == "active"
+    assert success.event_id in profile.state.evidence_event_ids
+    assert profile.input_tokens == 120
+    assert profile.platform_model_cost_usd == 0.25
+    assert profile.credits_debited_micro == 100
+    assert "properties" not in str(serialized)
+    assert "session_id" not in str(serialized)
+
+
+def test_activity_sections_page_independently_and_hide_session_ids(tmp_path):
+    analytics, events, _rollups, _states, users = _fixture(tmp_path)
+    for index in range(3):
+        _event(
+            events,
+            "backtest_completed",
+            NOW - timedelta(minutes=index + 1),
+            f"run:backtest_completed:run-{index}",
+            source_record_id=f"run-{index}",
+            outcome="succeeded",
+        )
+    context = RequestAnalyticsContext(
+        country_code="US",
+        device_category="desktop",
+        browser_family="Chrome",
+    )
+    session_id = str(uuid4())
+    for index, name in enumerate(("page_viewed", "session_heartbeat")):
+        events.accept_frontend_event(
+            user={"id": 1},
+            payload=FrontendAnalyticsEvent(
+                event_id=str(uuid4()),
+                schema_version=1,
+                event_name=name,
+                session_id=session_id,
+                occurred_at=NOW - timedelta(minutes=10 - index),
+                page_view="agents",
+                properties=({} if name == "page_viewed" else {"visible_ms": 500}),
+            ),
+            context=context,
+            received_at=NOW,
+        )
+    service = AnalyticsQueryService(store=analytics, user_store=users)
+
+    first_runs = service.get_user_activity(
+        user_id=1,
+        section="runs",
+        limit=2,
+        cursor=None,
+    )
+    second_runs = service.get_user_activity(
+        user_id=1,
+        section="runs",
+        limit=2,
+        cursor=first_runs.next_cursor,
+    )
+    sessions = service.get_user_activity(
+        user_id=1,
+        section="sessions",
+        limit=2,
+        cursor=None,
+    )
+
+    assert len(first_runs.items) == 2
+    assert len(second_runs.items) == 1
+    assert first_runs.next_cursor is not None
+    assert sessions.items[0].session_event_count == 2
+    assert sessions.items[0].visible_ms == 500
+    assert "session_id" not in str(sessions.model_dump(mode="json"))
+
+
+def test_overview_marks_only_failed_rollup_panel_unavailable(tmp_path, monkeypatch):
+    analytics, events, _rollups, _states, users = _fixture(tmp_path)
+    _event(
+        events,
+        "backtest_completed",
+        NOW - timedelta(minutes=1),
+        "run:backtest_completed:current",
+        outcome="succeeded",
+    )
+    service = AnalyticsQueryService(store=analytics, user_store=users)
+    monkeypatch.setattr(
+        service.query_store.rollups,
+        "list_rollups",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("private detail")),
+    )
+
+    overview = service.get_overview(
+        now=NOW,
+        filters=AnalyticsMetricFilters(
+            start=NOW - timedelta(days=1),
+            end=NOW,
+        ),
+    )
+
+    assert overview.active_users_7d == 1
+    assert overview.completed_runs is None
+    assert overview.availability["snapshot"].available is True
+    assert overview.availability["growth"].available is False
+    assert overview.availability["growth"].error_code == "temporarily_unavailable"

--- a/dashboard/backend/tests/test_analytics_integration.py
+++ b/dashboard/backend/tests/test_analytics_integration.py
@@ -1,0 +1,166 @@
+"""Cross-domain Analytics lifecycle wiring with synthetic source records."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from dashboard.backend.api.routers import backtests as backtests_router
+from dashboard.backend.api.v2 import runs as v2_runs
+from dashboard.backend.domain.runs import service as run_service
+from dashboard.backend.domain.runs.repository import RunStore
+from dashboard.backend.tests._v2_fakes import FakeBackend
+
+
+def test_protocol_owned_run_emits_requested_and_started_after_create(
+    tmp_path,
+    monkeypatch,
+):
+    store = RunStore(tmp_path / "analytics-protocol.db")
+    events = []
+    monkeypatch.setattr(run_service, "run_store", store)
+    monkeypatch.setattr(
+        run_service,
+        "get_environment",
+        lambda _environment_id: {
+            "type": "backtest",
+            "universe": ["AAPL"],
+            "constraints": {},
+        },
+    )
+    monkeypatch.setattr(
+        run_service.ebs,
+        "start_backtest",
+        lambda **_kwargs: {"backtest_id": "bt-owned"},
+    )
+    monkeypatch.setattr(
+        run_service.analytics_instrumentation,
+        "emit_run_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    monkeypatch.setattr(
+        run_service,
+        "run_view",
+        lambda run_id: {"run_id": run_id, "status": "running"},
+    )
+
+    result = run_service.create_run(
+        agent={
+            "agent_id": "agent-owned",
+            "session_id": "session-owned",
+            "owner_user_id": 7,
+            "name": "Owned",
+            "model_name": "model",
+        },
+        agent_version={"agent_version_id": "version-1"},
+        environment_id="backtest",
+        config={
+            "start_date": "2026-08-01",
+            "end_date": "2026-08-02",
+            "symbols": ["AAPL"],
+        },
+    )
+
+    assert result["status"] == "running"
+    assert [event["event_name"] for event in events] == [
+        "backtest_requested",
+        "backtest_started",
+    ]
+    assert all(event["run_id"] == result["run_id"] for event in events)
+
+
+def test_v2_cancel_emits_cancelled_only_after_ledger_update(monkeypatch):
+    events = []
+    updates = []
+    backend = FakeBackend(
+        run_id="run-analytics-cancel",
+        total_steps=2,
+        session_id="session-owned",
+    )
+    v2_runs.register_run(
+        "run-analytics-cancel",
+        backend,
+        "session-owned",
+        "agent-owned",
+    )
+    monkeypatch.setattr(
+        v2_runs.run_repo,
+        "run_store",
+        SimpleNamespace(
+            update_run=lambda run_id, **kwargs: updates.append((run_id, kwargs))
+        ),
+    )
+    monkeypatch.setattr(
+        v2_runs.analytics_instrumentation,
+        "emit_run_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    result = v2_runs.cancel_run(
+        "run-analytics-cancel",
+        agent={"session_id": "session-owned", "owner_user_id": 7},
+    )
+
+    assert result["status"] == "closed"
+    assert updates[0][1]["status"] == "closed"
+    assert [event["event_name"] for event in events] == [
+        "backtest_cancelled"
+    ]
+
+
+def test_dashboard_finalizer_emits_terminal_event_for_authenticated_slot(
+    monkeypatch,
+):
+    events = []
+    monkeypatch.setattr(
+        backtests_router.analytics_instrumentation,
+        "emit_run_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    with backtests_router._backtest_slots_lock:
+        backtests_router._active_slots["dashboard-run"] = {
+            "live_run_id": "dashboard-run",
+            "user_id": 7,
+            "owner_session": "browser",
+            "session_id": "agent-session",
+            "running": True,
+            "error": None,
+            "runs_count": 0,
+            "started_at": 1.0,
+            "progress_file": None,
+        }
+
+    backtests_router._finalize_slot(
+        "dashboard-run",
+        error=None,
+        runs_count=1,
+    )
+
+    assert [event["event_name"] for event in events] == [
+        "backtest_completed"
+    ]
+    assert events[0]["user_id"] == 7
+
+
+def test_dashboard_guest_slot_does_not_invent_analytics_subject(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        backtests_router.analytics_instrumentation,
+        "emit_run_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    with backtests_router._backtest_slots_lock:
+        backtests_router._active_slots["guest-run"] = {
+            "live_run_id": "guest-run",
+            "user_id": None,
+            "owner_session": "browser",
+            "session_id": "browser",
+            "running": True,
+            "error": None,
+            "runs_count": 0,
+            "started_at": 1.0,
+            "progress_file": None,
+        }
+
+    backtests_router._finalize_slot("guest-run", error=None, runs_count=1)
+
+    assert events == []

--- a/dashboard/backend/tests/test_analytics_integration.py
+++ b/dashboard/backend/tests/test_analytics_integration.py
@@ -2,13 +2,35 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 
+from fastapi.testclient import TestClient
+
+from dashboard.backend import users as users_module
 from dashboard.backend.api.routers import backtests as backtests_router
 from dashboard.backend.api.v2 import runs as v2_runs
+from dashboard.backend.app import app
+from dashboard.backend.domain.analytics import instrumentation
+from dashboard.backend.domain.analytics.query_service import (
+    AnalyticsQueryService,
+    get_analytics_query_service,
+)
+from dashboard.backend.domain.analytics.repository import AnalyticsStore
+from dashboard.backend.domain.analytics.service import (
+    AnalyticsService,
+    get_analytics_service,
+)
+from dashboard.backend.domain.analytics.states import (
+    AnalyticsStateStore,
+    recalculate_user_snapshot,
+)
 from dashboard.backend.domain.runs import service as run_service
 from dashboard.backend.domain.runs.repository import RunStore
 from dashboard.backend.tests._v2_fakes import FakeBackend
+from dashboard.backend.users import UserStore
 
 
 def test_protocol_owned_run_emits_requested_and_started_after_create(
@@ -164,3 +186,157 @@ def test_dashboard_guest_slot_does_not_invent_analytics_subject(monkeypatch):
     backtests_router._finalize_slot("guest-run", error=None, runs_count=1)
 
     assert events == []
+
+
+def test_synthetic_acceptance_scenario_has_no_real_credentials(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "analytics-acceptance.db"
+        users = UserStore(path)
+        admin = users.create_user(
+            "admin@example.test",
+            "Analytics Admin",
+            "SecurePass1!",
+        )
+        users.apply_admin_patch(admin["id"], role="admin")
+        subject = users.create_user(
+            "subject@example.test",
+            "Synthetic Subject",
+            "SecurePass1!",
+        )
+        store = AnalyticsStore(path)
+        event_service = AnalyticsService(store)
+        query_service = AnalyticsQueryService(store=store, user_store=users)
+        state_store = AnalyticsStateStore(store)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        monkeypatch.setattr(users_module, "user_store", users)
+        monkeypatch.setattr(
+            instrumentation,
+            "get_analytics_service",
+            lambda: event_service,
+        )
+        monkeypatch.setattr(
+            instrumentation,
+            "_snapshot_recalculator",
+            lambda user_id: recalculate_user_snapshot(
+                user_id,
+                now=now,
+                store=state_store,
+            ),
+        )
+        app.dependency_overrides[get_analytics_query_service] = lambda: query_service
+        app.dependency_overrides[get_analytics_service] = lambda: event_service
+
+        instrumentation.emit_account_event(
+            event_name="account_signed_up",
+            user_id=subject["id"],
+            source_record_id=subject["id"],
+            occurred_at=now - timedelta(days=10),
+        )
+        instrumentation.emit_credential_event(
+            event_name="credential_saved",
+            user_id=subject["id"],
+            credential_id="synthetic-credential",
+            provider_id="openrouter",
+            occurred_at=now - timedelta(hours=3),
+        )
+        instrumentation.emit_credential_event(
+            event_name="credential_verified",
+            user_id=subject["id"],
+            credential_id="synthetic-credential",
+            provider_id="openrouter",
+            occurred_at=now - timedelta(hours=2, minutes=59),
+        )
+        instrumentation.emit_agent_event(
+            event_name="agent_created",
+            user_id=subject["id"],
+            agent_id="synthetic-agent",
+            occurred_at=now - timedelta(hours=2, minutes=50),
+        )
+        instrumentation.emit_run_event(
+            event_name="backtest_failed",
+            user_id=subject["id"],
+            run_id="synthetic-byok-run",
+            error_category="provider_timeout",
+            occurred_at=now - timedelta(hours=2),
+        )
+        instrumentation.emit_resource_event(
+            event_name="model_usage_recorded",
+            user_id=subject["id"],
+            source_record_type="run",
+            source_record_id="synthetic-byok-run",
+            correlation_id="synthetic-byok-run",
+            provider_id="openrouter",
+            model_id="openai/gpt-5.5",
+            billing_mode="byok",
+            outcome="failed",
+            properties={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cost_micro_usd": 0,
+            },
+            occurred_at=now - timedelta(hours=1, minutes=59),
+        )
+        instrumentation.emit_run_event(
+            event_name="backtest_completed",
+            user_id=subject["id"],
+            run_id="synthetic-platform-run",
+            occurred_at=now - timedelta(hours=1),
+        )
+        instrumentation.emit_resource_event(
+            event_name="model_usage_recorded",
+            user_id=subject["id"],
+            source_record_type="run",
+            source_record_id="synthetic-platform-run",
+            correlation_id="synthetic-platform-run",
+            provider_id="openrouter",
+            model_id="openai/gpt-5.5",
+            billing_mode="platform_credits",
+            outcome="succeeded",
+            properties={
+                "input_tokens": 200,
+                "output_tokens": 40,
+                "cost_micro_usd": 420_000,
+            },
+            occurred_at=now - timedelta(minutes=59),
+        )
+        instrumentation.emit_resource_event(
+            event_name="credits_settled",
+            user_id=subject["id"],
+            source_record_type="credit_reservation",
+            source_record_id="synthetic-reservation",
+            correlation_id="synthetic-platform-run",
+            billing_mode="platform_credits",
+            properties={"amount_micro": 420, "bucket": "grant"},
+            occurred_at=now - timedelta(minutes=58),
+        )
+
+        token = users.create_session(admin["id"])
+        headers = {"Authorization": f"Bearer {token}"}
+        try:
+            with TestClient(app) as client:
+                overview_response = client.get(
+                    "/api/admin/analytics/overview",
+                    headers=headers,
+                )
+                profile_response = client.get(
+                    f"/api/admin/analytics/users/{subject['id']}",
+                    headers=headers,
+                )
+        finally:
+            app.dependency_overrides.pop(get_analytics_query_service, None)
+            app.dependency_overrides.pop(get_analytics_service, None)
+
+        assert overview_response.status_code == 200, overview_response.text
+        assert profile_response.status_code == 200, profile_response.text
+        overview = overview_response.json()
+        profile = profile_response.json()
+        assert overview["platform_model_cost_usd"] == 0.42
+        assert profile["billing_lane_mix"] == {
+            "byok": 1,
+            "platform_credits": 1,
+        }
+        assert profile["credits_debited_micro"] == 420
+        assert profile["state"]["status"] == "active"
+        assert profile["state"]["evidence_event_ids"]
+        assert "api_key" not in str(profile)

--- a/dashboard/backend/tests/test_analytics_maintenance.py
+++ b/dashboard/backend/tests/test_analytics_maintenance.py
@@ -1,0 +1,75 @@
+"""Analytics maintenance is bounded, idempotent, and safe to register."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import dashboard.backend.domain.analytics.maintenance as maintenance
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def test_maintenance_rebuilds_one_day_and_bounds_snapshot_repairs():
+    maintenance.reset_maintenance_guard_for_tests()
+    rollup_calls = []
+    repair_limits = []
+    repair_results = iter([25, 0])
+
+    def rebuild(day, **kwargs):
+        rollup_calls.append((day, kwargs["now"]))
+
+    def repair(**kwargs):
+        repair_limits.append(kwargs["limit"])
+        return next(repair_results)
+
+    first = maintenance.run_analytics_maintenance(
+        now=NOW,
+        snapshot_limit=250,
+        rebuild_rollup=rebuild,
+        repair_snapshots=repair,
+    )
+    second = maintenance.run_analytics_maintenance(
+        now=NOW,
+        snapshot_limit=250,
+        rebuild_rollup=rebuild,
+        repair_snapshots=repair,
+    )
+
+    assert first.rollup_days == (date(2026, 8, 25),)
+    assert second.rollup_days == first.rollup_days
+    assert first.rollup_rebuilt is True
+    assert second.rollup_rebuilt is False
+    assert first.repaired_snapshots == 25
+    assert second.repaired_snapshots == 0
+    assert repair_limits == [100, 100]
+    assert len(rollup_calls) == 1
+
+
+def test_maintenance_isolates_rollup_and_snapshot_failures():
+    maintenance.reset_maintenance_guard_for_tests()
+
+    def fail_rollup(*_args, **_kwargs):
+        raise RuntimeError("private database detail")
+
+    def fail_repair(**_kwargs):
+        raise RuntimeError("private user detail")
+
+    report = maintenance.run_analytics_maintenance(
+        now=NOW,
+        rebuild_rollup=fail_rollup,
+        repair_snapshots=fail_repair,
+    )
+
+    assert report.rollup_rebuilt is False
+    assert report.repaired_snapshots == 0
+    assert report.failures == 2
+
+
+def test_app_registers_analytics_maintenance_through_reaper():
+    app_file = Path(__file__).resolve().parents[1] / "app.py"
+    source = app_file.read_text(encoding="utf-8")
+
+    assert "register_reaper_sweep(run_analytics_maintenance)" in source
+    assert "analytics.maintenance_registration_failed" in source

--- a/dashboard/backend/tests/test_app_composition.py
+++ b/dashboard/backend/tests/test_app_composition.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from fastapi.routing import APIRoute
 
 from dashboard.backend.api.routers import admin as admin_canon
+from dashboard.backend.api.routers import admin_analytics as admin_analytics_canon
+from dashboard.backend.api.routers import analytics as analytics_canon
 from dashboard.backend.api.routers import backtests as backtests_canon
 from dashboard.backend.api.routers import config as config_canon
 from dashboard.backend.api.routers import credits as credits_canon
@@ -60,6 +62,19 @@ EXPECTED_ADMIN_CREDITS_ROUTES = {
     ("POST", "/admin/credits/grants/assign", "assign_grant"),
     ("POST", "/admin/credits/grants/reclaim", "reclaim_grant"),
     ("GET", "/admin/credits/activity", "get_grant_activity"),
+}
+EXPECTED_ANALYTICS_ROUTES = {
+    ("POST", "/analytics/events", "ingest_analytics_event"),
+}
+EXPECTED_ADMIN_ANALYTICS_ROUTES = {
+    ("GET", "/admin/analytics/overview", "get_overview"),
+    ("GET", "/admin/analytics/users", "list_users"),
+    ("GET", "/admin/analytics/users/{user_id}", "get_user_profile"),
+    (
+        "GET",
+        "/admin/analytics/users/{user_id}/activity",
+        "get_user_activity",
+    ),
 }
 EXPECTED_BACKTESTS_ROUTES = {
     ("POST", "/backtest/run", "run_backtest_endpoint"),
@@ -120,6 +135,10 @@ EXPECTED_FULL_CONTRACT = {
     ("GET", "/api/admin/users"),
     ("GET", "/api/admin/users/{user_id}"),
     ("PATCH", "/api/admin/users/{user_id}"),
+    ("GET", "/api/admin/analytics/overview"),
+    ("GET", "/api/admin/analytics/users"),
+    ("GET", "/api/admin/analytics/users/{user_id}"),
+    ("GET", "/api/admin/analytics/users/{user_id}/activity"),
     ("POST", "/api/admin/bootstrap"),
     ("POST", "/api/algo/chat"),
     ("GET", "/api/algo/defaults"),
@@ -145,6 +164,7 @@ EXPECTED_FULL_CONTRACT = {
     ("GET", "/api/auth/robinhood/callback"),
     ("POST", "/api/auth/robinhood/complete"),
     ("POST", "/api/auth/robinhood/start"),
+    ("POST", "/api/analytics/events"),
     ("GET", "/api/backtest/compare/latest"),
     ("GET", "/api/backtest/runs"),
     ("GET", "/api/backtest/{run_id}"),
@@ -288,7 +308,15 @@ def _imported_modules(path: Path):
 # ---------------------------------------------------------------------------
 
 def test_canonical_router_modules_import():
-    for mod in (health_canon, market_canon, config_canon, admin_canon, backtests_canon):
+    for mod in (
+        health_canon,
+        market_canon,
+        config_canon,
+        admin_canon,
+        analytics_canon,
+        admin_analytics_canon,
+        backtests_canon,
+    ):
         assert mod.router.__class__.__name__ == "APIRouter"
 
 
@@ -310,6 +338,17 @@ def test_credits_router_contract():
 
 def test_admin_credits_router_contract():
     assert _route_triples(admin_credits_canon.router) == EXPECTED_ADMIN_CREDITS_ROUTES
+
+
+def test_analytics_router_contract():
+    assert _route_triples(analytics_canon.router) == EXPECTED_ANALYTICS_ROUTES
+
+
+def test_admin_analytics_router_contract():
+    assert (
+        _route_triples(admin_analytics_canon.router)
+        == EXPECTED_ADMIN_ANALYTICS_ROUTES
+    )
 
 
 def test_admin_router_contract():
@@ -343,6 +382,14 @@ def test_extracted_routes_registered_exactly_once():
     )
     for method, path, _name in extracted:
         assert counts.get((method, path)) == 1, (method, path, counts.get((method, path)))
+    api_extracted = EXPECTED_ANALYTICS_ROUTES | EXPECTED_ADMIN_ANALYTICS_ROUTES
+    for method, path, _name in api_extracted:
+        app_path = f"/api{path}"
+        assert counts.get((method, app_path)) == 1, (
+            method,
+            app_path,
+            counts.get((method, app_path)),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -462,7 +509,15 @@ def test_cors_preflight_allows_every_routed_method():
 # ---------------------------------------------------------------------------
 
 def test_canonical_routers_do_not_import_scripts():
-    for mod in (health_canon, market_canon, config_canon, admin_canon, backtests_canon):
+    for mod in (
+        health_canon,
+        market_canon,
+        config_canon,
+        admin_canon,
+        analytics_canon,
+        admin_analytics_canon,
+        backtests_canon,
+    ):
         modules = _imported_modules(Path(mod.__file__))
         for m in modules:
             assert not m.startswith("dashboard.scripts"), (mod.__name__, m)

--- a/dashboard/backend/tests/test_auth.py
+++ b/dashboard/backend/tests/test_auth.py
@@ -92,6 +92,39 @@ def test_signup_login_me_logout_flow(client):
     assert me_after.status_code == 401
 
 
+def test_signup_and_login_emit_authoritative_account_events(client, monkeypatch):
+    from dashboard.backend.domain.analytics import instrumentation
+
+    events = []
+    monkeypatch.setattr(
+        instrumentation,
+        "emit_account_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    signup = client.post(
+        "/api/auth/signup",
+        json={
+            "email": "analytics@example.com",
+            "display_name": "Analytics",
+            "password": "securepass1",
+        },
+    )
+    login = client.post(
+        "/api/auth/login",
+        json={"email": "analytics@example.com", "password": "securepass1"},
+    )
+
+    assert signup.status_code == 200
+    assert login.status_code == 200
+    assert [event["event_name"] for event in events] == [
+        "account_signed_up",
+        "authenticated_session_started",
+    ]
+    assert all(event["user_id"] == signup.json()["user"]["id"] for event in events)
+    assert "password" not in repr(events)
+
+
 def test_me_requires_auth(client):
     response = client.get("/api/auth/me")
     assert response.status_code == 401

--- a/dashboard/backend/tests/test_store_twin_parity.py
+++ b/dashboard/backend/tests/test_store_twin_parity.py
@@ -48,6 +48,12 @@ import pytest
 # (sqlite module, sqlite class, postgres module, postgres class)
 _TWINS = [
     (
+        "dashboard.backend.domain.analytics.repository",
+        "AnalyticsStore",
+        "dashboard.backend.domain.analytics.repository_postgres",
+        "PostgresAnalyticsStore",
+    ),
+    (
         "dashboard.backend.domain.model_providers.repository",
         "ModelProviderStore",
         "dashboard.backend.domain.model_providers.repository_postgres",

--- a/dashboard/scripts/backfill_analytics.py
+++ b/dashboard/scripts/backfill_analytics.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Reconstruct up to 180 days of authoritative Analytics events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+
+from _bootstrap import ensure_repo_root
+
+
+def _before(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "--before must be an ISO-8601 timestamp with a timezone"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise argparse.ArgumentTypeError(
+            "--before must be an ISO-8601 timestamp with a timezone"
+        )
+    return parsed.astimezone(timezone.utc)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Backfill safe server-authoritative Analytics history.",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=180,
+        help="History window in days (1-180; default: 180).",
+    )
+    parser.add_argument(
+        "--before",
+        type=_before,
+        help="Inclusive ISO-8601 cutoff with timezone (default: now).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and count without writing events, snapshots, or rollups.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    ensure_repo_root()
+    from dashboard.backend.domain.analytics.backfill import backfill_analytics
+
+    try:
+        report = backfill_analytics(
+            days=args.days,
+            before=args.before,
+            dry_run=args.dry_run,
+        )
+    except ValueError as exc:
+        _parser().error(str(exc))
+    safe_counts = report.model_dump(exclude={"source_event_ids"})
+    print(json.dumps(safe_counts, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/scripts/benchmark_analytics_queries.py
+++ b/dashboard/scripts/benchmark_analytics_queries.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Benchmark Admin Analytics queries on deterministic disposable SQLite data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sqlite3
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, time as datetime_time, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _bootstrap import ensure_repo_root
+
+
+BENCHMARK_NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+OVERVIEW_P95_LIMIT_SECONDS = 1.0
+PROFILE_P95_LIMIT_SECONDS = 0.5
+
+
+def _bounded_integer(name: str, minimum: int, maximum: int):
+    def parse(value: str) -> int:
+        try:
+            parsed = int(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"{name} must be an integer") from exc
+        if not minimum <= parsed <= maximum:
+            raise argparse.ArgumentTypeError(
+                f"{name} must be from {minimum} through {maximum}"
+            )
+        return parsed
+
+    return parse
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark Admin Analytics overview and initial profile queries "
+            "using deterministic disposable SQLite data."
+        ),
+    )
+    parser.add_argument(
+        "--users",
+        type=_bounded_integer("--users", 1, 100_000),
+        default=10_000,
+    )
+    parser.add_argument(
+        "--events-per-user",
+        type=_bounded_integer("--events-per-user", 1, 1_000),
+        default=40,
+    )
+    parser.add_argument(
+        "--days",
+        type=_bounded_integer("--days", 1, 180),
+        default=180,
+    )
+    parser.add_argument(
+        "--iterations",
+        type=_bounded_integer("--iterations", 1, 100),
+        default=20,
+    )
+    return parser
+
+
+def _event_id(sequence: int) -> str:
+    return f"10000000-0000-4000-8000-{sequence:012x}"
+
+
+def _session_id(user_id: int) -> str:
+    return f"20000000-0000-4000-8000-{user_id:012x}"
+
+
+def _event_shape(index: int) -> tuple[str, str]:
+    return (
+        ("page_viewed", "experience"),
+        ("backtest_completed", "run"),
+        ("backtest_failed", "run"),
+        ("model_usage_recorded", "resource"),
+        ("credits_settled", "resource"),
+        ("credential_verified", "credential"),
+        ("agent_created", "agent"),
+        ("backtest_started", "run"),
+    )[index % 8]
+
+
+def _source_record_type(group: str) -> str:
+    return {
+        "run": "run",
+        "resource": "run",
+        "credential": "credential",
+        "agent": "agent",
+    }[group]
+
+
+def _seed(path: Path, *, users: int, events_per_user: int, days: int) -> None:
+    from dashboard.backend.domain.analytics.repository import (
+        AnalyticsStore,
+        _EVENT_COLUMNS,
+    )
+    from dashboard.backend.users import UserStore
+
+    UserStore(path)
+    AnalyticsStore(path)
+    now_iso = BENCHMARK_NOW.isoformat()
+    day_users: dict[str, set[int]] = defaultdict(set)
+    completed_by_day: Counter[str] = Counter()
+    failed_by_day: Counter[str] = Counter()
+    platform_cost_by_day: Counter[str] = Counter()
+    input_tokens_by_day: Counter[str] = Counter()
+    output_tokens_by_day: Counter[str] = Counter()
+
+    with sqlite3.connect(path) as conn:
+        conn.execute("PRAGMA journal_mode = MEMORY")
+        conn.execute("PRAGMA synchronous = OFF")
+        conn.executemany(
+            """
+            INSERT INTO users (
+                id, email, display_name, password_hash, role, created_at
+            ) VALUES (?, ?, ?, 'benchmark-only', 'user', ?)
+            """,
+            (
+                (
+                    user_id,
+                    f"user-{user_id:05d}@example.test",
+                    f"Benchmark User {user_id:05d}",
+                    (BENCHMARK_NOW - timedelta(days=user_id % days)).isoformat(),
+                )
+                for user_id in range(1, users + 1)
+            ),
+        )
+        conn.executemany(
+            """
+            INSERT INTO user_analytics_snapshots (
+                user_id, status, reason_code, human_readable_reason,
+                evidence_event_ids_json, calculated_at
+            ) VALUES (?, ?, ?, ?, '[]', ?)
+            """,
+            (
+                (
+                    user_id,
+                    "needs_attention" if user_id % 20 == 0 else "active",
+                    (
+                        "invalid_default_credential"
+                        if user_id % 20 == 0
+                        else "recent_successful_run_and_activity"
+                    ),
+                    (
+                        "The default model credential is invalid."
+                        if user_id % 20 == 0
+                        else "A successful run and recent meaningful activity are present."
+                    ),
+                    now_iso,
+                )
+                for user_id in range(1, users + 1)
+            ),
+        )
+
+        placeholders = ", ".join("?" for _ in _EVENT_COLUMNS)
+        insert_event = (
+            f"INSERT INTO analytics_events ({', '.join(_EVENT_COLUMNS)}) "
+            f"VALUES ({placeholders})"
+        )
+        batch: list[tuple[object, ...]] = []
+        sequence = 0
+        for user_id in range(1, users + 1):
+            for index in range(events_per_user):
+                sequence += 1
+                event_name, event_group = _event_shape(index)
+                day_offset = (user_id * 17 + index * 29) % days
+                day = BENCHMARK_NOW.date() - timedelta(days=day_offset)
+                seconds = (user_id * 131 + index * 977) % (12 * 60 * 60)
+                occurred_at = datetime.combine(
+                    day,
+                    datetime_time.min,
+                    tzinfo=timezone.utc,
+                ) + timedelta(seconds=seconds)
+                day_key = day.isoformat()
+                day_users[day_key].add(user_id)
+
+                is_frontend = event_group == "experience"
+                source_record_id = f"{user_id}-{index}"
+                source_event_id = (
+                    None
+                    if is_frontend
+                    else f"benchmark:{event_name}:{source_record_id}"
+                )
+                record_type = (
+                    None if is_frontend else _source_record_type(event_group)
+                )
+                correlation_id = (
+                    f"benchmark-run-{user_id}-{index // 8}"
+                    if event_group in {"run", "resource"}
+                    else None
+                )
+                provider_id = None
+                model_id = None
+                billing_mode = None
+                outcome = None
+                error_category = None
+                properties = "{}"
+                if event_name == "backtest_completed":
+                    outcome = "succeeded"
+                    completed_by_day[day_key] += 1
+                elif event_name == "backtest_failed":
+                    outcome = "failed"
+                    error_category = "provider_timeout"
+                    failed_by_day[day_key] += 1
+                elif event_name == "model_usage_recorded":
+                    provider_id = "openrouter"
+                    model_id = "openai/gpt-5.5"
+                    billing_mode = "platform_credits"
+                    outcome = "succeeded"
+                    input_tokens = 100 + index
+                    output_tokens = 25 + index
+                    cost_micro = 1_000 + index
+                    input_tokens_by_day[day_key] += input_tokens
+                    output_tokens_by_day[day_key] += output_tokens
+                    platform_cost_by_day[day_key] += cost_micro
+                    properties = json.dumps(
+                        {
+                            "cost_micro_usd": cost_micro,
+                            "input_tokens": input_tokens,
+                            "output_tokens": output_tokens,
+                        },
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                elif event_name == "credits_settled":
+                    billing_mode = "platform_credits"
+                    properties = '{"amount_micro":100,"bucket":"grant"}'
+                elif event_name == "credential_verified":
+                    provider_id = "openrouter"
+
+                batch.append(
+                    (
+                        _event_id(sequence),
+                        1,
+                        event_name,
+                        event_group,
+                        user_id,
+                        _session_id(user_id) if is_frontend else None,
+                        occurred_at.isoformat(),
+                        (occurred_at + timedelta(seconds=1)).isoformat(),
+                        "frontend" if is_frontend else "server",
+                        source_event_id,
+                        record_type,
+                        source_record_id if not is_frontend else None,
+                        correlation_id,
+                        "agents" if is_frontend else None,
+                        provider_id,
+                        model_id,
+                        billing_mode,
+                        outcome,
+                        error_category,
+                        "US" if is_frontend else None,
+                        "desktop" if is_frontend else None,
+                        "Chrome" if is_frontend else None,
+                        None,
+                        properties,
+                    )
+                )
+                if len(batch) == 5_000:
+                    conn.executemany(insert_event, batch)
+                    batch.clear()
+        if batch:
+            conn.executemany(insert_event, batch)
+
+        rollup_rows: list[tuple[object, ...]] = []
+        for day_key in sorted(day_users):
+            dimensions = ("", "", "", "", "", "")
+            rollup_rows.extend(
+                [
+                    (
+                        day_key,
+                        "daily_active_users",
+                        *dimensions,
+                        "",
+                        len(day_users[day_key]),
+                        0,
+                        now_iso,
+                    ),
+                    (
+                        day_key,
+                        "terminal_completed",
+                        *dimensions,
+                        "",
+                        completed_by_day[day_key],
+                        0,
+                        now_iso,
+                    ),
+                    (
+                        day_key,
+                        "terminal_failed",
+                        *dimensions,
+                        "",
+                        failed_by_day[day_key],
+                        0,
+                        now_iso,
+                    ),
+                    (
+                        day_key,
+                        "input_tokens",
+                        *dimensions,
+                        "",
+                        input_tokens_by_day[day_key],
+                        0,
+                        now_iso,
+                    ),
+                    (
+                        day_key,
+                        "output_tokens",
+                        *dimensions,
+                        "",
+                        output_tokens_by_day[day_key],
+                        0,
+                        now_iso,
+                    ),
+                    (
+                        day_key,
+                        "platform_model_cost_usd",
+                        "",
+                        "platform_credits",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        0,
+                        platform_cost_by_day[day_key],
+                        now_iso,
+                    ),
+                ]
+            )
+        conn.executemany(
+            """
+            INSERT INTO analytics_daily_rollups (
+                rollup_date, metric_name, event_name, billing_mode,
+                provider_id, model_id, outcome, error_category, user_state,
+                value_count, value_sum_micro, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rollup_rows,
+        )
+
+
+def _percentile(samples: list[float], quantile: float) -> float:
+    ordered = sorted(samples)
+    index = max(0, math.ceil(len(ordered) * quantile) - 1)
+    return ordered[index]
+
+
+def _measure(callback, iterations: int) -> list[float]:
+    samples = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        callback()
+        samples.append(time.perf_counter() - started)
+    return samples
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    ensure_repo_root()
+    with TemporaryDirectory(prefix="analytics-query-benchmark-") as tmpdir:
+        path = Path(tmpdir) / "analytics-benchmark.db"
+        env_names = (
+            "DATABASE_PATH",
+            "USERS_DATABASE_URL",
+            "CONTENT_DATABASE_URL",
+            "AGENT_RUNS_DATABASE_URL",
+        )
+        previous_env = {name: os.environ.get(name) for name in env_names}
+        os.environ["DATABASE_PATH"] = str(path)
+        for name in env_names[1:]:
+            os.environ.pop(name, None)
+        try:
+            from dashboard.backend.domain.analytics.metrics import (
+                AnalyticsMetricFilters,
+            )
+            from dashboard.backend.domain.analytics.query_service import (
+                AnalyticsQueryService,
+            )
+            from dashboard.backend.domain.analytics.repository import AnalyticsStore
+            from dashboard.backend.users import UserStore
+
+            seed_started = time.perf_counter()
+            _seed(
+                path,
+                users=args.users,
+                events_per_user=args.events_per_user,
+                days=args.days,
+            )
+            seed_seconds = time.perf_counter() - seed_started
+            service = AnalyticsQueryService(
+                store=AnalyticsStore(path),
+                user_store=UserStore(path),
+            )
+            filters = AnalyticsMetricFilters(
+                start=BENCHMARK_NOW - timedelta(days=min(args.days, 30)),
+                end=BENCHMARK_NOW + timedelta(seconds=1),
+            )
+            profile_user_id = max(1, args.users // 2)
+
+            service.get_overview(filters=filters, now=BENCHMARK_NOW)
+            service.get_user_profile(user_id=profile_user_id, now=BENCHMARK_NOW)
+            overview_samples = _measure(
+                lambda: service.get_overview(
+                    filters=filters,
+                    now=BENCHMARK_NOW,
+                ),
+                args.iterations,
+            )
+            profile_samples = _measure(
+                lambda: service.get_user_profile(
+                    user_id=profile_user_id,
+                    now=BENCHMARK_NOW,
+                ),
+                args.iterations,
+            )
+        finally:
+            for name, value in previous_env.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+    overview_p50 = _percentile(overview_samples, 0.50)
+    overview_p95 = _percentile(overview_samples, 0.95)
+    profile_p50 = _percentile(profile_samples, 0.50)
+    profile_p95 = _percentile(profile_samples, 0.95)
+    passed = (
+        overview_p95 <= OVERVIEW_P95_LIMIT_SECONDS
+        and profile_p95 <= PROFILE_P95_LIMIT_SECONDS
+    )
+    print(
+        json.dumps(
+            {
+                "days": args.days,
+                "events": args.users * args.events_per_user,
+                "events_per_user": args.events_per_user,
+                "iterations": args.iterations,
+                "overview": {
+                    "p50_seconds": round(overview_p50, 6),
+                    "p95_seconds": round(overview_p95, 6),
+                    "target_p95_seconds": OVERVIEW_P95_LIMIT_SECONDS,
+                },
+                "passed": passed,
+                "profile": {
+                    "p50_seconds": round(profile_p50, 6),
+                    "p95_seconds": round(profile_p95, 6),
+                    "target_p95_seconds": PROFILE_P95_LIMIT_SECONDS,
+                },
+                "seed_seconds": round(seed_seconds, 3),
+                "users": args.users,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/superpowers/plans/2026-08-26-admin-user-analytics-metrics.md
+++ b/docs/superpowers/plans/2026-08-26-admin-user-analytics-metrics.md
@@ -1,0 +1,975 @@
+# Admin Footprint and User Analytics — PR 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add server-authoritative instrumentation, metric computation, daily rollups, explainable user-state snapshots, an idempotent 180-day authoritative backfill, and read-only Admin Analytics query APIs without shipping the Admin Analytics UI.
+
+**Architecture:** PR 2 consumes the SQLite/PostgreSQL event repository, validation, authenticated ingestion, subject-exclusion, access-log, and retention contracts delivered by PR 1. A small domain instrumentation facade emits allowlisted events after source commits and never changes the source operation's result. Metrics and state calculation read authoritative source tables plus analytics events, write bounded daily rollups and current snapshots, and expose a query service that merges completed-day rollups with the current day's raw events. The API router is an Admin-gated adapter only; it does not contain metric or lifecycle logic.
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic 2, SQLite, psycopg 3 PostgreSQL twin repositories, pytest, existing `dashboard.backend` domain/API layering, UTC-aware `datetime`, and deterministic HMAC/error-category helpers from PR 1.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-admin-user-analytics-design.md`
+
+## Global Constraints
+
+- PR 2 scope is limited to Account, Credential, Agent, Run, Resource instrumentation; metric calculations; daily rollups; five explainable user states; authoritative backfill; and Admin query services/APIs. Do not implement the Admin Analytics tab or User Analytics Profile UI; those belong to PR 3.
+- Server-authoritative events are emitted only after the source operation reaches its authoritative committed outcome. Analytics append failures must never fail login, credential operations, Agent mutations, backtests, model execution, or Credits settlement.
+- Raw user-level event detail is retained for exactly 180 days through the PR 1 retention contract. Daily non-identifying rollups remain available long term. Admin profile-access audit records remain under the PR 1 365-day policy.
+- Analytics must never persist, return, or log full API keys/tokens, passwords/codes, prompts, strategy or portfolio text, raw provider response bodies, full IP addresses, raw User-Agent headers, or encrypted credential ciphertext.
+- The request identity is the authenticated `user_id` supplied by the server. Network data may use only PR 1's monthly HMAC pseudonymization and allowlisted browser/device reduction; missing or invalid `ANALYTICS_PSEUDONYMIZATION_KEY` omits `network_hash` and never stores plaintext.
+- SQLite and PostgreSQL implementations expose the same repository contract and produce equivalent event, rollup, snapshot, cursor, and API behavior.
+- Default metrics exclude Admin accounts and `analytics_excluded` subjects. `include_internal=true` is an explicit Admin-only diagnostic override.
+- Active users use meaningful accepted page visits or server-authoritative business events; token refresh, background polling, and unattended heartbeat traffic are excluded.
+- First-success conversion uses only mature signup cohorts whose seven-day observation window has elapsed. Backtest success rate is `completed / (completed + failed)` and excludes user-cancelled, queued, and running runs. Repeat run rate requires a second success at least 24 hours and at most 30 days after the first success. Platform model cost sums actual `platform_credits` evidence only; BYOK never contributes to ATL cost or ATL Credits debits.
+- User-state precedence is exactly `Blocked`, `Needs Attention`, `Dormant`, `Onboarding`, `Active`; each snapshot stores `status`, `reason_code`, `human_readable_reason`, `evidence_event_ids`, and `calculated_at`.
+- All `/api/admin/analytics/*` routes use the centralized `require_admin` dependency. Profile reads append an Admin analytics access record without storing response bodies.
+- Raw accepted events must be queryable within one minute. Completed historical days read primarily from `analytics_daily_rollups`; the current incomplete UTC day reads raw events and is merged by `AnalyticsQueryService`.
+- Backfill is deterministic and idempotent, uses `event_source='backfill'`, never fabricates page views/sessions/device/region/network data, and uses stable source-event IDs for every reconstructed record.
+- No real API keys, database URLs, `.superpowers/`, or `work/` paths may appear in tests, logs, plan commits, or API responses.
+
+## PR 1 Dependency Contract
+
+PR 2 must start only after PR 1 is merged or its equivalent foundation is present. The following names and signatures are the contract PR 2 consumes. If the merged PR 1 uses different internal names, stop implementation and ask the PR 1 owner to publish equivalent aliases in a separate PR 1 change; this PR 2 branch must not modify or reimplement the foundation tables, ingestion validation, retention, pseudonymization, subject settings, or access-log schema.
+
+```python
+# dashboard/backend/domain/analytics/models.py
+class AnalyticsEvent(BaseModel):
+    event_id: str
+    schema_version: int
+    event_name: str
+    event_group: Literal["account", "credential", "agent", "run", "resource", "experience"]
+    user_id: int
+    session_id: str | None
+    occurred_at: datetime
+    received_at: datetime
+    event_source: Literal["server", "frontend", "backfill"]
+    source_event_id: str | None
+    source_record_type: str | None
+    source_record_id: str | None
+    correlation_id: str | None
+    page_view: str | None
+    provider_id: str | None
+    model_id: str | None
+    billing_mode: str | None
+    outcome: str | None
+    error_category: str | None
+    country_code: str | None
+    device_category: str | None
+    browser_family: str | None
+    network_hash: str | None
+    properties_json: str
+
+
+# dashboard/backend/domain/analytics/repository.py and repository_postgres.py
+class AnalyticsRepository(Protocol):
+    def append_event(self, event: AnalyticsEvent) -> bool: ...
+    def list_events(self, filters: AnalyticsEventFilters, *, limit: int, cursor: str | None) -> Page[AnalyticsEvent]: ...
+    def upsert_daily_rollup(self, key: DailyRollupKey, values: DailyRollupValues) -> None: ...
+    def list_daily_rollups(self, filters: RollupFilters) -> list[DailyRollup]: ...
+    def get_user_snapshot(self, user_id: int) -> UserAnalyticsSnapshot | None: ...
+    def upsert_user_snapshot(self, snapshot: UserAnalyticsSnapshot) -> None: ...
+    def list_stale_snapshot_user_ids(self, before: datetime, *, limit: int) -> list[int]: ...
+    def record_admin_access(self, *, admin_user_id: int, subject_user_id: int, section: str, accessed_at: datetime) -> None: ...
+    def list_subject_settings(self) -> dict[int, SubjectSettings]: ...
+
+
+# dashboard/backend/domain/analytics/service.py
+def append_event_best_effort(event: AnalyticsEvent) -> bool: ...
+def record_admin_profile_access(*, admin_user_id: int, subject_user_id: int, section: str) -> None: ...
+
+
+# dashboard/backend/domain/analytics/privacy.py
+def classify_safe_error(exc: BaseException) -> str: ...
+def build_network_hash(*, client_ip: str | None, occurred_at: datetime) -> str | None: ...
+def reduce_user_agent(raw_user_agent: str | None) -> tuple[str | None, str | None]: ...
+```
+
+The PR 1 repository must expose the same methods through its SQLite and PostgreSQL factories. `append_event` returns `False` for a duplicate `source_event_id`/event identity and `True` for a newly stored event; callers must treat both as successful observation outcomes. `append_event_best_effort` returns `True` for inserted or already-present events and `False` only when observation failed, while swallowing storage exceptions after emitting a safe operational warning.
+
+## File Map
+
+| File | Responsibility in PR 2 |
+| --- | --- |
+| `dashboard/backend/domain/analytics/instrumentation.py` | Event names, server-event builders, correlation/source-ID rules, and best-effort lifecycle emitters. |
+| `dashboard/backend/domain/analytics/metrics.py` | Deterministic UTC metric formulas and filter normalization. |
+| `dashboard/backend/domain/analytics/rollups.py` | Bounded daily aggregation and raw/current-day merge helpers. |
+| `dashboard/backend/domain/analytics/states.py` | Five-state precedence, reason codes, evidence selection, and snapshot repair. |
+| `dashboard/backend/domain/analytics/backfill.py` | Deterministic 180-day reconstruction from authoritative stores. |
+| `dashboard/backend/domain/analytics/query_service.py` | Overview, user list, profile header, and independently pageable activity queries. |
+| `dashboard/backend/domain/analytics/maintenance.py` | Idempotent rollup and stale-snapshot repair pass registered from the composition root. |
+| `dashboard/backend/api/routers/admin_analytics.py` | Admin-only query endpoints and safe response models. |
+| `dashboard/backend/api/router.py` | Register the PR 2 Admin Analytics router exactly once. |
+| `dashboard/backend/app.py` | Register the analytics maintenance sweep from the existing reaper composition hook; no route bodies. |
+| `dashboard/backend/api/auth.py` | Emit signup and authenticated session-start events after successful source writes. |
+| `dashboard/backend/domain/model_providers/service.py` | Emit user credential lifecycle events after credential store commits. |
+| `dashboard/backend/domain/agents/service.py` | Emit Agent create/update/delete events after repository commits. |
+| `dashboard/backend/domain/runs/service.py` | Emit protocol run requested/queued/started/completed/failed/cancelled events after persisted transitions. |
+| `dashboard/backend/domain/backtesting/external_run_service.py` | Emit legacy `/api/v1/backtest/*` lifecycle events after its authoritative run persistence. |
+| `dashboard/backend/api/v2/runs.py` | Emit typed v2 run lifecycle and cancellation events after its direct `RunStore` writes. |
+| `dashboard/backend/api/routers/backtests.py` | Emit dashboard backtest lifecycle events at accepted, terminal, and cancellation outcomes. |
+| `dashboard/backend/infrastructure/llm/execution/service.py` | Emit model usage and safe execution-error events after usage/billing evidence is authoritative. |
+| `dashboard/backend/domain/credits/service.py` | Emit Credits reserved/settled/refunded events after ledger/reservation commits. |
+| `dashboard/scripts/backfill_analytics.py` | Operator-invoked backfill CLI using the domain backfill service; no secrets in arguments or output. |
+| `dashboard/backend/tests/domain/analytics/test_instrumentation.py` | Event contract, idempotency, and failure-isolation tests. |
+| `dashboard/backend/tests/domain/analytics/test_metrics.py` | UTC-boundary formulas and exclusion tests. |
+| `dashboard/backend/tests/domain/analytics/test_rollups.py` | Daily rollup dimensions, merge behavior, and idempotency. |
+| `dashboard/backend/tests/domain/analytics/test_states.py` | State precedence and deterministic evidence tests. |
+| `dashboard/backend/tests/domain/analytics/test_backfill.py` | 180-day cutoff, deterministic IDs, and replay tests. |
+| `dashboard/backend/tests/domain/analytics/test_repository_contract.py` | PR 1 repository consumption and SQLite/PostgreSQL parity contract. |
+| `dashboard/backend/tests/test_admin_analytics_api.py` | Admin authorization, filters, cursors, profile access logging, and safe responses. |
+| `dashboard/backend/tests/test_analytics_integration.py` | End-to-end synthetic lifecycle and source-operation failure isolation. |
+| `dashboard/backend/tests/test_analytics_maintenance.py` | Maintenance registration and bounded repair behavior. |
+| `dashboard/scripts/benchmark_analytics_queries.py` | Disposable synthetic overview/profile response-time verification. |
+
+### Task 1: Build the PR 2 instrumentation facade
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/instrumentation.py`
+- Test: `dashboard/backend/tests/domain/analytics/test_instrumentation.py`
+
+**Interfaces:**
+- Consumes: PR 1 `AnalyticsEvent`, `append_event_best_effort`, `classify_safe_error`, and the repository's allowlist validation.
+- Produces: `emit_account_event`, `emit_credential_event`, `emit_agent_event`, `emit_run_event`, `emit_resource_event`, and `emit_safe_error_event`, each returning `None` and swallowing append failures after writing a safe operational warning.
+
+- [ ] **Step 1: Write failing tests for event construction and isolation**
+
+```python
+def test_server_event_contains_no_sensitive_properties(monkeypatch):
+    captured = []
+    monkeypatch.setattr(instrumentation, "append_event_best_effort", lambda event: captured.append(event) or True)
+
+    emit_credential_event(
+        name="credential_saved",
+        user_id=7,
+        credential_id="cred-1",
+        provider_id="openrouter",
+        key_last_four="1234",
+    )
+
+    event = captured[0]
+    assert event.event_group == "credential"
+    assert event.source_event_id == "credential:credential_saved:cred-1"
+    assert event.properties_json == '{"key_last_four":"1234"}'
+    assert "api_key" not in event.properties_json
+
+
+def test_append_failure_does_not_escape(monkeypatch, capsys):
+    def fail(_event):
+        raise RuntimeError("database contains a secret-looking detail")
+
+    monkeypatch.setattr(instrumentation, "append_event_best_effort", fail)
+    emit_run_event(name="run_requested", user_id=7, run_id="run-1")
+    assert "database contains" not in capsys.readouterr().out
+
+
+def test_safe_error_event_uses_stable_category(monkeypatch):
+    captured = []
+    monkeypatch.setattr(instrumentation, "append_event_best_effort", lambda event: captured.append(event) or True)
+    emit_safe_error_event(user_id=7, source_record_type="run", source_record_id="run-1", exc=TimeoutError())
+    assert captured[0].error_category == "provider_timeout"
+    assert captured[0].properties_json == "{}"
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_instrumentation.py -q`
+
+Expected: FAIL because `dashboard.backend.domain.analytics.instrumentation` and its emitters do not exist.
+
+- [ ] **Step 3: Implement the minimal facade**
+
+```python
+def emit_run_event(*, name: str, user_id: int, run_id: str, status: str | None = None, correlation_id: str | None = None) -> None:
+    event = _server_event(
+        name=name,
+        group="run",
+        user_id=user_id,
+        source_record_type="run",
+        source_record_id=run_id,
+        source_event_id=f"run:{name}:{run_id}",
+        correlation_id=correlation_id or run_id,
+        outcome=status,
+    )
+    _append_after_commit(event)
+
+
+def _append_after_commit(event: AnalyticsEvent) -> None:
+    try:
+        observed = append_event_best_effort(event)
+    except Exception as exc:  # noqa: BLE001 - analytics is observational
+        print(f"WARNING: analytics append failed category={classify_safe_error(exc)}", flush=True)
+        return
+    if not observed:
+        print("WARNING: analytics append failed category=internal_error", flush=True)
+```
+
+Use fixed event-name/group maps and reject names not in the PR 2 allowlist before constructing an event. Build properties only from explicit keyword arguments; never serialize arbitrary source records, exception messages, prompts, credential ciphertext, or request headers.
+
+Use canonical source-event IDs shared by live instrumentation and backfill. Immutable outcomes use `{group}:{event_name}:{source_record_id}`. Repeatable mutations append an authoritative version: Agent/credential `updated_at`, Credits `operation_id`/reservation ID, or run call index. For example: `agent:agent_updated:a-1:2026-08-26T10:00:00+00:00`, `credential:credential_reverified:cred-1:2026-08-26T10:05:00+00:00`, and `resource:model_usage_recorded:run-1:3`. Never derive an ID from raw request JSON, prompt text, credential material, IP address, or User-Agent. Events without a stable non-secret source version set `source_event_id=None` rather than collapsing distinct operations.
+
+Source modules must import the module (`from dashboard.backend.domain.analytics import instrumentation as analytics_instrumentation`) and call `analytics_instrumentation.emit_*`. Do not bind emitters with direct function imports; module calls keep failure-isolation tests and runtime dependency replacement reliable.
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_instrumentation.py -q`
+
+Expected: PASS with event source IDs stable across repeated calls and append failures isolated.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/domain/analytics/instrumentation.py dashboard/backend/tests/domain/analytics/test_instrumentation.py
+git commit -m "feat: add analytics server instrumentation facade"
+```
+
+### Task 2: Instrument Account, Credential, and Agent outcomes
+
+**Files:**
+- Modify: `dashboard/backend/api/auth.py:388-575`
+- Modify: `dashboard/backend/domain/model_providers/service.py:662-770`
+- Modify: `dashboard/backend/domain/agents/service.py:301-735`
+- Test: `dashboard/backend/tests/domain/analytics/test_instrumentation.py`
+- Test: `dashboard/backend/tests/test_analytics_integration.py`
+
+**Interfaces:**
+- Consumes: Task 1 emitters; existing `user_store`, model-provider store, and Agent repository commit results.
+- Produces: exactly one post-commit event per authoritative signup, authenticated session start, credential lifecycle transition, and Agent lifecycle mutation. Failed source operations emit only a safe error event when a stable user/record identity exists; they do not emit a success event.
+
+- [ ] **Step 1: Pin failing source-operation tests**
+
+```python
+def test_signup_and_login_emit_account_events(client, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_account_event", lambda **kwargs: events.append(kwargs))
+    signup = client.post("/api/auth/signup", json={"email": "u@example.com", "display_name": "U", "password": "SecurePass1!"})
+    assert signup.status_code == 200
+    login = client.post("/api/auth/login", json={"email": "u@example.com", "password": "SecurePass1!"})
+    assert login.status_code == 200
+    assert [event["name"] for event in events] == ["account_signed_up", "session_started"]
+
+
+def test_credential_event_is_emitted_only_after_store_commit(credential_api, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_credential_event", lambda **kwargs: events.append(kwargs))
+    response = credential_api.create_verified_credential()
+    assert response.status_code == 201
+    assert events[0]["name"] == "credential_saved"
+
+
+def test_agent_delete_failure_does_not_emit_success(agent_context, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_agent_event", lambda **kwargs: events.append(kwargs))
+    agent_context.store.delete_agent = lambda _agent_id: False
+    agent_context.delete_agent()
+    assert events == []
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_instrumentation.py dashboard/backend/tests/test_analytics_integration.py -q`
+
+Expected: FAIL because lifecycle hooks are not wired to the source commits.
+
+- [ ] **Step 3: Add post-commit hooks at authoritative boundaries**
+
+Use these exact mappings:
+
+```python
+ACCOUNT_EVENTS = {
+    "signup": "account_signed_up",
+    "login": "session_started",
+}
+
+CREDENTIAL_EVENTS = {
+    "create": "credential_saved",
+    "verify_success": "credential_verified",
+    "verify_failure": "credential_invalid",
+    "set_default": "credential_defaulted",
+    "reverify_success": "credential_reverified",
+    "revoke": "credential_revoked",
+}
+
+AGENT_EVENTS = {
+    "create": "agent_created",
+    "update": "agent_updated",
+    "delete": "agent_deleted",
+}
+```
+
+In `auth.signup`, call `emit_account_event(name="account_signed_up", user_id=created_user["id"], source_record_type="user", source_record_id=str(created_user["id"]), occurred_at=created_user["created_at"])` after the user/session response can be formed. In `auth.login`, call `emit_account_event(name="session_started", ...)` only after the session token has been persisted. `session_started` uses a fresh Analytics event ID with `source_event_id=None`; it must not persist the raw authentication token, its database hash, its cookie value, or an authentication-session identifier as an Analytics session ID. It may attach only PR 1's monthly network HMAC, trusted country header, and reduced browser/device values calculated transiently from the request.
+
+In `ModelProviderService`, emit after each successful store method returns its public credential projection; include only provider ID, credential ID, lifecycle outcome, and permitted last-four value. Creating a credential always emits `credential_saved`; when the same authoritative operation finishes verification it additionally emits `credential_verified` or `credential_invalid` with its own stable source event ID. A later explicit verify emits `credential_reverified` on success or `credential_invalid` on failure. In `AgentService`, emit after `create_agent`, `update_agent`, and `delete_agent` return/confirm the repository result; never include pipeline prompts or runtime config contents.
+
+Only authenticated user-owned Agent operations are Analytics subjects. If an Agent has no `owner_user_id`, preserve the existing guest/API-only behavior and skip the user Analytics event instead of inventing an identity. For delete, capture the authenticated `owner_user_id` and safe Agent ID before the repository deletes the row, then emit only after `delete_agent` returns `True`.
+
+Wrap each emitter with the Task 1 best-effort boundary. A credential verification error maps to `credential_invalid` or `provider_unavailable`; it must not serialize the adapter exception or verification message.
+
+- [ ] **Step 4: Run the focused tests and full relevant auth/Agent/provider suites**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_instrumentation.py dashboard/backend/tests/test_analytics_integration.py dashboard/backend/tests/test_auth.py dashboard/backend/tests/test_agents_api.py dashboard/backend/tests/test_model_credentials_api.py -q`
+
+Expected: PASS; source-operation status codes and persisted rows remain unchanged when analytics append is forced to raise.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/api/auth.py dashboard/backend/domain/model_providers/service.py dashboard/backend/domain/agents/service.py dashboard/backend/tests/domain/analytics/test_instrumentation.py dashboard/backend/tests/test_analytics_integration.py
+git commit -m "feat: instrument account credential and agent lifecycles"
+```
+
+### Task 3: Instrument protocol and dashboard backtest lifecycles
+
+**Files:**
+- Modify: `dashboard/backend/domain/runs/service.py:340-430,600-735,900-1010`
+- Modify: `dashboard/backend/domain/backtesting/external_run_service.py:260-735`
+- Modify: `dashboard/backend/api/v2/runs.py:330-490`
+- Modify: `dashboard/backend/api/routers/backtests.py:620-910,1800-1940`
+- Test: `dashboard/backend/tests/domain/analytics/test_instrumentation.py`
+- Test: `dashboard/backend/tests/test_analytics_integration.py`
+
+**Interfaces:**
+- Consumes: Task 1 `emit_run_event`; `RunStore`/`BacktestDatabase` terminal state writes; existing run IDs, owner IDs, and correlation IDs.
+- Produces: one idempotent lifecycle event for `run_requested`, `run_queued`, `run_started`, `run_completed`, `run_failed`, and `run_cancelled` across legacy `/api/v1/backtest/*`, protocol `/api/v1/runs`, typed `/api/v2/runs`, and dashboard `/backtest/run` surfaces.
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+```python
+def test_protocol_run_emits_requested_started_completed_in_order(protocol_fixture, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_run_event", lambda **kwargs: events.append(kwargs))
+    run_id = protocol_fixture.create_run()
+    protocol_fixture.mark_started(run_id)
+    protocol_fixture.mark_completed(run_id)
+    assert [item["name"] for item in events] == ["run_requested", "run_started", "run_completed"]
+    assert all(item["correlation_id"] == run_id for item in events)
+
+
+def test_dashboard_failed_run_emits_failed_not_completed(backtest_fixture, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_run_event", lambda **kwargs: events.append(kwargs))
+    backtest_fixture.finish(error="provider unavailable")
+    assert [item["name"] for item in events] == ["run_failed"]
+    assert events[0]["error_category"] == "provider_unavailable"
+
+
+def test_cancelled_run_is_excluded_from_success_denominator(backtest_fixture, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_run_event", lambda **kwargs: events.append(kwargs))
+    backtest_fixture.cancel()
+    assert events[0]["name"] == "run_cancelled"
+
+
+@pytest.mark.parametrize("surface", ["legacy_v1", "protocol_v1", "typed_v2", "dashboard"])
+def test_every_run_surface_emits_authoritative_lifecycle(surface, run_surface_fixture, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_run_event", lambda **kwargs: events.append(kwargs))
+    run_surface_fixture(surface).complete_successfully()
+    assert events[0]["name"] in {"run_requested", "run_queued"}
+    assert events[-1]["name"] == "run_completed"
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_instrumentation.py dashboard/backend/tests/test_analytics_integration.py -q`
+
+Expected: FAIL because run lifecycle transitions do not yet call the analytics facade.
+
+- [ ] **Step 3: Hook only committed transitions**
+
+In `domain/runs/service.py`, resolve `user_id` from the persisted run's `agent_id` through the Agent repository; skip user Analytics when the Agent is API-only and has no account owner. Emit `run_requested` immediately after `run_store.create_run(..., status="running")` succeeds, emit `run_started` after the engine/session has been registered, and emit terminal events only after `run_store.update_run` commits the terminal status. In `_sync_status`, preserve the current terminal mapping and add the corresponding event after the update.
+
+Apply the same rule to `external_run_service.py` and `api/v2/runs.py`, because both write run state outside `domain/runs/service.py`. The typed v2 cancellation endpoint emits `run_cancelled` only after its `RunStore` update succeeds. The legacy v1 external service emits from its persisted `agent_runs` insertion/finalization, not from read-only status polling. Reaper/recovery transitions use the same stable source event IDs, so a terminal status observed twice remains one event.
+
+In `api/routers/backtests.py`, emit `run_queued` after the dashboard slot/run record is accepted, `run_started` after the worker has begun the authoritative run, and terminal events from `_finalize_slot` after the persisted `agent_runs` result is written. Use the existing live run ID as `source_record_id` and correlation ID. Pass only safe outcome/error-category values; retain detailed provider text in the existing source path, never in Analytics. When an authenticated run request is authoritatively refused before a run row exists, emit `safe_error_classified` with a fresh event ID and one stable category such as `credential_missing`, `provider_unavailable`, `credits_unavailable`, `model_not_allowed`, or `account_restricted`; this event is the evidence that can make the user's state `Blocked`.
+
+Guard each call with a stable source event ID generated by Task 1 so retries from reaper/recovery or duplicate finalizer calls cannot create duplicate events.
+
+- [ ] **Step 4: Run lifecycle and regression suites**
+
+Run: `pytest dashboard/backend/tests/domain/runs dashboard/backend/tests/test_protocol_api.py dashboard/backend/tests/test_v2_http_runs.py dashboard/backend/tests/test_external_backtest_api.py dashboard/backend/tests/test_run_lifecycle_unification.py dashboard/backend/tests/test_backtests_router.py dashboard/backend/tests/test_backtest_launch_visibility.py dashboard/backend/tests/test_analytics_integration.py -q`
+
+Expected: PASS; run state transitions and existing API responses remain byte-compatible apart from no new fields on existing run APIs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/domain/runs/service.py dashboard/backend/domain/backtesting/external_run_service.py dashboard/backend/api/v2/runs.py dashboard/backend/api/routers/backtests.py dashboard/backend/tests/domain/analytics/test_instrumentation.py dashboard/backend/tests/test_analytics_integration.py
+git commit -m "feat: instrument protocol and dashboard run lifecycles"
+```
+
+### Task 4: Instrument model usage, Credits reservations, settlements, refunds, and safe errors
+
+**Files:**
+- Modify: `dashboard/backend/infrastructure/llm/execution/service.py:80-330`
+- Modify: `dashboard/backend/domain/credits/service.py:219-315`
+- Test: `dashboard/backend/tests/domain/analytics/test_instrumentation.py`
+- Test: `dashboard/backend/tests/test_analytics_integration.py`
+
+**Interfaces:**
+- Consumes: `LLMExecutionRequest`, `LLMUsage`, `BillingEvidence`, reservation/settlement result models, and Task 1 resource emitters.
+- Produces: one `model_usage_recorded` event per authoritative usage evidence, one event for each successful `credits_reserved`, `credits_settled`, or `credits_refunded` operation, and safe error events for denied/unavailable execution paths. BYOK events include usage but never a Credits debit.
+
+- [ ] **Step 1: Write failing resource tests**
+
+```python
+def test_byok_usage_is_recorded_without_platform_cost_or_debit(execution_fixture, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_resource_event", lambda **kwargs: events.append(kwargs))
+    result = execution_fixture.execute_byok()
+    usage = next(item for item in events if item["name"] == "model_usage_recorded")
+    assert usage["billing_mode"] == "byok"
+    assert usage["platform_cost_usd"] == 0
+    assert usage["debited_credits_micro"] == 0
+
+
+def test_platform_settlement_emits_after_commit(execution_fixture, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_resource_event", lambda **kwargs: events.append(kwargs))
+    execution_fixture.execute_platform()
+    assert [item["name"] for item in events] == ["credits_reserved", "model_usage_recorded", "credits_settled"]
+
+
+def test_provider_error_is_safe_and_does_not_echo_body(execution_fixture, monkeypatch):
+    events = []
+    monkeypatch.setattr(instrumentation, "emit_safe_error_event", lambda **kwargs: events.append(kwargs))
+    execution_fixture.fail_with_provider_body("secret upstream response")
+    assert events[0]["error_category"] == "provider_unavailable"
+    assert "secret upstream response" not in repr(events[0])
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_instrumentation.py dashboard/backend/tests/test_analytics_integration.py -q`
+
+Expected: FAIL because execution and Credits boundaries do not emit resource events.
+
+- [ ] **Step 3: Add post-commit resource hooks**
+
+In `LLMExecutionService._execute_platform`, emit `credits_reserved` only after `reserve_llm_credits` returns an open reservation, emit `model_usage_recorded` after the provider usage and cost evidence has passed validation, and emit `credits_settled` only after `settle_llm_credits` returns. In `_release_after_failure`/`finalize_run`, emit `credits_refunded` only after release commits. For BYOK, emit `model_usage_recorded` with `billing_mode="byok"`, actual token counts, provider/model IDs, and zero ATL debit/cost.
+
+In `CreditsService`, instrument purchased/admin-grant refund operations after their ledger commits. Do not treat a purchased Credits ledger entry as a model-spend event; the analytics resource event must carry `resource_kind` so query code can keep purchased Credits separate from `user_entitlements.credits` model metering.
+
+Map `LLMExecutionError` and repository failures through the fixed safe categories: `credential_missing`, `credential_invalid`, `provider_timeout`, `provider_unavailable`, `credits_unavailable`, `model_not_allowed`, `internal_error`, or `usage_unavailable`. Never include exception strings, raw provider bodies, or serialized request messages.
+
+For execution failures that occur before a run exists, `emit_safe_error_event` uses `source_event_id=None` and the authenticated `user_id`; do not derive an idempotency key from prompt text, raw request JSON, or a credential. For failures tied to a persisted run/call, use `resource:error:{run_id}:{call_index}:{category}`.
+
+- [ ] **Step 4: Run execution, Credits, and integration suites**
+
+Run: `pytest dashboard/backend/tests/infrastructure/llm dashboard/backend/tests/domain/credits dashboard/backend/tests/test_credit_metering.py dashboard/backend/tests/integration/test_credits_checkout_flow.py dashboard/backend/tests/test_analytics_integration.py -q`
+
+Expected: PASS; BYOK never changes ATL Credits state and analytics failures never change reservation/settlement outcomes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/infrastructure/llm/execution/service.py dashboard/backend/domain/credits/service.py dashboard/backend/tests/domain/analytics/test_instrumentation.py dashboard/backend/tests/test_analytics_integration.py
+git commit -m "feat: instrument model usage and credits outcomes"
+```
+
+### Task 5: Implement deterministic metrics and daily rollups
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/metrics.py`
+- Create: `dashboard/backend/domain/analytics/rollups.py`
+- Test: `dashboard/backend/tests/domain/analytics/test_metrics.py`
+- Test: `dashboard/backend/tests/domain/analytics/test_rollups.py`
+
+**Interfaces:**
+- Consumes: PR 1 event query/repository contract, authoritative users/runs/usage/Credits stores, subject settings, and Task 1 event names.
+- Produces: `AnalyticsMetricFilters`, `calculate_overview_metrics(...)`, `rollup_day(...)`, `rollup_current_day(...)`, and bounded dimension keys used by Tasks 6 and 8.
+
+- [ ] **Step 1: Write formula tests with fixed UTC fixtures**
+
+```python
+def test_active_users_uses_meaningful_events_only(event_repo, fixed_now):
+    event_repo.seed_page("home", user_id=1, at=fixed_now - timedelta(days=1))
+    event_repo.seed_event("session_heartbeat", user_id=2, at=fixed_now - timedelta(days=1))
+    event_repo.seed_event("token_refreshed", user_id=3, at=fixed_now - timedelta(days=1))
+    result = calculate_active_users(event_repo, now=fixed_now, include_internal=False)
+    assert result == 1
+
+
+def test_first_success_conversion_excludes_immature_cohorts(authoritative, fixed_now):
+    authoritative.signup(user_id=1, at=fixed_now - timedelta(days=8))
+    authoritative.signup(user_id=2, at=fixed_now - timedelta(days=2))
+    authoritative.successful_run(user_id=1, at=fixed_now - timedelta(days=7, hours=1))
+    assert calculate_first_success_conversion(authoritative, now=fixed_now) == 1.0
+
+
+def test_success_rate_excludes_cancelled_and_non_terminal(authoritative, fixed_now):
+    authoritative.run("completed", at=fixed_now - timedelta(days=1))
+    authoritative.run("failed", at=fixed_now - timedelta(days=1))
+    authoritative.run("cancelled", at=fixed_now - timedelta(days=1))
+    authoritative.run("running", at=fixed_now - timedelta(hours=1))
+    assert calculate_backtest_success_rate(authoritative, now=fixed_now) == 0.5
+
+
+def test_platform_cost_excludes_byok(authoritative, fixed_now):
+    authoritative.usage(billing_mode="platform_credits", cost_usd=1.25, at=fixed_now - timedelta(days=1))
+    authoritative.usage(billing_mode="byok", cost_usd=99.0, at=fixed_now - timedelta(days=1))
+    assert calculate_platform_model_cost(authoritative, now=fixed_now) == 1.25
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_metrics.py dashboard/backend/tests/domain/analytics/test_rollups.py -q`
+
+Expected: FAIL because metric functions and rollup writers do not exist.
+
+- [ ] **Step 3: Implement formulas and bounded rollups**
+
+Use UTC-aware half-open intervals `[start, end)` for every date range. Normalize filters to a maximum range of 180 raw days while allowing historical rollup queries beyond that range. Implement the exact formulas:
+
+```python
+def backtest_success_rate(completed: int, failed: int) -> float | None:
+    denominator = completed + failed
+    return None if denominator == 0 else completed / denominator
+
+
+def repeat_run_rate(users_with_first_success: int, users_with_repeat_success: int) -> float | None:
+    return None if users_with_first_success == 0 else users_with_repeat_success / users_with_first_success
+```
+
+`rollup_day(day)` must aggregate only allowlisted dimensions: event name, billing mode, provider, model, outcome, error category, and user-state count. Never group by email, raw user ID, session ID, network hash, prompt, strategy, or arbitrary properties. Upsert on `(day, dimension_name, dimension_value, metric_name)` so rerunning a day is idempotent. `rollup_current_day` reads raw accepted events and overlays them on the previous completed-day rollups without mutating historical rows.
+
+Persist these bounded aggregate metric names: `daily_active_users`, `rolling_active_users_7d`, `completed_runs`, `terminal_completed`, `terminal_failed`, `mature_signup_cohort_users`, `first_success_within_7d_users`, `users_with_first_success`, `users_with_repeat_success_24h_30d`, `platform_model_cost_usd`, `input_tokens`, `output_tokens`, `affected_users`, and `user_state_count`. Cohort numerators/denominators are stored as counts so long-range conversion can be recomputed without retaining identifying cohort rows.
+
+Do not sum non-additive distinct-user counts across days. Store `rolling_active_users_7d` as the exact seven-day distinct count calculated at each completed day's UTC boundary; calculate the current incomplete day's value from raw events in the preceding seven days. `daily_active_users` is for the daily trend only. Likewise, compute an exact date-range `affected_users` count from raw events only while the requested range is inside the 180-day detail window; historical charts may use daily affected-user rollups but must not present their sum as a distinct range count.
+
+For `user_state_count`, calculate each non-excluded user's state as of the day's closing boundary from events and authoritative records available at that time. Do not copy today's `user_analytics_snapshots` backward into historical rollups.
+
+- [ ] **Step 4: Run metric, rollup, and regression tests**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_metrics.py dashboard/backend/tests/domain/analytics/test_rollups.py dashboard/backend/tests/test_analytics_integration.py -q`
+
+Expected: PASS; fixed-boundary cases, admin/exclusion filters, and repeat execution produce identical values.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/domain/analytics/metrics.py dashboard/backend/domain/analytics/rollups.py dashboard/backend/tests/domain/analytics/test_metrics.py dashboard/backend/tests/domain/analytics/test_rollups.py
+git commit -m "feat: calculate analytics metrics and daily rollups"
+```
+
+### Task 6: Add explainable five-state snapshots and repair logic
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/states.py`
+- Modify: `dashboard/backend/domain/analytics/instrumentation.py`
+- Test: `dashboard/backend/tests/domain/analytics/test_states.py`
+- Test: `dashboard/backend/tests/test_analytics_integration.py`
+
+**Interfaces:**
+- Consumes: Task 1 lifecycle/error events, authoritative user/run/credential/provider state, PR 1 snapshot repository methods, and subject exclusions.
+- Produces: `calculate_user_state(user_id, now=...) -> UserAnalyticsSnapshot`, `recalculate_user_snapshot(user_id, ...)`, and `repair_stale_snapshots(now=..., limit=...) -> int`.
+
+- [ ] **Step 1: Write precedence and evidence tests**
+
+```python
+def test_blocked_wins_over_needs_attention_and_onboarding(state_fixture, fixed_now):
+    state_fixture.attempted_run_without_billing(at=fixed_now - timedelta(hours=1))
+    state_fixture.failed_runs(count=3, within=timedelta(hours=24))
+    snapshot = calculate_user_state(state_fixture.user_id, now=fixed_now)
+    assert snapshot.status == "Blocked"
+    assert snapshot.reason_code == "billing_lane_unavailable"
+    assert snapshot.evidence_event_ids == [state_fixture.blocking_event_id]
+
+
+def test_new_user_without_run_is_onboarding_not_blocked(state_fixture, fixed_now):
+    snapshot = calculate_user_state(state_fixture.user_id, now=fixed_now)
+    assert snapshot.status == "Onboarding"
+    assert snapshot.reason_code == "no_successful_run"
+
+
+def test_needs_attention_requires_three_failures_or_invalid_default(state_fixture, fixed_now):
+    state_fixture.failed_runs(count=3, within=timedelta(hours=24))
+    snapshot = calculate_user_state(state_fixture.user_id, now=fixed_now)
+    assert snapshot.status == "Needs Attention"
+    assert snapshot.reason_code == "three_consecutive_failed_runs"
+
+
+def test_dormant_and_active_are_30_day_activity_states(state_fixture, fixed_now):
+    state_fixture.first_success(at=fixed_now - timedelta(days=45))
+    state_fixture.activity(at=fixed_now - timedelta(days=31))
+    assert calculate_user_state(state_fixture.user_id, now=fixed_now).status == "Dormant"
+    state_fixture.activity(at=fixed_now - timedelta(days=1))
+    assert calculate_user_state(state_fixture.user_id, now=fixed_now).status == "Active"
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_states.py -q`
+
+Expected: FAIL because state calculation and snapshot persistence do not exist.
+
+- [ ] **Step 3: Implement exact precedence and stable reason codes**
+
+Evaluate rules in this order and stop at the first match:
+
+```python
+STATE_RULES = (
+    ("Blocked", "billing_lane_unavailable", _is_blocked),
+    ("Needs Attention", "three_consecutive_failed_runs", _needs_attention),
+    ("Dormant", "no_meaningful_activity_30d", _is_dormant),
+    ("Onboarding", "no_successful_run", _is_onboarding),
+    ("Active", "recent_successful_run_and_activity", _is_active),
+)
+```
+
+Use additional stable reason codes `provider_disabled`, `account_restricted`, `invalid_default_credential`, `run_deadline_exceeded`, and `successful_run_missing` when those branches provide the strongest evidence. A blocking condition is unresolved only when its latest evidence is newer than the corresponding resolving event: verified/defaulted credential, provider re-enabled, Credits made available, restriction removed, or a later successful run. Three failed runs are "consecutive" only when the three newest terminal runs inside the preceding 24 hours are all failed; a completed or cancelled run breaks the sequence. A run is beyond its safe deadline only when the authoritative run remains non-terminal after its stored execution/decision deadline.
+
+A new user with no attempted core action is always `Onboarding`, even when no billing lane is configured. Evidence IDs must be sorted by occurrence time descending, then event ID ascending, and capped at five IDs. Upsert the snapshot after calculation; do not append immutable state history.
+
+After the state service exists, extend Task 1's `_append_after_commit` to call a registered `recalculate_user_snapshot(user_id)` callback for event names in `SNAPSHOT_RELEVANT_EVENTS`. The callback is best-effort and runs only when `append_event_best_effort` reports that the event is stored or already present; its failure produces a safe operational warning and never changes the source operation. Keep `repair_stale_snapshots` as the periodic safety net for failed callbacks, deploy restarts, and backfilled rows.
+
+- [ ] **Step 4: Run state and integration tests**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_states.py dashboard/backend/tests/test_analytics_integration.py -q`
+
+Expected: PASS; every user has exactly one state, reasons are deterministic, and snapshot failures do not alter source operations.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/domain/analytics/states.py dashboard/backend/domain/analytics/instrumentation.py dashboard/backend/tests/domain/analytics/test_states.py dashboard/backend/tests/test_analytics_integration.py
+git commit -m "feat: add explainable analytics user states"
+```
+
+### Task 7: Implement deterministic 180-day authoritative backfill and CLI
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/backfill.py`
+- Create: `dashboard/scripts/backfill_analytics.py`
+- Test: `dashboard/backend/tests/domain/analytics/test_backfill.py`
+
+**Interfaces:**
+- Consumes: users, Agent repository, `agent_runs`/protocol run stores, model usage evidence, Credits reservation/ledger stores, Task 1 emitters, and PR 1 idempotent append contract.
+- Produces: `backfill_analytics(*, now: datetime | None = None, days: int = 180) -> BackfillReport` and an operator CLI with `--days`, `--before`, and `--dry-run`.
+
+- [ ] **Step 1: Write failing cutoff, source-ID, and replay tests**
+
+```python
+def test_backfill_uses_only_authoritative_sources(backfill_fixture, fixed_now):
+    backfill_fixture.user(user_id=1, created_at=fixed_now - timedelta(days=10))
+    backfill_fixture.agent(agent_id="a-1", user_id=1, created_at=fixed_now - timedelta(days=9))
+    backfill_fixture.run(run_id="r-1", user_id=1, status="completed", created_at=fixed_now - timedelta(days=8))
+    backfill_fixture.page_view(user_id=1, at=fixed_now - timedelta(days=8))
+    report = backfill_analytics(now=fixed_now)
+    assert report.inserted == 3
+    assert all(event.event_source == "backfill" for event in backfill_fixture.events())
+    assert not any(event.event_name == "page_viewed" for event in backfill_fixture.events())
+
+
+def test_backfill_ids_are_deterministic_and_idempotent(backfill_fixture, fixed_now):
+    backfill_fixture.run(run_id="r-1", user_id=1, status="failed", created_at=fixed_now - timedelta(days=2))
+    first = backfill_analytics(now=fixed_now)
+    second = backfill_analytics(now=fixed_now)
+    assert first.inserted == 1
+    assert second.inserted == 0
+    assert first.source_event_ids == ["run:run_failed:r-1"]
+
+
+def test_backfill_excludes_records_older_than_180_days(backfill_fixture, fixed_now):
+    backfill_fixture.run(run_id="old", user_id=1, status="completed", created_at=fixed_now - timedelta(days=181))
+    assert backfill_analytics(now=fixed_now).inserted == 0
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_backfill.py -q`
+
+Expected: FAIL because the backfill service and CLI do not exist.
+
+- [ ] **Step 3: Implement source adapters and deterministic IDs**
+
+Reconstruct only these records when their authoritative timestamp is within `[now - 180 days, now]`:
+
+```python
+BACKFILL_ID_TEMPLATES = {
+    "signup": "account:account_signed_up:{user_id}",
+    "agent": "agent:agent_created:{agent_id}",
+    "run": "run:run_{terminal_status}:{run_id}",
+    "usage": "resource:model_usage_recorded:{run_id}:{call_index}",
+    "credits": "resource:credits_{outcome}:{reservation_id}",
+}
+```
+
+Emit signup, Agent-created, terminal run, model-usage, and Credits reservation/settlement/refund events from source rows. Use `session_id=None`, `page_view=None`, `country_code=None`, `device_category=None`, `browser_family=None`, and `network_hash=None` for all backfilled events. Never inspect or copy prompt, strategy, credential ciphertext, raw provider error, browser, IP, or arbitrary metadata fields. Sort source rows by `(occurred_at, stable source ID)` before appending so reports are repeatable.
+
+Resolve a historical run to a user only through authoritative ownership: `protocol_runs.agent_id -> external_agents.owner_user_id`, or `agent_runs.session_id -> external_agents.session_id -> owner_user_id`. If no authenticated owner can be proven, increment `skipped_unmapped_owner` and do not invent a user association. Read model usage and Credits outcomes from `credit_llm_reservations`, `credit_llm_usage_entries`, and their safe evidence fields; use `agent_runs.metadata.llm_execution` only when the typed `LLMRunEvidence` projection validates successfully.
+
+Use the same canonical source IDs as live instrumentation so running backfill after deployment does not duplicate already-observed events. Suppress per-event snapshot callbacks during bulk load, then recalculate one snapshot per affected user and rebuild every affected completed UTC day's rollup exactly once. `--dry-run` performs source enumeration and validation without appending events, snapshots, or rollups.
+
+The CLI must print counts and safe categories only:
+
+```bash
+python dashboard/scripts/backfill_analytics.py --days 180 --dry-run
+python dashboard/scripts/backfill_analytics.py --days 180
+```
+
+Reject `--days` outside `1..180` and never accept secrets or database URLs as command-line arguments.
+
+- [ ] **Step 4: Run backfill and CLI tests**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_backfill.py dashboard/backend/tests/test_analytics_integration.py -q && python dashboard/scripts/backfill_analytics.py --help`
+
+Expected: PASS; help lists only safe options, the second backfill inserts zero duplicates, and no page/session events are fabricated.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/domain/analytics/backfill.py dashboard/scripts/backfill_analytics.py dashboard/backend/tests/domain/analytics/test_backfill.py
+git commit -m "feat: add idempotent analytics historical backfill"
+```
+
+### Task 8: Build the Admin Analytics query service
+
+**Files:**
+- Create: `dashboard/backend/domain/analytics/query_service.py`
+- Create: `dashboard/backend/domain/analytics/maintenance.py`
+- Modify: `dashboard/backend/app.py:210-240`
+- Test: `dashboard/backend/tests/test_analytics_maintenance.py`
+- Test: `dashboard/backend/tests/test_admin_analytics_api.py`
+
+**Interfaces:**
+- Consumes: Tasks 5–7, PR 1 repository/settings/access-log contracts, `user_store`, Agent/run/provider/Credits stores, and centralized Admin identity.
+- Produces: `AnalyticsQueryService.get_overview`, `.list_users`, `.get_user_profile`, `.get_user_activity`, and `run_analytics_maintenance` for router and startup wiring.
+
+- [ ] **Step 1: Write failing query and maintenance tests**
+
+```python
+def test_query_service_merges_completed_rollups_with_current_raw_day(query_fixture, fixed_now):
+    query_fixture.rollup_completed_day(fixed_now.date() - timedelta(days=1), completed_runs=4)
+    query_fixture.raw_current_day_completed_run(user_id=7, at=fixed_now - timedelta(minutes=2))
+    overview = query_fixture.service.get_overview(now=fixed_now, filters=AnalyticsMetricFilters())
+    assert overview.completed_runs == 5
+    assert overview.last_updated == fixed_now
+
+
+def test_maintenance_is_bounded_and_idempotent(maintenance_fixture, fixed_now):
+    first = run_analytics_maintenance(now=fixed_now, snapshot_limit=25)
+    second = run_analytics_maintenance(now=fixed_now, snapshot_limit=25)
+    assert first.rollup_days == second.rollup_days
+    assert first.repaired_snapshots <= 25
+    assert second.repaired_snapshots == 0
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/test_analytics_maintenance.py dashboard/backend/tests/test_admin_analytics_api.py -q`
+
+Expected: FAIL because the query service and maintenance pass do not exist.
+
+- [ ] **Step 3: Implement safe query DTOs and source merge**
+
+Define these exact service methods:
+
+```python
+class AnalyticsQueryService:
+    def get_overview(self, *, filters: AnalyticsMetricFilters, now: datetime | None = None) -> AnalyticsOverview: ...
+    def list_users(self, *, filters: AnalyticsUserFilters, limit: int, offset: int) -> PaginatedUsers: ...
+    def get_user_profile(self, *, user_id: int, now: datetime | None = None) -> AnalyticsUserProfile: ...
+    def get_user_activity(self, *, user_id: int, section: ActivitySection, limit: int, cursor: str | None) -> Page[AnalyticsActivityItem]: ...
+```
+
+The overview DTO must contain `active_users_7d`, `first_success_conversion`, `backtest_success_rate`, `repeat_run_rate`, `platform_model_cost_usd`, `daily_active_users`, `daily_completed_runs`, `activation_funnel`, `user_state_counts`, `top_failure_categories`, `users_needing_attention`, `last_updated`, and the normalized filter echo. Each panel value carries `available: bool`; a failed component uses a fixed `error_code="temporarily_unavailable"` without exception text while other components remain populated.
+
+The user-list DTO contains display name, email, user ID, state/reason, last meaningful activity, recent run/failure counts, and a stable profile path. The profile DTO contains join date, last meaningful activity, state/evidence, primary billing lane, default provider, coarse country, reduced device/browser, activation milestones, recent footprint, run summary, billing-lane mix, input/output tokens, ATL platform cost, ATL Credits debited, and top product page. It never returns arbitrary `properties_json`.
+
+Normalize `limit` to `1..100`, `offset` to `>=0`, and cursors through the PR 1 signed/opaque cursor helper. For overview, query additive completed-day counts/costs from rollups, query the current UTC day from raw events, and merge by metric key. Read historical daily active-user points and completed-day rolling-seven counts directly from their rollup rows; never add distinct counts. Calculate the live rolling-seven active-user value from raw events because the entire window is inside 180-day retention. For user lists, join only display-safe fields from `user_store` with snapshot and bounded summary counts; default filter excludes Admin and `analytics_excluded`. For profile activity, allow only `timeline`, `runs`, `usage`, and `sessions`; sessions expose aggregate duration/count and reduced browser/device fields, never raw session IDs or headers. Query failures return a panel-level unavailable result with a fixed error code; they do not raise an all-or-nothing exception.
+
+`run_analytics_maintenance` must process one completed UTC day, recalculate stale snapshots in batches of at most 100, and return counts. Keep a process-local last-run guard so the existing run reaper can invoke it frequently without reprocessing the same day on every pass.
+
+- [ ] **Step 4: Wire maintenance through the composition root and run tests**
+
+Register `run_analytics_maintenance` using `dashboard.backend.domain.runs.service.register_reaper_sweep` inside `startup_event`, guarded by its own `try/except` and safe warning. Do not add Analytics route bodies to `app.py`.
+
+Run: `pytest dashboard/backend/tests/test_analytics_maintenance.py dashboard/backend/tests/test_admin_analytics_api.py dashboard/backend/tests/test_app_composition.py -q`
+
+Expected: PASS; startup remains non-blocking, maintenance errors do not prevent the server or reaper from starting, and responses contain only display-safe Analytics fields.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/domain/analytics/query_service.py dashboard/backend/domain/analytics/maintenance.py dashboard/backend/app.py dashboard/backend/tests/test_analytics_maintenance.py dashboard/backend/tests/test_admin_analytics_api.py
+git commit -m "feat: add analytics query service and maintenance pass"
+```
+
+### Task 9: Expose Admin Analytics query APIs
+
+**Files:**
+- Create: `dashboard/backend/api/routers/admin_analytics.py`
+- Modify: `dashboard/backend/api/router.py:1-60`
+- Test: `dashboard/backend/tests/test_admin_analytics_api.py`
+
+**Interfaces:**
+- Consumes: Task 8 `AnalyticsQueryService`, PR 1 `require_admin` and `record_admin_profile_access`, and existing request/query parsing conventions.
+- Produces: `GET /api/admin/analytics/overview`, `GET /api/admin/analytics/users`, `GET /api/admin/analytics/users/{user_id}`, and `GET /api/admin/analytics/users/{user_id}/activity`.
+
+- [ ] **Step 1: Write failing API and authorization tests**
+
+```python
+def test_non_admin_cannot_query_analytics(client, signed_in_user):
+    response = client.get("/api/admin/analytics/overview")
+    assert response.status_code == 403
+
+
+def test_admin_overview_accepts_documented_filters(admin_client, analytics_fixture):
+    response = admin_client.get(
+        "/api/admin/analytics/overview",
+        params={"from": "2026-08-01", "to": "2026-08-26", "billing_mode": "byok", "provider": "openrouter", "model": "gpt-4.1", "include_internal": "false"},
+    )
+    assert response.status_code == 200
+    assert response.json()["filters"]["billing_mode"] == "byok"
+
+
+def test_profile_read_records_access_without_response_body(admin_client, analytics_fixture):
+    response = admin_client.get(f"/api/admin/analytics/users/{analytics_fixture.user_id}")
+    assert response.status_code == 200
+    access = analytics_fixture.latest_admin_access()
+    assert access["subject_user_id"] == analytics_fixture.user_id
+    assert "response" not in access
+
+
+def test_activity_sections_are_independently_pageable(admin_client, analytics_fixture):
+    response = admin_client.get(f"/api/admin/analytics/users/{analytics_fixture.user_id}/activity", params={"section": "runs", "limit": 2})
+    assert response.status_code == 200
+    assert "next_cursor" in response.json()
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pytest dashboard/backend/tests/test_admin_analytics_api.py -q`
+
+Expected: FAIL because the router is not registered.
+
+- [ ] **Step 3: Implement the gated router and safe response models**
+
+```python
+router = APIRouter(
+    prefix="/admin/analytics",
+    tags=["admin-analytics"],
+    dependencies=[Depends(require_admin)],
+)
+
+
+@router.get("/overview", response_model=AnalyticsOverviewResponse)
+def get_overview(..., service: AnalyticsQueryService = Depends(get_analytics_query_service)):
+    return service.get_overview(filters=_filters_from_query(...))
+
+
+@router.get("/users", response_model=AnalyticsUserListResponse)
+def list_users(...):
+    return service.list_users(filters=_user_filters_from_query(...), limit=limit, offset=offset)
+
+
+@router.get("/users/{user_id}", response_model=AnalyticsUserProfileResponse)
+def get_user_profile(user_id: int, request: Request, current_admin: dict = Depends(require_admin), ...):
+    profile = service.get_user_profile(user_id=user_id)
+    record_admin_profile_access(admin_user_id=current_admin["id"], subject_user_id=user_id, section="overview")
+    return profile
+
+
+@router.get("/users/{user_id}/activity", response_model=AnalyticsActivityPageResponse)
+def get_user_activity(user_id: int, section: Literal["timeline", "runs", "usage", "sessions"], cursor: str | None = None, ...):
+    record_admin_profile_access(admin_user_id=current_admin["id"], subject_user_id=user_id, section=section)
+    return service.get_user_activity(user_id=user_id, section=section, limit=limit, cursor=cursor)
+```
+
+Use date-only query strings parsed to UTC midnight boundaries; reject `to < from`, unknown billing/provider/model filters, invalid status values, limits over 100, and malformed cursors with the existing safe 422/400 conventions. The router must never echo unknown query values in error details if they could contain sensitive text. Register it once in `api/router.py` and add route-pair coverage to the existing composition tests.
+
+`GET /users` accepts `q`, `status`, `last_activity_from`, `last_activity_to`, `sort`, `order`, `limit`, and `offset`. Allow `sort` only for `last_activity`, `joined_at`, `recent_runs`, or `recent_failures`; allow `order` only for `asc` or `desc`. `GET /users/{user_id}/activity` accepts exactly one section and its own cursor, so the PR 3 page can paginate Timeline, Runs, Usage, and Sessions independently.
+
+- [ ] **Step 4: Run API, route, and security tests**
+
+Run: `pytest dashboard/backend/tests/test_admin_analytics_api.py dashboard/backend/tests/test_app_composition.py dashboard/backend/tests/test_architecture_boundaries.py -q`
+
+Expected: PASS; every Analytics route is Admin-gated, profile access is logged, cursors paginate independently, and response JSON has no prohibited fields.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/api/routers/admin_analytics.py dashboard/backend/api/router.py dashboard/backend/tests/test_admin_analytics_api.py dashboard/backend/tests/test_app_composition.py
+git commit -m "feat: expose admin analytics query APIs"
+```
+
+### Task 10: Complete SQLite/PostgreSQL parity and end-to-end acceptance coverage
+
+**Files:**
+- Create: `dashboard/scripts/benchmark_analytics_queries.py`
+- Test: `dashboard/backend/tests/domain/analytics/test_repository_contract.py`
+- Test: `dashboard/backend/tests/test_analytics_integration.py`
+- Test: `dashboard/backend/tests/test_admin_analytics_api.py`
+
+**Interfaces:**
+- Consumes: all prior tasks and a disposable PostgreSQL database when the `POSTGRES_TEST_DATABASE_URL` test environment is available.
+- Produces: evidence that the complete PR 2 surface behaves equivalently on SQLite and PostgreSQL, that analytics failures are isolated, that the documented synthetic acceptance scenario passes without real credentials, and that the query targets can be measured on repeatable synthetic data.
+
+- [ ] **Step 1: Add repository contract and end-to-end failing tests**
+
+```python
+@pytest.mark.parametrize("backend", ["sqlite", "postgres"])
+def test_analytics_repository_contract(backend, analytics_repository_factory):
+    repo = analytics_repository_factory(backend)
+    event = make_event(user_id=7, source_event_id="source-1")
+    assert repo.append_event(event) is True
+    assert repo.append_event(event) is False
+    assert repo.list_events(AnalyticsEventFilters(user_id=7), limit=10, cursor=None).items[0].event_id == event.event_id
+
+
+def test_synthetic_acceptance_scenario(analytics_app_fixture):
+    analytics_app_fixture.create_user()
+    analytics_app_fixture.create_and_verify_fake_byok_credential()
+    analytics_app_fixture.record_failed_then_successful_run()
+    analytics_app_fixture.record_platform_usage_and_settlement()
+    overview = analytics_app_fixture.admin_overview()
+    profile = analytics_app_fixture.admin_profile()
+    assert overview["platform_model_cost_usd"] > 0
+    assert profile["billing_lane_mix"]["byok"] == 1
+    assert profile["billing_lane_mix"]["platform_credits"] == 1
+    assert profile["credits_debited_micro"] > 0
+    assert profile["state"]["evidence_event_ids"]
+```
+
+- [ ] **Step 2: Run the tests and verify the parity/acceptance cases fail or expose gaps**
+
+Run: `pytest dashboard/backend/tests/domain/analytics/test_repository_contract.py dashboard/backend/tests/test_analytics_integration.py dashboard/backend/tests/test_admin_analytics_api.py -q`
+
+Expected: Any failure identifies a concrete parity, privacy, or lifecycle gap; do not weaken assertions to accommodate backend divergence.
+
+- [ ] **Step 3: Fix only contract-level parity defects**
+
+Do not change PR 1 repository code on this branch. If parity tests expose a foundation defect, stop and report the exact failing contract to the PR 1 owner; resume PR 2 only after the foundation fix is merged or cherry-picked. Within PR 2 query/service code, normalize timestamps to the same UTC ISO representation, preserve duplicate source-event behavior, use the same cursor ordering `(occurred_at DESC, event_id DESC)`, and return identical null/empty conventions. Do not add joins across users/content/run databases; query services may compose separate stores in Python, as existing domain services do.
+
+Create `benchmark_analytics_queries.py` with deterministic synthetic generation flags `--users`, `--events-per-user`, `--days`, and `--iterations`. It must use a disposable database path, print p50/p95 for overview and initial profile, and exit non-zero when overview p95 exceeds 1.0 second or profile p95 exceeds 0.5 seconds. Default to `--users 10000 --events-per-user 40 --days 180 --iterations 20`; never connect to a database URL passed on the command line.
+
+- [ ] **Step 4: Run the full proportional verification set**
+
+Run: `pytest dashboard/backend/tests/domain/analytics -q && pytest dashboard/backend/tests/test_admin_analytics_api.py dashboard/backend/tests/test_analytics_integration.py dashboard/backend/tests/test_architecture_boundaries.py dashboard/backend/tests/test_app_composition.py -q && python dashboard/scripts/benchmark_analytics_queries.py --users 10000 --events-per-user 40 --days 180 --iterations 20 && pytest dashboard/backend/tests/ -q`
+
+Expected: PASS. If PostgreSQL integration is unavailable, the contract test must report a clean skip using the repository's existing `_postgres_testing.py` convention; SQLite coverage remains mandatory.
+
+- [ ] **Step 5: Commit the final verification-only changes**
+
+```bash
+git add dashboard/scripts/benchmark_analytics_queries.py dashboard/backend/tests/domain/analytics dashboard/backend/tests/test_admin_analytics_api.py dashboard/backend/tests/test_analytics_integration.py dashboard/backend/tests/test_architecture_boundaries.py dashboard/backend/tests/test_app_composition.py
+git commit -m "test: verify analytics parity and acceptance flow"
+```
+
+## Self-Review Checklist
+
+1. **Spec coverage:** Collection scope is covered by Tasks 1–4; metric formulas and rollups by Task 5; all five states and evidence by Task 6; authoritative 180-day backfill by Task 7; freshness/merge, filters, pagination, access logs, and partial failures by Tasks 8–9; SQLite/PostgreSQL parity and the synthetic acceptance scenario by Task 10. PR 3 UI is explicitly excluded.
+2. **Privacy coverage:** Every event builder uses fixed allowlists; credential and execution hooks pass IDs/provider/model/usage evidence only; backfill sets all client-derived fields to null; API response models are display-safe; tests assert secret/body absence.
+3. **Failure isolation:** Every source hook is post-commit and best-effort; startup maintenance is independently guarded; query panels return unavailable results rather than blanking the whole response.
+4. **Idempotency:** Server retries use stable source-event IDs; rollups upsert bounded keys; snapshots overwrite current state; backfill replay inserts zero duplicates.
+5. **Type consistency:** PR 1 types `AnalyticsEvent`, `AnalyticsRepository`, `append_event_best_effort`, and `record_admin_profile_access`, plus PR 2 types `AnalyticsMetricFilters`, `AnalyticsUserFilters`, `AnalyticsOverview`, `AnalyticsUserProfile`, and `AnalyticsActivityPageResponse`, are used consistently across all tasks.
+6. **Placeholder scan:** Every task has concrete files, interfaces, test code, commands, and an English commit message; no deferred implementation marker or unspecified generic testing/error-handling step remains.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-26-admin-user-analytics-metrics.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, and keep each commit independently testable.
+2. **Inline Execution** — execute the tasks in this session with executing-plans checkpoints.
+
+Do not start implementation until the user confirms the plan and selects an execution option.


### PR DESCRIPTION
## Summary

- instrument Account, Credential, Agent, Run, Resource, model-usage, and credits lifecycle events
- calculate explainable user metrics, daily rollups, and five user states
- add an idempotent 180-day authoritative backfill and maintenance flow
- expose privacy-safe Admin query services and four Admin-only analytics APIs
- verify SQLite/PostgreSQL query parity and benchmark representative 400,000-event workloads

## Dependency

This is PR 2 in the Admin Footprint & User Analytics stack.

- Base: #403
- Depends on the analytics contracts, repositories, ingestion, page-event collection, and retention interfaces from PR 1
- Does not include PR 1 Foundation changes or PR 3 frontend work

## Admin APIs

- `GET /api/admin/analytics/overview`
- `GET /api/admin/analytics/users`
- `GET /api/admin/analytics/users/{user_id}`
- `GET /api/admin/analytics/users/{user_id}/activity`

## Validation

- Analytics domain: 87 passed, 4 skipped
- Admin API/integration/composition: 56 passed
- Store twin parity: 49 passed
- Query benchmark at 400,000 events:
  - overview p95 approximately 0.460s (target <1.0s)
  - profile p95 approximately 0.0022s (target <0.5s)

## Known dependency blocker

The architecture suite has one failure inherited from PR 1: `dashboard/backend/domain/analytics/privacy.py` imports `dashboard.backend.api.rate_limit`. PR 2 does not modify that Foundation boundary; this draft should become ready after #403 resolves it.
