### PR TITLE
fix: make analytics backfill error path explicit

### DIFF
--- a/dashboard/scripts/backfill_analytics.py
+++ b/dashboard/scripts/backfill_analytics.py
@@ -63,6 +63,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     except ValueError as exc:
         _parser().error(str(exc))
+        return 2
     safe_counts = report.model_dump(exclude={"source_event_ids"})
     print(json.dumps(safe_counts, sort_keys=True, separators=(",", ":")))
     return 0


### PR DESCRIPTION
## Summary

- Make the ValueError error path in `dashboard/scripts/backfill_analytics.py` explicit for CodeQL.
- Preserve the existing argparse error behavior and success output.

## Validation

- `python -m compileall -q dashboard/scripts/backfill_analytics.py`
- `pytest dashboard/backend/tests/domain/analytics/test_backfill.py -q` (9 passed)

This is a follow-up to the already merged Admin Analytics changes in #405.